### PR TITLE
SDK admin: expose per-tenant region pinning (Go + Python)

### DIFF
--- a/sdk/entdb_sdk/_grpc_client.py
+++ b/sdk/entdb_sdk/_grpc_client.py
@@ -1749,6 +1749,7 @@ class GrpcClient:
         tenant_id: str,
         name: str,
         *,
+        region: str | None = None,
         timeout: float | None = None,
     ) -> dict[str, Any]:
         """Create a new tenant.
@@ -1757,10 +1758,16 @@ class GrpcClient:
             actor: Actor performing the operation
             tenant_id: Unique tenant identifier
             name: Tenant display name
+            region: Optional geographic region pin (e.g. ``"us-east-1"``,
+                ``"eu-west-1"``). When ``None`` the server defaults the
+                tenant to its own served region. Once the pin is set,
+                cross-region requests are rejected with
+                ``FAILED_PRECONDITION``.
             timeout: Per-call timeout in seconds
 
         Returns:
-            Dict with success, tenant, error fields
+            Dict with success, tenant (including the resolved region),
+            and error fields
         """
         stub = self._ensure_connected()
         metadata = self._build_metadata()
@@ -1769,6 +1776,7 @@ class GrpcClient:
             actor=actor,
             tenant_id=tenant_id,
             name=name,
+            region=region or "",
         )
 
         response = await self._retry(
@@ -1787,6 +1795,7 @@ class GrpcClient:
                 "tenant_id": response.tenant.tenant_id,
                 "name": response.tenant.name,
                 "status": response.tenant.status,
+                "region": response.tenant.region,
                 "created_at": response.tenant.created_at,
             }
         return result
@@ -1830,6 +1839,7 @@ class GrpcClient:
             "tenant_id": response.tenant.tenant_id,
             "name": response.tenant.name,
             "status": response.tenant.status,
+            "region": response.tenant.region,
             "created_at": response.tenant.created_at,
         }
 

--- a/sdk/entdb_sdk/client.py
+++ b/sdk/entdb_sdk/client.py
@@ -1694,6 +1694,7 @@ class DbClient:
         name: str,
         *,
         actor: str = "system:admin",
+        region: str | None = None,
         timeout: float | None = None,
     ) -> dict[str, Any]:
         """Create a new tenant in the global registry.
@@ -1702,6 +1703,10 @@ class DbClient:
             tenant_id: Unique tenant identifier
             name: Tenant display name
             actor: Actor performing the operation
+            region: Optional geographic region pin (e.g. ``"us-east-1"``,
+                ``"eu-west-1"``). When ``None`` the server defaults
+                the tenant to its own served region. The resolved
+                region is returned on the ``tenant`` dict.
             timeout: Per-call timeout in seconds
 
         Returns:
@@ -1712,6 +1717,7 @@ class DbClient:
             actor=actor,
             tenant_id=tenant_id,
             name=name,
+            region=region,
             timeout=timeout,
         )
 

--- a/sdk/go/entdb/admin.go
+++ b/sdk/go/entdb/admin.go
@@ -41,8 +41,13 @@ func (c *DbClient) Admin() *Admin {
 // Re-creating a tenant that already exists raises an underlying
 // uniqueness error from the global SQLite — there is no "create or
 // get" form by design.
-func (a *Admin) CreateTenant(ctx context.Context, actor, tenantID, name string) (*TenantDetail, error) {
-	return a.client.transport.CreateTenant(ctx, actor, tenantID, name)
+//
+// Pass [WithRegion] to pin the tenant to a specific geographic
+// region (e.g. ``WithRegion("eu-west-1")``); when omitted the
+// server defaults the tenant to its own served region. The pinned
+// region is reflected on [TenantDetail.Region].
+func (a *Admin) CreateTenant(ctx context.Context, actor, tenantID, name string, opts ...CreateTenantOption) (*TenantDetail, error) {
+	return a.client.transport.CreateTenant(ctx, actor, tenantID, name, opts...)
 }
 
 // CreateUser registers a new user in the global registry. ``email``

--- a/sdk/go/entdb/admin_test.go
+++ b/sdk/go/entdb/admin_test.go
@@ -52,6 +52,65 @@ func TestAdmin_CreateTenant_HappyPath(t *testing.T) {
 	}
 }
 
+func TestAdmin_CreateTenant_WithRegion(t *testing.T) {
+	svc := &fakeServer{
+		createTenantResp: &pb.CreateTenantResponse{
+			Success: true,
+			Tenant: &pb.TenantDetail{
+				TenantId:  "acme-eu",
+				Name:      "Acme EU",
+				Status:    "active",
+				Region:    "eu-west-1",
+				CreatedAt: 1_700_000_000_000,
+			},
+		},
+	}
+	tr := startFakeServer(t, svc)
+	c := newClientWithTransport("addr", tr)
+
+	td, err := c.Admin().CreateTenant(
+		context.Background(), "system:admin", "acme-eu", "Acme EU",
+		WithRegion("eu-west-1"),
+	)
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if td.Region != "eu-west-1" {
+		t.Errorf("decoded tenant region mismatch: got %q, want %q", td.Region, "eu-west-1")
+	}
+	if svc.createTenantReq.GetRegion() != "eu-west-1" {
+		t.Errorf("request region wrong: got %q, want %q",
+			svc.createTenantReq.GetRegion(), "eu-west-1")
+	}
+}
+
+func TestAdmin_CreateTenant_NoRegionDefaultsToEmpty(t *testing.T) {
+	// No WithRegion option — server is responsible for defaulting to
+	// its own served_region. The wire request must carry an empty
+	// region string so the server can detect "unset".
+	svc := &fakeServer{
+		createTenantResp: &pb.CreateTenantResponse{
+			Success: true,
+			Tenant: &pb.TenantDetail{
+				TenantId: "acme",
+				Name:     "Acme",
+				Status:   "active",
+			},
+		},
+	}
+	tr := startFakeServer(t, svc)
+	c := newClientWithTransport("addr", tr)
+
+	_, err := c.Admin().CreateTenant(context.Background(), "system:admin", "acme", "Acme")
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if svc.createTenantReq.GetRegion() != "" {
+		t.Errorf("expected empty region on wire when no option, got %q",
+			svc.createTenantReq.GetRegion())
+	}
+}
+
 func TestAdmin_CreateTenant_ServerSuccessFalseSurfacesAdminError(t *testing.T) {
 	svc := &fakeServer{
 		createTenantResp: &pb.CreateTenantResponse{

--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -86,7 +86,7 @@ type Transport interface {
 	// CreateUser, GetUserTenants) or want raw ``user_id`` form to
 	// match the global registry's identifier shape.
 
-	CreateTenant(ctx context.Context, actor, tenantID, name string) (*TenantDetail, error)
+	CreateTenant(ctx context.Context, actor, tenantID, name string, opts ...CreateTenantOption) (*TenantDetail, error)
 	CreateUser(ctx context.Context, actor, userID, email, name string) (*UserInfo, error)
 	AddTenantMember(ctx context.Context, actor, tenantID, userID, role string) error
 	RemoveTenantMember(ctx context.Context, actor, tenantID, userID string) error
@@ -146,10 +146,19 @@ type DeletionScheduled struct {
 
 // TenantDetail mirrors ``pb.TenantDetail`` — the identity-layer
 // description of a tenant (not its quota, not its data).
+//
+// ``Region`` is the geographic region the tenant's data is pinned to
+// (e.g. ``"us-east-1"``, ``"eu-west-1"``). It is set when the tenant
+// is created — either explicitly via [WithRegion] on
+// [Admin.CreateTenant] or, when omitted, defaulted server-side to
+// the serving region. Cross-region requests are rejected with
+// FAILED_PRECONDITION; clients that need to talk to a tenant in
+// another region must connect to a server in that region.
 type TenantDetail struct {
 	TenantID  string
 	Name      string
 	Status    string
+	Region    string
 	CreatedAt int64
 }
 
@@ -651,16 +660,21 @@ func (t *grpcTransport) RemoveGroupMember(ctx context.Context, tenantID, actor, 
 
 // ── Admin (cross-tenant identity) wire methods ───────────────────────
 
-func (t *grpcTransport) CreateTenant(ctx context.Context, actor, tenantID, name string) (*TenantDetail, error) {
+func (t *grpcTransport) CreateTenant(ctx context.Context, actor, tenantID, name string, opts ...CreateTenantOption) (*TenantDetail, error) {
 	client, err := t.ensureReady()
 	if err != nil {
 		return nil, err
+	}
+	cfg := createTenantConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 	var trailer metadata.MD
 	resp, err := client.CreateTenant(t.callContext(ctx), &pb.CreateTenantRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 		Name:     name,
+		Region:   cfg.region,
 	}, grpc.Trailer(&trailer))
 	if err != nil {
 		return nil, translateGRPCStatusWithTrailer(err, trailer, tenantID, t.address)
@@ -673,6 +687,7 @@ func (t *grpcTransport) CreateTenant(ctx context.Context, actor, tenantID, name 
 		TenantID:  td.GetTenantId(),
 		Name:      td.GetName(),
 		Status:    td.GetStatus(),
+		Region:    td.GetRegion(),
 		CreatedAt: td.GetCreatedAt(),
 	}, nil
 }

--- a/sdk/go/entdb/client_test.go
+++ b/sdk/go/entdb/client_test.go
@@ -146,7 +146,7 @@ func (m *mockTransport) RemoveGroupMember(_ context.Context, _, _, _, _ string) 
 	return nil
 }
 
-func (m *mockTransport) CreateTenant(_ context.Context, _, _, _ string) (*TenantDetail, error) {
+func (m *mockTransport) CreateTenant(_ context.Context, _, _, _ string, _ ...CreateTenantOption) (*TenantDetail, error) {
 	return nil, nil
 }
 

--- a/sdk/go/entdb/internal/pb/entdb.pb.go
+++ b/sdk/go/entdb/internal/pb/entdb.pb.go
@@ -1,3 +1,24 @@
+// ============================================================================
+// ⚠  INTERNAL TRANSPORT — DO NOT USE DIRECTLY  ⚠
+// ============================================================================
+//
+// This gRPC service is an INTERNAL transport between the EntDB server and the
+// official SDKs. It is NOT a stable public API.
+//
+//   ✗ DO NOT hand-roll a client against this proto (curl, grpcurl, custom
+//     stubs in any language). Doing so WILL break: field IDs, actor strings,
+//     ACL encoding, idempotency keys, schema fingerprints, and tenant
+//     routing have non-obvious invariants enforced by the SDKs.
+//   ✗ DO NOT treat the wire format as a public contract. RPCs, fields, and
+//     semantics may change without notice between releases.
+//
+//   ✓ Use the Go SDK:     github.com/elloloop/tenant-shard-db/sdk/go/entdb
+//   ✓ Use the Python SDK: pip install entdb-sdk
+//
+// If your language isn't supported, file an issue — don't reach for the
+// proto.
+// ============================================================================
+//
 // EntDB gRPC Service Definition
 //
 // This file defines the gRPC API for the EntDB database service.
@@ -4564,11 +4585,16 @@ func (x *ListUsersResponse) GetUsers() []*UserInfo {
 }
 
 type TenantDetail struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Status        string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
-	CreatedAt     int64                  `protobuf:"varint,4,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	TenantId  string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	Name      string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Status    string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	CreatedAt int64                  `protobuf:"varint,4,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// Geographic region the tenant's data is pinned to (e.g. "us-east-1",
+	// "eu-west-1"). Data-plane traffic for this tenant must land on a
+	// server configured for this region; cross-region requests are
+	// rejected with FAILED_PRECONDITION.
+	Region        string `protobuf:"bytes,5,opt,name=region,proto3" json:"region,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4631,11 +4657,21 @@ func (x *TenantDetail) GetCreatedAt() int64 {
 	return 0
 }
 
+func (x *TenantDetail) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
 type CreateTenantRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Actor         string                 `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
-	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	Name          string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Actor    string                 `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
+	TenantId string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	Name     string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// Geographic region pin. When empty, the server defaults the tenant
+	// to its own served region.
+	Region        string `protobuf:"bytes,4,opt,name=region,proto3" json:"region,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4687,6 +4723,13 @@ func (x *CreateTenantRequest) GetTenantId() string {
 func (x *CreateTenantRequest) GetName() string {
 	if x != nil {
 		return x.Name
+	}
+	return ""
+}
+
+func (x *CreateTenantRequest) GetRegion() string {
+	if x != nil {
+		return x.Region
 	}
 	return ""
 }
@@ -7267,17 +7310,19 @@ const file_entdb_proto_rawDesc = "" +
 	"\x05limit\x18\x03 \x01(\x05R\x05limit\x12\x16\n" +
 	"\x06offset\x18\x04 \x01(\x05R\x06offset\"=\n" +
 	"\x11ListUsersResponse\x12(\n" +
-	"\x05users\x18\x01 \x03(\v2\x12.entdb.v1.UserInfoR\x05users\"v\n" +
+	"\x05users\x18\x01 \x03(\v2\x12.entdb.v1.UserInfoR\x05users\"\x8e\x01\n" +
 	"\fTenantDetail\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x16\n" +
 	"\x06status\x18\x03 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
-	"created_at\x18\x04 \x01(\x03R\tcreatedAt\"\\\n" +
+	"created_at\x18\x04 \x01(\x03R\tcreatedAt\x12\x16\n" +
+	"\x06region\x18\x05 \x01(\tR\x06region\"t\n" +
 	"\x13CreateTenantRequest\x12\x14\n" +
 	"\x05actor\x18\x01 \x01(\tR\x05actor\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x12\n" +
-	"\x04name\x18\x03 \x01(\tR\x04name\"v\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x16\n" +
+	"\x06region\x18\x04 \x01(\tR\x06region\"v\n" +
 	"\x14CreateTenantResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12.\n" +
 	"\x06tenant\x18\x02 \x01(\v2\x16.entdb.v1.TenantDetailR\x06tenant\x12\x14\n" +

--- a/sdk/go/entdb/internal/pb/entdb_grpc.pb.go
+++ b/sdk/go/entdb/internal/pb/entdb_grpc.pb.go
@@ -1,3 +1,24 @@
+// ============================================================================
+// ⚠  INTERNAL TRANSPORT — DO NOT USE DIRECTLY  ⚠
+// ============================================================================
+//
+// This gRPC service is an INTERNAL transport between the EntDB server and the
+// official SDKs. It is NOT a stable public API.
+//
+//   ✗ DO NOT hand-roll a client against this proto (curl, grpcurl, custom
+//     stubs in any language). Doing so WILL break: field IDs, actor strings,
+//     ACL encoding, idempotency keys, schema fingerprints, and tenant
+//     routing have non-obvious invariants enforced by the SDKs.
+//   ✗ DO NOT treat the wire format as a public contract. RPCs, fields, and
+//     semantics may change without notice between releases.
+//
+//   ✓ Use the Go SDK:     github.com/elloloop/tenant-shard-db/sdk/go/entdb
+//   ✓ Use the Python SDK: pip install entdb-sdk
+//
+// If your language isn't supported, file an issue — don't reach for the
+// proto.
+// ============================================================================
+//
 // EntDB gRPC Service Definition
 //
 // This file defines the gRPC API for the EntDB database service.

--- a/sdk/go/entdb/options.go
+++ b/sdk/go/entdb/options.go
@@ -135,3 +135,26 @@ func WithLimit(n int32) QueryOption {
 func WithOffset(n int32) QueryOption {
 	return func(c *queryConfig) { c.offset = n }
 }
+
+// ── Admin.CreateTenant options ─────────────────────────────────────
+
+// createTenantConfig holds optional parameters for
+// [Admin.CreateTenant].
+type createTenantConfig struct {
+	region string
+}
+
+// CreateTenantOption configures a single [Admin.CreateTenant] call.
+type CreateTenantOption func(*createTenantConfig)
+
+// WithRegion pins the new tenant to a specific geographic region
+// (e.g. ``"us-east-1"``, ``"eu-west-1"``). Once set, every request
+// that touches the tenant must hit a server that serves the same
+// region; cross-region calls are rejected with FAILED_PRECONDITION.
+//
+// When this option is omitted the server defaults the tenant's
+// region to its own served region, so single-region deployments do
+// not need to set it.
+func WithRegion(region string) CreateTenantOption {
+	return func(c *createTenantConfig) { c.region = region }
+}

--- a/tests/unit/test_tenant_registry.py
+++ b/tests/unit/test_tenant_registry.py
@@ -682,3 +682,145 @@ class TestChangeMemberRoleHandler:
         )
 
         assert response.success is True
+
+
+# -- SDK admin surface: create_tenant region pinning -----------------------
+# These tests exercise the public SDK wrappers for create_tenant /
+# get_tenant — verifying that the new ``region`` kwarg is forwarded
+# to the wire CreateTenantRequest and that the resolved region from
+# TenantDetail is returned to callers. Wire shape coverage is the
+# point: a future proto edit that moves the field tag will break
+# them.
+
+
+class TestSDKCreateTenantRegion:
+    """SDK-side tests for region pinning on create_tenant."""
+
+    async def test_grpc_client_create_tenant_forwards_region(self) -> None:
+        """``GrpcClient.create_tenant`` writes ``region`` onto the
+        wire request and surfaces the resolved region back."""
+        from sdk.entdb_sdk._generated import (
+            CreateTenantResponse,
+            TenantDetail,
+        )
+        from sdk.entdb_sdk._grpc_client import GrpcClient
+
+        c = GrpcClient("localhost", 50051)
+        # Stand up a fake stub so we can inspect the request that
+        # _retry was given. _ensure_connected just unwraps _stub.
+        c._stub = MagicMock()
+        captured: dict[str, object] = {}
+
+        async def fake_retry(method, request, **_kwargs):
+            captured["request"] = request
+            return CreateTenantResponse(
+                success=True,
+                tenant=TenantDetail(
+                    tenant_id="acme-eu",
+                    name="Acme EU",
+                    status="active",
+                    region="eu-west-1",
+                    created_at=1_700_000_000_000,
+                ),
+            )
+
+        c._retry = fake_retry  # type: ignore[method-assign]
+
+        result = await c.create_tenant(
+            actor="system:admin",
+            tenant_id="acme-eu",
+            name="Acme EU",
+            region="eu-west-1",
+        )
+
+        # Wire request carries the region.
+        assert captured["request"].region == "eu-west-1"  # type: ignore[attr-defined]
+        # Tenant dict surfaces the resolved region.
+        assert result["success"] is True
+        assert result["tenant"]["region"] == "eu-west-1"
+
+    async def test_grpc_client_create_tenant_no_region_sends_empty(self) -> None:
+        """Omitting ``region`` sends an empty string on the wire so the
+        server can default to its own served region."""
+        from sdk.entdb_sdk._generated import CreateTenantResponse, TenantDetail
+        from sdk.entdb_sdk._grpc_client import GrpcClient
+
+        c = GrpcClient("localhost", 50051)
+        c._stub = MagicMock()
+        captured: dict[str, object] = {}
+
+        async def fake_retry(method, request, **_kwargs):
+            captured["request"] = request
+            return CreateTenantResponse(
+                success=True,
+                tenant=TenantDetail(
+                    tenant_id="acme",
+                    name="Acme",
+                    status="active",
+                    region="us-east-1",  # server defaulted
+                ),
+            )
+
+        c._retry = fake_retry  # type: ignore[method-assign]
+
+        result = await c.create_tenant(actor="system:admin", tenant_id="acme", name="Acme")
+
+        assert captured["request"].region == ""  # type: ignore[attr-defined]
+        # Even though caller didn't set it, the server's default is
+        # surfaced back in the tenant dict.
+        assert result["tenant"]["region"] == "us-east-1"
+
+    async def test_dbclient_create_tenant_passes_region_kwarg(self) -> None:
+        """The public ``DbClient.create_tenant`` wrapper forwards the
+        ``region`` kwarg to the underlying gRPC client."""
+        from sdk.entdb_sdk.client import DbClient
+
+        c = DbClient("localhost:50051")
+        c._connected = True
+        c._grpc = AsyncMock()
+        c._grpc.create_tenant = AsyncMock(
+            return_value={
+                "success": True,
+                "error": None,
+                "tenant": {
+                    "tenant_id": "acme-eu",
+                    "name": "Acme EU",
+                    "status": "active",
+                    "region": "eu-west-1",
+                    "created_at": 0,
+                },
+            }
+        )
+
+        result = await c.create_tenant("acme-eu", "Acme EU", region="eu-west-1")
+
+        c._grpc.create_tenant.assert_awaited_once()
+        kwargs = c._grpc.create_tenant.await_args.kwargs
+        assert kwargs["region"] == "eu-west-1"
+        assert kwargs["tenant_id"] == "acme-eu"
+        assert result["tenant"]["region"] == "eu-west-1"
+
+    async def test_grpc_client_get_tenant_returns_region(self) -> None:
+        """``get_tenant`` surfaces the persisted region back to callers."""
+        from sdk.entdb_sdk._generated import GetTenantResponse, TenantDetail
+        from sdk.entdb_sdk._grpc_client import GrpcClient
+
+        c = GrpcClient("localhost", 50051)
+        c._stub = MagicMock()
+
+        async def fake_retry(method, request, **_kwargs):
+            return GetTenantResponse(
+                found=True,
+                tenant=TenantDetail(
+                    tenant_id="acme-eu",
+                    name="Acme EU",
+                    status="active",
+                    region="eu-west-1",
+                ),
+            )
+
+        c._retry = fake_retry  # type: ignore[method-assign]
+
+        result = await c.get_tenant(actor="system:admin", tenant_id="acme-eu")
+        assert result is not None
+        assert result["region"] == "eu-west-1"


### PR DESCRIPTION
## Summary

Follow-up to #152 — exposes the new tenant `region` field through both SDK admin namespaces.

- **Go SDK**: new `WithRegion(string)` functional option on `Admin.CreateTenant`; `TenantDetail.Region` surfaces the resolved region. Regenerated `internal/pb` stubs to pick up the proto change.
- **Python SDK**: `region: str | None = None` kwarg on `GrpcClient.create_tenant` and the public `DbClient.create_tenant` wrapper; `create_tenant` and `get_tenant` now return `region` in the tenant dict.
- Both wrappers send an empty string when no region is set so the server can default to its own served region.

## Test plan

- [x] `TestAdmin_CreateTenant_WithRegion` and `TestAdmin_CreateTenant_NoRegionDefaultsToEmpty` (Go)
- [x] Four `TestSDKCreateTenantRegion` cases for the Python SDK (region forwarding, empty default, `DbClient` kwarg, `get_tenant` surfacing region)
- [x] `python -m pytest tests/unit/ tests/integration/ -q` — 2361 passed
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` — clean
- [x] `cd sdk/go/entdb && go vet ./... && go test ./...` — clean