### PR TITLE
Mark gRPC API as internal — clients must use the SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # EntDB - Production-Grade Database-as-a-Service
 
+> ## ⚠ Use an SDK — do not call gRPC directly
+>
+> The gRPC API is an **internal transport** between the server and the official SDKs. The wire format is not a stable public contract; field IDs, actor strings, ACL encoding, idempotency keys, schema fingerprints, and tenant routing all have non-obvious invariants the SDKs enforce.
+>
+> **Sanctioned clients:**
+> - **Go:** [`github.com/elloloop/tenant-shard-db/sdk/go/entdb`](sdk/go/entdb)
+> - **Python:** `pip install entdb-sdk`
+>
+> Hand-rolled clients (curl, grpcurl, custom stubs) **will break** and are unsupported. If your language isn't covered, please [open an issue](https://github.com/elloloop/tenant-shard-db/issues) — don't reach for the proto.
+
 EntDB is a production-ready multi-tenant database service built on event sourcing principles. It provides strong durability guarantees, flexible schema evolution, and built-in support for graph data models with nodes and edges.
 
 ## Features
@@ -12,8 +22,7 @@ EntDB is a production-ready multi-tenant database service built on event sourcin
 - **Full-Text Search**: SQLite FTS5 for mailbox search
 - **ACL System**: Principal-based visibility (user:X, role:X, tenant:*)
 - **Idempotent Operations**: Deduplication via idempotency keys
-- **gRPC API**: High-performance binary protocol (HTTP/REST via gateway sidecar)
-- **Python SDK**: Type-safe client with Plan builder
+- **Official SDKs**: Type-safe Go and Python clients with Plan builder (the only sanctioned entry points; gRPC is an internal transport)
 
 ## Quick Start
 

--- a/dbaas/entdb_server/api/grpc_server.py
+++ b/dbaas/entdb_server/api/grpc_server.py
@@ -3104,6 +3104,12 @@ class GrpcServer:
             f"gRPC server started on {bind_address}",
             extra={"host": self.host, "port": self.port},
         )
+        logger.warning(
+            "EntDB gRPC is an INTERNAL transport. Clients MUST use the official "
+            "SDKs (Go: github.com/elloloop/tenant-shard-db/sdk/go/entdb, "
+            "Python: pip install entdb-sdk). Hand-rolled gRPC clients are "
+            "unsupported and may break without notice."
+        )
 
     async def stop(self, grace_period: float = 5.0) -> None:
         """Stop the gRPC server gracefully.

--- a/dbaas/entdb_server/api/proto/entdb.proto
+++ b/dbaas/entdb_server/api/proto/entdb.proto
@@ -1,3 +1,24 @@
+// ============================================================================
+// ⚠  INTERNAL TRANSPORT — DO NOT USE DIRECTLY  ⚠
+// ============================================================================
+//
+// This gRPC service is an INTERNAL transport between the EntDB server and the
+// official SDKs. It is NOT a stable public API.
+//
+//   ✗ DO NOT hand-roll a client against this proto (curl, grpcurl, custom
+//     stubs in any language). Doing so WILL break: field IDs, actor strings,
+//     ACL encoding, idempotency keys, schema fingerprints, and tenant
+//     routing have non-obvious invariants enforced by the SDKs.
+//   ✗ DO NOT treat the wire format as a public contract. RPCs, fields, and
+//     semantics may change without notice between releases.
+//
+//   ✓ Use the Go SDK:     github.com/elloloop/tenant-shard-db/sdk/go/entdb
+//   ✓ Use the Python SDK: pip install entdb-sdk
+//
+// If your language isn't supported, file an issue — don't reach for the
+// proto.
+// ============================================================================
+//
 // EntDB gRPC Service Definition
 //
 // This file defines the gRPC API for the EntDB database service.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,5 +1,16 @@
 # API Reference
 
+> ## ⚠ Internal transport — use an SDK
+>
+> The gRPC and HTTP surfaces below are **internal transports** used by the official SDKs. They are not stable public contracts; the wire format may change between releases, and the SDKs enforce non-obvious invariants (field IDs, actor strings, ACL encoding, idempotency keys, schema fingerprints) that hand-rolled clients will get wrong.
+>
+> Use one of the sanctioned SDKs:
+>
+> - **Go:** [`github.com/elloloop/tenant-shard-db/sdk/go/entdb`](https://pkg.go.dev/github.com/elloloop/tenant-shard-db/sdk/go/entdb)
+> - **Python:** `pip install entdb-sdk`
+>
+> The reference below is for SDK maintainers and operators debugging the wire — not for application code.
+
 EntDB exposes both gRPC and HTTP APIs.
 
 ## gRPC API

--- a/sdk/go/entdb/README.md
+++ b/sdk/go/entdb/README.md
@@ -6,6 +6,12 @@ Official Go client for **EntDB** — a multi-tenant, event-sourced graph
 database with typed ACL, GDPR primitives, and built-in compliance
 exports.
 
+> **This SDK is the supported way to talk to EntDB from Go.** The
+> underlying gRPC transport is internal and not a stable public
+> contract — do not generate your own stubs against `entdb.proto`.
+> Field IDs, actor strings, ACL encoding, idempotency keys, and schema
+> fingerprints all have invariants the SDK enforces for you.
+
 The SDK ships a **single-shape API**: there is exactly one way to
 perform every operation. Nodes are created from generated proto
 messages, unique-key lookups go through typed `UniqueKey[T]` tokens


### PR DESCRIPTION
## Summary

The gRPC wire format is not a stable public contract. Field IDs, actor strings, ACL encoding, idempotency keys, schema fingerprints, and tenant routing all have invariants the SDKs enforce. Hand-rolled clients (curl, grpcurl, custom stubs) drift quickly and aren't supported.

This PR adds prominent warnings in the places clients (humans or LLMs) are likely to look:

- Top-of-file warning banner in `entdb.proto`
- `WARNING`-level log on gRPC server start
- Callouts in root `README.md`, `docs/api-reference.md`, and `sdk/go/entdb/README.md`

The Go and Python SDKs are documented as the only sanctioned entry points.

Network binding intentionally unchanged — SDKs connect over the network from clients that may live on different hosts, so localhost binding would break the supported path. Documentation/warning is the right lever.

## Test plan
- [x] `python -m pytest tests/unit/ tests/integration/ -q` (2344 passing)
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [ ] Verify the WARNING log appears on a fresh server start