### PR TITLE
Close #104: migrate payloads to field ids + tests

### DIFF
--- a/dbaas/entdb_server/apply/canonical_store.py
+++ b/dbaas/entdb_server/apply/canonical_store.py
@@ -3927,3 +3927,99 @@ class CanonicalStore:
         AUDIT records (per the export policy table in ADR-004).
         """
         return await self._run_sync(self._sync_export_user_data, tenant_id, user_id, registry)
+
+    def _sync_migrate_payloads_to_field_ids(
+        self,
+        tenant_id: str,
+        schema_registry: Any,
+    ) -> dict:
+        """Rewrite legacy name-keyed payload_json rows to id-keyed format.
+
+        Idempotent and atomic: the entire scan-and-rewrite runs inside a
+        single SQLite transaction so a partial failure leaves no half-
+        migrated rows behind.
+        """
+        from ..schema.field_id_translation import looks_id_keyed, name_to_id_keys
+
+        scanned = 0
+        migrated = 0
+        skipped = 0
+        unknown_type = 0
+
+        with self._get_connection(tenant_id) as conn:
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                rows = conn.execute(
+                    "SELECT node_id, type_id, payload_json FROM nodes WHERE tenant_id = ?",
+                    (tenant_id,),
+                ).fetchall()
+
+                for row in rows:
+                    scanned += 1
+                    node_id = row["node_id"]
+                    type_id = row["type_id"]
+                    payload_raw = row["payload_json"]
+
+                    try:
+                        parsed = json.loads(payload_raw) if payload_raw else {}
+                    except (ValueError, TypeError):
+                        # Unparseable payloads are left untouched.
+                        skipped += 1
+                        continue
+
+                    if not isinstance(parsed, dict):
+                        skipped += 1
+                        continue
+
+                    if looks_id_keyed(parsed):
+                        skipped += 1
+                        continue
+
+                    if schema_registry is None or not hasattr(schema_registry, "get_node_type"):
+                        unknown_type += 1
+                        continue
+
+                    if schema_registry.get_node_type(type_id) is None:
+                        unknown_type += 1
+                        continue
+
+                    new_payload = name_to_id_keys(parsed, type_id, schema_registry)
+                    new_json = json.dumps(new_payload)
+                    conn.execute(
+                        "UPDATE nodes SET payload_json = ? WHERE tenant_id = ? AND node_id = ?",
+                        (new_json, tenant_id, node_id),
+                    )
+                    migrated += 1
+
+                conn.execute("COMMIT")
+            except Exception:
+                with contextlib.suppress(Exception):
+                    conn.execute("ROLLBACK")
+                raise
+
+        return {
+            "scanned": scanned,
+            "migrated": migrated,
+            "skipped": skipped,
+            "unknown_type": unknown_type,
+        }
+
+    async def migrate_payloads_to_field_ids(
+        self,
+        tenant_id: str,
+        schema_registry: Any,
+    ) -> dict:
+        """Rewrite legacy name-keyed payload_json rows to id-keyed format.
+
+        Idempotent: rows already in id-keyed form (per ``looks_id_keyed``) are
+        skipped. Unknown field names are dropped silently (consistent with
+        ``name_to_id_keys`` ingress behavior). Rows whose ``type_id`` is not in
+        the registry are left unchanged.
+
+        Returns a summary dict::
+
+            {"scanned": int, "migrated": int, "skipped": int, "unknown_type": int}
+        """
+        return await self._run_sync(
+            self._sync_migrate_payloads_to_field_ids, tenant_id, schema_registry
+        )

--- a/tests/unit/test_field_id_migration.py
+++ b/tests/unit/test_field_id_migration.py
@@ -1,0 +1,289 @@
+"""
+Unit tests for ``CanonicalStore.migrate_payloads_to_field_ids``.
+
+The migration helper rewrites legacy name-keyed payload_json rows in the
+nodes table to the id-keyed format expected by EntDB v2 (issue #104).
+
+Tests cover:
+    - Migration of legacy name-keyed rows
+    - Idempotency (second pass migrates nothing)
+    - Unknown field names dropped during migration
+    - Rows whose type_id is not in the registry are left unchanged
+    - Mixed tenant (legacy + already-migrated rows)
+    - Empty tenant
+    - Registry None (graceful no-op via unknown_type counter)
+    - Returned summary counts match the actual DB state
+"""
+
+import json
+import tempfile
+
+import pytest
+
+from dbaas.entdb_server.apply.canonical_store import CanonicalStore
+from dbaas.entdb_server.schema import NodeTypeDef, SchemaRegistry, field
+
+
+def _make_registry() -> SchemaRegistry:
+    """Build a small registry with two node types used by the tests."""
+    registry = SchemaRegistry()
+    registry.register_node_type(
+        NodeTypeDef(
+            type_id=101,
+            name="Task",
+            fields=(
+                field(1, "title", "str"),
+                field(2, "status", "str"),
+            ),
+        )
+    )
+    registry.register_node_type(
+        NodeTypeDef(
+            type_id=202,
+            name="Note",
+            fields=(field(1, "body", "str"),),
+        )
+    )
+    return registry
+
+
+def _insert_row(
+    store: CanonicalStore,
+    tenant_id: str,
+    node_id: str,
+    type_id: int,
+    payload: dict,
+) -> None:
+    """Insert a raw nodes row, bypassing CanonicalStore's serializer.
+
+    This lets the test seed name-keyed (legacy) payloads directly so the
+    migration helper has something to rewrite.
+    """
+    with store._get_connection(tenant_id) as conn:
+        conn.execute(
+            """
+            INSERT INTO nodes (
+                tenant_id, node_id, type_id, payload_json,
+                created_at, updated_at, owner_actor, acl_blob
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                tenant_id,
+                node_id,
+                type_id,
+                json.dumps(payload),
+                1000,
+                1000,
+                "user:tester",
+                "[]",
+            ),
+        )
+
+
+def _read_payload(store: CanonicalStore, tenant_id: str, node_id: str) -> dict:
+    with store._get_connection(tenant_id) as conn:
+        row = conn.execute(
+            "SELECT payload_json FROM nodes WHERE tenant_id = ? AND node_id = ?",
+            (tenant_id, node_id),
+        ).fetchone()
+    return json.loads(row["payload_json"])
+
+
+class TestMigratePayloadsToFieldIds:
+    """Tests for ``CanonicalStore.migrate_payloads_to_field_ids``."""
+
+    @pytest.fixture
+    def data_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+
+    @pytest.fixture
+    def store(self, data_dir):
+        return CanonicalStore(data_dir, wal_mode=False)
+
+    @pytest.fixture
+    def registry(self):
+        return _make_registry()
+
+    @pytest.mark.asyncio
+    async def test_migrates_legacy_name_keyed_rows(self, store, registry):
+        """A legacy name-keyed row is rewritten to id-keyed form."""
+        tenant_id = "tenant_legacy"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(store, tenant_id, "n1", 101, {"title": "buy milk", "status": "open"})
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+
+        assert result == {"scanned": 1, "migrated": 1, "skipped": 0, "unknown_type": 0}
+        assert _read_payload(store, tenant_id, "n1") == {"1": "buy milk", "2": "open"}
+
+    @pytest.mark.asyncio
+    async def test_idempotent_second_pass_is_noop(self, store, registry):
+        """Running the migration twice migrates zero rows on the second pass."""
+        tenant_id = "tenant_idem"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(store, tenant_id, "n1", 101, {"title": "x"})
+        _insert_row(store, tenant_id, "n2", 202, {"body": "hello"})
+
+        first = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+        assert first["migrated"] == 2
+
+        second = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+        assert second == {"scanned": 2, "migrated": 0, "skipped": 2, "unknown_type": 0}
+
+        # Payloads remain in id-keyed form after the second pass.
+        assert _read_payload(store, tenant_id, "n1") == {"1": "x"}
+        assert _read_payload(store, tenant_id, "n2") == {"1": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_names_dropped(self, store, registry):
+        """Unknown field names are silently dropped during migration."""
+        tenant_id = "tenant_drop"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(
+            store,
+            tenant_id,
+            "n1",
+            101,
+            {"title": "keep me", "bogus": "drop me", "status": "open"},
+        )
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+
+        assert result["migrated"] == 1
+        assert _read_payload(store, tenant_id, "n1") == {"1": "keep me", "2": "open"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_type_id_left_unchanged(self, store, registry):
+        """Rows whose type_id is not registered are not modified."""
+        tenant_id = "tenant_unknown_type"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(store, tenant_id, "n1", 999, {"foo": "bar"})
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+
+        assert result == {
+            "scanned": 1,
+            "migrated": 0,
+            "skipped": 0,
+            "unknown_type": 1,
+        }
+        # Payload untouched.
+        assert _read_payload(store, tenant_id, "n1") == {"foo": "bar"}
+
+    @pytest.mark.asyncio
+    async def test_mixed_legacy_and_migrated_rows(self, store, registry):
+        """A tenant containing both legacy and id-keyed rows migrates only the legacy ones."""
+        tenant_id = "tenant_mixed"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(store, tenant_id, "legacy1", 101, {"title": "old", "status": "open"})
+        _insert_row(store, tenant_id, "legacy2", 202, {"body": "old note"})
+        _insert_row(store, tenant_id, "modern1", 101, {"1": "new", "2": "done"})
+        _insert_row(store, tenant_id, "modern2", 202, {"1": "new note"})
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+
+        assert result == {
+            "scanned": 4,
+            "migrated": 2,
+            "skipped": 2,
+            "unknown_type": 0,
+        }
+        assert _read_payload(store, tenant_id, "legacy1") == {"1": "old", "2": "open"}
+        assert _read_payload(store, tenant_id, "legacy2") == {"1": "old note"}
+        assert _read_payload(store, tenant_id, "modern1") == {"1": "new", "2": "done"}
+        assert _read_payload(store, tenant_id, "modern2") == {"1": "new note"}
+
+    @pytest.mark.asyncio
+    async def test_empty_tenant_zero_counts(self, store, registry):
+        """A tenant with no nodes returns all-zero counts."""
+        tenant_id = "tenant_empty"
+        await store.initialize_tenant(tenant_id)
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+
+        assert result == {"scanned": 0, "migrated": 0, "skipped": 0, "unknown_type": 0}
+
+    @pytest.mark.asyncio
+    async def test_registry_none_marks_unknown_type(self, store):
+        """A None registry marks every legacy row as unknown_type (graceful no-op)."""
+        tenant_id = "tenant_no_registry"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(store, tenant_id, "n1", 101, {"title": "x"})
+        _insert_row(store, tenant_id, "n2", 202, {"body": "y"})
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, None)
+
+        assert result == {
+            "scanned": 2,
+            "migrated": 0,
+            "skipped": 0,
+            "unknown_type": 2,
+        }
+        # Rows untouched.
+        assert _read_payload(store, tenant_id, "n1") == {"title": "x"}
+        assert _read_payload(store, tenant_id, "n2") == {"body": "y"}
+
+    @pytest.mark.asyncio
+    async def test_summary_counts_match_db_state(self, store, registry):
+        """The returned summary numbers match what's actually stored in the DB."""
+        tenant_id = "tenant_summary"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(store, tenant_id, "legacy", 101, {"title": "a"})
+        _insert_row(store, tenant_id, "already", 101, {"1": "b"})
+        _insert_row(store, tenant_id, "unk", 999, {"foo": "bar"})
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+
+        assert result["scanned"] == 3
+        assert result["migrated"] == 1
+        assert result["skipped"] == 1
+        assert result["unknown_type"] == 1
+
+        # Confirm DB matches that breakdown.
+        with store._get_connection(tenant_id) as conn:
+            rows = conn.execute(
+                "SELECT node_id, payload_json FROM nodes WHERE tenant_id = ?",
+                (tenant_id,),
+            ).fetchall()
+        payloads = {r["node_id"]: json.loads(r["payload_json"]) for r in rows}
+        assert payloads["legacy"] == {"1": "a"}
+        assert payloads["already"] == {"1": "b"}
+        assert payloads["unk"] == {"foo": "bar"}
+
+    @pytest.mark.asyncio
+    async def test_empty_payload_treated_as_id_keyed(self, store, registry):
+        """An empty payload counts as already id-keyed and is skipped."""
+        tenant_id = "tenant_empty_payload"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(store, tenant_id, "n1", 101, {})
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+
+        assert result == {"scanned": 1, "migrated": 0, "skipped": 1, "unknown_type": 0}
+        assert _read_payload(store, tenant_id, "n1") == {}
+
+    @pytest.mark.asyncio
+    async def test_multiple_node_types_in_one_pass(self, store, registry):
+        """The migration handles a heterogeneous mix of node types in one pass."""
+        tenant_id = "tenant_multi_type"
+        await store.initialize_tenant(tenant_id)
+
+        _insert_row(store, tenant_id, "t1", 101, {"title": "alpha", "status": "open"})
+        _insert_row(store, tenant_id, "t2", 101, {"title": "beta"})
+        _insert_row(store, tenant_id, "t3", 202, {"body": "gamma"})
+
+        result = await store.migrate_payloads_to_field_ids(tenant_id, registry)
+
+        assert result == {"scanned": 3, "migrated": 3, "skipped": 0, "unknown_type": 0}
+        assert _read_payload(store, tenant_id, "t1") == {"1": "alpha", "2": "open"}
+        assert _read_payload(store, tenant_id, "t2") == {"1": "beta"}
+        assert _read_payload(store, tenant_id, "t3") == {"1": "gamma"}

--- a/tests/unit/test_field_id_storage.py
+++ b/tests/unit/test_field_id_storage.py
@@ -1,0 +1,293 @@
+"""
+Unit tests for field-ID based payload translation.
+
+Covers the helpers in
+``dbaas.entdb_server.schema.field_id_translation`` which translate
+between name-keyed (wire) and id-keyed (on-disk) payloads, including:
+
+- ``looks_id_keyed``
+- ``name_to_id_keys``
+- ``id_to_name_keys``
+- ``translate_payload_json_to_names``
+- ``translate_filter_name_to_id``
+- round-trip + field-rename safety properties
+"""
+
+from __future__ import annotations
+
+import json
+
+from dbaas.entdb_server.schema.field_id_translation import (
+    id_to_name_keys,
+    looks_id_keyed,
+    name_to_id_keys,
+    translate_filter_name_to_id,
+    translate_payload_json_to_names,
+)
+from dbaas.entdb_server.schema.registry import SchemaRegistry
+from dbaas.entdb_server.schema.types import NodeTypeDef, field
+
+
+def _make_task_registry() -> SchemaRegistry:
+    """Build a tiny registry with one Task type for reuse in tests."""
+    registry = SchemaRegistry()
+    registry.register_node_type(
+        NodeTypeDef(
+            type_id=101,
+            name="Task",
+            fields=(
+                field(1, "title", "str"),
+                field(2, "status", "str"),
+                field(3, "priority", "int"),
+            ),
+        )
+    )
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# looks_id_keyed
+# ---------------------------------------------------------------------------
+
+
+class TestLooksIdKeyed:
+    def test_empty_dict_is_id_keyed(self):
+        assert looks_id_keyed({}) is True
+
+    def test_all_digit_keys(self):
+        assert looks_id_keyed({"1": "a", "2": "b", "42": "c"}) is True
+
+    def test_name_keys_not_id_keyed(self):
+        assert looks_id_keyed({"title": "a", "status": "b"}) is False
+
+    def test_mixed_keys_not_id_keyed(self):
+        assert looks_id_keyed({"1": "a", "title": "b"}) is False
+
+    def test_empty_string_key_not_id_keyed(self):
+        assert looks_id_keyed({"": "a"}) is False
+
+    def test_non_string_key_not_id_keyed(self):
+        # Integer keys look numeric but the helper demands strings.
+        assert looks_id_keyed({1: "a"}) is False
+
+    def test_digit_with_leading_space_not_id_keyed(self):
+        assert looks_id_keyed({" 1": "a"}) is False
+
+
+# ---------------------------------------------------------------------------
+# name_to_id_keys
+# ---------------------------------------------------------------------------
+
+
+class TestNameToIdKeys:
+    def test_happy_path(self):
+        registry = _make_task_registry()
+        out = name_to_id_keys({"title": "x", "status": "open"}, 101, registry)
+        assert out == {"1": "x", "2": "open"}
+
+    def test_unknown_field_dropped(self):
+        registry = _make_task_registry()
+        out = name_to_id_keys({"title": "x", "bogus": "drop-me", "status": "open"}, 101, registry)
+        assert out == {"1": "x", "2": "open"}
+        assert "bogus" not in out
+
+    def test_none_payload_returns_empty(self):
+        registry = _make_task_registry()
+        assert name_to_id_keys(None, 101, registry) == {}
+
+    def test_empty_payload_returns_empty(self):
+        registry = _make_task_registry()
+        assert name_to_id_keys({}, 101, registry) == {}
+
+    def test_already_id_keyed_known_id_passthrough(self):
+        registry = _make_task_registry()
+        # Caller already sent "1" — it's a registered field id, leave it alone.
+        out = name_to_id_keys({"1": "x"}, 101, registry)
+        assert out == {"1": "x"}
+
+    def test_already_id_keyed_unknown_id_dropped(self):
+        registry = _make_task_registry()
+        # "99" is a digit string but not a registered field id — drop it.
+        out = name_to_id_keys({"99": "x"}, 101, registry)
+        assert out == {}
+
+    def test_registry_none_passthrough(self):
+        out = name_to_id_keys({"title": "x"}, 101, None)
+        assert out == {"title": "x"}
+
+    def test_registry_without_get_node_type_passthrough(self):
+        class NotARegistry:
+            pass
+
+        out = name_to_id_keys({"title": "x"}, 101, NotARegistry())
+        assert out == {"title": "x"}
+
+    def test_type_not_found_passthrough(self):
+        registry = _make_task_registry()
+        out = name_to_id_keys({"title": "x"}, 999, registry)
+        assert out == {"title": "x"}
+
+    def test_all_unknown_drops_to_empty(self):
+        registry = _make_task_registry()
+        out = name_to_id_keys({"a": 1, "b": 2}, 101, registry)
+        assert out == {}
+
+    def test_preserves_value_types(self):
+        registry = _make_task_registry()
+        out = name_to_id_keys({"title": None, "status": ["a"], "priority": 3}, 101, registry)
+        assert out == {"1": None, "2": ["a"], "3": 3}
+
+
+# ---------------------------------------------------------------------------
+# id_to_name_keys
+# ---------------------------------------------------------------------------
+
+
+class TestIdToNameKeys:
+    def test_happy_path(self):
+        registry = _make_task_registry()
+        out = id_to_name_keys({"1": "x", "2": "open"}, 101, registry)
+        assert out == {"title": "x", "status": "open"}
+
+    def test_unknown_id_preserved_verbatim(self):
+        registry = _make_task_registry()
+        out = id_to_name_keys({"1": "x", "999": "future"}, 101, registry)
+        assert out == {"title": "x", "999": "future"}
+
+    def test_none_payload_returns_empty(self):
+        registry = _make_task_registry()
+        assert id_to_name_keys(None, 101, registry) == {}
+
+    def test_empty_payload_returns_empty(self):
+        registry = _make_task_registry()
+        assert id_to_name_keys({}, 101, registry) == {}
+
+    def test_registry_none_passthrough(self):
+        out = id_to_name_keys({"1": "x"}, 101, None)
+        assert out == {"1": "x"}
+
+    def test_type_not_found_passthrough(self):
+        registry = _make_task_registry()
+        out = id_to_name_keys({"1": "x"}, 999, registry)
+        assert out == {"1": "x"}
+
+    def test_legacy_name_key_fallthrough(self):
+        # A legacy name-keyed row (not yet migrated) should be handed back
+        # as-is so the read path still works.
+        registry = _make_task_registry()
+        out = id_to_name_keys({"title": "x", "2": "open"}, 101, registry)
+        assert out == {"title": "x", "status": "open"}
+
+
+# ---------------------------------------------------------------------------
+# translate_payload_json_to_names
+# ---------------------------------------------------------------------------
+
+
+class TestTranslatePayloadJsonToNames:
+    def test_empty_string_returns_empty_object(self):
+        registry = _make_task_registry()
+        assert translate_payload_json_to_names("", 101, registry) == "{}"
+
+    def test_none_returns_empty_object(self):
+        registry = _make_task_registry()
+        assert translate_payload_json_to_names(None, 101, registry) == "{}"
+
+    def test_empty_object_literal_returns_empty_object(self):
+        registry = _make_task_registry()
+        assert translate_payload_json_to_names("{}", 101, registry) == "{}"
+
+    def test_malformed_json_returned_unchanged(self):
+        registry = _make_task_registry()
+        bad = "{not json"
+        assert translate_payload_json_to_names(bad, 101, registry) == bad
+
+    def test_non_dict_json_returned_unchanged(self):
+        registry = _make_task_registry()
+        arr = "[1, 2, 3]"
+        assert translate_payload_json_to_names(arr, 101, registry) == arr
+
+    def test_happy_path_roundtrip(self):
+        registry = _make_task_registry()
+        raw = json.dumps({"1": "hello", "2": "open"})
+        out = translate_payload_json_to_names(raw, 101, registry)
+        assert json.loads(out) == {"title": "hello", "status": "open"}
+
+    def test_unknown_id_preserved_in_json(self):
+        registry = _make_task_registry()
+        raw = json.dumps({"1": "x", "77": "future"})
+        out = translate_payload_json_to_names(raw, 101, registry)
+        assert json.loads(out) == {"title": "x", "77": "future"}
+
+
+# ---------------------------------------------------------------------------
+# translate_filter_name_to_id
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateFilterNameToId:
+    def test_none_returns_none(self):
+        registry = _make_task_registry()
+        assert translate_filter_name_to_id(None, 101, registry) is None
+
+    def test_happy_path(self):
+        registry = _make_task_registry()
+        out = translate_filter_name_to_id({"status": "open"}, 101, registry)
+        assert out == {"2": "open"}
+
+    def test_unknown_name_dropped(self):
+        registry = _make_task_registry()
+        out = translate_filter_name_to_id({"status": "open", "bogus": "x"}, 101, registry)
+        assert out == {"2": "open"}
+
+    def test_empty_filter_returns_empty_dict(self):
+        registry = _make_task_registry()
+        out = translate_filter_name_to_id({}, 101, registry)
+        assert out == {}
+
+
+# ---------------------------------------------------------------------------
+# Round-trip + field-rename safety
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripAndRename:
+    def test_roundtrip_known_fields(self):
+        registry = _make_task_registry()
+        original = {"title": "x", "status": "open", "priority": 5}
+        ided = name_to_id_keys(original, 101, registry)
+        back = id_to_name_keys(ided, 101, registry)
+        assert back == original
+
+    def test_field_rename_safety(self):
+        # Initial schema: field_id=1 is called "title".
+        reg_v1 = SchemaRegistry()
+        reg_v1.register_node_type(
+            NodeTypeDef(
+                type_id=101,
+                name="Task",
+                fields=(field(1, "title", "str"),),
+            )
+        )
+
+        # Ingress under v1: "title" -> "1" on disk.
+        stored = name_to_id_keys({"title": "x"}, 101, reg_v1)
+        assert stored == {"1": "x"}
+
+        # Schema evolves: same field_id=1 but now named "heading".
+        reg_v2 = SchemaRegistry()
+        reg_v2.register_node_type(
+            NodeTypeDef(
+                type_id=101,
+                name="Task",
+                fields=(field(1, "heading", "str"),),
+            )
+        )
+
+        # The on-disk row is unchanged; read under v2 surfaces the new name.
+        out = id_to_name_keys(stored, 101, reg_v2)
+        assert out == {"heading": "x"}
+
+        # And the JSON egress path behaves the same way.
+        out_json = translate_payload_json_to_names(json.dumps(stored), 101, reg_v2)
+        assert json.loads(out_json) == {"heading": "x"}


### PR DESCRIPTION
## Summary

Closes the remaining gaps on #104 (proto field ID storage). The translation helpers and gRPC wiring landed in #106; this PR adds the data migration and the test coverage.

- `CanonicalStore.migrate_payloads_to_field_ids(tenant_id, registry)` — idempotent, transactional, rewrites legacy name-keyed `payload_json` rows to id-keyed format. Drops unknown field names and leaves rows with unknown `type_id` unchanged.
- `tests/unit/test_field_id_storage.py` — 38 tests covering the translation helpers (round-trip, field rename safety, registry edge cases).
- `tests/unit/test_field_id_migration.py` — 10 tests for the migration helper (idempotency, mixed-state DBs, empty payloads, unknown type bucketing).

## Test plan

- [x] `pytest tests/unit/test_field_id_storage.py tests/unit/test_field_id_migration.py` → 48 passed
- [x] `pytest tests/unit/` → 1186 passed
- [x] `uvx ruff@0.15.7 check` clean
- [x] `uvx ruff@0.15.7 format --check` clean

Closes #104.