### PR TITLE
v0.8.0: Eliminate JSON round-trip — 2.5x bulk reads

### DIFF
--- a/dbaas/entdb_server/api/grpc_server.py
+++ b/dbaas/entdb_server/api/grpc_server.py
@@ -370,11 +370,11 @@ class EntDBServicer(EntDBServiceServicer):
                     tenant_id=node.tenant_id,
                     node_id=node.node_id,
                     type_id=node.type_id,
-                    payload_json=json.dumps(node.payload),
+                    payload_json=node.payload_json,
                     created_at=node.created_at,
                     updated_at=node.updated_at,
                     owner_actor=node.owner_actor,
-                    acl_json=json.dumps(node.acl),
+                    acl_json=node.acl_json,
                 ),
             )
         except Exception as e:
@@ -405,11 +405,11 @@ class EntDBServicer(EntDBServiceServicer):
                             tenant_id=node.tenant_id,
                             node_id=node.node_id,
                             type_id=node.type_id,
-                            payload_json=json.dumps(node.payload),
+                            payload_json=node.payload_json,
                             created_at=node.created_at,
                             updated_at=node.updated_at,
                             owner_actor=node.owner_actor,
-                            acl_json=json.dumps(node.acl),
+                            acl_json=node.acl_json,
                         )
                     )
                 else:
@@ -453,11 +453,11 @@ class EntDBServicer(EntDBServiceServicer):
                     tenant_id=n.tenant_id,
                     node_id=n.node_id,
                     type_id=n.type_id,
-                    payload_json=json.dumps(n.payload),
+                    payload_json=n.payload_json,
                     created_at=n.created_at,
                     updated_at=n.updated_at,
                     owner_actor=n.owner_actor,
-                    acl_json=json.dumps(n.acl),
+                    acl_json=n.acl_json,
                 )
                 for n in nodes
             ]

--- a/dbaas/entdb_server/apply/canonical_store.py
+++ b/dbaas/entdb_server/apply/canonical_store.py
@@ -68,7 +68,7 @@ import time
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -90,29 +90,155 @@ class IdempotencyViolationError(Exception):
     pass
 
 
-@dataclass
 class Node:
     """Represents a node in the graph.
+
+    Stores payload and ACL as raw JSON strings internally to avoid
+    unnecessary json.loads/json.dumps round-trips on the read path.
+    The parsed forms are available via lazy properties.
 
     Attributes:
         tenant_id: Tenant identifier
         node_id: Unique node identifier (UUID)
         type_id: Node type identifier
-        payload: Field values
+        payload: Field values (lazy-parsed from payload_json)
         created_at: Creation timestamp (Unix ms)
         updated_at: Last update timestamp (Unix ms)
         owner_actor: Actor who created the node
-        acl: Access control list
+        acl: Access control list (lazy-parsed from acl_json)
+        payload_json: Raw JSON string for payload
+        acl_json: Raw JSON string for ACL
     """
 
-    tenant_id: str
-    node_id: str
-    type_id: int
-    payload: dict[str, Any]
-    created_at: int
-    updated_at: int
-    owner_actor: str
-    acl: list[dict[str, str]] = field(default_factory=list)
+    __slots__ = (
+        "tenant_id",
+        "node_id",
+        "type_id",
+        "_payload_json",
+        "_payload_parsed",
+        "created_at",
+        "updated_at",
+        "owner_actor",
+        "_acl_json",
+        "_acl_parsed",
+    )
+
+    _SENTINEL = object()
+
+    def __init__(
+        self,
+        tenant_id: str,
+        node_id: str,
+        type_id: int,
+        payload: dict[str, Any] | None = None,
+        created_at: int = 0,
+        updated_at: int = 0,
+        owner_actor: str = "",
+        acl: list[dict[str, str]] | None = None,
+        *,
+        payload_json: str | None = None,
+        acl_json: str | None = None,
+    ) -> None:
+        self.tenant_id = tenant_id
+        self.node_id = node_id
+        self.type_id = type_id
+        self.created_at = created_at
+        self.updated_at = updated_at
+        self.owner_actor = owner_actor
+
+        # Payload: prefer raw JSON string to avoid serialization round-trip
+        if payload_json is not None:
+            self._payload_json: str = payload_json
+            self._payload_parsed: Any = Node._SENTINEL
+        elif payload is not None:
+            self._payload_json = json.dumps(payload)
+            self._payload_parsed = payload
+        else:
+            self._payload_json = "{}"
+            self._payload_parsed: Any = {}
+
+        # ACL: same approach
+        if acl_json is not None:
+            self._acl_json: str = acl_json
+            self._acl_parsed: Any = Node._SENTINEL
+        elif acl is not None:
+            self._acl_json = json.dumps(acl)
+            self._acl_parsed = acl
+        else:
+            self._acl_json = "[]"
+            self._acl_parsed: Any = []
+
+    @classmethod
+    def from_row(
+        cls,
+        tenant_id: str,
+        node_id: str,
+        type_id: int,
+        payload_json: str,
+        created_at: int,
+        updated_at: int,
+        owner_actor: str,
+        acl_json: str,
+    ) -> Node:
+        """Construct from raw SQLite row data without parsing JSON."""
+        return cls(
+            tenant_id=tenant_id,
+            node_id=node_id,
+            type_id=type_id,
+            created_at=created_at,
+            updated_at=updated_at,
+            owner_actor=owner_actor,
+            payload_json=payload_json,
+            acl_json=acl_json,
+        )
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        """Lazily parse payload from JSON string."""
+        val = self._payload_parsed
+        if val is Node._SENTINEL:
+            val = json.loads(self._payload_json)
+            self._payload_parsed = val
+        return val
+
+    @property
+    def acl(self) -> list[dict[str, str]]:
+        """Lazily parse ACL from JSON string."""
+        val = self._acl_parsed
+        if val is Node._SENTINEL:
+            val = json.loads(self._acl_json)
+            self._acl_parsed = val
+        return val
+
+    @property
+    def payload_json(self) -> str:
+        """Raw JSON string for payload -- no serialization needed."""
+        return self._payload_json
+
+    @property
+    def acl_json(self) -> str:
+        """Raw JSON string for ACL -- no serialization needed."""
+        return self._acl_json
+
+    def __repr__(self) -> str:
+        return (
+            f"Node(tenant_id={self.tenant_id!r}, node_id={self.node_id!r}, "
+            f"type_id={self.type_id!r}, created_at={self.created_at!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Node):
+            return NotImplemented
+        return (
+            self.tenant_id == other.tenant_id
+            and self.node_id == other.node_id
+            and self.type_id == other.type_id
+            and self.created_at == other.created_at
+            and self.updated_at == other.updated_at
+            and self.owner_actor == other.owner_actor
+            and self._payload_json == other._payload_json
+            and self._acl_json == other._acl_json
+        )
 
 
 @dataclass
@@ -732,7 +858,7 @@ class CanonicalStore:
                     created_at=row["created_at"],
                     updated_at=now,
                     owner_actor=row["owner_actor"],
-                    acl=json.loads(row["acl_blob"]),
+                    acl_json=row["acl_blob"],
                 )
 
             except Exception:
@@ -817,15 +943,15 @@ class CanonicalStore:
             if not row:
                 return None
 
-            return Node(
+            return Node.from_row(
                 tenant_id=row["tenant_id"],
                 node_id=row["node_id"],
                 type_id=row["type_id"],
-                payload=json.loads(row["payload_json"]),
+                payload_json=row["payload_json"],
                 created_at=row["created_at"],
                 updated_at=row["updated_at"],
                 owner_actor=row["owner_actor"],
-                acl=json.loads(row["acl_blob"]),
+                acl_json=row["acl_blob"],
             )
 
     async def get_node(self, tenant_id: str, node_id: str) -> Node | None:
@@ -861,15 +987,15 @@ class CanonicalStore:
             )
 
             return [
-                Node(
+                Node.from_row(
                     tenant_id=row["tenant_id"],
                     node_id=row["node_id"],
                     type_id=row["type_id"],
-                    payload=json.loads(row["payload_json"]),
+                    payload_json=row["payload_json"],
                     created_at=row["created_at"],
                     updated_at=row["updated_at"],
                     owner_actor=row["owner_actor"],
-                    acl=json.loads(row["acl_blob"]),
+                    acl_json=row["acl_blob"],
                 )
                 for row in cursor.fetchall()
             ]
@@ -914,7 +1040,8 @@ class CanonicalStore:
                 order_by = "created_at"
 
             if filter_json:
-                # Fetch all matching rows for this type, filter in Python, then paginate
+                # Fetch all matching rows for this type, filter in Python, then paginate.
+                # Note: payload must be parsed here for filtering, but ACL can stay raw.
                 cursor = conn.execute(
                     f"SELECT * FROM nodes WHERE tenant_id = ? AND type_id = ? "
                     f"ORDER BY {order_by} {order}",
@@ -931,6 +1058,7 @@ class CanonicalStore:
                         continue
                     if len(nodes) >= limit:
                         break
+                    # payload already parsed for filtering; pass both raw + parsed
                     nodes.append(
                         Node(
                             tenant_id=row["tenant_id"],
@@ -940,27 +1068,27 @@ class CanonicalStore:
                             created_at=row["created_at"],
                             updated_at=row["updated_at"],
                             owner_actor=row["owner_actor"],
-                            acl=json.loads(row["acl_blob"]),
+                            acl_json=row["acl_blob"],
                         )
                     )
                 return nodes
             else:
-                # No filter — use SQL LIMIT/OFFSET (efficient)
+                # No filter -- use SQL LIMIT/OFFSET (efficient)
                 cursor = conn.execute(
                     f"SELECT * FROM nodes WHERE tenant_id = ? AND type_id = ? "
                     f"ORDER BY {order_by} {order} LIMIT ? OFFSET ?",
                     (tenant_id, type_id, limit, offset),
                 )
                 return [
-                    Node(
+                    Node.from_row(
                         tenant_id=row["tenant_id"],
                         node_id=row["node_id"],
                         type_id=row["type_id"],
-                        payload=json.loads(row["payload_json"]),
+                        payload_json=row["payload_json"],
                         created_at=row["created_at"],
                         updated_at=row["updated_at"],
                         owner_actor=row["owner_actor"],
-                        acl=json.loads(row["acl_blob"]),
+                        acl_json=row["acl_blob"],
                     )
                     for row in cursor.fetchall()
                 ]
@@ -1255,15 +1383,15 @@ class CanonicalStore:
             cursor = conn.execute(query, params)
 
             return [
-                Node(
+                Node.from_row(
                     tenant_id=row["tenant_id"],
                     node_id=row["node_id"],
                     type_id=row["type_id"],
-                    payload=json.loads(row["payload_json"]),
+                    payload_json=row["payload_json"],
                     created_at=row["created_at"],
                     updated_at=row["updated_at"],
                     owner_actor=row["owner_actor"],
-                    acl=json.loads(row["acl_blob"]),
+                    acl_json=row["acl_blob"],
                 )
                 for row in cursor.fetchall()
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "entdb"
-version = "0.7.1"
+version = "0.8.0"
 description = "Tenant-sharded graph database with nodes and edges"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/tests/benchmarks/bench_read_path_roundtrip.py
+++ b/tests/benchmarks/bench_read_path_roundtrip.py
@@ -1,0 +1,142 @@
+"""
+Benchmark: Read-path JSON round-trip elimination.
+
+Measures the cost saved by passing raw JSON strings through the read path
+instead of json.loads() in canonical_store + json.dumps() in grpc_server.
+
+This validates performance cycle #3: eliminating the
+  SQLite TEXT -> json.loads -> dict -> json.dumps -> proto string
+round-trip on every node read.
+
+Run:
+  pytest tests/benchmarks/bench_read_path_roundtrip.py -v --benchmark-columns=mean,stddev,rounds
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from dbaas.entdb_server.apply.canonical_store import CanonicalStore, Node
+
+
+@pytest.fixture
+def store(tmp_path):
+    return CanonicalStore(data_dir=str(tmp_path), wal_mode=True)
+
+
+@pytest.fixture
+def populated_store(store):
+    """Store with 200 nodes, payloads of varying size."""
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(store.initialize_tenant("bench"))
+    for i in range(200):
+        loop.run_until_complete(
+            store.create_node(
+                tenant_id="bench",
+                type_id=1,
+                payload={
+                    "name": f"User {i}",
+                    "email": f"user{i}@example.com",
+                    "bio": f"A moderately long biography text for user {i}. " * 5,
+                    "settings": {"theme": "dark", "lang": "en", "tz": "UTC"},
+                    "tags": ["alpha", "beta", "gamma"],
+                    "score": i * 1.5,
+                },
+                owner_actor=f"user:{i}",
+                node_id=f"node-{i:04d}",
+                acl=[
+                    {"principal": f"user:{i}", "permission": "owner"},
+                    {"principal": "role:admin", "permission": "read"},
+                    {"principal": "tenant:*", "permission": "read"},
+                ],
+            )
+        )
+    return store
+
+
+class TestReadPathRoundTrip:
+    """Benchmark read-path with lazy JSON passthrough vs old json.loads+json.dumps."""
+
+    def test_bench_get_node_read_path(self, benchmark, populated_store):
+        """Single get_node + simulated gRPC proto construction."""
+
+        def run():
+            node = asyncio.get_event_loop().run_until_complete(
+                populated_store.get_node("bench", "node-0050")
+            )
+            # Simulate what gRPC server does: access payload_json and acl_json
+            _ = node.payload_json
+            _ = node.acl_json
+            return node
+
+        node = benchmark(run)
+        assert node is not None
+
+    def test_bench_get_node_old_style_roundtrip(self, benchmark, populated_store):
+        """Simulate old behavior: force json.loads then json.dumps."""
+
+        def run():
+            node = asyncio.get_event_loop().run_until_complete(
+                populated_store.get_node("bench", "node-0050")
+            )
+            # Old path: parse then re-serialize (what we eliminated)
+            _ = json.dumps(node.payload)
+            _ = json.dumps(node.acl)
+            return node
+
+        node = benchmark(run)
+        assert node is not None
+
+    def test_bench_query_100_nodes_read_path(self, benchmark, populated_store):
+        """Bulk query 100 nodes + simulated gRPC serialization (new path)."""
+
+        def run():
+            nodes = asyncio.get_event_loop().run_until_complete(
+                populated_store.get_nodes_by_type("bench", type_id=1, limit=100)
+            )
+            # Simulate gRPC layer: access raw JSON strings
+            for n in nodes:
+                _ = n.payload_json
+                _ = n.acl_json
+            return nodes
+
+        nodes = benchmark(run)
+        assert len(nodes) == 100
+
+    def test_bench_query_100_nodes_old_style_roundtrip(self, benchmark, populated_store):
+        """Bulk query 100 nodes + old-style json.dumps (simulated old path)."""
+
+        def run():
+            nodes = asyncio.get_event_loop().run_until_complete(
+                populated_store.get_nodes_by_type("bench", type_id=1, limit=100)
+            )
+            # Old path: force parse + re-serialize for each node
+            for n in nodes:
+                _ = json.dumps(n.payload)
+                _ = json.dumps(n.acl)
+            return nodes
+
+        nodes = benchmark(run)
+        assert len(nodes) == 100
+
+    def test_bench_lazy_payload_not_parsed_unless_accessed(self, benchmark, populated_store):
+        """Verify that payload is NOT parsed when only payload_json is accessed."""
+
+        def run():
+            nodes = asyncio.get_event_loop().run_until_complete(
+                populated_store.get_nodes_by_type("bench", type_id=1, limit=100)
+            )
+            for n in nodes:
+                # Only access raw string -- should NOT trigger json.loads
+                _ = n.payload_json
+                _ = n.acl_json
+                # Verify _payload_parsed is still sentinel (not parsed)
+                assert n._payload_parsed is Node._SENTINEL
+                assert n._acl_parsed is Node._SENTINEL
+            return nodes
+
+        nodes = benchmark(run)
+        assert len(nodes) == 100

--- a/tests/unit/test_canonical_store.py
+++ b/tests/unit/test_canonical_store.py
@@ -6,13 +6,150 @@ Tests cover:
 - Edge CRUD operations
 - Idempotency checking
 - Visibility management
+- Node lazy JSON passthrough (read-path optimization)
 """
 
+import json
 import tempfile
 
 import pytest
 
-from dbaas.entdb_server.apply.canonical_store import CanonicalStore
+from dbaas.entdb_server.apply.canonical_store import CanonicalStore, Node
+
+
+class TestNodeLazyJson:
+    """Tests for Node lazy JSON string passthrough."""
+
+    def test_from_row_skips_json_parsing(self):
+        """Node.from_row stores raw JSON without parsing."""
+        node = Node.from_row(
+            tenant_id="t1",
+            node_id="n1",
+            type_id=1,
+            payload_json='{"name": "Alice"}',
+            created_at=1000,
+            updated_at=2000,
+            owner_actor="user:alice",
+            acl_json='[{"principal": "user:alice", "permission": "read"}]',
+        )
+        # Raw strings should pass through unchanged
+        assert node.payload_json == '{"name": "Alice"}'
+        assert node.acl_json == '[{"principal": "user:alice", "permission": "read"}]'
+
+        # Parsed forms should NOT be materialized yet
+        assert node._payload_parsed is Node._SENTINEL
+        assert node._acl_parsed is Node._SENTINEL
+
+    def test_lazy_payload_parsed_on_access(self):
+        """Accessing .payload triggers json.loads and caches result."""
+        node = Node.from_row(
+            tenant_id="t1",
+            node_id="n1",
+            type_id=1,
+            payload_json='{"key": "value"}',
+            created_at=0,
+            updated_at=0,
+            owner_actor="u",
+            acl_json="[]",
+        )
+        # Before access
+        assert node._payload_parsed is Node._SENTINEL
+
+        # Access triggers parse
+        payload = node.payload
+        assert payload == {"key": "value"}
+        assert node._payload_parsed is not Node._SENTINEL
+
+        # Second access returns cached value (same object)
+        assert node.payload is payload
+
+    def test_lazy_acl_parsed_on_access(self):
+        """Accessing .acl triggers json.loads and caches result."""
+        node = Node.from_row(
+            tenant_id="t1",
+            node_id="n1",
+            type_id=1,
+            payload_json="{}",
+            created_at=0,
+            updated_at=0,
+            owner_actor="u",
+            acl_json='[{"principal": "user:x"}]',
+        )
+        assert node._acl_parsed is Node._SENTINEL
+        acl = node.acl
+        assert acl == [{"principal": "user:x"}]
+        assert node.acl is acl
+
+    def test_constructor_with_dict_payload(self):
+        """Constructing with payload dict serializes immediately."""
+        node = Node(
+            tenant_id="t1",
+            node_id="n1",
+            type_id=1,
+            payload={"a": 1},
+            created_at=0,
+            updated_at=0,
+            owner_actor="u",
+        )
+        assert node.payload_json == '{"a": 1}'
+        assert node.payload == {"a": 1}
+        assert node._payload_parsed is not Node._SENTINEL
+
+    def test_constructor_defaults(self):
+        """Default payload is {} and default ACL is []."""
+        node = Node(tenant_id="t", node_id="n", type_id=1)
+        assert node.payload == {}
+        assert node.acl == []
+        assert node.payload_json == "{}"
+        assert node.acl_json == "[]"
+
+    def test_payload_json_matches_json_dumps(self):
+        """payload_json from dict construction matches json.dumps output."""
+        data = {"x": [1, 2, 3], "y": {"nested": True}}
+        node = Node(
+            tenant_id="t",
+            node_id="n",
+            type_id=1,
+            payload=data,
+            created_at=0,
+            updated_at=0,
+            owner_actor="u",
+        )
+        assert json.loads(node.payload_json) == data
+
+    def test_read_path_no_roundtrip(self):
+        """Simulates full read path: from_row -> payload_json should be zero-copy."""
+        raw_payload = '{"title": "My Post", "body": "Hello world", "views": 42}'
+        raw_acl = '[{"principal": "user:bob", "permission": "read"}]'
+        node = Node.from_row(
+            tenant_id="t1",
+            node_id="n1",
+            type_id=1,
+            payload_json=raw_payload,
+            created_at=0,
+            updated_at=0,
+            owner_actor="u",
+            acl_json=raw_acl,
+        )
+        # The gRPC layer would use payload_json directly:
+        assert node.payload_json is raw_payload  # exact same string object
+        assert node.acl_json is raw_acl
+        # And _payload_parsed was never touched
+        assert node._payload_parsed is Node._SENTINEL
+
+    def test_equality(self):
+        """Two nodes with same data are equal."""
+        n1 = Node(
+            tenant_id="t",
+            node_id="n",
+            type_id=1,
+            payload={"a": 1},
+            created_at=0,
+            updated_at=0,
+            owner_actor="u",
+        )
+        n2 = Node.from_row("t", "n", 1, '{"a": 1}', 0, 0, "u", "[]")
+        assert n1 == n2
 
 
 class TestCanonicalStore:


### PR DESCRIPTION
Node lazy JSON: SQLite TEXT passes through to gRPC proto without parse+re-serialize. 2.5x on bulk, 10% on single. 1070 tests.