### PR TITLE
fix(docker): SDK image PYTHONPATH so import entdb_sdk works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,14 +156,16 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Copy all code including examples
 COPY . /app/
 
-# Set Python path
-ENV PYTHONPATH="/app"
+# entdb_sdk lives at /app/sdk/entdb_sdk, dbaas at /app/dbaas. Both must
+# be on PYTHONPATH so `import entdb_sdk` and `import dbaas` work in
+# sample apps without each app having to set its own PYTHONPATH.
+ENV PYTHONPATH="/app:/app/sdk"
 
 # Switch to non-root user
 USER entdb
 
 # Default command for SDK stage
-CMD ["python", "-c", "print('EntDB SDK ready')"]
+CMD ["python", "-c", "import entdb_sdk; print(f'EntDB SDK {entdb_sdk.__version__} ready')"]
 
 # =============================================================================
 # Console stage - Read-only data browser


### PR DESCRIPTION
## Summary

Caught by the release-time smoke test added in #158 — the sdk-stage image set `PYTHONPATH=/app` but the SDK lives at `/app/sdk/entdb_sdk/`, so `import entdb_sdk` raised `ModuleNotFoundError`. The image was shipping an SDK it couldn't import.

Fix: set `PYTHONPATH=/app:/app/sdk` (same as the server stage) and switch the default CMD to exercise `import entdb_sdk` + print the version, so the failure mode is loud rather than silent.

This is exactly the regression class #158 was built to catch — the v1.9.1 tag's release workflow failed at the SDK smoke gate and **nothing was published** (no ghcr image, no PyPI, no Go module proxy entry). System working as designed.

## Test plan

- [x] `docker build --target sdk` succeeds
- [x] `docker run --rm entdb-sdk python -c "import entdb_sdk; from entdb_sdk import DbClient, register_proto_schema, Permission, Actor; print(entdb_sdk.__version__)"` → prints version
- [x] `ruff check .` — clean
- [ ] CI green
- [ ] After merge: re-cut as v1.9.2 (v1.9.1 is now associated with the failed run; cleaner to skip)