### PR TITLE
Close #105 (partial): collapse GrpcNode layer, add schema fingerprint

### DIFF
--- a/sdk/entdb_sdk/_grpc_client.py
+++ b/sdk/entdb_sdk/_grpc_client.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import grpc
@@ -109,8 +109,19 @@ _DEFAULT_TIMEOUT: float = 30.0
 
 
 @dataclass
-class GrpcNode:
-    """Internal node representation from gRPC response."""
+class Node:
+    """A node from the database.
+
+    Attributes:
+        tenant_id: Tenant identifier
+        node_id: Unique node ID
+        type_id: Node type ID
+        payload: Field values
+        created_at: Creation timestamp (Unix ms)
+        updated_at: Last update timestamp (Unix ms)
+        owner_actor: Creator
+        acl: Access control list
+    """
 
     tenant_id: str
     node_id: str
@@ -119,12 +130,21 @@ class GrpcNode:
     created_at: int
     updated_at: int
     owner_actor: str
-    acl: list[dict[str, str]]
+    acl: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass
-class GrpcEdge:
-    """Internal edge representation from gRPC response."""
+class Edge:
+    """An edge from the database.
+
+    Attributes:
+        tenant_id: Tenant identifier
+        edge_type_id: Edge type ID
+        from_node_id: Source node
+        to_node_id: Target node
+        props: Edge properties
+        created_at: Creation timestamp
+    """
 
     tenant_id: str
     edge_type_id: int
@@ -132,6 +152,32 @@ class GrpcEdge:
     to_node_id: str
     props: dict[str, Any]
     created_at: int
+
+
+def _node_from_proto(n: Any) -> Node:
+    """Build a user-facing Node directly from a proto Node message."""
+    return Node(
+        tenant_id=n.tenant_id,
+        node_id=n.node_id,
+        type_id=n.type_id,
+        payload=_struct_to_dict(n.payload),
+        created_at=n.created_at,
+        updated_at=n.updated_at,
+        owner_actor=n.owner_actor,
+        acl=_acl_proto_to_list(n.acl),
+    )
+
+
+def _edge_from_proto(e: Any) -> Edge:
+    """Build a user-facing Edge directly from a proto Edge message."""
+    return Edge(
+        tenant_id=e.tenant_id,
+        edge_type_id=e.edge_type_id,
+        from_node_id=e.from_node_id,
+        to_node_id=e.to_node_id,
+        props=_struct_to_dict(e.props),
+        created_at=e.created_at,
+    )
 
 
 @dataclass
@@ -554,7 +600,7 @@ class GrpcClient:
         wait_timeout_ms: int = 0,
         trace_id: str = "",
         timeout: float | None = None,
-    ) -> GrpcNode | None:
+    ) -> Node | None:
         """Get a node by ID.
 
         Args:
@@ -568,7 +614,7 @@ class GrpcClient:
             timeout: Per-call timeout in seconds
 
         Returns:
-            GrpcNode if found, None otherwise
+            Node if found, None otherwise
         """
         stub = self._ensure_connected()
         metadata = self._build_metadata()
@@ -591,17 +637,7 @@ class GrpcClient:
         if not response.found:
             return None
 
-        node = response.node
-        return GrpcNode(
-            tenant_id=node.tenant_id,
-            node_id=node.node_id,
-            type_id=node.type_id,
-            payload=_struct_to_dict(node.payload),
-            created_at=node.created_at,
-            updated_at=node.updated_at,
-            owner_actor=node.owner_actor,
-            acl=_acl_proto_to_list(node.acl),
-        )
+        return _node_from_proto(response.node)
 
     async def get_nodes(
         self,
@@ -614,7 +650,7 @@ class GrpcClient:
         wait_timeout_ms: int = 0,
         trace_id: str = "",
         timeout: float | None = None,
-    ) -> tuple[list[GrpcNode], list[str]]:
+    ) -> tuple[list[Node], list[str]]:
         """Get multiple nodes by IDs.
 
         Args:
@@ -648,19 +684,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        nodes = [
-            GrpcNode(
-                tenant_id=n.tenant_id,
-                node_id=n.node_id,
-                type_id=n.type_id,
-                payload=_struct_to_dict(n.payload),
-                created_at=n.created_at,
-                updated_at=n.updated_at,
-                owner_actor=n.owner_actor,
-                acl=_acl_proto_to_list(n.acl),
-            )
-            for n in response.nodes
-        ]
+        nodes = [_node_from_proto(n) for n in response.nodes]
 
         return nodes, list(response.missing_ids)
 
@@ -679,7 +703,7 @@ class GrpcClient:
         wait_timeout_ms: int = 0,
         trace_id: str = "",
         timeout: float | None = None,
-    ) -> tuple[list[GrpcNode], bool]:
+    ) -> tuple[list[Node], bool]:
         """Query nodes by type.
 
         Args:
@@ -731,19 +755,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        nodes = [
-            GrpcNode(
-                tenant_id=n.tenant_id,
-                node_id=n.node_id,
-                type_id=n.type_id,
-                payload=_struct_to_dict(n.payload),
-                created_at=n.created_at,
-                updated_at=n.updated_at,
-                owner_actor=n.owner_actor,
-                acl=_acl_proto_to_list(n.acl),
-            )
-            for n in response.nodes
-        ]
+        nodes = [_node_from_proto(n) for n in response.nodes]
 
         return nodes, response.has_more
 
@@ -757,7 +769,7 @@ class GrpcClient:
         *,
         trace_id: str = "",
         timeout: float | None = None,
-    ) -> tuple[list[GrpcEdge], bool]:
+    ) -> tuple[list[Edge], bool]:
         """Get outgoing edges from a node.
 
         Args:
@@ -789,17 +801,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        edges = [
-            GrpcEdge(
-                tenant_id=e.tenant_id,
-                edge_type_id=e.edge_type_id,
-                from_node_id=e.from_node_id,
-                to_node_id=e.to_node_id,
-                props=_struct_to_dict(e.props),
-                created_at=e.created_at,
-            )
-            for e in response.edges
-        ]
+        edges = [_edge_from_proto(e) for e in response.edges]
 
         return edges, response.has_more
 
@@ -813,7 +815,7 @@ class GrpcClient:
         *,
         trace_id: str = "",
         timeout: float | None = None,
-    ) -> tuple[list[GrpcEdge], bool]:
+    ) -> tuple[list[Edge], bool]:
         """Get incoming edges to a node.
 
         Args:
@@ -845,17 +847,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        edges = [
-            GrpcEdge(
-                tenant_id=e.tenant_id,
-                edge_type_id=e.edge_type_id,
-                from_node_id=e.from_node_id,
-                to_node_id=e.to_node_id,
-                props=_struct_to_dict(e.props),
-                created_at=e.created_at,
-            )
-            for e in response.edges
-        ]
+        edges = [_edge_from_proto(e) for e in response.edges]
 
         return edges, response.has_more
 
@@ -1068,7 +1060,7 @@ class GrpcClient:
         offset: int = 0,
         trace_id: str = "",
         timeout: float | None = None,
-    ) -> tuple[list[GrpcNode], bool]:
+    ) -> tuple[list[Node], bool]:
         """Get connected nodes via edge type with ACL filtering.
 
         Args:
@@ -1102,21 +1094,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        nodes = [
-            GrpcNode(
-                tenant_id=n.tenant_id,
-                node_id=n.node_id,
-                type_id=n.type_id,
-                payload=json_format.MessageToDict(n.payload)
-                if n.payload and n.payload.fields
-                else {},
-                created_at=n.created_at,
-                updated_at=n.updated_at,
-                owner_actor=n.owner_actor,
-                acl=[{"principal": e.principal, "permission": e.permission} for e in n.acl],
-            )
-            for n in response.nodes
-        ]
+        nodes = [_node_from_proto(n) for n in response.nodes]
 
         return nodes, response.has_more
 
@@ -1220,7 +1198,7 @@ class GrpcClient:
         offset: int = 0,
         trace_id: str = "",
         timeout: float | None = None,
-    ) -> tuple[list[GrpcNode], bool]:
+    ) -> tuple[list[Node], bool]:
         """List nodes shared with the calling actor.
 
         Args:
@@ -1250,21 +1228,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        nodes = [
-            GrpcNode(
-                tenant_id=n.tenant_id,
-                node_id=n.node_id,
-                type_id=n.type_id,
-                payload=json_format.MessageToDict(n.payload)
-                if n.payload and n.payload.fields
-                else {},
-                created_at=n.created_at,
-                updated_at=n.updated_at,
-                owner_actor=n.owner_actor,
-                acl=[{"principal": e.principal, "permission": e.permission} for e in n.acl],
-            )
-            for n in response.nodes
-        ]
+        nodes = [_node_from_proto(n) for n in response.nodes]
 
         return nodes, response.has_more
 

--- a/sdk/entdb_sdk/client.py
+++ b/sdk/entdb_sdk/client.py
@@ -35,7 +35,7 @@ class _Unset(Enum):
 
 _UNSET = _Unset.TOKEN
 
-from ._grpc_client import GrpcClient
+from ._grpc_client import Edge, GrpcClient, Node
 from .errors import (
     ConnectionError,
     UnknownFieldError,
@@ -43,6 +43,11 @@ from .errors import (
 )
 from .registry import SchemaRegistry, get_registry
 from .schema import EdgeTypeDef, NodeTypeDef
+
+# Re-exported for backwards compatibility. Node/Edge are defined in
+# _grpc_client.py so the gRPC layer can build them directly from proto
+# messages without an intermediate shape.
+__all__ = ["Node", "Edge"]
 
 logger = logging.getLogger(__name__)
 
@@ -60,52 +65,6 @@ class Receipt:
     tenant_id: str
     idempotency_key: str
     stream_position: str | None = None
-
-
-@dataclass
-class Node:
-    """A node from the database.
-
-    Attributes:
-        tenant_id: Tenant identifier
-        node_id: Unique node ID
-        type_id: Node type ID
-        payload: Field values
-        created_at: Creation timestamp (Unix ms)
-        updated_at: Last update timestamp (Unix ms)
-        owner_actor: Creator
-        acl: Access control list
-    """
-
-    tenant_id: str
-    node_id: str
-    type_id: int
-    payload: dict[str, Any]
-    created_at: int
-    updated_at: int
-    owner_actor: str
-    acl: list[dict[str, str]] = field(default_factory=list)
-
-
-@dataclass
-class Edge:
-    """An edge from the database.
-
-    Attributes:
-        tenant_id: Tenant identifier
-        edge_type_id: Edge type ID
-        from_node_id: Source node
-        to_node_id: Target node
-        props: Edge properties
-        created_at: Creation timestamp
-    """
-
-    tenant_id: str
-    edge_type_id: int
-    from_node_id: str
-    to_node_id: str
-    props: dict[str, Any]
-    created_at: int
 
 
 @dataclass
@@ -432,6 +391,8 @@ class DbClient:
         api_key: str | None = None,
         max_retries: int = 3,
         registry: SchemaRegistry | None = None,
+        schema_module: Any | None = None,
+        schema_fingerprint: str | None = None,
     ) -> None:
         """Initialize client.
 
@@ -441,6 +402,12 @@ class DbClient:
             api_key: Optional API key for authentication
             max_retries: Maximum number of retries for transient gRPC failures
             registry: Optional schema registry
+            schema_module: Optional generated schema module (e.g. the module
+                produced by ``entdb codegen``). If provided and it exposes a
+                ``SCHEMA_FINGERPRINT`` attribute, that value will be sent on
+                every write for server-side version checks.
+            schema_fingerprint: Optional explicit schema fingerprint. Takes
+                precedence over ``schema_module`` and the registry.
         """
         # Parse address
         if ":" in address:
@@ -460,6 +427,25 @@ class DbClient:
         self.registry = registry or get_registry()
         self._connected = False
         self._last_offsets: dict[str, str] = {}  # tenant_id -> stream_position
+        self._schema_fingerprint: str | None = schema_fingerprint
+        if self._schema_fingerprint is None and schema_module is not None:
+            self._schema_fingerprint = getattr(schema_module, "SCHEMA_FINGERPRINT", None)
+
+    def _resolve_schema_fingerprint(self) -> str:
+        """Resolve the schema fingerprint to send with write requests.
+
+        Precedence:
+        1. Explicit ``schema_fingerprint`` passed to ``DbClient(...)``
+        2. ``SCHEMA_FINGERPRINT`` from a generated ``schema_module``
+        3. ``registry.fingerprint`` if the registry has been frozen
+        4. Empty string (backward-compat, server skips the check)
+        """
+        explicit = getattr(self, "_schema_fingerprint", None)
+        if explicit:
+            return explicit
+        registry = getattr(self, "registry", None)
+        reg_fp = getattr(registry, "fingerprint", None) if registry is not None else None
+        return reg_fp or ""
 
     def _ensure_connected(self) -> None:
         """Raise if not connected.
@@ -608,7 +594,7 @@ class DbClient:
         trace_id = trace_id or str(uuid.uuid4())
         resolved_offset = self._resolve_offset(tenant_id, after_offset)
 
-        grpc_node = await self._grpc.get_node(
+        return await self._grpc.get_node(
             tenant_id=tenant_id,
             actor=actor,
             type_id=node_type.type_id,
@@ -617,20 +603,6 @@ class DbClient:
             wait_timeout_ms=30000 if resolved_offset else 0,
             trace_id=trace_id,
             timeout=timeout,
-        )
-
-        if grpc_node is None:
-            return None
-
-        return Node(
-            tenant_id=grpc_node.tenant_id,
-            node_id=grpc_node.node_id,
-            type_id=grpc_node.type_id,
-            payload=grpc_node.payload,
-            created_at=grpc_node.created_at,
-            updated_at=grpc_node.updated_at,
-            owner_actor=grpc_node.owner_actor,
-            acl=grpc_node.acl,
         )
 
     async def get_many(
@@ -664,7 +636,7 @@ class DbClient:
         trace_id = trace_id or str(uuid.uuid4())
         resolved_offset = self._resolve_offset(tenant_id, after_offset)
 
-        grpc_nodes, missing = await self._grpc.get_nodes(
+        return await self._grpc.get_nodes(
             tenant_id=tenant_id,
             actor=actor,
             type_id=node_type.type_id,
@@ -674,22 +646,6 @@ class DbClient:
             trace_id=trace_id,
             timeout=timeout,
         )
-
-        nodes = [
-            Node(
-                tenant_id=n.tenant_id,
-                node_id=n.node_id,
-                type_id=n.type_id,
-                payload=n.payload,
-                created_at=n.created_at,
-                updated_at=n.updated_at,
-                owner_actor=n.owner_actor,
-                acl=n.acl,
-            )
-            for n in grpc_nodes
-        ]
-
-        return nodes, missing
 
     async def query(
         self,
@@ -730,7 +686,7 @@ class DbClient:
         trace_id = trace_id or str(uuid.uuid4())
         resolved_offset = self._resolve_offset(tenant_id, after_offset)
 
-        grpc_nodes, _ = await self._grpc.query_nodes(
+        nodes, _ = await self._grpc.query_nodes(
             tenant_id=tenant_id,
             actor=actor,
             type_id=node_type.type_id,
@@ -745,19 +701,7 @@ class DbClient:
             timeout=timeout,
         )
 
-        return [
-            Node(
-                tenant_id=n.tenant_id,
-                node_id=n.node_id,
-                type_id=n.type_id,
-                payload=n.payload,
-                created_at=n.created_at,
-                updated_at=n.updated_at,
-                owner_actor=n.owner_actor,
-                acl=n.acl,
-            )
-            for n in grpc_nodes
-        ]
+        return nodes
 
     async def edges_out(
         self,
@@ -792,7 +736,7 @@ class DbClient:
         _ = resolved_offset  # reserved for gRPC support
 
         edge_type_id = edge_type.edge_id if edge_type else None
-        grpc_edges, _ = await self._grpc.get_edges_from(
+        edges, _ = await self._grpc.get_edges_from(
             tenant_id=tenant_id,
             actor=actor,
             node_id=node_id,
@@ -801,17 +745,7 @@ class DbClient:
             timeout=timeout,
         )
 
-        return [
-            Edge(
-                tenant_id=e.tenant_id,
-                edge_type_id=e.edge_type_id,
-                from_node_id=e.from_node_id,
-                to_node_id=e.to_node_id,
-                props=e.props,
-                created_at=e.created_at,
-            )
-            for e in grpc_edges
-        ]
+        return edges
 
     async def edges_in(
         self,
@@ -846,7 +780,7 @@ class DbClient:
         _ = resolved_offset  # reserved for gRPC support
 
         edge_type_id = edge_type.edge_id if edge_type else None
-        grpc_edges, _ = await self._grpc.get_edges_to(
+        edges, _ = await self._grpc.get_edges_to(
             tenant_id=tenant_id,
             actor=actor,
             node_id=node_id,
@@ -855,17 +789,7 @@ class DbClient:
             timeout=timeout,
         )
 
-        return [
-            Edge(
-                tenant_id=e.tenant_id,
-                edge_type_id=e.edge_type_id,
-                from_node_id=e.from_node_id,
-                to_node_id=e.to_node_id,
-                props=e.props,
-                created_at=e.created_at,
-            )
-            for e in grpc_edges
-        ]
+        return edges
 
     async def search(
         self,
@@ -959,7 +883,7 @@ class DbClient:
             actor=actor,
             operations=operations,
             idempotency_key=idempotency_key,
-            schema_fingerprint=self.registry.fingerprint,
+            schema_fingerprint=self._resolve_schema_fingerprint(),
             wait_applied=wait_applied,
             trace_id=trace_id,
             timeout=timeout,
@@ -1029,7 +953,7 @@ class DbClient:
         resolved_offset = self._resolve_offset(tenant_id, after_offset)
         _ = resolved_offset  # reserved for gRPC support
 
-        grpc_nodes, _ = await self._grpc.get_connected_nodes(
+        nodes, _ = await self._grpc.get_connected_nodes(
             tenant_id=tenant_id,
             actor=actor,
             node_id=node_id,
@@ -1040,19 +964,7 @@ class DbClient:
             timeout=timeout,
         )
 
-        return [
-            Node(
-                tenant_id=n.tenant_id,
-                node_id=n.node_id,
-                type_id=n.type_id,
-                payload=n.payload,
-                created_at=n.created_at,
-                updated_at=n.updated_at,
-                owner_actor=n.owner_actor,
-                acl=n.acl,
-            )
-            for n in grpc_nodes
-        ]
+        return nodes
 
     async def share(
         self,
@@ -1165,7 +1077,7 @@ class DbClient:
         resolved_offset = self._resolve_offset(tenant_id, after_offset)
         _ = resolved_offset  # reserved for gRPC support
 
-        grpc_nodes, _ = await self._grpc.list_shared_with_me(
+        nodes, _ = await self._grpc.list_shared_with_me(
             tenant_id=tenant_id,
             actor=actor,
             limit=limit,
@@ -1174,19 +1086,7 @@ class DbClient:
             timeout=timeout,
         )
 
-        return [
-            Node(
-                tenant_id=n.tenant_id,
-                node_id=n.node_id,
-                type_id=n.type_id,
-                payload=n.payload,
-                created_at=n.created_at,
-                updated_at=n.updated_at,
-                owner_actor=n.owner_actor,
-                acl=n.acl,
-            )
-            for n in grpc_nodes
-        ]
+        return nodes
 
     async def group_add(
         self,

--- a/sdk/entdb_sdk/codegen.py
+++ b/sdk/entdb_sdk/codegen.py
@@ -10,6 +10,8 @@ Usage:
 
 from __future__ import annotations
 
+import hashlib
+import json
 import subprocess
 import sys
 import tempfile
@@ -328,15 +330,98 @@ def _extract_field(fd) -> FieldInfo:
     )
 
 
+# ── Schema Fingerprint ────────────────────────────────────────────────
+
+
+def _field_to_canonical(f: FieldInfo) -> dict[str, Any]:
+    """Canonical dict representation of a FieldInfo for fingerprinting."""
+    return {
+        "field_id": f.field_id,
+        "name": f.name,
+        "kind": f.kind,
+        "required": f.required,
+        "searchable": f.searchable,
+        "indexed": f.indexed,
+        "pii": f.pii,
+        "phi": f.phi,
+        "pii_false": f.pii_false,
+        "enum_values": list(f.enum_values) if f.enum_values else None,
+        "ref_type_id": f.ref_type_id,
+        "deprecated": f.deprecated,
+        "description": f.description,
+        "default_value": f.default_value,
+    }
+
+
+def compute_schema_fingerprint(nodes: list[NodeInfo], edges: list[EdgeInfo]) -> str:
+    """Compute a deterministic sha256 fingerprint of a parsed schema.
+
+    The fingerprint is a sha256 over a canonical JSON representation of
+    all NodeTypeDef + EdgeTypeDef + FieldDef tuples, sorted by type_id
+    and field_id. The returned value is prefixed with ``sha256:`` and
+    matches the format used by the server-side schema registry.
+    """
+    canonical = {
+        "node_types": [
+            {
+                "type_id": n.type_id,
+                "name": n.name,
+                "acl_public": n.acl_public,
+                "acl_tenant_visible": n.acl_tenant_visible,
+                "acl_inherit": n.acl_inherit,
+                "is_private": n.is_private,
+                "data_policy": n.data_policy,
+                "subject_field": n.subject_field,
+                "retention_days": n.retention_days,
+                "legal_basis": n.legal_basis,
+                "deprecated": n.deprecated,
+                "description": n.description,
+                "fields": [
+                    _field_to_canonical(f) for f in sorted(n.fields, key=lambda f: f.field_id)
+                ],
+            }
+            for n in sorted(nodes, key=lambda n: n.type_id)
+        ],
+        "edge_types": [
+            {
+                "edge_id": e.edge_id,
+                "name": e.name,
+                "from_type": e.from_type,
+                "to_type": e.to_type,
+                "propagate_share": e.propagate_share,
+                "unique_per_from": e.unique_per_from,
+                "data_policy": e.data_policy,
+                "on_subject_exit": e.on_subject_exit,
+                "retention_days": e.retention_days,
+                "legal_basis": e.legal_basis,
+                "deprecated": e.deprecated,
+                "description": e.description,
+                "props": [
+                    _field_to_canonical(f) for f in sorted(e.props, key=lambda f: f.field_id)
+                ],
+            }
+            for e in sorted(edges, key=lambda e: e.edge_id)
+        ],
+    }
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
 # ── Code Generators ───────────────────────────────────────────────────
 
 
 def generate_python(nodes: list[NodeInfo], edges: list[EdgeInfo]) -> str:
     """Generate Python EntDB schema module from parsed proto."""
+    fingerprint = compute_schema_fingerprint(nodes, edges)
     lines = [
         '"""EntDB schema — generated from .proto. Do not edit."""',
         "",
         "from entdb_sdk import AclDefaults, DataPolicy, EdgeTypeDef, NodeTypeDef, SubjectExitPolicy, field",
+        "",
+        "# Deterministic fingerprint of the generated schema. Sent to the",
+        "# server on every write so stale clients can be rejected cleanly.",
+        f"SCHEMA_FINGERPRINT = {fingerprint!r}",
         "",
     ]
 
@@ -448,11 +533,15 @@ def generate_python(nodes: list[NodeInfo], edges: list[EdgeInfo]) -> str:
 
 def generate_go(nodes: list[NodeInfo], edges: list[EdgeInfo], package: str = "schema") -> str:
     """Generate Go EntDB schema module from parsed proto."""
+    fingerprint = compute_schema_fingerprint(nodes, edges)
     lines = [
         "// EntDB schema — generated from .proto. Do not edit.",
         f"package {package}",
         "",
         'import "github.com/elloloop/entdb/sdk/go/entdb"',
+        "",
+        "// SchemaFingerprint is a deterministic sha256 digest of the generated schema.",
+        f'const SchemaFingerprint = "{fingerprint}"',
         "",
     ]
 

--- a/tests/unit/test_sdk_offset_tracking.py
+++ b/tests/unit/test_sdk_offset_tracking.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from sdk.entdb_sdk._grpc_client import GrpcCommitResult, GrpcNode, GrpcReceipt
+from sdk.entdb_sdk._grpc_client import GrpcCommitResult, GrpcReceipt, Node
 from sdk.entdb_sdk.client import _UNSET, DbClient
 from sdk.entdb_sdk.schema import EdgeTypeDef, FieldDef, FieldKind, NodeTypeDef
 
@@ -45,8 +45,8 @@ TASK = _task_type()
 EDGE = _edge_type()
 
 
-def _make_grpc_node(tenant_id: str = "t1", node_id: str = "n1") -> GrpcNode:
-    return GrpcNode(
+def _make_grpc_node(tenant_id: str = "t1", node_id: str = "n1") -> Node:
+    return Node(
         tenant_id=tenant_id,
         node_id=node_id,
         type_id=101,


### PR DESCRIPTION
## Summary

Partial close on #105 (SDK consolidation). Tackles items that are safe to ship independently:

- **Delete `GrpcNode`/`GrpcEdge` intermediate types** — the gRPC layer now builds user-facing `Node`/`Edge` directly from proto messages, eliminating 7 redundant remapping loops (-163 lines across `_grpc_client.py` + `client.py`)
- **Schema fingerprint embedding** — `entdb codegen` now emits `SCHEMA_FINGERPRINT = "sha256:..."` in generated modules. `DbClient` sends it with every `ExecuteAtomicRequest` (precedence: explicit kwarg > schema_module > registry > empty)
- Varint parsing removal (item 5) and validation dedup (item 3) were already done in #106

Remaining items for a follow-up PR: schema.py wrapping proto descriptors, typed message classes, hierarchical API.

## Test plan

- [x] `pytest tests/unit/` → 1186 passed
- [x] `pytest tests/integration/` → 693 passed
- [x] `uvx ruff@0.15.7 check` clean
- [x] `uvx ruff@0.15.7 format --check` clean

Closes #105 (partial — remaining items tracked in issue).