### PR TITLE
Go SDK: Actor type, Permission enum, typed ACL

### DIFF
--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -22,6 +22,8 @@ type Transport interface {
 	QueryNodes(ctx context.Context, tenantID, actor string, typeID int, filter map[string]any) ([]*Node, error)
 	// ExecuteAtomic commits a batch of operations atomically.
 	ExecuteAtomic(ctx context.Context, tenantID, actor, idempotencyKey string, ops []Operation) (*CommitResult, error)
+	// Share grants permission on a node to another actor.
+	Share(ctx context.Context, tenantID, actor, nodeID, grantee, permission string) error
 }
 
 // grpcTransport is the production Transport backed by a gRPC connection.
@@ -76,8 +78,11 @@ func (t *grpcTransport) QueryNodes(_ context.Context, _, _ string, _ int, _ map[
 }
 
 func (t *grpcTransport) ExecuteAtomic(_ context.Context, _, _, _ string, _ []Operation) (*CommitResult, error) {
-	// Requires generated proto stubs to implement.
 	return nil, &EntDBError{Message: "not implemented: requires proto stubs", Code: "NOT_IMPLEMENTED"}
+}
+
+func (t *grpcTransport) Share(_ context.Context, _, _, _, _, _ string) error {
+	return &EntDBError{Message: "not implemented: requires proto stubs", Code: "NOT_IMPLEMENTED"}
 }
 
 // DbClient is the main entry point for the EntDB Go SDK.
@@ -149,7 +154,7 @@ func (c *DbClient) Config() clientConfig { return c.config }
 // Tenant returns a TenantScope for the given tenant, allowing callers to
 // chain .Actor(actor) to get a fully-scoped handle.
 //
-//	scope := client.Tenant("acme").Actor("user:bob")
+//	scope := client.Tenant("acme").Actor(entdb.UserActor("bob"))
 //	node, err := scope.Get(ctx, 1, "node-123")
 func (c *DbClient) Tenant(tenantID string) *TenantScope {
 	return &TenantScope{

--- a/sdk/go/entdb/client_test.go
+++ b/sdk/go/entdb/client_test.go
@@ -49,6 +49,10 @@ func (m *mockTransport) ExecuteAtomic(_ context.Context, _, _, _ string, _ []Ope
 	return m.commitResp, m.commitErr
 }
 
+func (m *mockTransport) Share(_ context.Context, _, _, _, _, _ string) error {
+	return nil
+}
+
 func newTestClient(t *testing.T, transport *mockTransport, opts ...ClientOption) *DbClient {
 	t.Helper()
 	return newClientWithTransport("localhost:50051", transport, opts...)

--- a/sdk/go/entdb/plan_test.go
+++ b/sdk/go/entdb/plan_test.go
@@ -44,7 +44,7 @@ func TestPlan_CreateWithACL(t *testing.T) {
 	mock := &mockTransport{}
 	plan := newPlan(mock, "t1", "user:alice", "key-1")
 
-	acl := []ACLEntry{{Principal: "user:bob", Permission: "read"}}
+	acl := []ACLEntry{{Grantee: UserActor("bob"), Permission: PermissionRead}}
 	alias := plan.CreateWithACL(1, map[string]any{"title": "Secret"}, acl)
 	if alias == "" {
 		t.Fatal("expected non-empty alias")
@@ -54,8 +54,8 @@ func TestPlan_CreateWithACL(t *testing.T) {
 	if len(ops[0].ACL) != 1 {
 		t.Fatalf("expected 1 ACL entry, got %d", len(ops[0].ACL))
 	}
-	if ops[0].ACL[0].Principal != "user:bob" {
-		t.Errorf("expected principal user:bob, got %s", ops[0].ACL[0].Principal)
+	if ops[0].ACL[0].Grantee != UserActor("bob") {
+		t.Errorf("expected principal user:bob, got %s", ops[0].ACL[0].Grantee.String())
 	}
 }
 
@@ -226,11 +226,11 @@ func TestScope_Chaining(t *testing.T) {
 	mock := &mockTransport{getNodeResp: expected}
 	client := newClientWithTransport("localhost:50051", mock)
 
-	scope := client.Tenant("acme").Actor("user:bob")
+	scope := client.Tenant("acme").Actor(UserActor("bob"))
 	if scope.TenantID() != "acme" {
 		t.Errorf("expected tenant acme, got %s", scope.TenantID())
 	}
-	if scope.ActorID() != "user:bob" {
+	if scope.ActorID() != UserActor("bob") {
 		t.Errorf("expected actor user:bob, got %s", scope.ActorID())
 	}
 
@@ -248,7 +248,7 @@ func TestScope_Query(t *testing.T) {
 	mock := &mockTransport{queryResp: expected}
 	client := newClientWithTransport("localhost:50051", mock)
 
-	scope := client.Tenant("acme").Actor("user:bob")
+	scope := client.Tenant("acme").Actor(UserActor("bob"))
 	nodes, err := scope.Query(context.Background(), 1, map[string]any{"status": "active"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -262,11 +262,11 @@ func TestScope_Plan(t *testing.T) {
 	mock := &mockTransport{}
 	client := newClientWithTransport("localhost:50051", mock)
 
-	plan := client.Tenant("acme").Actor("user:bob").Plan()
+	plan := client.Tenant("acme").Actor(UserActor("bob")).Plan()
 	if plan.TenantID() != "acme" {
 		t.Errorf("expected tenant acme, got %s", plan.TenantID())
 	}
-	if plan.Actor() != "user:bob" {
+	if plan.Actor() != "user:bob" /* Plan stores string internally */ {
 		t.Errorf("expected actor user:bob, got %s", plan.Actor())
 	}
 }
@@ -279,8 +279,8 @@ func TestNode_Fields(t *testing.T) {
 		Payload:    map[string]any{"title": "Hello", "count": 7},
 		CreatedAt:  1000,
 		UpdatedAt:  2000,
-		OwnerActor: "user:alice",
-		ACL:        []ACLEntry{{Principal: "user:bob", Permission: "read"}},
+		OwnerActor: UserActor("alice"),
+		ACL:        []ACLEntry{{Grantee: UserActor("bob"), Permission: PermissionRead}},
 	}
 	if node.TenantID != "t1" {
 		t.Errorf("TenantID = %s, want t1", node.TenantID)
@@ -294,8 +294,14 @@ func TestNode_Fields(t *testing.T) {
 	if len(node.ACL) != 1 {
 		t.Fatalf("ACL len = %d, want 1", len(node.ACL))
 	}
-	if node.ACL[0].Principal != "user:bob" {
-		t.Errorf("ACL[0].Principal = %s, want user:bob", node.ACL[0].Principal)
+	if node.ACL[0].Grantee != UserActor("bob") {
+		t.Errorf("ACL[0].Grantee = %s, want user:bob", node.ACL[0].Grantee)
+	}
+	if node.ACL[0].Permission != PermissionRead {
+		t.Errorf("ACL[0].Permission = %s, want read", node.ACL[0].Permission)
+	}
+	if node.OwnerActor != UserActor("alice") {
+		t.Errorf("OwnerActor = %s, want user:alice", node.OwnerActor)
 	}
 }
 
@@ -371,5 +377,80 @@ func TestErrors(t *testing.T) {
 				t.Errorf("Error() = %q, want %q", msg, tt.wantMsg)
 			}
 		})
+	}
+}
+
+func TestActor_Constructors(t *testing.T) {
+	tests := []struct {
+		name  string
+		actor Actor
+		kind  string
+		id    string
+		str   string
+	}{
+		{"user", UserActor("bob"), "user", "bob", "user:bob"},
+		{"group", GroupActor("admins"), "group", "admins", "group:admins"},
+		{"service", ServiceActor("api"), "service", "api", "service:api"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.actor.Kind() != tt.kind {
+				t.Errorf("Kind() = %q, want %q", tt.actor.Kind(), tt.kind)
+			}
+			if tt.actor.ID() != tt.id {
+				t.Errorf("ID() = %q, want %q", tt.actor.ID(), tt.id)
+			}
+			if tt.actor.String() != tt.str {
+				t.Errorf("String() = %q, want %q", tt.actor.String(), tt.str)
+			}
+		})
+	}
+}
+
+func TestActor_ParseActor(t *testing.T) {
+	a, err := ParseActor("user:charlie")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a != UserActor("charlie") {
+		t.Errorf("got %v, want user:charlie", a)
+	}
+	_, err = ParseActor("invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid actor string")
+	}
+}
+
+func TestActor_Equality(t *testing.T) {
+	a := UserActor("bob")
+	b := UserActor("bob")
+	c := GroupActor("bob")
+	if a != b {
+		t.Error("same actors should be equal")
+	}
+	if a == c {
+		t.Error("different kinds should not be equal")
+	}
+}
+
+func TestPermission_Values(t *testing.T) {
+	if string(PermissionRead) != "read" {
+		t.Errorf("PermissionRead = %q, want read", PermissionRead)
+	}
+	if string(PermissionWrite) != "write" {
+		t.Errorf("PermissionWrite = %q, want write", PermissionWrite)
+	}
+	if string(PermissionAdmin) != "admin" {
+		t.Errorf("PermissionAdmin = %q, want admin", PermissionAdmin)
+	}
+}
+
+func TestScope_Share(t *testing.T) {
+	mock := &mockTransport{}
+	client := newTestClient(t, mock)
+	scope := client.Tenant("acme").Actor(UserActor("alice"))
+	err := scope.Share(context.Background(), "n1", UserActor("charlie"), PermissionWrite)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/sdk/go/entdb/scope.go
+++ b/sdk/go/entdb/scope.go
@@ -9,9 +9,9 @@ type TenantScope struct {
 	tenantID string
 }
 
-// Actor binds an actor to this tenant scope, returning a fully-scoped
+// Actor binds a typed Actor to this tenant scope, returning a fully-scoped
 // ActorScope ready for reads and writes.
-func (s *TenantScope) Actor(actor string) *ActorScope {
+func (s *TenantScope) Actor(actor Actor) *ActorScope {
 	return &ActorScope{
 		client:   s.client,
 		tenantID: s.tenantID,
@@ -23,31 +23,34 @@ func (s *TenantScope) Actor(actor string) *ActorScope {
 func (s *TenantScope) TenantID() string { return s.tenantID }
 
 // ActorScope is a fully-scoped handle with (client, tenantID, actor) pre-bound.
-// Every read/write method delegates to DbClient, injecting tenantID and actor
-// automatically.
 type ActorScope struct {
 	client   *DbClient
 	tenantID string
-	actor    string
+	actor    Actor
 }
 
 // TenantID returns the tenant this scope is bound to.
 func (s *ActorScope) TenantID() string { return s.tenantID }
 
 // ActorID returns the actor this scope is bound to.
-func (s *ActorScope) ActorID() string { return s.actor }
+func (s *ActorScope) ActorID() Actor { return s.actor }
 
 // Get retrieves a single node by type and ID.
 func (s *ActorScope) Get(ctx context.Context, typeID int, nodeID string) (*Node, error) {
-	return s.client.Get(ctx, s.tenantID, s.actor, typeID, nodeID)
+	return s.client.Get(ctx, s.tenantID, s.actor.String(), typeID, nodeID)
 }
 
 // Query retrieves nodes matching a filter.
 func (s *ActorScope) Query(ctx context.Context, typeID int, filter map[string]any) ([]*Node, error) {
-	return s.client.Query(ctx, s.tenantID, s.actor, typeID, filter)
+	return s.client.Query(ctx, s.tenantID, s.actor.String(), typeID, filter)
+}
+
+// Share grants permission on a node to another actor.
+func (s *ActorScope) Share(ctx context.Context, nodeID string, grantee Actor, perm Permission) error {
+	return s.client.transport.Share(ctx, s.tenantID, s.actor.String(), nodeID, grantee.String(), string(perm))
 }
 
 // Plan creates a new Plan pre-bound to this scope's tenant and actor.
 func (s *ActorScope) Plan() *Plan {
-	return s.client.NewPlan(s.tenantID, s.actor)
+	return s.client.NewPlan(s.tenantID, s.actor.String())
 }

--- a/sdk/go/entdb/types.go
+++ b/sdk/go/entdb/types.go
@@ -1,5 +1,66 @@
 package entdb
 
+import "fmt"
+
+// ── Actor ───────────────────────────────────────────────────────────
+
+// Actor is a typed principal identifier that replaces raw "user:bob" strings.
+// Use the constructor functions UserActor, GroupActor, ServiceActor.
+type Actor struct {
+	kind string
+	id   string
+}
+
+// UserActor creates an Actor for a user principal.
+func UserActor(id string) Actor { return Actor{kind: "user", id: id} }
+
+// GroupActor creates an Actor for a group principal.
+func GroupActor(id string) Actor { return Actor{kind: "group", id: id} }
+
+// ServiceActor creates an Actor for a service principal.
+func ServiceActor(id string) Actor { return Actor{kind: "service", id: id} }
+
+// ParseActor parses a "kind:id" string into an Actor.
+func ParseActor(s string) (Actor, error) {
+	for i, c := range s {
+		if c == ':' {
+			return Actor{kind: s[:i], id: s[i+1:]}, nil
+		}
+	}
+	return Actor{}, fmt.Errorf("entdb: invalid actor %q (expected kind:id)", s)
+}
+
+// Kind returns the actor kind (user, group, service).
+func (a Actor) Kind() string { return a.kind }
+
+// ID returns the actor identifier.
+func (a Actor) ID() string { return a.id }
+
+// String returns the "kind:id" wire format.
+func (a Actor) String() string { return a.kind + ":" + a.id }
+
+// ── Permission ──────────────────────────────────────────────────────
+
+// Permission represents an ACL permission level.
+type Permission string
+
+const (
+	PermissionRead  Permission = "read"
+	PermissionWrite Permission = "write"
+	PermissionAdmin Permission = "admin"
+)
+
+// ── ACL ─────────────────────────────────────────────────────────────
+
+// ACLEntry represents an access control list entry.
+type ACLEntry struct {
+	Grantee    Actor      `json:"grantee"`
+	Permission Permission `json:"permission"`
+	ExpiresAt  int64      `json:"expires_at,omitempty"`
+}
+
+// ── Node / Edge ─────────────────────────────────────────────────────
+
 // Node represents a graph node in EntDB.
 type Node struct {
 	TenantID   string         `json:"tenant_id"`
@@ -8,7 +69,7 @@ type Node struct {
 	Payload    map[string]any `json:"payload"`
 	CreatedAt  int64          `json:"created_at"`
 	UpdatedAt  int64          `json:"updated_at"`
-	OwnerActor string         `json:"owner_actor"`
+	OwnerActor Actor          `json:"owner_actor"`
 	ACL        []ACLEntry     `json:"acl,omitempty"`
 }
 
@@ -22,12 +83,7 @@ type Edge struct {
 	CreatedAt  int64          `json:"created_at"`
 }
 
-// ACLEntry represents an access control list entry.
-type ACLEntry struct {
-	Principal  string `json:"principal"`
-	Permission string `json:"permission"`
-	ExpiresAt  int64  `json:"expires_at,omitempty"`
-}
+// ── Transaction ─────────────────────────────────────────────────────
 
 // Receipt tracks a committed transaction.
 type Receipt struct {
@@ -45,19 +101,16 @@ type CommitResult struct {
 	Error          string   `json:"error,omitempty"`
 }
 
+// ── Operations ──────────────────────────────────────────────────────
+
 // OperationType enumerates the kinds of operations in a Plan.
 type OperationType int
 
 const (
-	// OpCreateNode is a node creation operation.
 	OpCreateNode OperationType = iota
-	// OpUpdateNode is a node update operation.
 	OpUpdateNode
-	// OpDeleteNode is a node deletion operation.
 	OpDeleteNode
-	// OpCreateEdge is an edge creation operation.
 	OpCreateEdge
-	// OpDeleteEdge is an edge deletion operation.
 	OpDeleteEdge
 )
 


### PR DESCRIPTION
## Summary

Brings the Go SDK to parity with the Python SDK's strong typing:

- **`Actor` type** — `UserActor("bob")`, `GroupActor("admins")`, `ServiceActor("api")` with `ParseActor()` for wire format
- **`Permission` enum** — `PermissionRead`, `PermissionWrite`, `PermissionAdmin`
- **`ACLEntry`** — `Grantee Actor` + `Permission Permission` (was `Principal string` + `Permission string`)
- **`Node.OwnerActor`** — `Actor` type (was `string`)
- **`TenantScope.Actor()`** — accepts `Actor` type
- **`ActorScope.Share()`** — new method with typed `Actor` + `Permission`
- **`Transport.Share()`** — added to interface

## Test plan

- [x] `go test ./...` → 32 passed (5 new: Actor constructors, parse, equality, Permission values, Share)
- [x] `go vet ./...` clean
- [x] `pytest tests/unit/` → 1343 passed (no regression)