### PR TITLE
ci: native arm64 runners + per-platform digests + path-filtered PR jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,54 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Compute which kinds of files changed so heavy jobs can skip when
+  # they're irrelevant (e.g. unit tests on a Dockerfile-only change).
+  # Path-filter is fast (~5s); the savings on the heavy jobs are large.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      go: ${{ steps.filter.outputs.go }}
+      docker: ${{ steps.filter.outputs.docker }}
+      ci: ${{ steps.filter.outputs.ci }}
+      schema: ${{ steps.filter.outputs.schema }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # On `push` events to main/develop the action diffs against
+          # the previous commit; on PRs it diffs against the base ref.
+          # `pyproject.toml` is in every filter because it can change
+          # what gets installed in any environment.
+          filters: |
+            python:
+              - 'dbaas/**'
+              - 'sdk/entdb_sdk/**'
+              - 'console/**'
+              - 'playground/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.github/workflows/ci.yml'
+            go:
+              - 'sdk/go/**'
+              - '.github/workflows/ci.yml'
+            docker:
+              - 'Dockerfile'
+              - 'docker-compose*.yml'
+              - 'tests/e2e/**'
+              - 'pyproject.toml'
+              - '.github/workflows/ci.yml'
+            ci:
+              - '.github/workflows/**'
+            schema:
+              - 'dbaas/entdb_server/schema/**'
+              - 'dbaas/entdb_server/api/**.proto'
+              - 'sdk/entdb_sdk/schema*'
+              - '.schema-snapshot.json'
+              - '.github/workflows/ci.yml'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -29,6 +77,8 @@ jobs:
   type-check:
     name: Type Check
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -42,6 +92,8 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -59,6 +111,8 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -71,6 +125,8 @@ jobs:
   schema-compat:
     name: Schema Compatibility Check
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.schema == 'true' || needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -90,6 +146,8 @@ jobs:
   docker-build:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -105,7 +163,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [docker-build]
+    needs: [changes, docker-build]
+    if: needs.changes.outputs.docker == 'true' || needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -126,9 +185,23 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
 
+  # Aggregator job for branch protection. `if: always()` so it runs even
+  # when upstream jobs were skipped by path filters; the script then
+  # fails only if a non-skipped job didn't succeed. Skipped == OK.
   all-checks:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [lint, unit-tests, integration-tests, docker-build, e2e-tests]
+    if: always()
+    needs: [lint, type-check, unit-tests, integration-tests, schema-compat, docker-build, e2e-tests, security-scan]
     steps:
-      - run: echo "All CI checks passed!"
+      - name: Verify required checks
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS" | jq .
+          if echo "$NEEDS" | jq -e 'to_entries | any(.value.result == "failure" or .value.result == "cancelled")' >/dev/null; then
+            echo "::error::At least one upstream job failed or was cancelled"
+            exit 1
+          fi
+          echo "All required checks passed (skipped checks counted as success)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,20 +10,43 @@ env:
   PYTHON_VERSION: "3.11"
 
 jobs:
-  build-and-push:
-    name: Build and Push Images
-    runs-on: ubuntu-latest
+  # Build each (target × platform) on its native runner — no QEMU. Each
+  # leg runs in parallel; wall-clock = max(slowest native build), not
+  # max(slowest emulated build). Each leg builds, smoke-tests on its
+  # native arch, and pushes the resulting image *by digest* (no tag).
+  # The merge job then stitches the per-platform digests into a single
+  # multi-arch manifest under the semver tags.
+  build:
+    name: Build (${{ matrix.target }}, ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: server
             suffix: ""
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - target: server
+            suffix: ""
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
           - target: sdk
             suffix: "-sdk"
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - target: sdk
+            suffix: "-sdk"
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
@@ -35,8 +58,123 @@ jobs:
           echo "__version__ = \"$VER\"" > sdk/entdb_sdk/_version.py
           echo "__version__ = \"$VER\"" > dbaas/entdb_server/_version.py
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Stage 1: build a loadable single-platform image and run a real
+      # smoke test on the same native runner. This catches startup-time
+      # regressions (e.g. missing dep, broken import, broken CMD) and
+      # arch-specific issues — each platform's smoke runs on its own
+      # native arch, not under emulation.
+      - name: Build (smoke, load only)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          load: true
+          push: false
+          target: ${{ matrix.target }}
+          tags: entdb-smoke:${{ matrix.target }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.target }}-${{ matrix.arch }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+
+      - name: Smoke test - server image boots and healthcheck reports SERVING
+        if: matrix.target == 'server'
+        run: |
+          set -euo pipefail
+          docker run -d --name entdb-smoke \
+            -e WAL_BACKEND=local \
+            -p 50051:50051 \
+            entdb-smoke:server-${{ matrix.arch }}
+          for i in $(seq 1 30); do
+            if docker exec entdb-smoke \
+                python -m dbaas.entdb_server.healthcheck --addr=localhost:50051; then
+              echo "::notice::Server (${{ matrix.arch }}) healthy after ${i} attempts"
+              docker rm -f entdb-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Server (${{ matrix.arch }}) did not become healthy within 60s"
+          docker logs entdb-smoke
+          docker rm -f entdb-smoke
+          exit 1
+
+      - name: Smoke test - SDK image imports entdb_sdk
+        if: matrix.target == 'sdk'
+        run: |
+          set -euo pipefail
+          docker run --rm entdb-smoke:sdk-${{ matrix.arch }} \
+            python -c "import entdb_sdk; print('entdb_sdk', entdb_sdk.__version__, 'on ${{ matrix.arch }}')"
+
+      # Stage 2: smoke passed — push the same image to the registry by
+      # digest only (no tag). Buildkit reuses the cached layers from the
+      # smoke build via the gha cache scope above.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          target: ${{ matrix.target }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.suffix }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.target }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.arch }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.target }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-platform digests for each target into a single
+  # multi-arch manifest list, applying the semver / latest / sha tags
+  # from docker/metadata-action.
+  merge:
+    name: Merge multi-arch manifest (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: server
+            suffix: ""
+          - target: sdk
+            suffix: "-sdk"
+
+    steps:
+      - name: Download per-platform digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-${{ matrix.target }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -63,79 +201,22 @@ jobs:
             # SHA
             type=sha,prefix=sha-
 
-      # Stage 1: build a single-arch image into the local docker daemon so
-      # we can boot it and run a real smoke test BEFORE pushing anything
-      # to the registry. This catches the "image fails at startup" class
-      # of bug (e.g. missing runtime dep) that the multi-arch push step
-      # cannot, since `load: true` is incompatible with multi-platform.
-      - name: Build (smoke, linux/amd64, load only)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64
-          load: true
-          push: false
-          target: ${{ matrix.target }}
-          tags: entdb-smoke:${{ matrix.target }}
-          cache-from: type=gha
-          # Don't write smoke build to cache — let the multi-arch push
-          # step own the cache so its layers are reused.
-          build-args: |
-            VERSION=${{ github.ref_name }}
-            COMMIT=${{ github.sha }}
-
-      - name: Smoke test - server image boots and healthcheck reports SERVING
-        if: matrix.target == 'server'
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
         run: |
-          set -euo pipefail
-          docker run -d --name entdb-smoke \
-            -e WAL_BACKEND=local \
-            -p 50051:50051 \
-            entdb-smoke:server
-          # Poll the in-image healthcheck (the same one Docker / k8s use).
-          # Wait up to 60s for the server to come up.
-          for i in $(seq 1 30); do
-            if docker exec entdb-smoke \
-                python -m dbaas.entdb_server.healthcheck --addr=localhost:50051; then
-              echo "::notice::Server healthy after ${i} attempts"
-              docker rm -f entdb-smoke
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "::error::Server did not become healthy within 60s — refusing to publish image"
-          docker logs entdb-smoke
-          docker rm -f entdb-smoke
-          exit 1
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.suffix }}@sha256:%s ' *)
 
-      - name: Smoke test - SDK image imports entdb_sdk
-        if: matrix.target == 'sdk'
+      - name: Inspect resulting manifest
         run: |
-          set -euo pipefail
-          docker run --rm entdb-smoke:sdk \
-            python -c "import entdb_sdk; print('entdb_sdk', entdb_sdk.__version__)"
-
-      # Stage 2: smoke passed — now build the multi-arch image and push.
-      # Buildkit reuses layers from the smoke build via gha cache.
-      - name: Build and push (multi-arch)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: ${{ matrix.target }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            VERSION=${{ github.ref_name }}
-            COMMIT=${{ github.sha }}
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.suffix }}:${{ steps.meta.outputs.version }}
 
   publish-go-sdk:
     name: Publish Go SDK
     runs-on: ubuntu-latest
-    needs: [build-and-push]
+    needs: [merge]
     permissions:
       contents: write
     steps:
@@ -179,7 +260,7 @@ jobs:
   publish-pypi:
     name: Publish SDK to PyPI
     runs-on: ubuntu-latest
-    needs: [build-and-push]
+    needs: [merge]
     permissions:
       id-token: write
 
@@ -229,7 +310,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-and-push]
+    needs: [merge]
     permissions:
       contents: write
 


### PR DESCRIPTION
Two independent wins, both motivated by the v1.9.2 release wall-clock and the cost of running every PR check on a Dockerfile-only change.

## release.yml — drop QEMU, build natively per arch

The previous build was `linux/amd64,linux/arm64` on `ubuntu-latest`, so arm64 layers were emulated under QEMU. Each `RUN` step (pip resolve, install, bytecode compile) ran through CPU emulation, ~3–5× slower than native. Wall-clock was bounded by the slowest (emulated) leg.

Now the matrix has four legs, each on its own native runner:

| target × platform | runner |
|---|---|
| server × linux/amd64 | `ubuntu-latest` |
| server × linux/arm64 | `ubuntu-24.04-arm` |
| sdk × linux/amd64 | `ubuntu-latest` |
| sdk × linux/arm64 | `ubuntu-24.04-arm` |

`ubuntu-24.04-arm` is GitHub's free arm64 runner for public repos. All four legs run in parallel, no QEMU.

Each leg:
1. Loads a single-platform image into the local docker daemon (`load: true`).
2. Runs the existing smoke test on that arch's native runner — server: `docker run` + healthcheck poll; sdk: import + version. Smoking each arch (instead of just amd64) catches arch-specific regressions for free.
3. On smoke pass, pushes the image to ghcr **by digest only** (`push-by-digest=true`, no tag). Buildkit reuses the smoke build's layers via per-(target,arch) gha cache scope.
4. Uploads the digest as a workflow artifact.

A new `merge` job (matrix: target=server,sdk) downloads the per-platform digests for its target and runs `docker buildx imagetools create` to stitch them into a single multi-arch manifest under the existing semver tags from `docker/metadata-action` (`1.9.2` / `1.9` / `1` / `latest` / `sha-…`). It also inspects the resulting manifest so a malformed list fails loudly.

`publish-go-sdk`, `publish-pypi`, `create-release` now `needs: [merge]` — downstream jobs only run after consumers can actually pull the multi-arch image. The PyPI wheel smoke and SDK image smoke from #158 / #160 are unchanged.

## ci.yml — path-filter heavy jobs on PRs

Previously every PR (including one-line Dockerfile diffs) ran lint + type-check + unit + integration + schema-compat + docker-build + e2e + security-scan + benchmarks.

Add a `changes` job using `dorny/paths-filter@v3` (~5s) with outputs:

- `python` — `dbaas/`, `sdk/entdb_sdk/`, `console/`, `playground/`, `tests/`, `pyproject.toml`
- `go` — `sdk/go/`
- `docker` — `Dockerfile`, `docker-compose*.yml`, `tests/e2e/`, `pyproject.toml`
- `schema` — `dbaas/entdb_server/schema/`, `*.proto`, `.schema-snapshot.json`

Each heavy job gates on the relevant filter; lint and security-scan still run unconditionally. The `all-checks` aggregator is now `if: always()` and inspects `${{ toJSON(needs) }}`, failing only when a non-skipped job didn't succeed — skipped jobs count as success, which is required for path-filtering to work without breaking branch-protection's required-status-checks.

## Estimated savings (from v1.9.2 numbers)

- **Release build phase:** ~3m → ~75s (slowest native leg, not slowest emulated leg).
- **PR CI for a Dockerfile-only change:** ~3m → ~45s (lint + security + docker-build + e2e + 5s changes job).
- **PR CI for a pure Python refactor under `tests/`:** no longer rebuilds the Docker image or runs e2e.

## Test plan

- [x] Both YAMLs parse (`yaml.safe_load`)
- [ ] CI run on this PR exercises the `changes` job + path-filter logic (this PR touches only `.github/workflows/`, so the `ci` filter fires; python/docker filters should be false; heavy jobs should skip)
- [ ] Next release tag (v1.9.3 or whatever) exercises the new four-leg native build + manifest merge end-to-end
- [ ] Verify the resulting `:latest` / semver / `sha-` tags resolve correctly on `docker pull` from both an arm64 and an amd64 host

## Risks / caveats

- `ubuntu-24.04-arm` is GA and free for public repos but has different runner labels from the hosted amd64 fleet. If quota is ever an issue this is the first place to look.
- The `merge` job is now a single point of failure for getting consumer-visible tags. If the per-platform legs all push by digest and merge fails, the digests are orphaned (untagged) in ghcr — harmless but worth a periodic cleanup script as a follow-up.
- Branch protection's required-status-check list, if any, may include job names that have changed. If the repo enforces "Build and Push Images" by name, that check is now `Build (server, amd64)` etc. — the rule list will need to be updated post-merge.