### PR TITLE
Fix Node.payload wire format to be field-id-keyed (PR-D)

### DIFF
--- a/console/gateway/console_client.py
+++ b/console/gateway/console_client.py
@@ -11,11 +11,11 @@ decoupled and able to browse any EntDB instance without schema code.
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import Any
 
+from google.protobuf import json_format
 from grpc import aio as grpc_aio
 
 # Import generated stubs - Console has its own copy
@@ -34,6 +34,13 @@ from entdb_sdk._generated import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _struct_to_dict(s: Any) -> dict[str, Any]:
+    """Convert a protobuf Struct to a Python dict."""
+    if not s or not getattr(s, "fields", None):
+        return {}
+    return json_format.MessageToDict(s)
 
 
 @dataclass
@@ -74,6 +81,68 @@ class ConsoleClient:
         self._port = port
         self._channel: grpc_aio.Channel | None = None
         self._stub: EntDBServiceStub | None = None
+        # Cache of {tenant_id: {type_id: {field_id_int: field_name}}}.
+        # Populated lazily by ``_get_id_to_name_map`` when translating
+        # id-keyed payloads back to names for the Console UI.
+        self._field_name_cache: dict[str, dict[int, dict[int, str]]] = {}
+
+    async def _get_id_to_name_map(self, tenant_id: str, type_id: int) -> dict[int, str]:
+        """Return a ``{field_id: field_name}`` map for ``type_id``.
+
+        Fetches the tenant's schema on first use and caches it. The
+        wire payload is field-id-keyed (per CLAUDE.md invariant #6) so
+        the Console must translate ids to names locally for display.
+        """
+        per_tenant = self._field_name_cache.get(tenant_id)
+        if per_tenant is None:
+            per_tenant = {}
+            self._field_name_cache[tenant_id] = per_tenant
+        cached = per_tenant.get(type_id)
+        if cached is not None:
+            return cached
+        try:
+            schema = await self.get_schema(tenant_id)
+        except Exception:
+            return {}
+        node_types = schema.get("schema", {}).get("node_types", []) or []
+        for nt in node_types:
+            try:
+                tid = int(nt.get("type_id", 0))
+            except (TypeError, ValueError):
+                continue
+            mapping: dict[int, str] = {}
+            for f in nt.get("fields", []) or []:
+                fid_raw = f.get("field_id")
+                fname = f.get("name")
+                if fid_raw is None or fname is None:
+                    continue
+                try:
+                    mapping[int(fid_raw)] = str(fname)
+                except (TypeError, ValueError):
+                    continue
+            per_tenant[tid] = mapping
+        return per_tenant.get(type_id, {})
+
+    async def _translate_payload(
+        self, tenant_id: str, type_id: int, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Translate an id-keyed payload to a name-keyed payload.
+
+        Unknown id keys are kept verbatim so partial/forward-compat
+        schemas don't drop data on display.
+        """
+        if not payload:
+            return {}
+        id_to_name = await self._get_id_to_name_map(tenant_id, type_id)
+        if not id_to_name:
+            return dict(payload)
+        out: dict[str, Any] = {}
+        for key, value in payload.items():
+            if isinstance(key, str) and key.isdigit():
+                out[id_to_name.get(int(key), key)] = value
+            else:
+                out[key] = value
+        return out
 
     async def connect(self) -> None:
         """Connect to EntDB server."""
@@ -124,7 +193,7 @@ class ConsoleClient:
         request = GetSchemaRequest(tenant_id=tenant_id or "")
         response = await self._stub.GetSchema(request)
         return {
-            "schema": json.loads(response.schema_json) if response.schema_json else {},
+            "schema": _struct_to_dict(response.schema),
             "fingerprint": response.fingerprint,
         }
 
@@ -150,11 +219,13 @@ class ConsoleClient:
             return None
 
         n = response.node
+        raw_payload = _struct_to_dict(n.payload)
+        translated = await self._translate_payload(tenant_id, n.type_id, raw_payload)
         return ConsoleNode(
             node_id=n.node_id,
             type_id=n.type_id,
             tenant_id=n.tenant_id,
-            payload=json.loads(n.payload_json) if n.payload_json else {},
+            payload=translated,
             owner_actor=n.owner_actor,
             created_at=n.created_at,
             updated_at=n.updated_at,
@@ -181,18 +252,21 @@ class ConsoleClient:
 
         response = await self._stub.QueryNodes(request)
 
-        nodes = [
-            ConsoleNode(
-                node_id=n.node_id,
-                type_id=n.type_id,
-                tenant_id=n.tenant_id,
-                payload=json.loads(n.payload_json) if n.payload_json else {},
-                owner_actor=n.owner_actor,
-                created_at=n.created_at,
-                updated_at=n.updated_at,
+        nodes = []
+        for n in response.nodes:
+            raw_payload = _struct_to_dict(n.payload)
+            translated = await self._translate_payload(tenant_id, n.type_id, raw_payload)
+            nodes.append(
+                ConsoleNode(
+                    node_id=n.node_id,
+                    type_id=n.type_id,
+                    tenant_id=n.tenant_id,
+                    payload=translated,
+                    owner_actor=n.owner_actor,
+                    created_at=n.created_at,
+                    updated_at=n.updated_at,
+                )
             )
-            for n in response.nodes
-        ]
 
         return nodes, response.has_more
 
@@ -223,7 +297,7 @@ class ConsoleClient:
                 from_node_id=e.from_node_id,
                 to_node_id=e.to_node_id,
                 tenant_id=e.tenant_id,
-                props=json.loads(e.props_json) if e.props_json else {},
+                props=_struct_to_dict(e.props),
                 created_at=e.created_at,
             )
             for e in response.edges
@@ -256,7 +330,7 @@ class ConsoleClient:
                 from_node_id=e.from_node_id,
                 to_node_id=e.to_node_id,
                 tenant_id=e.tenant_id,
-                props=json.loads(e.props_json) if e.props_json else {},
+                props=_struct_to_dict(e.props),
                 created_at=e.created_at,
             )
             for e in response.edges
@@ -343,7 +417,7 @@ class ConsoleClient:
                 "source_node_id": item.source_node_id,
                 "thread_id": item.thread_id,
                 "ts": item.ts,
-                "state": json.loads(item.state_json) if item.state_json else {},
+                "state": _struct_to_dict(item.state),
                 "snippet": item.snippet,
             }
             for item in response.items

--- a/dbaas/entdb_server/api/grpc_server.py
+++ b/dbaas/entdb_server/api/grpc_server.py
@@ -31,9 +31,7 @@ from grpc import aio as grpc_aio
 
 from ..metrics import record_grpc_request
 from ..schema.field_id_translation import (
-    id_to_name_keys,
     name_to_id_keys,
-    translate_payload_json_to_names,
 )
 from ..sharding import ShardingConfig
 from .generated import (
@@ -789,18 +787,6 @@ class EntDBServicer(EntDBServiceServicer):
 
         return result
 
-    def _payload_id_to_name_dict(self, n: Any) -> dict[str, Any]:
-        """Egress helper: return the stored payload keyed by field name.
-
-        Reads ``node.payload`` (id-keyed on disk) and uses the schema
-        registry to remap keys.  See :func:`id_to_name_keys`.
-        """
-        return id_to_name_keys(n.payload, n.type_id, self.schema_registry)
-
-    def _payload_id_to_name_json(self, n: Any) -> str:
-        """Egress helper: return a JSON string payload keyed by field name."""
-        return translate_payload_json_to_names(n.payload_json, n.type_id, self.schema_registry)
-
     def _convert_node_ref(self, ref: Any) -> Any:
         """Convert protobuf node reference to internal format."""
         ref_type = ref.WhichOneof("ref")
@@ -928,7 +914,7 @@ class EntDBServicer(EntDBServiceServicer):
                     tenant_id=node.tenant_id,
                     node_id=node.node_id,
                     type_id=node.type_id,
-                    payload=_dict_to_struct(self._payload_id_to_name_dict(node)),
+                    payload=_dict_to_struct(node.payload),
                     created_at=node.created_at,
                     updated_at=node.updated_at,
                     owner_actor=node.owner_actor,
@@ -1070,7 +1056,7 @@ class EntDBServicer(EntDBServiceServicer):
                     tenant_id=n.tenant_id,
                     node_id=n.node_id,
                     type_id=n.type_id,
-                    payload=_dict_to_struct(self._payload_id_to_name_dict(n)),
+                    payload=_dict_to_struct(n.payload),
                     created_at=n.created_at,
                     updated_at=n.updated_at,
                     owner_actor=n.owner_actor,
@@ -1148,7 +1134,7 @@ class EntDBServicer(EntDBServiceServicer):
                         tenant_id=node.tenant_id,
                         node_id=node.node_id,
                         type_id=node.type_id,
-                        payload=_dict_to_struct(self._payload_id_to_name_dict(node)),
+                        payload=_dict_to_struct(node.payload),
                         created_at=node.created_at,
                         updated_at=node.updated_at,
                         owner_actor=node.owner_actor,
@@ -1234,7 +1220,7 @@ class EntDBServicer(EntDBServiceServicer):
                     tenant_id=n.tenant_id,
                     node_id=n.node_id,
                     type_id=n.type_id,
-                    payload=_dict_to_struct(self._payload_id_to_name_dict(n)),
+                    payload=_dict_to_struct(n.payload),
                     created_at=n.created_at,
                     updated_at=n.updated_at,
                     owner_actor=n.owner_actor,
@@ -1565,18 +1551,20 @@ class EntDBServicer(EntDBServiceServicer):
     def _node_to_proto(self, n: Any) -> Node:
         """Convert an internal Node to a protobuf Node message.
 
-        Egress translates the stored id-keyed payload back to name-keyed
-        JSON so clients always see field names (issue #104).
+        Per CLAUDE.md invariant #6 the wire format is field-id-keyed:
+        ``Node.payload`` carries the on-disk dict (e.g. ``{"1": "x"}``)
+        without translation. Clients (Python/Go SDKs) name-translate at
+        the SDK boundary using their own schema registry.
         """
         return Node(
             tenant_id=n.tenant_id,
             node_id=n.node_id,
             type_id=n.type_id,
-            payload_json=self._payload_id_to_name_json(n),
+            payload=_dict_to_struct(n.payload),
             created_at=n.created_at,
             updated_at=n.updated_at,
             owner_actor=n.owner_actor,
-            acl_json=n.acl_json,
+            acl=_acl_list_to_proto(n.acl),
         )
 
     async def GetConnectedNodes(

--- a/sdk/entdb_sdk/_grpc_client.py
+++ b/sdk/entdb_sdk/_grpc_client.py
@@ -198,13 +198,62 @@ class Edge:
     created_at: int
 
 
-def _node_from_proto(n: Any) -> Node:
-    """Build a user-facing Node directly from a proto Node message."""
+def _payload_id_to_name(payload: dict[str, Any], type_id: int, registry: Any) -> dict[str, Any]:
+    """Translate an id-keyed payload dict to a name-keyed payload dict.
+
+    The wire format is field-id-keyed (per ``CLAUDE.md`` invariant #6
+    and the Go SDK contract at ``sdk/go/entdb/marshal.go:342``). The
+    Python SDK exposes payloads to users as name-keyed for ergonomics,
+    so we translate at the SDK boundary using the local schema
+    registry.
+
+    Behavior:
+        * Empty payload → empty dict.
+        * Registry without a definition for ``type_id`` → pass through
+          unchanged (schema-less mode, e.g. raw tests).
+        * Keys that aren't digit strings (legacy / partial migrations)
+          are passed through verbatim.
+        * Unknown id keys are kept as the raw id-string so that
+          forward-compatible clients don't lose data.
+    """
+    if not payload:
+        return {}
+    if registry is None or not hasattr(registry, "get_node_type"):
+        return dict(payload)
+    node_type = registry.get_node_type(type_id)
+    if node_type is None:
+        return dict(payload)
+    id_to_name: dict[int, str] = {}
+    for f in getattr(node_type, "fields", ()) or ():
+        fid = getattr(f, "field_id", None)
+        fname = getattr(f, "name", None)
+        if fid is not None and fname is not None:
+            id_to_name[int(fid)] = fname
+    out: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(key, str) and key.isdigit():
+            name = id_to_name.get(int(key))
+            out[name if name is not None else key] = value
+        else:
+            out[key] = value
+    return out
+
+
+def _node_from_proto(n: Any, registry: Any = None) -> Node:
+    """Build a user-facing Node directly from a proto Node message.
+
+    The wire payload is id-keyed; the SDK translates to name-keyed for
+    ergonomic user code via the supplied schema ``registry``. When no
+    registry is supplied (or the type is not registered) the payload
+    is passed through unchanged.
+    """
+    raw = _struct_to_dict(n.payload)
+    payload = _payload_id_to_name(raw, n.type_id, registry) if registry is not None else raw
     return Node(
         tenant_id=n.tenant_id,
         node_id=n.node_id,
         type_id=n.type_id,
-        payload=_struct_to_dict(n.payload),
+        payload=payload,
         created_at=n.created_at,
         updated_at=n.updated_at,
         owner_actor=n.owner_actor,
@@ -263,6 +312,7 @@ class GrpcClient:
         credentials: grpc.ChannelCredentials | None = None,
         api_key: str | None = None,
         max_retries: int = 3,
+        registry: Any = None,
     ) -> None:
         """Initialize the gRPC client.
 
@@ -273,6 +323,8 @@ class GrpcClient:
             credentials: Optional TLS credentials
             api_key: Optional API key for authentication
             max_retries: Maximum number of retries for transient failures
+            registry: Optional schema registry used to translate the
+                id-keyed wire payload back to user-facing field names.
         """
         self._host = host
         self._port = port
@@ -280,6 +332,7 @@ class GrpcClient:
         self._credentials = credentials
         self._api_key = api_key
         self._max_retries = max_retries
+        self._registry = registry
         self._channel: grpc_aio.Channel | None = None
         self._stub: EntDBServiceStub | None = None
 
@@ -720,7 +773,7 @@ class GrpcClient:
         if not response.found:
             return None
 
-        return _node_from_proto(response.node)
+        return _node_from_proto(response.node, self._registry)
 
     async def get_node_by_key(
         self,
@@ -777,7 +830,7 @@ class GrpcClient:
 
         if not response.found:
             return None
-        return _node_from_proto(response.node)
+        return _node_from_proto(response.node, self._registry)
 
     async def get_nodes(
         self,
@@ -824,7 +877,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        nodes = [_node_from_proto(n) for n in response.nodes]
+        nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
 
         return nodes, list(response.missing_ids)
 
@@ -895,7 +948,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        nodes = [_node_from_proto(n) for n in response.nodes]
+        nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
 
         return nodes, response.has_more
 
@@ -1105,7 +1158,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        return [_node_from_proto(n) for n in response.nodes]
+        return [_node_from_proto(n, self._registry) for n in response.nodes]
 
     async def get_mailbox(
         self,
@@ -1282,7 +1335,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        nodes = [_node_from_proto(n) for n in response.nodes]
+        nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
 
         return nodes, response.has_more
 
@@ -1416,7 +1469,7 @@ class GrpcClient:
             metadata=metadata,
         )
 
-        nodes = [_node_from_proto(n) for n in response.nodes]
+        nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
 
         return nodes, response.has_more
 

--- a/sdk/entdb_sdk/client.py
+++ b/sdk/entdb_sdk/client.py
@@ -646,14 +646,15 @@ class DbClient:
             host = address
             port = 50051  # Default gRPC port
 
+        self.registry = registry or get_registry()
         self._grpc = GrpcClient(
             host=host,
             port=port,
             secure=secure,
             api_key=api_key,
             max_retries=max_retries,
+            registry=self.registry,
         )
-        self.registry = registry or get_registry()
         self._connected = False
         self._last_offsets: dict[str, str] = {}  # tenant_id -> stream_position
         self._schema_fingerprint: str | None = schema_fingerprint

--- a/sdk/go/entdb/payload_roundtrip_test.go
+++ b/sdk/go/entdb/payload_roundtrip_test.go
@@ -1,0 +1,124 @@
+package entdb
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	pb "github.com/elloloop/tenant-shard-db/sdk/go/entdb/internal/pb"
+	"github.com/elloloop/tenant-shard-db/sdk/go/entdb/internal/testpb"
+)
+
+// TestPayloadRoundTrip_IDKeyed_HydratesProtoFields verifies that a
+// field-id-keyed wire payload (the contract per CLAUDE.md invariant
+// #6 and the marshal.go:342 comment) round-trips into the typed
+// proto message via Get[T] without requiring any name fallback.
+//
+// This is the regression test for the PR-D fix: the server now sends
+// id-keyed payloads on read RPCs, and the Go SDK marshal layer must
+// resolve those ids to proto field numbers without dropping data.
+func TestPayloadRoundTrip_IDKeyed_HydratesProtoFields(t *testing.T) {
+	// Build an id-keyed payload exactly as the server now writes it
+	// onto the wire. Keys are "1" (sku), "2" (name), "3" (price_cents).
+	payload, err := structpb.NewStruct(map[string]any{
+		"1": "WIDGET-1",
+		"2": "Widget Deluxe",
+		"3": float64(1499), // structpb stores numerics as float64
+	})
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+
+	svc := &fakeServer{
+		getNodeResp: &pb.GetNodeResponse{
+			Found: true,
+			Node: &pb.Node{
+				TenantId:   "acme",
+				NodeId:     "node-1",
+				TypeId:     201, // testpb.Product type_id
+				OwnerActor: "user:alice",
+				CreatedAt:  1000,
+				UpdatedAt:  2000,
+				Payload:    payload,
+			},
+		},
+	}
+	tr := startFakeServer(t, svc)
+	client := newClientWithTransport("bufnet", tr)
+	scope := client.Tenant("acme").Actor(UserActor("alice"))
+
+	got, err := Get[*testpb.Product](context.Background(), scope, "node-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+
+	// Verify the typed proto fields are populated from id-keyed input.
+	if got.SKU() != "WIDGET-1" {
+		t.Errorf("SKU = %q, want WIDGET-1", got.SKU())
+	}
+	if got.Name() != "Widget Deluxe" {
+		t.Errorf("Name = %q, want Widget Deluxe", got.Name())
+	}
+	if got.PriceCents() != 1499 {
+		t.Errorf("PriceCents = %d, want 1499", got.PriceCents())
+	}
+}
+
+// TestPayloadRoundTrip_QueryReturnsTypedSlice mirrors the GetNode
+// case for Query[T]: id-keyed wire payloads must hydrate the typed
+// slice without any name-key fallback.
+func TestPayloadRoundTrip_QueryReturnsTypedSlice(t *testing.T) {
+	mk := func(sku, name string, price float64) *structpb.Struct {
+		s, err := structpb.NewStruct(map[string]any{
+			"1": sku,
+			"2": name,
+			"3": price,
+		})
+		if err != nil {
+			t.Fatalf("payload: %v", err)
+		}
+		return s
+	}
+
+	svc := &fakeServer{
+		queryResp: &pb.QueryNodesResponse{
+			Nodes: []*pb.Node{
+				{
+					TenantId: "acme",
+					NodeId:   "n1",
+					TypeId:   201,
+					Payload:  mk("A", "Apple", 100),
+				},
+				{
+					TenantId: "acme",
+					NodeId:   "n2",
+					TypeId:   201,
+					Payload:  mk("B", "Banana", 200),
+				},
+			},
+		},
+	}
+	tr := startFakeServer(t, svc)
+	client := newClientWithTransport("bufnet", tr)
+	scope := client.Tenant("acme").Actor(UserActor("alice"))
+
+	got, err := Query[*testpb.Product](context.Background(), scope, nil)
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d products, want 2", len(got))
+	}
+
+	skus := map[string]string{got[0].SKU(): got[0].Name(), got[1].SKU(): got[1].Name()}
+	if skus["A"] != "Apple" {
+		t.Errorf("expected A=Apple, got %v", skus)
+	}
+	if skus["B"] != "Banana" {
+		t.Errorf("expected B=Banana, got %v", skus)
+	}
+}

--- a/tests/integration/test_payload_roundtrip_python.py
+++ b/tests/integration/test_payload_roundtrip_python.py
@@ -1,0 +1,188 @@
+"""
+Round-trip integration test for the Python SDK over gRPC.
+
+Verifies the wire-format invariant introduced in the PR-D fix:
+``Node.payload`` is field-id-keyed on the wire, and the SDK
+translates id → name on the client side using the local schema
+registry. A user writing a proto message with set fields and
+reading the node back must see the same field names in
+``Node.payload``.
+
+We spin up a real ``EntDBServicer`` + ``Applier`` + in-process gRPC
+server on a localhost port, then connect a real ``DbClient`` and
+exercise create + read + query.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import tempfile
+
+import pytest
+from grpc import aio as grpc_aio
+
+from dbaas.entdb_server.api.generated import add_EntDBServiceServicer_to_server
+from dbaas.entdb_server.api.grpc_server import EntDBServicer
+from dbaas.entdb_server.apply.applier import Applier, MailboxFanoutConfig
+from dbaas.entdb_server.apply.canonical_store import CanonicalStore
+from dbaas.entdb_server.global_store import GlobalStore
+from dbaas.entdb_server.schema.registry import SchemaRegistry as ServerSchemaRegistry
+from dbaas.entdb_server.schema.types import FieldDef as ServerFieldDef
+from dbaas.entdb_server.schema.types import FieldKind as ServerFieldKind
+from dbaas.entdb_server.schema.types import NodeTypeDef as ServerNodeTypeDef
+from dbaas.entdb_server.wal.memory import InMemoryWalStream
+from sdk.entdb_sdk import register_proto_schema
+from sdk.entdb_sdk.client import DbClient
+from sdk.entdb_sdk.registry import get_registry, reset_registry
+from tests._test_schemas import test_schema_pb2 as ts
+
+
+def _free_port() -> int:
+    """Grab an unused localhost port for the in-process server."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture
+async def live_server():
+    """Start a real gRPC server with applier + servicer, yield port + sdk_registry."""
+    reset_registry()
+    register_proto_schema(ts)
+    sdk_registry = get_registry()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Server-side schema mirrors the test_schema (Product type 9001).
+        server_registry = ServerSchemaRegistry()
+        server_registry.register_node_type(
+            ServerNodeTypeDef(
+                type_id=9001,
+                name="Product",
+                fields=(
+                    ServerFieldDef(field_id=1, name="sku", kind=ServerFieldKind.STRING),
+                    ServerFieldDef(field_id=2, name="name", kind=ServerFieldKind.STRING),
+                    ServerFieldDef(field_id=3, name="price_cents", kind=ServerFieldKind.INTEGER),
+                    ServerFieldDef(
+                        field_id=4,
+                        name="status",
+                        kind=ServerFieldKind.ENUM,
+                        enum_values=("draft", "active", "archived"),
+                    ),
+                ),
+            )
+        )
+
+        global_store = GlobalStore(tmpdir)
+        await global_store.create_tenant("acme", "Acme")
+        await global_store.create_user("alice", "alice@example.com", "Alice")
+        await global_store.add_member("acme", "alice", role="owner")
+
+        canonical = CanonicalStore(data_dir=tmpdir)
+        await canonical.initialize_tenant("acme")
+
+        wal = InMemoryWalStream(num_partitions=1)
+        await wal.connect()
+
+        applier = Applier(
+            wal=wal,
+            canonical_store=canonical,
+            topic="test-wal",
+            group_id="test",
+            fanout_config=MailboxFanoutConfig(enabled=False),
+            batch_size=1,
+        )
+        applier_task = asyncio.create_task(applier.start())
+
+        servicer = EntDBServicer(
+            wal=wal,
+            canonical_store=canonical,
+            schema_registry=server_registry,
+            topic="test-wal",
+            global_store=global_store,
+        )
+
+        port = _free_port()
+        server = grpc_aio.server()
+        add_EntDBServiceServicer_to_server(servicer, server)
+        server.add_insecure_port(f"127.0.0.1:{port}")
+        await server.start()
+
+        try:
+            yield port, sdk_registry
+        finally:
+            await server.stop(grace=0)
+            await applier.stop()
+            try:
+                await asyncio.wait_for(applier_task, timeout=2.0)
+            except asyncio.TimeoutError:
+                applier_task.cancel()
+            try:
+                await wal.close()
+            except Exception:
+                pass
+            global_store.close()
+            reset_registry()
+
+
+@pytest.mark.asyncio
+async def test_sdk_roundtrip_preserves_named_fields(live_server):
+    """SDK user writes a proto message and reads name-keyed payload back.
+
+    The wire is id-keyed; the SDK translates on egress, so the
+    user-facing ``node.payload`` must round-trip with the original
+    proto field names ('sku', 'name', 'price_cents').
+    """
+    port, sdk_registry = live_server
+
+    async with DbClient(f"127.0.0.1:{port}", registry=sdk_registry) as db:
+        plan = db.atomic("acme", "user:alice")
+        plan.create(
+            ts.Product(sku="WIDGET-1", name="Widget", price_cents=1499),
+            as_="prod1",
+        )
+        result = await plan.commit(wait_applied=True)
+        assert result.success, f"commit failed: {result.error}"
+        assert len(result.created_node_ids) == 1
+        new_id = result.created_node_ids[0]
+
+        product_type = sdk_registry.get_node_type(9001)
+        assert product_type is not None
+        node = await db.get(product_type, new_id, "acme", "user:alice")
+        assert node is not None
+        assert node.payload.get("sku") == "WIDGET-1"
+        assert node.payload.get("name") == "Widget"
+        assert node.payload.get("price_cents") == 1499
+        # No id-keyed leakage (the wire was id-keyed but SDK translated).
+        assert "1" not in node.payload
+        assert "2" not in node.payload
+        assert "3" not in node.payload
+
+
+@pytest.mark.asyncio
+async def test_sdk_roundtrip_query_nodes(live_server):
+    """``DbClient.query`` returns name-keyed payloads to SDK consumers."""
+    port, sdk_registry = live_server
+
+    async with DbClient(f"127.0.0.1:{port}", registry=sdk_registry) as db:
+        plan = db.atomic("acme", "user:alice")
+        plan.create(ts.Product(sku="A", name="Apple", price_cents=100), as_="a")
+        plan.create(ts.Product(sku="B", name="Banana", price_cents=200), as_="b")
+        result = await plan.commit(wait_applied=True)
+        assert result.success, f"commit failed: {result.error}"
+
+        product_type = sdk_registry.get_node_type(9001)
+        nodes = await db.query(product_type, "acme", "user:alice", limit=10)
+        assert len(nodes) == 2
+        for n in nodes:
+            assert "sku" in n.payload, (
+                f"expected name-keyed payload after SDK translation, got {n.payload}"
+            )
+            assert "name" in n.payload
+            assert "price_cents" in n.payload
+            # No id-keyed keys leaked through.
+            assert not any(k.isdigit() for k in n.payload), (
+                f"expected no id-keyed keys, got {n.payload}"
+            )

--- a/tests/unit/test_field_id_storage.py
+++ b/tests/unit/test_field_id_storage.py
@@ -3,7 +3,8 @@ Unit tests for field-ID based payload translation.
 
 Covers the helpers in
 ``dbaas.entdb_server.schema.field_id_translation`` which translate
-between name-keyed (wire) and id-keyed (on-disk) payloads, including:
+between name-keyed (client/SDK ingress) and id-keyed (on-disk and
+on-the-wire) payloads, including:
 
 - ``looks_id_keyed``
 - ``name_to_id_keys``
@@ -11,6 +12,12 @@ between name-keyed (wire) and id-keyed (on-disk) payloads, including:
 - ``translate_payload_json_to_names``
 - ``translate_filter_name_to_id``
 - round-trip + field-rename safety properties
+
+Note: as of PR-D both storage and the gRPC wire are id-keyed; the
+only translation point is the **write ingress** boundary where the
+server accepts name-keyed input from clients and converts to ids
+before persisting. Egress now ships id-keyed payloads to clients,
+which translate to names locally via their own schema registry.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_payload_wire_format.py
+++ b/tests/unit/test_payload_wire_format.py
@@ -1,0 +1,241 @@
+"""
+gRPC wire-format contract for Node.payload.
+
+Per ``CLAUDE.md`` and the Go SDK comment at
+``sdk/go/entdb/marshal.go:342``, the wire format for ``Node.payload``
+is **field-id-keyed** (e.g. ``{"1": "alice@example.com", "2": "..."}``),
+not field-name-keyed. Storage is id-keyed, the wire is id-keyed; the
+only translation point is the **write** boundary, where the server
+accepts name-keyed input from clients and converts to ids before
+storing.
+
+These tests assert the read-path contract: GetNode, GetNodes,
+QueryNodes, SearchNodes, and the payload variants used by the
+ACL v2 handlers (GetConnectedNodes, ListSharedWithMe, etc.) must
+return id-keyed payloads.
+
+Background: prior to this fix, the server applied
+``_payload_id_to_name_dict`` and ``_payload_id_to_name_json`` on the
+read path, which silently translated id-keyed storage → name-keyed
+wire. The Go SDK's marshal layer expects id-keyed and falls back to
+name-matching only as a tolerance. The fallback drops fields silently
+when names disagree (e.g. snake_case proto vs camelCase schema), so a
+write+read round-trip would lose data.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.struct_pb2 import Struct, Value
+
+from dbaas.entdb_server.api.generated import (
+    CreateNodeOp,
+    ExecuteAtomicRequest,
+    GetNodeRequest,
+    GetNodesRequest,
+    Operation,
+    QueryNodesRequest,
+    RequestContext,
+)
+from dbaas.entdb_server.api.grpc_server import EntDBServicer
+from dbaas.entdb_server.apply.applier import Applier, MailboxFanoutConfig
+from dbaas.entdb_server.apply.canonical_store import CanonicalStore
+from dbaas.entdb_server.global_store import GlobalStore
+from dbaas.entdb_server.schema.registry import SchemaRegistry
+from dbaas.entdb_server.schema.types import FieldDef, FieldKind, NodeTypeDef
+from dbaas.entdb_server.wal.memory import InMemoryWalStream
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def setup():
+    """Spin up servicer + applier with a User type registered.
+
+    The User type uses the same shape as the bug report:
+    field_id=1 → email, field_id=2 → password_hash.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        registry = SchemaRegistry()
+        registry.register_node_type(
+            NodeTypeDef(
+                type_id=101,
+                name="User",
+                fields=(
+                    FieldDef(field_id=1, name="email", kind=FieldKind.STRING),
+                    FieldDef(field_id=2, name="password_hash", kind=FieldKind.STRING),
+                ),
+            )
+        )
+
+        global_store = GlobalStore(tmpdir)
+        await global_store.create_tenant("acme", "Acme Corp")
+
+        canonical = CanonicalStore(data_dir=tmpdir)
+        await canonical.initialize_tenant("acme")
+
+        wal = InMemoryWalStream(num_partitions=1)
+        await wal.connect()
+
+        # Drive an Applier so writes through ExecuteAtomic actually land
+        # in canonical_store and are visible to subsequent reads.
+        applier = Applier(
+            wal=wal,
+            canonical_store=canonical,
+            topic="test-wal",
+            group_id="test",
+            fanout_config=MailboxFanoutConfig(enabled=False),
+            batch_size=1,
+        )
+
+        servicer = EntDBServicer(
+            wal=wal,
+            canonical_store=canonical,
+            schema_registry=registry,
+            topic="test-wal",
+            global_store=global_store,
+        )
+
+        applier_task = asyncio.create_task(applier.start())
+        await asyncio.sleep(0.05)
+
+        try:
+            yield servicer, applier
+        finally:
+            await applier.stop()
+            try:
+                await asyncio.wait_for(applier_task, timeout=2.0)
+            except asyncio.TimeoutError:
+                applier_task.cancel()
+            try:
+                await wal.close()
+            except Exception:
+                pass
+            global_store.close()
+
+
+def _name_keyed_struct(d: dict) -> Struct:
+    """Build a Struct with name-keyed payload (the SDK wire shape on writes)."""
+    s = Struct()
+    for k, v in d.items():
+        s.fields[k].CopyFrom(Value(string_value=v))
+    return s
+
+
+async def _write_user(servicer, payload_name_keyed: dict, node_id: str = "user-1") -> None:
+    """Drive a write through ExecuteAtomic with name-keyed payload (the SDK convention)."""
+    ctx = AsyncMock()
+    ctx.abort = AsyncMock()
+    request = ExecuteAtomicRequest(
+        context=RequestContext(tenant_id="acme", actor="user:alice"),
+        idempotency_key=f"idem-{node_id}-{int(time.time() * 1e6)}",
+        operations=[
+            Operation(
+                create_node=CreateNodeOp(
+                    type_id=101,
+                    id=node_id,
+                    data=_name_keyed_struct(payload_name_keyed),
+                )
+            )
+        ],
+        wait_applied=True,
+        wait_timeout_ms=2000,
+    )
+    resp = await servicer.ExecuteAtomic(request, ctx)
+    assert resp.success, f"ExecuteAtomic failed: {resp.error}"
+
+
+# ── Tests ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_node_returns_id_keyed_payload(setup):
+    """GetNode must return id-keyed payload on the wire (not name-keyed).
+
+    The user's repro: write a User with email + password_hash; the read
+    side must surface the values keyed by field_id ('1', '2'), per the
+    documented invariant that translation only happens at the write
+    ingress boundary.
+    """
+    servicer, _ = setup
+    await _write_user(
+        servicer,
+        {"email": "alice@example.com", "password_hash": "$2a$ZZZ"},
+    )
+
+    ctx = AsyncMock()
+    ctx.abort = AsyncMock()
+    resp = await servicer.GetNode(
+        GetNodeRequest(
+            context=RequestContext(tenant_id="acme", actor="user:alice"),
+            type_id=101,
+            node_id="user-1",
+        ),
+        ctx,
+    )
+
+    assert resp.found is True
+    payload = MessageToDict(resp.node.payload)
+    assert payload == {
+        "1": "alice@example.com",
+        "2": "$2a$ZZZ",
+    }, f"expected id-keyed payload on the wire, got {payload}"
+
+
+@pytest.mark.asyncio
+async def test_get_nodes_returns_id_keyed_payload(setup):
+    """GetNodes (batch) must return id-keyed payloads on the wire."""
+    servicer, _ = setup
+    await _write_user(servicer, {"email": "a@x.com", "password_hash": "ha"}, node_id="u1")
+    await _write_user(servicer, {"email": "b@x.com", "password_hash": "hb"}, node_id="u2")
+
+    ctx = AsyncMock()
+    ctx.abort = AsyncMock()
+    resp = await servicer.GetNodes(
+        GetNodesRequest(
+            context=RequestContext(tenant_id="acme", actor="user:alice"),
+            type_id=101,
+            node_ids=["u1", "u2"],
+        ),
+        ctx,
+    )
+
+    assert len(resp.nodes) == 2
+    for node in resp.nodes:
+        payload = MessageToDict(node.payload)
+        assert set(payload.keys()) == {"1", "2"}, (
+            f"expected id-keyed keys for node {node.node_id}, got {payload}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_query_nodes_returns_id_keyed_payload(setup):
+    """QueryNodes must return id-keyed payloads on the wire."""
+    servicer, _ = setup
+    await _write_user(
+        servicer, {"email": "alice@example.com", "password_hash": "$2a$"}, node_id="u1"
+    )
+
+    ctx = AsyncMock()
+    ctx.abort = AsyncMock()
+    resp = await servicer.QueryNodes(
+        QueryNodesRequest(
+            context=RequestContext(tenant_id="acme", actor="user:alice"),
+            type_id=101,
+            limit=10,
+        ),
+        ctx,
+    )
+
+    assert len(resp.nodes) >= 1
+    payload = MessageToDict(resp.nodes[0].payload)
+    assert payload.get("1") == "alice@example.com"
+    assert payload.get("2") == "$2a$"
+    assert "email" not in payload, "wire must be id-keyed, found 'email' key"
+    assert "password_hash" not in payload, "wire must be id-keyed, found 'password_hash' key"


### PR DESCRIPTION
## Summary

Restores the documented gRPC wire-format invariant for `Node.payload`: it is now **field-id-keyed** end-to-end (storage and wire), with name-translation isolated to the **write ingress** boundary on the server and the **read** boundary inside each SDK.

Prior to this PR, the server applied id→name translation on every read RPC, which silently disagreed with the Go SDK's marshal layer (sdk/go/entdb/marshal.go:342 explicitly expects id-keyed and uses name-matching only as a tolerant fallback). When the wire name disagreed with the proto field name (snake_case vs camelCase, schema not registered, etc.), the fallback `continue`d on the unmappable key and silently dropped fields. A write+read round-trip would therefore lose data.

## Why

- CLAUDE.md invariant #6: *"Payloads are stored keyed by `field_id`. Translation happens at the gRPC boundary only."* — the boundary is **write ingress**, not read egress.
- Go SDK: `applyPayloadToMessage` parses keys with `strconv.Atoi(key)` first; the name lookup is only a forgiveness path for hand-rolled callers.
- The reserved proto fields `payload_json` / `acl_json` / `props_json` / `state_json` / `schema_json` (removed in #150) confirm the move to typed Struct on the wire — this PR finishes wiring the read path to that shape.

## What changed

**Server** — `dbaas/entdb_server/api/grpc_server.py`
- Drop `_payload_id_to_name_dict` / `_payload_id_to_name_json` helpers and the 5 read-path callers (GetNode, SearchNodes, GetNodes, QueryNodes, `_node_to_proto`). Pass `node.payload` (id-keyed dict) directly into `_dict_to_struct`.
- `_node_to_proto` (used by GetConnectedNodes / ListSharedWithMe) previously assigned to the reserved `payload_json` / `acl_json` proto fields and would have raised `ValueError` at runtime. Switched to the live `payload` Struct + repeated `AclEntry` shape.

**Python SDK** — `sdk/entdb_sdk/_grpc_client.py`, `sdk/entdb_sdk/client.py`
- Added `_payload_id_to_name()` helper that translates id-keyed payloads back to name-keyed dicts via the local schema registry (preserves backward-compat for SDK consumers).
- `GrpcClient` now accepts an optional `registry`; `DbClient` passes its own registry through. `_node_from_proto` consults the registry on every read so SDK consumers continue to see name-keyed `Node.payload`.

**Console gateway** — `console/gateway/console_client.py`
- The previous code accessed the reserved `payload_json` / `schema_json` / `props_json` / `state_json` fields and was broken at runtime against the current proto. Switched to the live Struct fields and added a per-tenant schema cache + id→name translator (`_get_id_to_name_map`, `_translate_payload`) that lazy-loads via `GetSchema`.

## Tests added

- `tests/unit/test_payload_wire_format.py` — failing-first server contract test (3 tests) asserting GetNode / GetNodes / QueryNodes return id-keyed Struct payloads. Drives writes through `ExecuteAtomic` against a real Servicer + Applier + CanonicalStore + GlobalStore.
- `tests/integration/test_payload_roundtrip_python.py` — end-to-end test (2 tests) through a real in-process gRPC server + `DbClient`: write a proto `Product`, read it back, verify the user-facing payload is name-keyed (SDK translated). Uses the existing `tests/_test_schemas/test_schema.proto`.
- `sdk/go/entdb/payload_roundtrip_test.go` — Go SDK round-trip (2 tests) exercising `Get[*Product]` and `Query[*Product]` over an id-keyed wire payload via the existing `fakeServer` pattern from `grpc_transport_test.go`.

## Backward-compat notes

- SDK consumers continue to see name-keyed `Node.payload` (Python and Go both translate at the SDK boundary using their local schema registry). No SDK API change; only behaviour parity restored.
- Hand-rolled gRPC clients that read `Node.payload` directly will now see id-keyed keys (`{"1": "..."}` instead of `{"email": "..."}`). The gRPC API was marked internal in #150, so this is documented breakage and the only supported clients are the two SDKs.

## Files changed

- 4 modified (server, Python SDK x2, Console)
- 1 modified docstring (`tests/unit/test_field_id_storage.py`)
- 3 new test files (Python unit, Python integration, Go SDK)

## Test plan

- [x] `python -m pytest tests/unit/ tests/integration/ -q` — 2362 tests pass
- [x] `uvx ruff@0.15.7 check .` — clean
- [x] `uvx ruff@0.15.7 format --check .` — clean
- [x] `cd sdk/go/entdb && go vet ./... && go test ./...` — pass