### PR TITLE
Replace broken HTTP healthcheck with standard gRPC Health probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,18 +123,18 @@ ENV PYTHONPATH="/app:/app/sdk"
 
 # Default configuration
 ENV GRPC_BIND="0.0.0.0:50051"
-ENV HTTP_ENABLED="true"
-ENV HTTP_BIND="0.0.0.0:8081"
 ENV DATA_DIR="/var/lib/entdb"
 ENV LOG_LEVEL="INFO"
 ENV LOG_FORMAT="json"
 
 # Expose ports
-EXPOSE 50051 8081
+EXPOSE 50051
 
-# Health check
+# Health check via the standard gRPC Health Checking Protocol
+# (grpc.health.v1.Health/Check). The probe script ships in the image
+# alongside the server — no separate binary download.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8081/v1/health || exit 1
+    CMD python -m dbaas.entdb_server.healthcheck --addr=localhost:50051 || exit 1
 
 # Default command
 CMD ["python", "-m", "dbaas.entdb_server.main"]

--- a/dbaas/entdb_server/api/grpc_server.py
+++ b/dbaas/entdb_server/api/grpc_server.py
@@ -3096,6 +3096,19 @@ class GrpcServer:
         # Register servicer
         add_EntDBServiceServicer_to_server(self.servicer, self._server)
 
+        # Register the standard gRPC Health Checking Protocol
+        # (grpc.health.v1.Health). Orchestrators (k8s, ECS, Docker
+        # HEALTHCHECK) probe via grpc_health_probe / equivalent rather
+        # than relying on a separate HTTP endpoint. Status is set to
+        # SERVING immediately; we don't currently degrade it on
+        # backend-component failure (snapshot/applier errors don't make
+        # the gRPC surface unhealthy — those have their own metrics).
+        from grpc_health.v1 import health, health_pb2, health_pb2_grpc
+
+        self._health_servicer = health.aio.HealthServicer()
+        health_pb2_grpc.add_HealthServicer_to_server(self._health_servicer, self._server)
+        await self._health_servicer.set("", health_pb2.HealthCheckResponse.SERVING)
+
         # Enable reflection for debugging tools like grpcurl
         if self.reflection_enabled:
             try:
@@ -3105,6 +3118,7 @@ class GrpcServer:
 
                 SERVICE_NAMES = (
                     entdb_pb2.DESCRIPTOR.services_by_name["EntDBService"].full_name,
+                    health_pb2.DESCRIPTOR.services_by_name["Health"].full_name,
                     reflection.SERVICE_NAME,
                 )
                 reflection.enable_server_reflection(SERVICE_NAMES, self._server)

--- a/dbaas/entdb_server/healthcheck.py
+++ b/dbaas/entdb_server/healthcheck.py
@@ -1,0 +1,61 @@
+"""
+Healthcheck CLI — calls the standard gRPC Health Checking RPC.
+
+Mirrors ``grpc_health_probe`` so we don't need to download a Go binary
+into the image just to call ``grpc.health.v1.Health/Check``. Used by
+the Docker ``HEALTHCHECK`` instruction.
+
+Exit codes:
+    0  — service is SERVING
+    1  — service is not serving, channel failed, or RPC errored
+
+Usage:
+    python -m dbaas.entdb_server.healthcheck [--addr HOST:PORT] [--service NAME]
+
+Defaults: ``--addr=localhost:50051``, ``--service=``  (empty = default service).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import grpc
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="gRPC Health Check probe")
+    parser.add_argument("--addr", default="localhost:50051", help="gRPC server host:port")
+    parser.add_argument(
+        "--service",
+        default="",
+        help="Service name to probe (empty = default service)",
+    )
+    parser.add_argument("--timeout", type=float, default=5.0, help="RPC timeout in seconds")
+    args = parser.parse_args()
+
+    try:
+        channel = grpc.insecure_channel(args.addr)
+        stub = health_pb2_grpc.HealthStub(channel)
+        resp = stub.Check(
+            health_pb2.HealthCheckRequest(service=args.service),
+            timeout=args.timeout,
+        )
+    except grpc.RpcError as exc:
+        print(f"healthcheck: RPC failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"healthcheck: {exc}", file=sys.stderr)
+        return 1
+
+    if resp.status == health_pb2.HealthCheckResponse.SERVING:
+        return 0
+
+    status_name = health_pb2.HealthCheckResponse.ServingStatus.Name(resp.status)
+    print(f"healthcheck: status={status_name}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       minio-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "python", "-c", "import grpc; ch = grpc.insecure_channel('localhost:50051'); grpc.channel_ready_future(ch).result(timeout=5)"]
+      test: ["CMD", "python", "-m", "dbaas.entdb_server.healthcheck", "--addr=localhost:50051"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ server = [
     "aiobotocore>=2.11.0",
     "aiohttp>=3.9.0",
     "grpcio>=1.60.0",
+    "grpcio-health-checking>=1.60.0",
     "PyJWT>=2.8.0",
     "cryptography>=41.0.0",
 ]

--- a/tests/unit/test_health_check.py
+++ b/tests/unit/test_health_check.py
@@ -1,0 +1,71 @@
+"""
+Standard gRPC Health Checking Protocol.
+
+The server must expose ``grpc.health.v1.Health/Check`` so orchestrators
+(Docker HEALTHCHECK, k8s livenessProbe, ECS) can probe it via
+``grpc_health_probe`` or equivalent. Without this, the only way to
+know the server is up was via a (non-existent) HTTP endpoint or by
+attempting a full ``EntDBService`` RPC, which can't be done without
+auth context in production.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import grpc
+import pytest
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+
+from dbaas.entdb_server.api.grpc_server import EntDBServicer, GrpcServer
+
+
+def _make_server(port: int) -> GrpcServer:
+    servicer = EntDBServicer(
+        wal=MagicMock(),
+        canonical_store=MagicMock(),
+        schema_registry=MagicMock(),
+    )
+    return GrpcServer(servicer=servicer, host="127.0.0.1", port=port, max_workers=2)
+
+
+@pytest.mark.asyncio
+async def test_health_servicer_registered_and_serving():
+    """The standard Health servicer is wired into the gRPC server.
+
+    Guards against silent regression — if someone removes the
+    ``add_HealthServicer_to_server`` call, this test fails before the
+    Docker HEALTHCHECK does.
+    """
+    server = _make_server(port=0)
+    await server.start()
+    try:
+        assert hasattr(server, "_health_servicer"), (
+            "GrpcServer.start() must register the standard gRPC Health servicer"
+        )
+        # The async HealthServicer stores statuses in a private dict
+        # keyed by service name; the empty string is the default service
+        # (what grpc_health_probe uses with no -service flag).
+        statuses = server._health_servicer._server_status
+        assert statuses[""] == health_pb2.HealthCheckResponse.SERVING
+    finally:
+        await server.stop(grace_period=0.1)
+
+
+@pytest.mark.asyncio
+async def test_health_check_via_real_client():
+    """End-to-end: open a gRPC channel and call ``Health/Check``.
+
+    Mirrors exactly what ``grpc_health_probe -addr=:50051`` does. If
+    this test passes, the Docker HEALTHCHECK works.
+    """
+    # Pick a high, unlikely-to-conflict port for the real-client probe.
+    server = _make_server(port=50099)
+    await server.start()
+    try:
+        async with grpc.aio.insecure_channel("127.0.0.1:50099") as channel:
+            stub = health_pb2_grpc.HealthStub(channel)
+            resp = await stub.Check(health_pb2.HealthCheckRequest(service=""), timeout=5.0)
+            assert resp.status == health_pb2.HealthCheckResponse.SERVING
+    finally:
+        await server.stop(grace_period=0.1)


### PR DESCRIPTION
## Summary

The Docker `HEALTHCHECK` instruction pointed at `curl http://localhost:8081/v1/health`, but the server has **no HTTP listener** — only the gRPC server on `:50051`. The check fails silently in any deployment that relied on it; orchestrators have been working around it with channel-ready Python one-liners.

This PR wires up the **standard gRPC Health Checking Protocol** (`grpc.health.v1.Health/Check`) so orchestrator-native probes work out of the box.

## Changes

- `pyproject.toml`: add `grpcio-health-checking>=1.60.0` to the `server` extra.
- `dbaas/entdb_server/api/grpc_server.py`: register `grpc_health.v1.health.aio.HealthServicer` on the gRPC server, set the default service to `SERVING`, and list it in reflection so `grpcurl list` discovers it.
- `dbaas/entdb_server/healthcheck.py`: standalone Python probe — mirrors what `grpc_health_probe -addr=:50051` would do, without dragging a Go binary into the image.
- `Dockerfile` (server stage):
  - Swap the broken `curl :8081/v1/health` HEALTHCHECK for `python -m dbaas.entdb_server.healthcheck`.
  - Drop `EXPOSE 8081`, `ENV HTTP_BIND`, `ENV HTTP_ENABLED` — vestigial, pointed at a server that never existed.
- `docker-compose.yml`: align the server-service healthcheck with the same probe (replaces the inline channel-ready workaround).
- `tests/unit/test_health_check.py`: asserts the servicer is registered and a real-client roundtrip returns `SERVING`.

## Why this approach (vs. installing `grpc_health_probe`)

The image is Python-based. Adding a 6 MB static Go binary just to call `Health/Check` is wasteful when `grpcio` is already in the image. The probe script is ~50 LOC, pure-Python, and mirrors `grpc_health_probe`'s flag surface (`--addr`, `--service`, `--timeout`). Operators who prefer the Go binary can swap the HEALTHCHECK line themselves.

## Test plan
- [x] `python -m pytest tests/unit/ tests/integration/ -q` (2359 passing, +2 net new)
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [ ] Build the server image and verify `docker inspect` reports `Health.Status=healthy` after start
- [ ] Verify `grpc_health_probe -addr=<container>:50051` returns `SERVING` against the running container (third-party tooling check)