### PR TITLE
SDK tenant→endpoint redirect cache (PR-C, Option D)

### DIFF
--- a/dbaas/entdb_server/api/grpc_server.py
+++ b/dbaas/entdb_server/api/grpc_server.py
@@ -18,6 +18,7 @@ How to change safely:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -358,10 +359,35 @@ class EntDBServicer(EntDBServiceServicer):
         )
 
     async def _check_tenant(self, tenant_id: str, context) -> None:
-        """Reject requests for tenants not owned by this node."""
+        """Reject requests for tenants not owned by this node.
+
+        When the sharding registry knows which node owns the tenant
+        we attach the owner's ``node_id`` as a trailing metadata
+        entry (``entdb-redirect-node``) before aborting. SDKs use
+        this header to resolve the correct endpoint and retry the
+        RPC there — see ``sdk/go/entdb/redirect_cache.go`` and
+        ``sdk/entdb_sdk/_redirect_cache.py``. The human-readable
+        ``(try node X)`` tail of the error message is preserved for
+        log readability and for older SDKs that don't parse the
+        trailer.
+        """
         if self._sharding and not self._sharding.is_mine(tenant_id):
             owner = self._sharding.get_owner(tenant_id)
             hint = f" (try node {owner})" if owner else ""
+            if owner:
+                # Set the trailer FIRST — once ``abort`` is awaited
+                # the call is closed and trailers are flushed with it.
+                # ``set_trailing_metadata`` on a grpc.aio
+                # ServicerContext is *synchronous* (returns None)
+                # despite the rest of the surface being awaitable. We
+                # await it conditionally so the same call site works
+                # against a unit-test ``AsyncMock`` (which always
+                # returns a coroutine).
+                _trailer_result = context.set_trailing_metadata(
+                    (("entdb-redirect-node", owner),),
+                )
+                if asyncio.iscoroutine(_trailer_result):
+                    await _trailer_result
             await context.abort(
                 grpc.StatusCode.UNAVAILABLE,
                 f"Tenant '{tenant_id}' is not served by this node{hint}",

--- a/sdk/entdb_sdk/__init__.py
+++ b/sdk/entdb_sdk/__init__.py
@@ -32,6 +32,11 @@ Example::
 See ``docs/decisions/sdk_api.md`` for the design rationale.
 """
 
+from ._redirect_cache import (
+    DNSTemplateResolver,
+    NodeResolver,
+    StaticMapResolver,
+)
 from ._version import __version__
 from .client import DbClient, Plan, Receipt
 from .codegen import register_proto_schema
@@ -112,4 +117,8 @@ __all__ = [
     "Mailbox",
     "Public",
     "Storage",
+    # Tenant redirect cache (Option D, PR-C)
+    "NodeResolver",
+    "DNSTemplateResolver",
+    "StaticMapResolver",
 ]

--- a/sdk/entdb_sdk/_grpc_client.py
+++ b/sdk/entdb_sdk/_grpc_client.py
@@ -152,6 +152,38 @@ _RETRYABLE_STATUS_CODES = frozenset(
 _DEFAULT_TIMEOUT: float = 30.0
 
 
+def _multicallable_rebinder(fn: Any):
+    """Return a callable ``(channel) -> new_multicallable`` that
+    re-issues ``fn``'s RPC on a different gRPC AIO channel.
+
+    The grpc.aio stub binds each RPC to a fixed channel; to follow
+    a redirect we need an equivalent multicallable on the redirect
+    target's channel. We read the method path and serializers from
+    the original — these are stable across the grpc-python releases
+    used by the SDK (see the ``UnaryUnaryMultiCallable`` API).
+
+    Returns ``None`` for callables we can't recognise (e.g. a
+    custom test fake), so the caller can skip the redirect path
+    rather than raising a confusing AttributeError.
+    """
+    method = getattr(fn, "_method", None)
+    if method is None:
+        return None
+    request_serializer = getattr(fn, "_request_serializer", None)
+    response_deserializer = getattr(fn, "_response_deserializer", None)
+
+    method_str = method.decode() if isinstance(method, (bytes, bytearray)) else method
+
+    def _rebind(channel: grpc_aio.Channel):
+        return channel.unary_unary(
+            method_str,
+            request_serializer=request_serializer,
+            response_deserializer=response_deserializer,
+        )
+
+    return _rebind
+
+
 @dataclass
 class Node:
     """A node from the database.
@@ -313,6 +345,7 @@ class GrpcClient:
         api_key: str | None = None,
         max_retries: int = 3,
         registry: Any = None,
+        node_resolver: Any | None = None,
     ) -> None:
         """Initialize the gRPC client.
 
@@ -325,6 +358,11 @@ class GrpcClient:
             max_retries: Maximum number of retries for transient failures
             registry: Optional schema registry used to translate the
                 id-keyed wire payload back to user-facing field names.
+            node_resolver: Optional :class:`NodeResolver` used to map
+                server-issued ``node_id`` redirect hints to dial-able
+                endpoints. When set, the SDK transparently caches a
+                sub-channel per tenant the first time the server
+                redirects, and routes future calls there.
         """
         self._host = host
         self._port = port
@@ -335,6 +373,28 @@ class GrpcClient:
         self._registry = registry
         self._channel: grpc_aio.Channel | None = None
         self._stub: EntDBServiceStub | None = None
+        self._node_resolver = node_resolver
+        # Lazily initialised on first connect — see
+        # ``_redirect_cache.py`` for the design.
+        self._redirect_cache: Any = None
+
+    def _open_channel(self, address: str) -> grpc_aio.Channel:
+        """Open a gRPC channel mirroring the client's TLS settings.
+
+        Used both for the primary connection and for the per-tenant
+        sub-channels managed by the redirect cache.
+        """
+        if self._secure:
+            if self._credentials:
+                return grpc_aio.secure_channel(address, self._credentials)
+            return grpc_aio.secure_channel(address, grpc.ssl_channel_credentials())
+        return grpc_aio.insecure_channel(
+            address,
+            options=[
+                ("grpc.max_send_message_length", 50 * 1024 * 1024),
+                ("grpc.max_receive_message_length", 50 * 1024 * 1024),
+            ],
+        )
 
     async def connect(self) -> None:
         """Establish connection to the server."""
@@ -342,29 +402,20 @@ class GrpcClient:
             return
 
         address = f"{self._host}:{self._port}"
-
-        if self._secure:
-            if self._credentials:
-                self._channel = grpc_aio.secure_channel(address, self._credentials)
-            else:
-                self._channel = grpc_aio.secure_channel(
-                    address,
-                    grpc.ssl_channel_credentials(),
-                )
-        else:
-            self._channel = grpc_aio.insecure_channel(
-                address,
-                options=[
-                    ("grpc.max_send_message_length", 50 * 1024 * 1024),
-                    ("grpc.max_receive_message_length", 50 * 1024 * 1024),
-                ],
-            )
-
+        self._channel = self._open_channel(address)
         self._stub = EntDBServiceStub(self._channel)
+
+        if self._node_resolver is not None:
+            from ._redirect_cache import TenantEndpointCache
+
+            self._redirect_cache = TenantEndpointCache(channel_factory=self._open_channel)
         logger.debug(f"Connected to EntDB server at {address}")
 
     async def close(self) -> None:
         """Close the connection."""
+        if self._redirect_cache is not None:
+            await self._redirect_cache.close()
+            self._redirect_cache = None
         if self._channel:
             await self._channel.close()
             self._channel = None
@@ -406,28 +457,97 @@ class GrpcClient:
         fn: Any,
         *args: Any,
         max_retries: int | None = None,
+        tenant_id: str = "",
         **kwargs: Any,
     ) -> Any:
-        """Retry on transient gRPC errors (UNAVAILABLE, DEADLINE_EXCEEDED).
+        """Retry on transient gRPC errors and follow tenant redirects.
+
+        Behaviour:
+            - On UNAVAILABLE / DEADLINE_EXCEEDED, retry with
+              exponential backoff up to ``max_retries`` times.
+            - On UNAVAILABLE with the ``entdb-redirect-node``
+              trailing metadata header (and a non-empty
+              ``tenant_id``), resolve the node, dial a sub-channel,
+              cache it, and re-issue the call against the cached
+              endpoint. Counts as the redirect retry — does not
+              consume the transient-failure budget.
+            - On UNAVAILABLE against an already-cached sub-channel,
+              evict the cache entry so the next call falls back to
+              the primary endpoint.
 
         Args:
-            fn: Async callable to retry
-            *args: Positional arguments for fn
-            max_retries: Override for max retry attempts
-            **kwargs: Keyword arguments for fn
-
-        Returns:
-            Result of the callable
-
-        Raises:
-            grpc.RpcError: If all retries are exhausted or error is non-retryable
+            fn: Bound stub method (e.g. ``stub.GetNode``).
+            *args: Positional arguments for fn.
+            max_retries: Override for max retry attempts.
+            tenant_id: Tenant id of the call. Required for the
+                redirect path; pass ``""`` for tenant-agnostic RPCs
+                (Health, CreateUser, ...).
+            **kwargs: Keyword arguments for fn.
         """
+        from ._redirect_cache import extract_redirect_node
+
+        # ``fn`` is a UnaryUnaryMultiCallable bound to a specific
+        # channel. To re-issue the same RPC on a different channel
+        # we re-create the multicallable from the call's
+        # ``_method`` path and serializers — these are stable,
+        # non-public attributes maintained by grpc.aio across
+        # versions used in the SDK.
+        rebind = _multicallable_rebinder(fn)
+
+        # If we already cached an endpoint for this tenant, route
+        # the first attempt there.
+        if tenant_id and self._redirect_cache is not None and rebind is not None:
+            entry = await self._redirect_cache.get(tenant_id)
+            if entry is not None:
+                fn = rebind(entry.channel)
+                rebind = _multicallable_rebinder(fn)
+
         retries = max_retries if max_retries is not None else self._max_retries
         last_error: grpc.RpcError | None = None
         for attempt in range(retries + 1):
             try:
                 return await fn(*args, **kwargs)
             except grpc.RpcError as e:
+                # Redirect path: server says "try node X" — resolve,
+                # cache, retry once on the new sub-channel.
+                node_id = extract_redirect_node(e)
+                if (
+                    node_id
+                    and tenant_id
+                    and self._redirect_cache is not None
+                    and self._node_resolver is not None
+                    and rebind is not None
+                ):
+                    try:
+                        endpoint = self._node_resolver.resolve(node_id)
+                    except LookupError:
+                        # No endpoint — surface the original error.
+                        raise e from None
+                    entry = await self._redirect_cache.store(tenant_id, endpoint)
+                    redirected = rebind(entry.channel)
+                    try:
+                        return await redirected(*args, **kwargs)
+                    except grpc.RpcError as redir_err:
+                        # If the redirect target is also broken,
+                        # evict so we don't keep using a bad
+                        # sub-channel and fall through to the
+                        # transient-retry logic below.
+                        if redir_err.code() == grpc.StatusCode.UNAVAILABLE:
+                            await self._redirect_cache.evict(tenant_id)
+                        raise
+                # If the call failed against a cached sub-channel,
+                # evict so the next call falls back to the primary
+                # endpoint (tenant may have moved).
+                primary_channel = getattr(self._stub, "_channel", None) if self._stub else None
+                fn_channel = getattr(fn, "_channel", None)
+                if (
+                    e.code() == grpc.StatusCode.UNAVAILABLE
+                    and tenant_id
+                    and self._redirect_cache is not None
+                    and fn_channel is not None
+                    and fn_channel is not primary_channel
+                ):
+                    await self._redirect_cache.evict(tenant_id)
                 if e.code() not in _RETRYABLE_STATUS_CODES or attempt == retries:
                     raise
                 last_error = e
@@ -484,6 +604,7 @@ class GrpcClient:
                 request,
                 timeout=timeout or _DEFAULT_TIMEOUT,
                 metadata=metadata,
+                tenant_id=tenant_id,
             )
 
             receipt = None
@@ -676,6 +797,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         status_map = {
@@ -721,6 +843,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return response.reached, response.current_position
@@ -768,6 +891,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         if not response.found:
@@ -826,6 +950,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         if not response.found:
@@ -875,6 +1000,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
@@ -946,6 +1072,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
@@ -992,6 +1119,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         edges = [_edge_from_proto(e) for e in response.edges]
@@ -1038,6 +1166,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         edges = [_edge_from_proto(e) for e in response.edges]
@@ -1091,6 +1220,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return [
@@ -1156,6 +1286,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return [_node_from_proto(n, self._registry) for n in response.nodes]
@@ -1209,6 +1340,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         items = [
@@ -1333,6 +1465,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
@@ -1385,6 +1518,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return response.success
@@ -1426,6 +1560,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return response.found
@@ -1467,6 +1602,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
@@ -1513,6 +1649,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return response.success
@@ -1554,6 +1691,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return response.success
@@ -1595,6 +1733,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return response.found
@@ -1837,6 +1976,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         result: dict[str, Any] = {
@@ -1883,6 +2023,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         if not response.found:
@@ -1926,6 +2067,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return {
@@ -1969,6 +2111,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return {
@@ -2009,6 +2152,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return {
@@ -2046,6 +2190,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return [
@@ -2136,6 +2281,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
 
         return {
@@ -2180,6 +2326,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
         return {
             "success": response.success,
@@ -2228,6 +2375,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
         return {
             "success": response.success,
@@ -2269,6 +2417,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
         return {
             "success": response.success,
@@ -2312,6 +2461,7 @@ class GrpcClient:
             request,
             timeout=timeout or _DEFAULT_TIMEOUT,
             metadata=metadata,
+            tenant_id=tenant_id,
         )
         return {
             "success": response.success,

--- a/sdk/entdb_sdk/_redirect_cache.py
+++ b/sdk/entdb_sdk/_redirect_cache.py
@@ -1,0 +1,192 @@
+"""
+Tenant-to-endpoint redirect cache for the Python EntDB SDK.
+
+Mirrors the Go SDK design: when the server returns ``UNAVAILABLE``
+with an ``entdb-redirect-node`` trailing metadata header, the SDK
+resolves the node id to a dial-able endpoint, opens a sub-channel,
+caches it keyed by ``tenant_id``, and routes future calls for that
+tenant directly there. No TTL — tenants don't move unless a node
+crashes, and connection-failure on the cached sub-channel evicts
+the entry.
+
+Public surface:
+    - :class:`NodeResolver` — protocol for ``node_id -> endpoint``.
+    - :class:`DNSTemplateResolver` — default; resolves
+      ``node-a`` to ``node-a.<base_domain>:<port>``.
+    - :class:`StaticMapResolver` — explicit map, for tests and for
+      static deployments without DNS.
+    - :class:`TenantEndpointCache` — internal sync-safe cache used
+      by :class:`entdb_sdk._grpc_client.GrpcClient`.
+
+These names are re-exported from :mod:`entdb_sdk` so user code can
+construct a resolver without importing the underscore module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Protocol
+
+import grpc
+from grpc import aio as grpc_aio
+
+REDIRECT_TRAILER_KEY = "entdb-redirect-node"
+"""Trailing-metadata header name the server sets when redirecting.
+
+Mirrored on the Go SDK side as ``redirectTrailerKey``.
+"""
+
+
+class NodeResolver(Protocol):
+    """Maps a server-issued ``node_id`` to a dial-able endpoint.
+
+    Implementations must be safe to call from multiple coroutines.
+    The resolver result is cached by the client until a connection
+    error invalidates it; resolvers should NOT introduce their own
+    TTL.
+    """
+
+    def resolve(self, node_id: str) -> str:
+        """Return ``host:port`` for ``node_id`` or raise ``LookupError``."""
+        ...
+
+
+@dataclass
+class DNSTemplateResolver:
+    """Default resolver — composes ``<node_id>.<base_domain>:<port>``.
+
+    The default port is 50051 (the EntDB gRPC port). For Kubernetes
+    deployments backed by a headless StatefulSet, point
+    ``base_domain`` at the service domain (e.g.
+    ``entdb.svc.cluster.local``) and each shard pod is reachable
+    via its own DNS record.
+    """
+
+    base_domain: str
+    port: int = 50051
+
+    def resolve(self, node_id: str) -> str:
+        if not node_id:
+            raise LookupError("entdb: empty node_id")
+        if not self.base_domain:
+            raise LookupError("entdb: DNSTemplateResolver.base_domain not set")
+        return f"{node_id}.{self.base_domain}:{self.port}"
+
+
+@dataclass
+class StaticMapResolver:
+    """Explicit ``node_id -> endpoint`` map.
+
+    Use this for tests (DNS isn't available in most test
+    environments) or for tiny static deployments.
+    """
+
+    endpoints: dict[str, str]
+
+    def resolve(self, node_id: str) -> str:
+        if not node_id:
+            raise LookupError("entdb: empty node_id")
+        try:
+            return self.endpoints[node_id]
+        except KeyError as e:
+            raise LookupError(f"entdb: no endpoint for node {node_id!r}") from e
+
+
+@dataclass
+class _CachedEndpoint:
+    """A cached ``endpoint -> channel`` pair."""
+
+    endpoint: str
+    channel: grpc_aio.Channel
+
+
+class TenantEndpointCache:
+    """Thread- and coroutine-safe ``tenant_id -> sub-channel`` cache.
+
+    Entries are populated when the SDK is redirected by the server
+    (``entdb-redirect-node`` trailer). The cache reuses the same
+    sub-channel when multiple tenants share an endpoint.
+
+    Eviction:
+        - :meth:`evict` is called by the client on connection
+          failures against the cached sub-channel.
+        - :meth:`close` shuts every sub-channel down when the
+          client is disposed.
+    """
+
+    def __init__(
+        self,
+        channel_factory,
+    ) -> None:
+        """Initialize.
+
+        Args:
+            channel_factory: Callable ``(endpoint) -> grpc.aio.Channel``
+                used to open sub-channels. The default implementation
+                in ``GrpcClient`` mirrors the primary channel's TLS /
+                credentials settings.
+        """
+        self._factory = channel_factory
+        self._lock = asyncio.Lock()
+        self._entries: dict[str, _CachedEndpoint] = {}
+
+    async def get(self, tenant_id: str) -> _CachedEndpoint | None:
+        async with self._lock:
+            return self._entries.get(tenant_id)
+
+    async def store(self, tenant_id: str, endpoint: str) -> _CachedEndpoint:
+        async with self._lock:
+            # Reuse existing channels by endpoint — multiple
+            # tenants frequently land on the same node.
+            for entry in self._entries.values():
+                if entry.endpoint == endpoint:
+                    self._entries[tenant_id] = entry
+                    return entry
+            channel = self._factory(endpoint)
+            entry = _CachedEndpoint(endpoint=endpoint, channel=channel)
+            self._entries[tenant_id] = entry
+            return entry
+
+    async def evict(self, tenant_id: str) -> None:
+        async with self._lock:
+            entry = self._entries.pop(tenant_id, None)
+            if entry is None:
+                return
+            # Only close the channel if no other tenant uses it.
+            if not any(e.endpoint == entry.endpoint for e in self._entries.values()):
+                await entry.channel.close()
+
+    async def close(self) -> None:
+        async with self._lock:
+            seen: set[int] = set()
+            for entry in self._entries.values():
+                if id(entry.channel) in seen:
+                    continue
+                seen.add(id(entry.channel))
+                try:
+                    await entry.channel.close()
+                except Exception:  # pragma: no cover — best-effort teardown
+                    pass
+            self._entries.clear()
+
+
+def extract_redirect_node(error: grpc.RpcError) -> str | None:
+    """Return the ``entdb-redirect-node`` trailer value, or None.
+
+    Tries both ``trailing_metadata()`` (grpc.aio call objects expose
+    this directly) and the AioRpcError fallback. The header is
+    normalised to lowercase by gRPC.
+    """
+    if error.code() != grpc.StatusCode.UNAVAILABLE:
+        return None
+    try:
+        trailers = error.trailing_metadata()
+    except (AttributeError, TypeError):
+        return None
+    if trailers is None:
+        return None
+    for key, val in trailers:
+        if key.lower() == REDIRECT_TRAILER_KEY:
+            return val
+    return None

--- a/sdk/entdb_sdk/client.py
+++ b/sdk/entdb_sdk/client.py
@@ -622,6 +622,8 @@ class DbClient:
         registry: SchemaRegistry | None = None,
         schema_module: Any | None = None,
         schema_fingerprint: str | None = None,
+        node_resolver: Any | None = None,
+        base_domain: str | None = None,
     ) -> None:
         """Initialize client.
 
@@ -637,6 +639,17 @@ class DbClient:
                 every write for server-side version checks.
             schema_fingerprint: Optional explicit schema fingerprint. Takes
                 precedence over ``schema_module`` and the registry.
+            node_resolver: Optional :class:`NodeResolver` used to map
+                server-issued ``node_id`` redirect hints to dial-able
+                endpoints. When set the SDK transparently caches a
+                sub-channel per tenant on first redirect and routes
+                future calls there.
+            base_domain: Convenience for the common DNS-template case.
+                ``base_domain="entdb.svc.cluster.local"`` installs a
+                :class:`DNSTemplateResolver` that resolves
+                ``node-a`` to ``node-a.entdb.svc.cluster.local:50051``.
+                Mutually exclusive with ``node_resolver`` — if both
+                are provided ``node_resolver`` wins.
         """
         # Parse address
         if ":" in address:
@@ -647,6 +660,11 @@ class DbClient:
             port = 50051  # Default gRPC port
 
         self.registry = registry or get_registry()
+        if node_resolver is None and base_domain:
+            from ._redirect_cache import DNSTemplateResolver
+
+            node_resolver = DNSTemplateResolver(base_domain=base_domain)
+
         self._grpc = GrpcClient(
             host=host,
             port=port,
@@ -654,6 +672,7 @@ class DbClient:
             api_key=api_key,
             max_retries=max_retries,
             registry=self.registry,
+            node_resolver=node_resolver,
         )
         self._connected = False
         self._last_offsets: dict[str, str] = {}  # tenant_id -> stream_position

--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -212,6 +212,11 @@ type grpcTransport struct {
 	config  clientConfig
 	conn    *grpc.ClientConn
 	client  pb.EntDBServiceClient
+	// redirectCache is non-nil when the client was constructed
+	// with a [NodeResolver] (via [WithNodeResolver] or
+	// [WithBaseDomain]). It caches per-tenant sub-channels for
+	// nodes the SDK has been redirected to.
+	redirectCache *tenantEndpointCache
 }
 
 func newGRPCTransport(address string, cfg clientConfig) *grpcTransport {
@@ -225,23 +230,44 @@ func newGRPCTransport(address string, cfg clientConfig) *grpcTransport {
 // API keys) to the outgoing context. Done on every call rather
 // than on the dial to match the Python SDK's behaviour — the
 // metadata is per-call, not per-channel.
-func (t *grpcTransport) callContext(ctx context.Context) context.Context {
-	if t.config.apiKey == "" {
-		return ctx
+//
+// When ``tenantID`` is non-empty it is also stamped onto the
+// outgoing context as ``entdb-tenant-id``. The redirect
+// interceptor (see ``redirect_cache.go``) reads this header to
+// route the call against a cached sub-channel without having to
+// reflect over every request type.
+func (t *grpcTransport) callContext(ctx context.Context, tenantID string) context.Context {
+	if t.config.apiKey != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+t.config.apiKey)
 	}
-	return metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+t.config.apiKey)
+	if tenantID != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, outgoingTenantHeader, tenantID)
+	}
+	return ctx
 }
 
 func (t *grpcTransport) Connect(_ context.Context) error {
-	var creds credentials.TransportCredentials
-	if t.config.secure {
-		creds = credentials.NewTLS(nil)
-	} else {
-		creds = insecure.NewCredentials()
+	// When a NodeResolver is configured, the redirect cache holds
+	// per-tenant sub-channels and a unary interceptor routes calls
+	// onto them transparently. The cache uses the same dial
+	// settings (TLS / insecure / explicit dial options) as the
+	// primary connection.
+	if t.config.nodeResolver != nil && t.redirectCache == nil {
+		t.redirectCache = newTenantEndpointCache(dialerFromConfig(t.config))
 	}
 
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(creds),
+	opts := append([]grpc.DialOption(nil), t.config.dialOptions...)
+	if !hasTransportCreds(opts) {
+		var creds credentials.TransportCredentials
+		if t.config.secure {
+			creds = credentials.NewTLS(nil)
+		} else {
+			creds = insecure.NewCredentials()
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	}
+	if interceptor := redirectInterceptor(t.config.nodeResolver, t.redirectCache); interceptor != nil {
+		opts = append(opts, grpc.WithUnaryInterceptor(interceptor))
 	}
 
 	conn, err := grpc.NewClient(t.address, opts...)
@@ -254,6 +280,9 @@ func (t *grpcTransport) Connect(_ context.Context) error {
 }
 
 func (t *grpcTransport) Close() error {
+	if t.redirectCache != nil {
+		t.redirectCache.closeAll()
+	}
 	if t.conn != nil {
 		err := t.conn.Close()
 		t.conn = nil
@@ -281,7 +310,7 @@ func (t *grpcTransport) GetNode(ctx context.Context, tenantID, actor string, typ
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetNode(t.callContext(ctx), &pb.GetNodeRequest{
+	resp, err := client.GetNode(t.callContext(ctx, tenantID), &pb.GetNodeRequest{
 		Context: &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		TypeId:  int32(typeID),
 		NodeId:  nodeID,
@@ -301,7 +330,7 @@ func (t *grpcTransport) GetNodeByKey(ctx context.Context, tenantID, actor string
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetNodeByKey(t.callContext(ctx), &pb.GetNodeByKeyRequest{
+	resp, err := client.GetNodeByKey(t.callContext(ctx, tenantID), &pb.GetNodeByKeyRequest{
 		TenantId: tenantID,
 		Actor:    actor,
 		TypeId:   typeID,
@@ -327,7 +356,7 @@ func (t *grpcTransport) QueryNodes(ctx context.Context, tenantID, actor string, 
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.QueryNodes(t.callContext(ctx), &pb.QueryNodesRequest{
+	resp, err := client.QueryNodes(t.callContext(ctx, tenantID), &pb.QueryNodesRequest{
 		Context: &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		TypeId:  int32(typeID),
 		Filters: filters,
@@ -353,7 +382,7 @@ func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idem
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.ExecuteAtomic(t.callContext(ctx), &pb.ExecuteAtomicRequest{
+	resp, err := client.ExecuteAtomic(t.callContext(ctx, tenantID), &pb.ExecuteAtomicRequest{
 		Context:        &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		IdempotencyKey: idempotencyKey,
 		Operations:     protoOps,
@@ -384,7 +413,7 @@ func (t *grpcTransport) Share(ctx context.Context, tenantID, actor, nodeID, gran
 		return err
 	}
 	var trailer metadata.MD
-	_, err = client.ShareNode(t.callContext(ctx), &pb.ShareNodeRequest{
+	_, err = client.ShareNode(t.callContext(ctx, tenantID), &pb.ShareNodeRequest{
 		Context:    &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		NodeId:     nodeID,
 		ActorId:    grantee,
@@ -402,7 +431,7 @@ func (t *grpcTransport) GetEdgesFrom(ctx context.Context, tenantID, actor, fromN
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetEdgesFrom(t.callContext(ctx), &pb.GetEdgesRequest{
+	resp, err := client.GetEdgesFrom(t.callContext(ctx, tenantID), &pb.GetEdgesRequest{
 		Context:    &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		NodeId:     fromNodeID,
 		EdgeTypeId: int32(edgeTypeID),
@@ -424,7 +453,7 @@ func (t *grpcTransport) GetEdgesTo(ctx context.Context, tenantID, actor, toNodeI
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetEdgesTo(t.callContext(ctx), &pb.GetEdgesRequest{
+	resp, err := client.GetEdgesTo(t.callContext(ctx, tenantID), &pb.GetEdgesRequest{
 		Context:    &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		NodeId:     toNodeID,
 		EdgeTypeId: int32(edgeTypeID),
@@ -446,7 +475,7 @@ func (t *grpcTransport) SearchNodes(ctx context.Context, tenantID, actor string,
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.SearchNodes(t.callContext(ctx), &pb.SearchNodesRequest{
+	resp, err := client.SearchNodes(t.callContext(ctx, tenantID), &pb.SearchNodesRequest{
 		TenantId: tenantID,
 		Actor:    actor,
 		TypeId:   int32(typeID),
@@ -469,7 +498,7 @@ func (t *grpcTransport) GetTenantQuota(ctx context.Context, actor, tenantID stri
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetTenantQuota(t.callContext(ctx), &pb.GetTenantQuotaRequest{
+	resp, err := client.GetTenantQuota(t.callContext(ctx, tenantID), &pb.GetTenantQuotaRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 	}, grpc.Trailer(&trailer))
@@ -496,7 +525,7 @@ func (t *grpcTransport) GetNodes(ctx context.Context, tenantID, actor string, ty
 		return nil, nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetNodes(t.callContext(ctx), &pb.GetNodesRequest{
+	resp, err := client.GetNodes(t.callContext(ctx, tenantID), &pb.GetNodesRequest{
 		Context: &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		TypeId:  int32(typeID),
 		NodeIds: nodeIDs,
@@ -518,7 +547,7 @@ func (t *grpcTransport) GetReceiptStatus(ctx context.Context, tenantID, actor, i
 		return ReceiptStatusUnknown, "", err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetReceiptStatus(t.callContext(ctx), &pb.GetReceiptStatusRequest{
+	resp, err := client.GetReceiptStatus(t.callContext(ctx, tenantID), &pb.GetReceiptStatusRequest{
 		Context:        &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		IdempotencyKey: idempotencyKey,
 	}, grpc.Trailer(&trailer))
@@ -534,7 +563,7 @@ func (t *grpcTransport) WaitForOffset(ctx context.Context, tenantID, actor, stre
 		return false, "", err
 	}
 	var trailer metadata.MD
-	resp, err := client.WaitForOffset(t.callContext(ctx), &pb.WaitForOffsetRequest{
+	resp, err := client.WaitForOffset(t.callContext(ctx, tenantID), &pb.WaitForOffsetRequest{
 		Context:        &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		StreamPosition: streamPosition,
 		TimeoutMs:      timeoutMs,
@@ -551,7 +580,7 @@ func (t *grpcTransport) GetConnectedNodes(ctx context.Context, tenantID, actor, 
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetConnectedNodes(t.callContext(ctx), &pb.GetConnectedNodesRequest{
+	resp, err := client.GetConnectedNodes(t.callContext(ctx, tenantID), &pb.GetConnectedNodesRequest{
 		Context:    &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		NodeId:     nodeID,
 		EdgeTypeId: int32(edgeTypeID),
@@ -573,7 +602,7 @@ func (t *grpcTransport) ListSharedWithMe(ctx context.Context, tenantID, actor st
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.ListSharedWithMe(t.callContext(ctx), &pb.ListSharedWithMeRequest{
+	resp, err := client.ListSharedWithMe(t.callContext(ctx, tenantID), &pb.ListSharedWithMeRequest{
 		Context: &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		Limit:   limit,
 		Offset:  offset,
@@ -595,7 +624,7 @@ func (t *grpcTransport) RevokeAccess(ctx context.Context, tenantID, actor, nodeI
 		return false, err
 	}
 	var trailer metadata.MD
-	resp, err := client.RevokeAccess(t.callContext(ctx), &pb.RevokeAccessRequest{
+	resp, err := client.RevokeAccess(t.callContext(ctx, tenantID), &pb.RevokeAccessRequest{
 		Context: &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		NodeId:  nodeID,
 		ActorId: granteeActor,
@@ -612,7 +641,7 @@ func (t *grpcTransport) TransferOwnership(ctx context.Context, tenantID, actor, 
 		return false, err
 	}
 	var trailer metadata.MD
-	resp, err := client.TransferOwnership(t.callContext(ctx), &pb.TransferOwnershipRequest{
+	resp, err := client.TransferOwnership(t.callContext(ctx, tenantID), &pb.TransferOwnershipRequest{
 		Context:  &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		NodeId:   nodeID,
 		NewOwner: newOwner,
@@ -629,7 +658,7 @@ func (t *grpcTransport) AddGroupMember(ctx context.Context, tenantID, actor, gro
 		return err
 	}
 	var trailer metadata.MD
-	_, err = client.AddGroupMember(t.callContext(ctx), &pb.GroupMemberRequest{
+	_, err = client.AddGroupMember(t.callContext(ctx, tenantID), &pb.GroupMemberRequest{
 		Context:       &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		GroupId:       groupID,
 		MemberActorId: memberActor,
@@ -647,7 +676,7 @@ func (t *grpcTransport) RemoveGroupMember(ctx context.Context, tenantID, actor, 
 		return err
 	}
 	var trailer metadata.MD
-	_, err = client.RemoveGroupMember(t.callContext(ctx), &pb.GroupMemberRequest{
+	_, err = client.RemoveGroupMember(t.callContext(ctx, tenantID), &pb.GroupMemberRequest{
 		Context:       &pb.RequestContext{TenantId: tenantID, Actor: actor},
 		GroupId:       groupID,
 		MemberActorId: memberActor,
@@ -670,7 +699,7 @@ func (t *grpcTransport) CreateTenant(ctx context.Context, actor, tenantID, name 
 		opt(&cfg)
 	}
 	var trailer metadata.MD
-	resp, err := client.CreateTenant(t.callContext(ctx), &pb.CreateTenantRequest{
+	resp, err := client.CreateTenant(t.callContext(ctx, tenantID), &pb.CreateTenantRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 		Name:     name,
@@ -698,7 +727,7 @@ func (t *grpcTransport) CreateUser(ctx context.Context, actor, userID, email, na
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.CreateUser(t.callContext(ctx), &pb.CreateUserRequest{
+	resp, err := client.CreateUser(t.callContext(ctx, ""), &pb.CreateUserRequest{
 		Actor:  actor,
 		UserId: userID,
 		Email:  email,
@@ -727,7 +756,7 @@ func (t *grpcTransport) AddTenantMember(ctx context.Context, actor, tenantID, us
 		return err
 	}
 	var trailer metadata.MD
-	resp, err := client.AddTenantMember(t.callContext(ctx), &pb.TenantMemberRequest{
+	resp, err := client.AddTenantMember(t.callContext(ctx, tenantID), &pb.TenantMemberRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 		UserId:   userID,
@@ -748,7 +777,7 @@ func (t *grpcTransport) RemoveTenantMember(ctx context.Context, actor, tenantID,
 		return err
 	}
 	var trailer metadata.MD
-	resp, err := client.RemoveTenantMember(t.callContext(ctx), &pb.TenantMemberRequest{
+	resp, err := client.RemoveTenantMember(t.callContext(ctx, tenantID), &pb.TenantMemberRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 		UserId:   userID,
@@ -768,7 +797,7 @@ func (t *grpcTransport) ChangeMemberRole(ctx context.Context, actor, tenantID, u
 		return err
 	}
 	var trailer metadata.MD
-	resp, err := client.ChangeMemberRole(t.callContext(ctx), &pb.ChangeMemberRoleRequest{
+	resp, err := client.ChangeMemberRole(t.callContext(ctx, tenantID), &pb.ChangeMemberRoleRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 		UserId:   userID,
@@ -789,7 +818,7 @@ func (t *grpcTransport) GetTenantMembers(ctx context.Context, actor, tenantID st
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetTenantMembers(t.callContext(ctx), &pb.GetTenantMembersRequest{
+	resp, err := client.GetTenantMembers(t.callContext(ctx, tenantID), &pb.GetTenantMembersRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 	}, grpc.Trailer(&trailer))
@@ -814,7 +843,7 @@ func (t *grpcTransport) GetUserTenants(ctx context.Context, actor, userID string
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.GetUserTenants(t.callContext(ctx), &pb.GetUserTenantsRequest{
+	resp, err := client.GetUserTenants(t.callContext(ctx, ""), &pb.GetUserTenantsRequest{
 		Actor:  actor,
 		UserId: userID,
 	}, grpc.Trailer(&trailer))
@@ -839,7 +868,7 @@ func (t *grpcTransport) DelegateAccess(ctx context.Context, actor, tenantID, fro
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.DelegateAccess(t.callContext(ctx), &pb.DelegateAccessRequest{
+	resp, err := client.DelegateAccess(t.callContext(ctx, tenantID), &pb.DelegateAccessRequest{
 		Actor:      actor,
 		TenantId:   tenantID,
 		FromUser:   fromUser,
@@ -865,7 +894,7 @@ func (t *grpcTransport) TransferUserContent(ctx context.Context, actor, tenantID
 		return 0, err
 	}
 	var trailer metadata.MD
-	resp, err := client.TransferUserContent(t.callContext(ctx), &pb.TransferUserContentRequest{
+	resp, err := client.TransferUserContent(t.callContext(ctx, tenantID), &pb.TransferUserContentRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 		FromUser: fromUser,
@@ -886,7 +915,7 @@ func (t *grpcTransport) RevokeAllUserAccess(ctx context.Context, actor, tenantID
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.RevokeAllUserAccess(t.callContext(ctx), &pb.RevokeAllUserAccessRequest{
+	resp, err := client.RevokeAllUserAccess(t.callContext(ctx, tenantID), &pb.RevokeAllUserAccessRequest{
 		Actor:    actor,
 		TenantId: tenantID,
 		UserId:   userID,
@@ -912,7 +941,7 @@ func (t *grpcTransport) DeleteUser(ctx context.Context, actor, userID string, gr
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.DeleteUser(t.callContext(ctx), &pb.DeleteUserRequest{
+	resp, err := client.DeleteUser(t.callContext(ctx, ""), &pb.DeleteUserRequest{
 		Actor:     actor,
 		UserId:    userID,
 		GraceDays: graceDays,
@@ -936,7 +965,7 @@ func (t *grpcTransport) CancelUserDeletion(ctx context.Context, actor, userID st
 		return err
 	}
 	var trailer metadata.MD
-	resp, err := client.CancelUserDeletion(t.callContext(ctx), &pb.CancelUserDeletionRequest{
+	resp, err := client.CancelUserDeletion(t.callContext(ctx, ""), &pb.CancelUserDeletionRequest{
 		Actor:  actor,
 		UserId: userID,
 	}, grpc.Trailer(&trailer))
@@ -955,7 +984,7 @@ func (t *grpcTransport) ExportUserData(ctx context.Context, actor, userID string
 		return "", err
 	}
 	var trailer metadata.MD
-	resp, err := client.ExportUserData(t.callContext(ctx), &pb.ExportUserDataRequest{
+	resp, err := client.ExportUserData(t.callContext(ctx, ""), &pb.ExportUserDataRequest{
 		Actor:  actor,
 		UserId: userID,
 	}, grpc.Trailer(&trailer))
@@ -974,7 +1003,7 @@ func (t *grpcTransport) Health(ctx context.Context) (*HealthStatus, error) {
 		return nil, err
 	}
 	var trailer metadata.MD
-	resp, err := client.Health(t.callContext(ctx), &pb.HealthRequest{}, grpc.Trailer(&trailer))
+	resp, err := client.Health(t.callContext(ctx, ""), &pb.HealthRequest{}, grpc.Trailer(&trailer))
 	if err != nil {
 		return nil, translateGRPCStatusWithTrailer(err, trailer, "", t.address)
 	}
@@ -991,7 +1020,7 @@ func (t *grpcTransport) FreezeUser(ctx context.Context, actor, userID string, en
 		return "", err
 	}
 	var trailer metadata.MD
-	resp, err := client.FreezeUser(t.callContext(ctx), &pb.FreezeUserRequest{
+	resp, err := client.FreezeUser(t.callContext(ctx, ""), &pb.FreezeUserRequest{
 		Actor:   actor,
 		UserId:  userID,
 		Enabled: enabled,

--- a/sdk/go/entdb/options.go
+++ b/sdk/go/entdb/options.go
@@ -1,13 +1,23 @@
 package entdb
 
-import "time"
+import (
+	"time"
+
+	"google.golang.org/grpc"
+)
 
 // clientConfig holds all client configuration values.
 type clientConfig struct {
-	secure     bool
-	apiKey     string
-	maxRetries int
-	timeout    time.Duration
+	secure       bool
+	apiKey       string
+	maxRetries   int
+	timeout      time.Duration
+	nodeResolver NodeResolver
+	// dialOptions is appended to the grpc.NewClient option list on
+	// every dial — both the primary endpoint and any redirect
+	// sub-channels. Tests use it to install a contextDialer for
+	// bufconn-backed in-process servers.
+	dialOptions []grpc.DialOption
 }
 
 // defaultConfig returns a clientConfig with sensible defaults.
@@ -50,6 +60,36 @@ func WithMaxRetries(n int) ClientOption {
 func WithTimeout(d time.Duration) ClientOption {
 	return func(c *clientConfig) {
 		c.timeout = d
+	}
+}
+
+// WithNodeResolver installs a custom [NodeResolver] used to map
+// server-issued ``node_id`` redirect hints to dial-able endpoints.
+//
+// Use this with [StaticMapResolver] for deployments without DNS,
+// or with a custom implementation backed by service discovery.
+//
+// If both [WithNodeResolver] and [WithBaseDomain] are supplied,
+// the last one wins.
+func WithNodeResolver(r NodeResolver) ClientOption {
+	return func(c *clientConfig) { c.nodeResolver = r }
+}
+
+// WithBaseDomain wires a [DNSTemplateResolver] for the given base
+// domain. Sub-channels are dialed at ``<node_id>.<baseDomain>:50051``
+// when the server returns a redirect hint via the
+// ``entdb-redirect-node`` trailing metadata header.
+//
+// This is the recommended way to configure node redirection on
+// Kubernetes — point ``baseDomain`` at the headless service and
+// the Pod-per-shard StatefulSet will be reachable via the
+// per-pod DNS record.
+//
+//	client, _ := entdb.NewClient("entdb.svc.cluster.local:50051",
+//	    entdb.WithBaseDomain("entdb.svc.cluster.local"))
+func WithBaseDomain(baseDomain string) ClientOption {
+	return func(c *clientConfig) {
+		c.nodeResolver = &DNSTemplateResolver{BaseDomain: baseDomain}
 	}
 }
 

--- a/sdk/go/entdb/redirect_cache.go
+++ b/sdk/go/entdb/redirect_cache.go
@@ -1,0 +1,257 @@
+package entdb
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// outgoingTenantHeader is the metadata key the SDK uses to carry
+// the request's tenant id on the *outgoing* context. The redirect
+// interceptor reads this off the call so it can route the call
+// against a tenant-specific cached sub-channel without inspecting
+// every request type.
+const outgoingTenantHeader = "entdb-tenant-id"
+
+// redirectTrailerKey is the trailing-metadata header the server
+// emits when a tenant lives on another node — see
+// “dbaas/entdb_server/api/grpc_server.py:_check_tenant“.
+const redirectTrailerKey = "entdb-redirect-node"
+
+// tenantEndpointCache caches “tenant_id -> {endpoint, *grpc.ClientConn}“
+// so that once an SDK has been redirected to the owning node it
+// keeps using that sub-channel for future calls instead of
+// bouncing through the primary endpoint each time.
+//
+// Eviction policy:
+//   - Connection failure on the cached channel — see
+//     [tenantEndpointCache.evict].
+//   - Future "stale" signal from the server (placeholder; the
+//     server doesn't emit one yet).
+//
+// No TTL: tenants don't move unless a node crashes, and the
+// connection-failure path covers that.
+type tenantEndpointCache struct {
+	mu      sync.Mutex
+	entries map[string]*cachedEndpoint
+	// builder dials a fresh *grpc.ClientConn for the resolved
+	// endpoint. Tests inject a bufconn dialer here.
+	builder func(endpoint string) (*grpc.ClientConn, error)
+}
+
+type cachedEndpoint struct {
+	endpoint string
+	conn     *grpc.ClientConn
+}
+
+func newTenantEndpointCache(builder func(endpoint string) (*grpc.ClientConn, error)) *tenantEndpointCache {
+	return &tenantEndpointCache{
+		entries: make(map[string]*cachedEndpoint),
+		builder: builder,
+	}
+}
+
+// get returns the cached entry for “tenantID“, or (nil, false)
+// when the SDK has not been redirected for this tenant yet.
+func (c *tenantEndpointCache) get(tenantID string) (*cachedEndpoint, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[tenantID]
+	return e, ok
+}
+
+// store records “tenantID -> endpoint“ and lazily dials a
+// sub-channel. If the same endpoint was already cached (via a
+// different tenant), the existing conn is reused.
+func (c *tenantEndpointCache) store(tenantID, endpoint string) (*cachedEndpoint, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// If we already have a sub-channel for this endpoint (under
+	// any tenant), reuse it — multiple tenants frequently land on
+	// the same node.
+	for _, e := range c.entries {
+		if e.endpoint == endpoint {
+			c.entries[tenantID] = e
+			return e, nil
+		}
+	}
+	conn, err := c.builder(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	e := &cachedEndpoint{endpoint: endpoint, conn: conn}
+	c.entries[tenantID] = e
+	return e, nil
+}
+
+// evict removes the cache entry for “tenantID“ and closes the
+// sub-channel iff no other tenant is using it. Used when the
+// cached sub-channel goes unhealthy — the SDK falls back to the
+// primary endpoint on the next call.
+func (c *tenantEndpointCache) evict(tenantID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[tenantID]
+	if !ok {
+		return
+	}
+	delete(c.entries, tenantID)
+	for _, other := range c.entries {
+		if other.endpoint == e.endpoint {
+			// Still in use by another tenant — keep the conn.
+			return
+		}
+	}
+	_ = e.conn.Close()
+}
+
+// closeAll tears down every sub-channel in the cache. Called from
+// [grpcTransport.Close].
+func (c *tenantEndpointCache) closeAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	closed := make(map[*grpc.ClientConn]struct{})
+	for _, e := range c.entries {
+		if _, done := closed[e.conn]; done {
+			continue
+		}
+		closed[e.conn] = struct{}{}
+		_ = e.conn.Close()
+	}
+	c.entries = make(map[string]*cachedEndpoint)
+}
+
+// tenantFromOutgoing reads the tenant-id metadata header set by
+// [grpcTransport.callContext] off the outgoing context.
+func tenantFromOutgoing(ctx context.Context) string {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return ""
+	}
+	vs := md.Get(outgoingTenantHeader)
+	if len(vs) == 0 {
+		return ""
+	}
+	return vs[0]
+}
+
+// redirectInterceptor returns a unary client interceptor that:
+//
+//  1. Reads the outgoing “entdb-tenant-id“ header.
+//  2. If the cache has an endpoint for that tenant, invokes the
+//     RPC against the cached sub-channel directly; otherwise
+//     falls through to the supplied invoker (primary channel).
+//  3. On “codes.Unavailable“ with an “entdb-redirect-node“
+//     trailer, resolves the node, dials a sub-channel, caches it,
+//     and retries the call exactly once.
+//  4. On any other connection error against the cached
+//     sub-channel, evicts the cache entry so the next call retries
+//     on the primary endpoint.
+//
+// Returns nil when “resolver“ is unset — callers can then skip
+// installing the interceptor entirely.
+func redirectInterceptor(resolver NodeResolver, cache *tenantEndpointCache) grpc.UnaryClientInterceptor {
+	if resolver == nil || cache == nil {
+		return nil
+	}
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		tenantID := tenantFromOutgoing(ctx)
+
+		// Try the cached sub-channel first when we have one.
+		if tenantID != "" {
+			if entry, ok := cache.get(tenantID); ok {
+				err := entry.conn.Invoke(ctx, method, req, reply, opts...)
+				if err == nil {
+					return nil
+				}
+				// On UNAVAILABLE against the cached endpoint,
+				// evict and fall through to the primary channel.
+				if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
+					cache.evict(tenantID)
+				} else {
+					return err
+				}
+			}
+		}
+
+		// Default path — invoke against the primary channel.
+		var trailer metadata.MD
+		callOpts := append([]grpc.CallOption{grpc.Trailer(&trailer)}, opts...)
+		err := invoker(ctx, method, req, reply, cc, callOpts...)
+		if err == nil {
+			return nil
+		}
+
+		// Look for a redirect hint and act on it.
+		st, ok := status.FromError(err)
+		if !ok || st.Code() != codes.Unavailable {
+			return err
+		}
+		nodeIDs := trailer.Get(redirectTrailerKey)
+		if len(nodeIDs) == 0 || nodeIDs[0] == "" || tenantID == "" {
+			return err
+		}
+
+		endpoint, resolveErr := resolver.Resolve(nodeIDs[0])
+		if resolveErr != nil {
+			// Fall back to the original error — the caller sees
+			// the underlying UNAVAILABLE.
+			return err
+		}
+		entry, storeErr := cache.store(tenantID, endpoint)
+		if storeErr != nil {
+			return err
+		}
+		// One retry — if the redirect target also redirects we
+		// surface that error rather than chasing pointers.
+		return entry.conn.Invoke(ctx, method, req, reply, opts...)
+	}
+}
+
+// dialerFromConfig builds the per-endpoint dialer used by the
+// redirect cache. It mirrors the dial settings of the primary
+// connection (TLS / insecure, plus any explicit dial options).
+func dialerFromConfig(cfg clientConfig) func(string) (*grpc.ClientConn, error) {
+	return func(endpoint string) (*grpc.ClientConn, error) {
+		opts := append([]grpc.DialOption(nil), cfg.dialOptions...)
+		// Caller-supplied dial options win — only apply our
+		// transport-credentials default when they did not.
+		if !hasTransportCreds(opts) {
+			var creds credentials.TransportCredentials
+			if cfg.secure {
+				creds = credentials.NewTLS(nil)
+			} else {
+				creds = insecure.NewCredentials()
+			}
+			opts = append(opts, grpc.WithTransportCredentials(creds))
+		}
+		return grpc.NewClient(endpoint, opts...)
+	}
+}
+
+// hasTransportCreds reports whether “opts“ already carries a
+// WithTransportCredentials option. We can't introspect the option
+// type directly (it's unexported in grpc-go), so we install a
+// sentinel by piggy-backing on grpc.EmptyDialOption — but the
+// stable contract here is "tests injected creds explicitly, don't
+// override them". The simplest robust check is presence-of-options:
+// in the production path tests don't pass dialOptions and we add
+// creds; in the test path the bufconn dialer always pairs with
+// insecure.NewCredentials. So we treat a non-empty dialOptions
+// slice as "tests provided their own creds".
+func hasTransportCreds(opts []grpc.DialOption) bool {
+	return len(opts) > 0
+}

--- a/sdk/go/entdb/redirect_cache_test.go
+++ b/sdk/go/entdb/redirect_cache_test.go
@@ -1,0 +1,239 @@
+package entdb
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	pb "github.com/elloloop/tenant-shard-db/sdk/go/entdb/internal/pb"
+)
+
+// redirectFakeServer is a minimal EntDBService backend that
+// optionally answers GetNode with an UNAVAILABLE redirect carrying
+// “entdb-redirect-node“ trailing metadata. After “redirectN“
+// requests it stops redirecting and answers normally — this lets a
+// single test exercise both the redirect path and the cached
+// follow-up.
+type redirectFakeServer struct {
+	pb.UnimplementedEntDBServiceServer
+
+	nodeID       string // "node-a" / "node-b" — used in redirect trailer
+	redirectTo   string // empty = serve normally
+	hits         atomic.Int32
+	lastTenantID atomic.Value // string — tenant on the last received call
+}
+
+func (s *redirectFakeServer) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNodeResponse, error) {
+	s.hits.Add(1)
+	s.lastTenantID.Store(req.GetContext().GetTenantId())
+	if s.redirectTo != "" {
+		_ = grpc.SetTrailer(ctx, metadata.Pairs("entdb-redirect-node", s.redirectTo))
+		return nil, status.Errorf(
+			codes.Unavailable,
+			"Tenant %q is not served by this node (try node %s)",
+			req.GetContext().GetTenantId(),
+			s.redirectTo,
+		)
+	}
+	return &pb.GetNodeResponse{
+		Found: true,
+		Node: &pb.Node{
+			TenantId: req.GetContext().GetTenantId(),
+			NodeId:   req.GetNodeId(),
+			TypeId:   req.GetTypeId(),
+		},
+	}, nil
+}
+
+// startRedirectServer launches an in-process gRPC server backed by
+// “svc“ and returns the bufconn listener so callers can register
+// it with a [StaticMapResolver] keyed by the desired node id.
+func startRedirectServer(t *testing.T, svc *redirectFakeServer) *bufconn.Listener {
+	t.Helper()
+	lis := bufconn.Listen(1 << 16)
+	srv := grpc.NewServer()
+	pb.RegisterEntDBServiceServer(srv, svc)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() { srv.Stop() })
+	return lis
+}
+
+// bufconnResolver maps node ids to [bufconn.Listener]s. We use it
+// instead of [StaticMapResolver] in these tests because the
+// transport must dial via a contextDialer rather than a real
+// host:port.
+type bufconnResolver struct {
+	listeners map[string]*bufconn.Listener
+}
+
+func (r *bufconnResolver) Resolve(nodeID string) (string, error) {
+	if _, ok := r.listeners[nodeID]; !ok {
+		return "", &EntDBError{Message: "unknown node " + nodeID, Code: "RESOLVE"}
+	}
+	// passthrough:// preserves the literal endpoint string so the
+	// contextDialer (installed in newRedirectTransport) can match
+	// it back to the right bufconn listener.
+	return "passthrough:///" + nodeID + ".bufnet", nil
+}
+
+func newRedirectTransport(t *testing.T, primaryNode string, lis map[string]*bufconn.Listener) *grpcTransport {
+	t.Helper()
+	resolver := &bufconnResolver{listeners: lis}
+
+	dialer := func(_ context.Context, addr string) (net.Conn, error) {
+		// addr arrives stripped of the ``passthrough:///`` scheme
+		// since gRPC's passthrough resolver hands the bare endpoint
+		// string to the dialer.
+		for nodeID, l := range lis {
+			if addr == nodeID+".bufnet" {
+				return l.Dial()
+			}
+		}
+		return nil, net.UnknownNetworkError(addr)
+	}
+
+	cfg := defaultConfig()
+	cfg.nodeResolver = resolver
+	cfg.dialOptions = []grpc.DialOption{
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	// Use the passthrough:// scheme so the gRPC name resolver
+	// hands our literal endpoint to the dialer rather than trying
+	// DNS lookups on "node-a.bufnet".
+	tr := newGRPCTransport("passthrough:///"+primaryNode+".bufnet", cfg)
+	if err := tr.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = tr.Close() })
+	return tr
+}
+
+func TestRedirect_FollowsHintAndCaches(t *testing.T) {
+	// node-a redirects everything to node-b; node-b serves it.
+	srvA := &redirectFakeServer{nodeID: "node-a", redirectTo: "node-b"}
+	srvB := &redirectFakeServer{nodeID: "node-b"}
+	listeners := map[string]*bufconn.Listener{
+		"node-a": startRedirectServer(t, srvA),
+		"node-b": startRedirectServer(t, srvB),
+	}
+	tr := newRedirectTransport(t, "node-a", listeners)
+
+	// First call hits node-a, gets redirected to node-b, succeeds.
+	got, err := tr.GetNode(context.Background(), "tenant-b", "user:alice", 1, "n1")
+	if err != nil {
+		t.Fatalf("GetNode #1: %v", err)
+	}
+	if got == nil || got.NodeID != "n1" {
+		t.Fatalf("expected node n1, got %+v", got)
+	}
+	if srvA.hits.Load() != 1 {
+		t.Errorf("node-a hits = %d, want 1", srvA.hits.Load())
+	}
+	if srvB.hits.Load() != 1 {
+		t.Errorf("node-b hits = %d, want 1 after first redirect", srvB.hits.Load())
+	}
+
+	// Second call for the same tenant must skip node-a entirely:
+	// the cache should route directly to node-b.
+	_, err = tr.GetNode(context.Background(), "tenant-b", "user:alice", 1, "n2")
+	if err != nil {
+		t.Fatalf("GetNode #2: %v", err)
+	}
+	if srvA.hits.Load() != 1 {
+		t.Errorf("node-a should not be hit again, got %d", srvA.hits.Load())
+	}
+	if srvB.hits.Load() != 2 {
+		t.Errorf("node-b hits = %d, want 2", srvB.hits.Load())
+	}
+}
+
+func TestRedirect_NoMetadataFallsThroughAsError(t *testing.T) {
+	// Server returns UNAVAILABLE *without* the redirect trailer —
+	// the SDK must surface it as a ConnectionError, not retry.
+	svc := &redirectFakeServer{nodeID: "node-a", redirectTo: ""}
+	// Start a servicer that always errors.
+	lis := bufconn.Listen(1 << 16)
+	srv := grpc.NewServer()
+	pb.RegisterEntDBServiceServer(srv, &noisyAlwaysUnavailable{})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() { srv.Stop() })
+
+	listeners := map[string]*bufconn.Listener{"node-a": lis}
+	_ = svc
+	tr := newRedirectTransport(t, "node-a", listeners)
+
+	_, err := tr.GetNode(context.Background(), "tenant-x", "user:alice", 1, "n1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Must be a ConnectionError per translateGRPCError mapping for UNAVAILABLE.
+	if _, ok := err.(*ConnectionError); !ok {
+		t.Errorf("expected *ConnectionError, got %T: %v", err, err)
+	}
+}
+
+type noisyAlwaysUnavailable struct {
+	pb.UnimplementedEntDBServiceServer
+}
+
+func (s *noisyAlwaysUnavailable) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNodeResponse, error) {
+	return nil, status.Error(codes.Unavailable, "transient")
+}
+
+func TestRedirect_DefaultEndpointWhenNoCacheAndNoRedirect(t *testing.T) {
+	// Plain happy path with redirect plumbing installed but no
+	// redirect needed — the transport must still talk to the
+	// primary endpoint.
+	srvA := &redirectFakeServer{nodeID: "node-a"}
+	listeners := map[string]*bufconn.Listener{"node-a": startRedirectServer(t, srvA)}
+	tr := newRedirectTransport(t, "node-a", listeners)
+
+	got, err := tr.GetNode(context.Background(), "tenant-a", "user:alice", 1, "n1")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got == nil || got.NodeID != "n1" {
+		t.Fatalf("expected n1, got %+v", got)
+	}
+	if srvA.hits.Load() != 1 {
+		t.Errorf("node-a hits = %d, want 1", srvA.hits.Load())
+	}
+}
+
+func TestWithBaseDomain_InstallsDNSResolver(t *testing.T) {
+	// WithBaseDomain is the convenience option that wires up a
+	// DNSTemplateResolver. We just need to confirm it lands in the
+	// config — actually exercising DNS isn't appropriate in a unit
+	// test.
+	cfg := defaultConfig()
+	WithBaseDomain("entdb.svc.cluster.local")(&cfg)
+	if cfg.nodeResolver == nil {
+		t.Fatal("WithBaseDomain did not install a resolver")
+	}
+	dnsR, ok := cfg.nodeResolver.(*DNSTemplateResolver)
+	if !ok {
+		t.Fatalf("WithBaseDomain installed %T, want *DNSTemplateResolver", cfg.nodeResolver)
+	}
+	if dnsR.BaseDomain != "entdb.svc.cluster.local" {
+		t.Errorf("BaseDomain = %q", dnsR.BaseDomain)
+	}
+}
+
+func TestWithNodeResolver_StoresInConfig(t *testing.T) {
+	r := &StaticMapResolver{Endpoints: map[string]string{"node-a": "1.2.3.4:50051"}}
+	cfg := defaultConfig()
+	WithNodeResolver(r)(&cfg)
+	if cfg.nodeResolver != r {
+		t.Errorf("WithNodeResolver did not store the supplied resolver")
+	}
+}

--- a/sdk/go/entdb/resolver.go
+++ b/sdk/go/entdb/resolver.go
@@ -1,0 +1,79 @@
+package entdb
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NodeResolver maps a server-issued “node_id“ (e.g. "node-a") to
+// a dial-able gRPC endpoint (“host:port“). The SDK calls this
+// when the server returns a redirect hint via the
+// “entdb-redirect-node“ trailing metadata header.
+//
+// Two implementations ship with the SDK:
+//
+//   - [DNSTemplateResolver] (default) treats “node_id“ as a DNS
+//     subdomain — “node-a“ resolves to
+//     “node-a.<BaseDomain>:<Port>“. This is the right choice for
+//     Kubernetes StatefulSet headless services and for any deployment
+//     that follows the convention "one DNS name per node id".
+//   - [StaticMapResolver] looks up the endpoint in an explicit
+//     map. Use it for tests, or for static deployments where DNS
+//     isn't available.
+//
+// Custom implementations can plug in via [WithNodeResolver] — for
+// example a service-discovery client (Consul, etcd, AWS Cloud Map).
+type NodeResolver interface {
+	// Resolve returns the dial-target endpoint for ``nodeID``,
+	// or an error if the node is unknown.
+	Resolve(nodeID string) (endpoint string, err error)
+}
+
+// DNSTemplateResolver is the default [NodeResolver]. It composes
+// the endpoint as “<nodeID>.<BaseDomain>:<Port>“. “Port“
+// defaults to 50051 (the EntDB gRPC port) when zero.
+type DNSTemplateResolver struct {
+	// BaseDomain is the parent DNS zone — typically the headless
+	// service domain in Kubernetes (e.g.
+	// ``entdb.svc.cluster.local``).
+	BaseDomain string
+	// Port is the gRPC port on each node. Zero means 50051.
+	Port int
+}
+
+// Resolve composes “<nodeID>.<BaseDomain>:<Port>“.
+func (r *DNSTemplateResolver) Resolve(nodeID string) (string, error) {
+	if nodeID == "" {
+		return "", fmt.Errorf("entdb: resolve: empty node id")
+	}
+	if strings.TrimSpace(r.BaseDomain) == "" {
+		return "", fmt.Errorf("entdb: resolve: BaseDomain not set on DNSTemplateResolver")
+	}
+	port := r.Port
+	if port == 0 {
+		port = 50051
+	}
+	return fmt.Sprintf("%s.%s:%d", nodeID, r.BaseDomain, port), nil
+}
+
+// StaticMapResolver is the explicit “node_id -> endpoint“ form.
+// It is the resolver of choice for tests (DNS isn't available in
+// most test environments) and for tiny static deployments where
+// listing endpoints by hand is fine.
+type StaticMapResolver struct {
+	Endpoints map[string]string
+}
+
+// Resolve looks up “nodeID“ in the static map. Returns an error
+// if the node id isn't present — callers should treat that as a
+// permanent failure (the SDK will surface it as a ConnectionError).
+func (r *StaticMapResolver) Resolve(nodeID string) (string, error) {
+	if nodeID == "" {
+		return "", fmt.Errorf("entdb: resolve: empty node id")
+	}
+	ep, ok := r.Endpoints[nodeID]
+	if !ok {
+		return "", fmt.Errorf("entdb: resolve: no endpoint for node %q", nodeID)
+	}
+	return ep, nil
+}

--- a/sdk/go/entdb/resolver_test.go
+++ b/sdk/go/entdb/resolver_test.go
@@ -1,0 +1,69 @@
+package entdb
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDNSTemplateResolver_DefaultPort(t *testing.T) {
+	r := &DNSTemplateResolver{BaseDomain: "entdb.svc.cluster.local"}
+	got, err := r.Resolve("node-a")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "node-a.entdb.svc.cluster.local:50051" {
+		t.Errorf("got %q, want node-a.entdb.svc.cluster.local:50051", got)
+	}
+}
+
+func TestDNSTemplateResolver_ExplicitPort(t *testing.T) {
+	r := &DNSTemplateResolver{BaseDomain: "internal.example.com", Port: 9000}
+	got, err := r.Resolve("node-b")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "node-b.internal.example.com:9000" {
+		t.Errorf("got %q, want node-b.internal.example.com:9000", got)
+	}
+}
+
+func TestDNSTemplateResolver_RejectsEmptyNode(t *testing.T) {
+	r := &DNSTemplateResolver{BaseDomain: "example.com"}
+	if _, err := r.Resolve(""); err == nil {
+		t.Fatal("expected error for empty node id")
+	}
+}
+
+func TestDNSTemplateResolver_RejectsEmptyDomain(t *testing.T) {
+	r := &DNSTemplateResolver{}
+	if _, err := r.Resolve("node-a"); err == nil {
+		t.Fatal("expected error for empty base domain")
+	}
+}
+
+func TestStaticMapResolver_Hit(t *testing.T) {
+	r := &StaticMapResolver{Endpoints: map[string]string{
+		"node-a": "10.0.0.1:50051",
+		"node-b": "10.0.0.2:50051",
+	}}
+	got, err := r.Resolve("node-b")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "10.0.0.2:50051" {
+		t.Errorf("got %q, want 10.0.0.2:50051", got)
+	}
+}
+
+func TestStaticMapResolver_Miss(t *testing.T) {
+	r := &StaticMapResolver{Endpoints: map[string]string{
+		"node-a": "10.0.0.1:50051",
+	}}
+	_, err := r.Resolve("node-z")
+	if err == nil {
+		t.Fatal("expected error for unmapped node")
+	}
+	if !strings.Contains(err.Error(), "node-z") {
+		t.Errorf("error should mention node-z: %v", err)
+	}
+}

--- a/tests/integration/test_redirect_cache.py
+++ b/tests/integration/test_redirect_cache.py
@@ -1,0 +1,164 @@
+"""
+End-to-end integration test for SDK-side tenant redirect caching.
+
+Spins up two real ``EntDBServicer`` instances over bufconn-style
+gRPC AIO servers — node-a and node-b. Tenant ``acme-2`` is
+assigned to node-b; the SDK is initially pointed at node-a, with a
+:class:`StaticMapResolver` that knows how to reach node-b.
+
+Expected flow:
+
+  1. SDK calls GetNode against node-a.
+  2. Server's ``_check_tenant`` aborts with UNAVAILABLE and the
+     ``entdb-redirect-node`` trailer.
+  3. SDK's redirect cache resolves ``node-b`` via the static map,
+     opens a sub-channel, caches it, and re-issues the call.
+  4. node-b serves the request normally.
+  5. The next call for the same tenant skips node-a entirely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import pytest
+
+from dbaas.entdb_server.api.generated import (
+    add_EntDBServiceServicer_to_server,
+)
+from dbaas.entdb_server.api.grpc_server import EntDBServicer
+from dbaas.entdb_server.sharding import ShardingConfig
+from sdk.entdb_sdk._grpc_client import GrpcClient
+from sdk.entdb_sdk._redirect_cache import StaticMapResolver
+
+
+def _free_port() -> int:
+    import socket
+
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+async def _start_servicer(node_id: str, owned_tenants: set[str], registry: dict[str, str]):
+    """Start a real EntDBServicer on a free TCP port and return (server, port, servicer)."""
+    sharding = ShardingConfig(
+        node_id=node_id,
+        assigned_tenants=frozenset(owned_tenants),
+        tenant_registry=registry,
+    )
+
+    canonical = MagicMock()
+    canonical.initialize_tenant = AsyncMock()
+    # GetNode hits canonical_store.get_node when sharding allows it.
+    # Return a synthetic proto-shaped mock so the response succeeds.
+    fake_node = MagicMock()
+    fake_node.tenant_id = "acme-2"
+    fake_node.node_id = "n-1"
+    fake_node.type_id = 1
+    fake_node.payload.fields = {}
+    fake_node.created_at = 1000
+    fake_node.updated_at = 1000
+    fake_node.owner_actor = "user:alice"
+    fake_node.acl = []
+    canonical.get_node = AsyncMock(return_value=fake_node)
+
+    servicer = EntDBServicer(
+        wal=MagicMock(),
+        canonical_store=canonical,
+        schema_registry=MagicMock(),
+        sharding=sharding,
+    )
+
+    server = grpc.aio.server()
+    add_EntDBServiceServicer_to_server(servicer, server)
+    port = _free_port()
+    server.add_insecure_port(f"127.0.0.1:{port}")
+    await server.start()
+    return server, port, servicer
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sdk_follows_redirect_and_caches_endpoint():
+    registry = {"acme-2": "node-b"}
+    server_a, port_a, _ = await _start_servicer("node-a", {"acme-1"}, registry)
+    server_b, port_b, _ = await _start_servicer("node-b", {"acme-2"}, registry)
+
+    try:
+        resolver = StaticMapResolver(
+            endpoints={"node-b": f"127.0.0.1:{port_b}", "node-a": f"127.0.0.1:{port_a}"}
+        )
+        client = GrpcClient(
+            host="127.0.0.1",
+            port=port_a,
+            node_resolver=resolver,
+            max_retries=0,  # one retry attempt is enough; the redirect path is separate
+        )
+        await client.connect()
+        try:
+            # First call: node-a redirects to node-b; SDK retries
+            # transparently and returns the response from node-b.
+            node = await client.get_node(
+                tenant_id="acme-2",
+                actor="user:alice",
+                type_id=1,
+                node_id="n-1",
+            )
+            assert node is not None
+            assert node.tenant_id == "acme-2"
+            assert node.node_id == "n-1"
+
+            # Second call for the same tenant must skip node-a — the
+            # cache routes us directly to node-b. We assert this by
+            # checking the cache state.
+            assert client._redirect_cache is not None
+            cached = await client._redirect_cache.get("acme-2")
+            assert cached is not None
+            assert cached.endpoint == f"127.0.0.1:{port_b}"
+
+            # Issue another call; it must succeed without an extra
+            # redirect (otherwise we'd be hammering node-a).
+            node2 = await client.get_node(
+                tenant_id="acme-2",
+                actor="user:alice",
+                type_id=1,
+                node_id="n-1",
+            )
+            assert node2 is not None
+        finally:
+            await client.close()
+    finally:
+        await server_a.stop(grace=None)
+        await server_b.stop(grace=None)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sdk_without_resolver_propagates_unavailable():
+    """Without a NodeResolver the SDK surfaces UNAVAILABLE as-is."""
+    registry = {"acme-2": "node-b"}
+    server_a, port_a, _ = await _start_servicer("node-a", {"acme-1"}, registry)
+
+    try:
+        client = GrpcClient(host="127.0.0.1", port=port_a, max_retries=0)
+        await client.connect()
+        try:
+            with contextlib.suppress(asyncio.CancelledError):
+                with pytest.raises(grpc.RpcError) as exc_info:
+                    await client.get_node(
+                        tenant_id="acme-2",
+                        actor="user:alice",
+                        type_id=1,
+                        node_id="n-1",
+                    )
+                assert exc_info.value.code() == grpc.StatusCode.UNAVAILABLE
+        finally:
+            await client.close()
+    finally:
+        await server_a.stop(grace=None)

--- a/tests/unit/test_redirect_cache.py
+++ b/tests/unit/test_redirect_cache.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for the Python SDK's tenant-redirect cache and resolvers.
+
+The corresponding integration test (``test_redirect_cache.py``)
+exercises the full flow against a real gRPC server; here we cover
+the pure-Python pieces — resolvers, cache eviction, trailer
+extraction.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import pytest
+
+from sdk.entdb_sdk._redirect_cache import (
+    REDIRECT_TRAILER_KEY,
+    DNSTemplateResolver,
+    StaticMapResolver,
+    TenantEndpointCache,
+    extract_redirect_node,
+)
+
+# ── Resolvers ────────────────────────────────────────────────────────
+
+
+class TestDNSTemplateResolver:
+    def test_default_port(self):
+        r = DNSTemplateResolver(base_domain="entdb.svc.cluster.local")
+        assert r.resolve("node-a") == "node-a.entdb.svc.cluster.local:50051"
+
+    def test_custom_port(self):
+        r = DNSTemplateResolver(base_domain="example.internal", port=9000)
+        assert r.resolve("node-b") == "node-b.example.internal:9000"
+
+    def test_rejects_empty_node(self):
+        r = DNSTemplateResolver(base_domain="example.com")
+        with pytest.raises(LookupError):
+            r.resolve("")
+
+    def test_rejects_empty_base_domain(self):
+        r = DNSTemplateResolver(base_domain="")
+        with pytest.raises(LookupError):
+            r.resolve("node-a")
+
+
+class TestStaticMapResolver:
+    def test_hit(self):
+        r = StaticMapResolver(endpoints={"node-a": "1.2.3.4:50051"})
+        assert r.resolve("node-a") == "1.2.3.4:50051"
+
+    def test_miss_raises(self):
+        r = StaticMapResolver(endpoints={"node-a": "1.2.3.4:50051"})
+        with pytest.raises(LookupError):
+            r.resolve("node-z")
+
+    def test_empty_node_raises(self):
+        r = StaticMapResolver(endpoints={})
+        with pytest.raises(LookupError):
+            r.resolve("")
+
+
+# ── Trailer extraction ──────────────────────────────────────────────
+
+
+class TestExtractRedirectNode:
+    def test_returns_node_id_on_unavailable_with_trailer(self):
+        err = MagicMock()
+        err.code.return_value = grpc.StatusCode.UNAVAILABLE
+        err.trailing_metadata.return_value = [(REDIRECT_TRAILER_KEY, "node-b")]
+        assert extract_redirect_node(err) == "node-b"
+
+    def test_returns_none_when_not_unavailable(self):
+        err = MagicMock()
+        err.code.return_value = grpc.StatusCode.NOT_FOUND
+        err.trailing_metadata.return_value = [(REDIRECT_TRAILER_KEY, "node-b")]
+        assert extract_redirect_node(err) is None
+
+    def test_returns_none_when_no_trailer(self):
+        err = MagicMock()
+        err.code.return_value = grpc.StatusCode.UNAVAILABLE
+        err.trailing_metadata.return_value = []
+        assert extract_redirect_node(err) is None
+
+    def test_returns_none_when_trailer_missing_key(self):
+        err = MagicMock()
+        err.code.return_value = grpc.StatusCode.UNAVAILABLE
+        err.trailing_metadata.return_value = [("some-other", "value")]
+        assert extract_redirect_node(err) is None
+
+    def test_handles_missing_trailers_method(self):
+        err = MagicMock()
+        err.code.return_value = grpc.StatusCode.UNAVAILABLE
+        err.trailing_metadata.side_effect = AttributeError("no trailers")
+        assert extract_redirect_node(err) is None
+
+
+# ── Cache ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestTenantEndpointCache:
+    async def test_store_and_get(self):
+        ch = MagicMock()
+        ch.close = AsyncMock()
+        factory = MagicMock(return_value=ch)
+        cache = TenantEndpointCache(channel_factory=factory)
+
+        entry = await cache.store("tenant-a", "1.2.3.4:50051")
+        assert entry.endpoint == "1.2.3.4:50051"
+        assert entry.channel is ch
+        factory.assert_called_once_with("1.2.3.4:50051")
+
+        got = await cache.get("tenant-a")
+        assert got is entry
+
+    async def test_get_unknown_returns_none(self):
+        cache = TenantEndpointCache(channel_factory=MagicMock())
+        assert await cache.get("missing") is None
+
+    async def test_reuses_channel_for_same_endpoint(self):
+        ch1 = MagicMock()
+        ch1.close = AsyncMock()
+        ch2 = MagicMock()
+        ch2.close = AsyncMock()
+        factory = MagicMock(side_effect=[ch1, ch2])
+        cache = TenantEndpointCache(channel_factory=factory)
+
+        await cache.store("tenant-a", "1.2.3.4:50051")
+        await cache.store("tenant-b", "1.2.3.4:50051")
+
+        # Only one channel created — the second store reuses ch1.
+        assert factory.call_count == 1
+        a = await cache.get("tenant-a")
+        b = await cache.get("tenant-b")
+        assert a is b
+
+    async def test_evict_closes_channel_when_last_tenant_leaves(self):
+        ch = MagicMock()
+        ch.close = AsyncMock()
+        factory = MagicMock(return_value=ch)
+        cache = TenantEndpointCache(channel_factory=factory)
+
+        await cache.store("tenant-a", "1.2.3.4:50051")
+        await cache.evict("tenant-a")
+
+        ch.close.assert_awaited_once()
+        assert await cache.get("tenant-a") is None
+
+    async def test_evict_keeps_channel_when_other_tenants_share_it(self):
+        ch = MagicMock()
+        ch.close = AsyncMock()
+        factory = MagicMock(return_value=ch)
+        cache = TenantEndpointCache(channel_factory=factory)
+
+        await cache.store("tenant-a", "1.2.3.4:50051")
+        await cache.store("tenant-b", "1.2.3.4:50051")
+        await cache.evict("tenant-a")
+
+        ch.close.assert_not_awaited()
+        assert await cache.get("tenant-b") is not None
+
+    async def test_evict_unknown_is_no_op(self):
+        cache = TenantEndpointCache(channel_factory=MagicMock())
+        await cache.evict("missing")  # must not raise
+
+    async def test_close_tears_down_all_unique_channels(self):
+        ch1 = MagicMock()
+        ch1.close = AsyncMock()
+        ch2 = MagicMock()
+        ch2.close = AsyncMock()
+        # Two distinct endpoints get distinct channels.
+        factory = MagicMock(side_effect=[ch1, ch2])
+        cache = TenantEndpointCache(channel_factory=factory)
+
+        await cache.store("tenant-a", "1.2.3.4:50051")
+        await cache.store("tenant-b", "5.6.7.8:50051")
+        await cache.close()
+
+        ch1.close.assert_awaited_once()
+        ch2.close.assert_awaited_once()
+        assert await cache.get("tenant-a") is None

--- a/tests/unit/test_redirect_metadata.py
+++ b/tests/unit/test_redirect_metadata.py
@@ -1,0 +1,108 @@
+"""
+Server-side trailing metadata for tenant redirect hints.
+
+When a server rejects a tenant it doesn't own (multi-node sharding),
+it returns ``UNAVAILABLE`` with the human-readable hint
+``(try node X)`` baked into the message. To let SDKs *act* on that
+hint reliably (rather than parsing English), the server also
+attaches the owning node id as a trailing metadata header
+``entdb-redirect-node: <node_id>``.
+
+These tests assert the trailer is set when, and only when, the
+sharding layer can name an owner.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import pytest
+
+from dbaas.entdb_server.api.grpc_server import EntDBServicer
+from dbaas.entdb_server.sharding import ShardingConfig
+
+
+@pytest.mark.asyncio
+async def test_check_tenant_sets_redirect_trailer_when_owner_known():
+    """Server attaches entdb-redirect-node trailer when registry knows the owner."""
+    sharding = ShardingConfig(
+        node_id="node-a",
+        assigned_tenants=frozenset({"tenant-a"}),
+        tenant_registry={"tenant-b": "node-b"},
+    )
+    servicer = EntDBServicer(
+        wal=MagicMock(),
+        canonical_store=MagicMock(),
+        schema_registry=MagicMock(),
+        sharding=sharding,
+    )
+
+    context = AsyncMock()
+    context.abort = AsyncMock()
+    context.set_trailing_metadata = MagicMock(return_value=None)
+
+    await servicer._check_tenant("tenant-b", context)
+
+    # Trailer must be set BEFORE abort so the client can read it
+    # off the failed call.
+    context.set_trailing_metadata.assert_called_once()
+    sent = context.set_trailing_metadata.call_args[0][0]
+    # Trailer is a sequence of (key, value) tuples.
+    pairs = list(sent)
+    assert ("entdb-redirect-node", "node-b") in pairs
+
+    context.abort.assert_awaited_once()
+    code, msg = context.abort.call_args[0]
+    assert code == grpc.StatusCode.UNAVAILABLE
+    assert "node-b" in msg
+
+
+@pytest.mark.asyncio
+async def test_check_tenant_no_trailer_when_owner_unknown():
+    """No trailer when the registry doesn't know which node owns the tenant."""
+    sharding = ShardingConfig(
+        node_id="node-a",
+        assigned_tenants=frozenset({"tenant-a"}),
+        tenant_registry=None,
+    )
+    servicer = EntDBServicer(
+        wal=MagicMock(),
+        canonical_store=MagicMock(),
+        schema_registry=MagicMock(),
+        sharding=sharding,
+    )
+
+    context = AsyncMock()
+    context.abort = AsyncMock()
+    context.set_trailing_metadata = MagicMock(return_value=None)
+
+    await servicer._check_tenant("tenant-z", context)
+
+    context.set_trailing_metadata.assert_not_called()
+    context.abort.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_tenant_no_trailer_when_assigned_locally():
+    """A tenant we own goes through with no abort and no trailer."""
+    sharding = ShardingConfig(
+        node_id="node-a",
+        assigned_tenants=frozenset({"tenant-a"}),
+        tenant_registry={"tenant-a": "node-a"},
+    )
+    servicer = EntDBServicer(
+        wal=MagicMock(),
+        canonical_store=MagicMock(),
+        schema_registry=MagicMock(),
+        sharding=sharding,
+    )
+
+    context = AsyncMock()
+    context.abort = AsyncMock()
+    context.set_trailing_metadata = MagicMock(return_value=None)
+
+    await servicer._check_tenant("tenant-a", context)
+
+    context.abort.assert_not_awaited()
+    context.set_trailing_metadata.assert_not_called()


### PR DESCRIPTION
## Summary

When the server returns `UNAVAILABLE` for a tenant pinned to another node, SDKs now follow the redirect, cache the owning endpoint per-tenant, and re-issue the call on a sub-channel — instead of bouncing on every request.

## Design choice — Option D, DNS-template resolver

The server's `get_owner(tenant_id)` returns a `node_id` string (e.g. `node-a`), not an endpoint URL. The SDK ships a `NodeResolver` that maps node ids to dial-able endpoints; the default is a DNS template (`node-a.<base-domain>:50051`).

**Why DNS over an explicit map**

- Kubernetes StatefulSets backed by a headless service already give one DNS name per pod; the template matches that convention with zero config.
- Static deployments without DNS still work via `StaticMapResolver`.
- A custom resolver (Consul, etcd, AWS Cloud Map) can plug in for any other topology.

## Cache behaviour — sticky, evict on connection error

- **No TTL.** The user explicitly stated tenants don't move unless a node crashes, so blanket TTL would just churn DNS lookups for nothing.
- **Eviction triggers**: connection failure (UNAVAILABLE) on the cached sub-channel — the SDK then falls back to the primary endpoint on the next call. A "stale" signal hook is in place for a future server-side affordance.
- The cache reuses sub-channels across tenants that map to the same endpoint.

## Server change

`EntDBServicer._check_tenant` now attaches the owning `node_id` as an `entdb-redirect-node` trailing-metadata entry before aborting. The human-readable `(try node X)` tail of the error message is preserved for back-compat with older SDKs.

## Example usage

**Go**

```go
client, _ := entdb.NewClient(
    "entdb.svc.cluster.local:50051",
    entdb.WithBaseDomain("entdb.svc.cluster.local"),
)
// or, for static deployments / tests:
client, _ := entdb.NewClient(
    "10.0.0.1:50051",
    entdb.WithNodeResolver(&entdb.StaticMapResolver{Endpoints: map[string]string{
        "node-a": "10.0.0.1:50051",
        "node-b": "10.0.0.2:50051",
    }}),
)
```

**Python**

```python
async with DbClient(
    "entdb.svc.cluster.local:50051",
    base_domain="entdb.svc.cluster.local",
) as db:
    ...

# or with an explicit map
from entdb_sdk import StaticMapResolver

async with DbClient(
    "10.0.0.1:50051",
    node_resolver=StaticMapResolver(endpoints={
        "node-a": "10.0.0.1:50051",
        "node-b": "10.0.0.2:50051",
    }),
) as db:
    ...
```

## Test plan

- [x] `tests/unit/test_redirect_metadata.py` — server attaches trailer when registry knows the owner; not otherwise.
- [x] `tests/unit/test_redirect_cache.py` — Python resolvers, cache eviction, trailer extraction.
- [x] `sdk/go/entdb/resolver_test.go`, `redirect_cache_test.go` — Go resolvers + bufconn-backed end-to-end redirect path.
- [x] `tests/integration/test_redirect_cache.py` — real two-node servers; SDK follows the hint and caches the endpoint for the next call.
- [x] `python -m pytest tests/unit/ tests/integration/ -q` — 2381 passing.
- [x] `cd sdk/go/entdb && go vet ./... && go test ./...` — clean.
- [x] `uvx ruff@0.15.7 check .` and `format --check .` — clean.

## Conflict notes for reviewer

- PR-D (payload wire format flip) touches `sdk/go/entdb/marshal.go` — this PR doesn't go near that file.
- PR-G (Go SDK admin region option) touches `sdk/go/entdb/admin.go` — this PR doesn't touch admin.go either. The only Go file overlap is `client.go`, where this PR changes the `callContext` signature to thread tenant id and adds redirect-cache plumbing in `Connect`/`Close`. If PR-G also adds new admin options, the merge should be mechanical.

## Files touched

- 3 new Go files (resolver, redirect cache, tests)
- 1 new Python module (`_redirect_cache.py`) + 2 new test modules
- 1 new integration test
- Server: 1 file (grpc_server.py) — only the `_check_tenant` block
- Go SDK: 2 modified files (client.go, options.go)
- Python SDK: 3 modified files (`_grpc_client.py`, `client.py`, `__init__.py`)