### PR TITLE
fix(docker): track pyproject.toml deps via uv + smoke-test images before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,61 @@ jobs:
             # SHA
             type=sha,prefix=sha-
 
-      - name: Build and push
+      # Stage 1: build a single-arch image into the local docker daemon so
+      # we can boot it and run a real smoke test BEFORE pushing anything
+      # to the registry. This catches the "image fails at startup" class
+      # of bug (e.g. missing runtime dep) that the multi-arch push step
+      # cannot, since `load: true` is incompatible with multi-platform.
+      - name: Build (smoke, linux/amd64, load only)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          push: false
+          target: ${{ matrix.target }}
+          tags: entdb-smoke:${{ matrix.target }}
+          cache-from: type=gha
+          # Don't write smoke build to cache — let the multi-arch push
+          # step own the cache so its layers are reused.
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+
+      - name: Smoke test - server image boots and healthcheck reports SERVING
+        if: matrix.target == 'server'
+        run: |
+          set -euo pipefail
+          docker run -d --name entdb-smoke \
+            -e WAL_BACKEND=local \
+            -p 50051:50051 \
+            entdb-smoke:server
+          # Poll the in-image healthcheck (the same one Docker / k8s use).
+          # Wait up to 60s for the server to come up.
+          for i in $(seq 1 30); do
+            if docker exec entdb-smoke \
+                python -m dbaas.entdb_server.healthcheck --addr=localhost:50051; then
+              echo "::notice::Server healthy after ${i} attempts"
+              docker rm -f entdb-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Server did not become healthy within 60s — refusing to publish image"
+          docker logs entdb-smoke
+          docker rm -f entdb-smoke
+          exit 1
+
+      - name: Smoke test - SDK image imports entdb_sdk
+        if: matrix.target == 'sdk'
+        run: |
+          set -euo pipefail
+          docker run --rm entdb-smoke:sdk \
+            python -c "import entdb_sdk; print('entdb_sdk', entdb_sdk.__version__)"
+
+      # Stage 2: smoke passed — now build the multi-arch image and push.
+      # Buildkit reuses layers from the smoke build via gha cache.
+      - name: Build and push (multi-arch)
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -153,6 +207,19 @@ jobs:
         run: |
           cd sdk
           python -m build
+
+      # Smoke-test the built wheel in a clean venv before publishing.
+      # If the wheel can't be imported, refuse to push it to PyPI.
+      - name: Smoke test - install wheel and import entdb_sdk
+        run: |
+          set -euo pipefail
+          uv venv /tmp/sdk-smoke
+          uv pip install --python /tmp/sdk-smoke/bin/python sdk/dist/*.whl
+          /tmp/sdk-smoke/bin/python -c "
+          import entdb_sdk
+          from entdb_sdk import DbClient, register_proto_schema, Permission, Actor
+          print('entdb_sdk', entdb_sdk.__version__)
+          "
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,37 +55,42 @@ COPY playground/frontend/ playground/frontend/
 RUN cd playground/frontend && npm run build
 
 # =============================================================================
-# Builder stage - install dependencies
+# Builder stage - install dependencies via uv from pyproject.toml
 # =============================================================================
 FROM base AS builder
 
-# Install build dependencies
+# Pull pinned uv binary from the official distroless image. uv resolves
+# and installs the dependency tree from pyproject.toml extras, so the
+# image deps cannot drift from the declared deps.
+COPY --from=ghcr.io/astral-sh/uv:0.5.14 /uv /uvx /usr/local/bin/
+
+# Build deps for any wheels that need compilation (cryptography, grpcio
+# on uncommon archs). Most wheels are prebuilt.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Create virtual environment
-RUN python -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never
 
-# Copy requirements and install dependencies
-COPY pyproject.toml ./
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    pip install --no-cache-dir \
-    aiokafka>=0.10.0 \
-    aiobotocore>=2.11.0 \
-    aiohttp>=3.9.0 \
-    grpcio>=1.60.0 \
-    grpcio-tools>=1.60.0 \
-    uvicorn>=0.27.0 \
-    fastapi>=0.109.0 \
-    pydantic>=2.5.0 \
-    pydantic-settings>=2.0.0 \
-    pyyaml>=6.0.0 \
-    aiofiles>=23.2.0 \
-    PyJWT>=2.8.0 \
-    cryptography>=41.0.0
+RUN uv venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:$PATH"
+
+# pyproject.toml is the single source of truth for runtime deps.
+# `uv pip compile` resolves the named extras into a flat requirement
+# list, which `uv pip install` then installs. The entdb package itself
+# is NOT installed here — modules are imported from /app via PYTHONPATH
+# at the per-stage level, so a code change does not invalidate this
+# dependency layer.
+COPY pyproject.toml README.md ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip compile pyproject.toml \
+        --extra server --extra console --extra playground \
+        -o /tmp/requirements.txt && \
+    uv pip install --no-cache -r /tmp/requirements.txt
 
 # =============================================================================
 # Server stage - production image
@@ -210,10 +215,6 @@ FROM base AS playground
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Install playground dependencies (SDK from PyPI)
-COPY playground/requirements.txt /app/playground/
-RUN pip install --no-cache-dir -r /app/playground/requirements.txt
-
 # Copy application code
 COPY playground/*.py /app/playground/
 
@@ -248,13 +249,11 @@ CMD ["uvicorn", "playground.app:app", "--host", "0.0.0.0", "--port", "8081"]
 # =============================================================================
 FROM builder AS test
 
-# Install test dependencies
-RUN pip install --no-cache-dir \
-    pytest>=7.4.0 \
-    pytest-asyncio>=0.23.0 \
-    pytest-cov>=4.1.0 \
-    pytest-timeout>=2.2.0 \
-    httpx>=0.26.0
+# Install dev extras (pytest, mypy, grpcio-tools, etc.) on top of the
+# runtime venv. Source of truth is pyproject.toml [dev] extras.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip compile pyproject.toml --extra dev -o /tmp/dev-requirements.txt && \
+    uv pip install --no-cache -r /tmp/dev-requirements.txt
 
 # Copy all code
 COPY . /app/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,25 @@ server = [
     "grpcio-health-checking>=1.60.0",
     "PyJWT>=2.8.0",
     "cryptography>=41.0.0",
+    "PyYAML>=6.0.0",
+]
+console = [
+    "fastapi>=0.109.0",
+    "uvicorn[standard]>=0.27.0",
+    "pydantic>=2.5.0",
+    "pydantic-settings>=2.1.0",
+    "httpx>=0.26.0",
+    "python-multipart>=0.0.6",
+    "aiofiles>=23.2.0",
+]
+playground = [
+    "aiohttp>=3.9.0",
+    "uvicorn>=0.27.0",
+    "fastapi>=0.109.0",
+    "pydantic>=2.5.0",
+    "pydantic-settings>=2.0.0",
+    "PyYAML>=6.0.0",
+    "aiofiles>=23.2.0",
 ]
 pubsub = [
     "google-cloud-pubsub>=2.18.0",
@@ -77,7 +96,7 @@ dev = [
     "grpcio-tools>=1.60.0",
 ]
 all = [
-    "entdb[server,sdk,metrics,tracing,pubsub,servicebus,eventhubs,azure-storage,gcs,dev]",
+    "entdb[server,console,playground,sdk,metrics,tracing,pubsub,servicebus,eventhubs,azure-storage,gcs,dev]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- **Root cause of the unstartable v1.9.0 image**: the Dockerfile maintained a hand-rolled pip list that drifted from `pyproject.toml`. PR #153 added `grpcio-health-checking` to the `[server]` extra but never updated the Dockerfile, so the image shipped without it and the server crashed at startup with `ModuleNotFoundError: No module named 'grpc_health'` from `grpc_server.py:3171` (and the in-image `healthcheck.py` probe).
- Make `pyproject.toml` the single source of truth for image deps via `uv pip compile`, so this drift cannot happen again.
- Add release-time smoke tests that **refuse to publish** a server image that doesn't boot, an SDK image that doesn't import, or a Python wheel that doesn't import.

## What changed

**`pyproject.toml`**
- Add `PyYAML` to `[server]` (already used by `main.py`, was implicit via the Dockerfile pip list).
- New `[console]` extra: `fastapi`, `uvicorn[standard]`, `pydantic`, `pydantic-settings`, `httpx`, `python-multipart`, `aiofiles`. Mirrors `console/requirements.txt`.
- New `[playground]` extra: `aiohttp`, `uvicorn`, `fastapi`, `pydantic`, `pydantic-settings`, `PyYAML`, `aiofiles`. Mirrors `playground/requirements.txt`.
- `[all]` pulls in `[console]` and `[playground]` alongside `[server]`.

**`Dockerfile`**
- Builder stage copies the pinned uv binary from `ghcr.io/astral-sh/uv:0.5.14` and runs:
  ```
  uv pip compile pyproject.toml \
      --extra server --extra console --extra playground \
      -o /tmp/requirements.txt
  uv pip install --no-cache -r /tmp/requirements.txt
  ```
  The hand-rolled pip list (and the drift bug class it enabled) is gone.
- Test stage: same pattern with `--extra dev`.
- `UV_LINK_MODE=copy`, `UV_COMPILE_BYTECODE=1`, `UV_PYTHON_DOWNLOADS=never` for a deterministic install.

**`.github/workflows/release.yml`**
- `build-and-push` now runs in two stages per matrix target:
  1. Build `linux/amd64` with `load: true`, then run a real smoke test against the loaded image.
     - `server`: `docker run` with `WAL_BACKEND=local`, then poll the in-image healthcheck (`python -m dbaas.entdb_server.healthcheck`) for up to 60s. If it never returns `SERVING`, the job fails and **nothing is pushed**. This is the exact gate that would have blocked v1.9.0.
     - `sdk`: `docker run` + `import entdb_sdk`.
  2. Build the multi-arch image (`linux/amd64,linux/arm64`) and push to ghcr — only after step 1 passes. Layers are reused via the gha cache.
- `publish-pypi`: install the freshly-built wheel into a clean uv venv and import `DbClient`, `register_proto_schema`, `Permission`, `Actor` before handing the wheel to `pypa/gh-action-pypi-publish`. A wheel that can't be imported fails the job before it hits PyPI.

## Why this prevents the regression

The v1.9.0 failure mode was: pyproject said the dep was needed, the image didn't have it, CI didn't notice, the tag got published, and consumers had to roll back to v1.8.0. After this PR:

1. The image cannot ship without a dep that's declared in pyproject — the Dockerfile reads pyproject directly.
2. Even if a wholly new failure mode appears (broken code, missing system lib, wrong CMD), the release workflow boots the image and runs the standard health probe before pushing. No SERVING → no push.
3. Same protection on the Python SDK side: an unimportable wheel fails CI before PyPI sees it.

## Test plan

Local verification before pushing:

- [x] `docker build --target server` succeeds with the new Dockerfile
- [x] Resolved dep tree contains `grpcio-health-checking==1.80.0`
- [x] `docker run -e WAL_BACKEND=local` + in-image `python -m dbaas.entdb_server.healthcheck` returns SERVING
- [x] `from grpc_health.v1 import health, health_pb2, health_pb2_grpc` (the line that broke v1.9.0) succeeds in a fresh venv built from the same pyproject extras
- [x] `import dbaas.entdb_server.main` succeeds in that venv
- [x] `pytest tests/unit tests/integration -q` — 2413 passed
- [x] `uvx ruff@0.15.7 check .` — clean
- [x] `uvx ruff@0.15.7 format --check .` — clean

CI verification on this branch:

- [ ] `docker-build` (CI) builds the new Dockerfile
- [ ] `e2e-tests` boots the server image
- [ ] `lint`, `unit-tests`, `integration-tests` pass
- [ ] On a real release tag the new smoke gates exercise (will validate post-merge by cutting `v1.9.1`)

## Follow-ups (not in this PR, intentionally scoped out)

- Drop `console/requirements.txt` and `playground/requirements.txt` — they're now redundant with the new pyproject.toml extras. Needs a sweep of docs / local-dev scripts that reference them.
- Add `uv.lock` for byte-reproducible release builds. Adds noise to this diff and is independent of the bug fix; doing it separately.
- The `e2e-tests` compose still overrides the Dockerfile `HEALTHCHECK` with an inline `python -c "import grpc; ..."` block. The release smoke test now covers the `HEALTHCHECK` path; aligning e2e onto the same probe is a small follow-up that would also catch this regression class at PR time.