### PR TITLE
fix(security): close privilege escalation via client-supplied actor in gRPC handlers

### DIFF
--- a/dbaas/entdb_server/api/grpc_server.py
+++ b/dbaas/entdb_server/api/grpc_server.py
@@ -415,6 +415,27 @@ class EntDBServicer(EntDBServiceServicer):
             return actor[5:]
         return actor
 
+    def _trusted_actor(self, request_actor: str) -> str:
+        """Return the actor string a handler should use for everything
+        downstream of the gRPC ingress boundary.
+
+        The trusted identity from :class:`AuthInterceptor` ALWAYS wins
+        when present. The caller-supplied ``actor`` is only honoured
+        when the interceptor did not run (no-auth deployments and
+        unit tests). This is the belt-and-suspenders companion to the
+        choke-point fixes inside :meth:`_is_admin_or_system`,
+        :meth:`_check_tenant_access` and :meth:`_check_cross_tenant_read`
+        — every handler should immediately rebind its ``actor``
+        variable to the trusted value so a future authorization
+        helper added in the chain cannot honour a forged claim.
+
+        See ``dbaas/entdb_server/auth/auth_interceptor.py`` for
+        details on the underlying ``ContextVar``.
+        """
+        from ..auth.auth_interceptor import get_authoritative_actor
+
+        return get_authoritative_actor(request_actor)
+
     async def _check_tenant_access(
         self,
         tenant_id: str,
@@ -444,7 +465,14 @@ class EntDBServicer(EntDBServiceServicer):
 
         Args:
             tenant_id:    Tenant identifier to check.
-            actor:        Actor string (``user:<id>``, ``system:*`` etc).
+            actor:        Actor string (``user:<id>``, ``system:*`` etc)
+                          taken from the request payload. The helper
+                          ALWAYS substitutes the trusted identity from
+                          :class:`AuthInterceptor` before deciding —
+                          a payload claim of ``"system:admin"`` from a
+                          regular ``user:eve`` is downgraded to
+                          ``user:eve``. This is the defence-in-depth
+                          fix for the actor-trust privilege escalation.
             context:      gRPC servicer context for ``abort()``.
             require_write: If True, the caller is requesting a write op.
             op_kind:      One of ``"read"``, ``"create"``, ``"write"``,
@@ -457,6 +485,13 @@ class EntDBServicer(EntDBServiceServicer):
             ``None`` only when the call has been aborted (the abort raises,
             so callers will not actually receive ``None`` in practice).
         """
+        # Substitute the trusted identity so a careless caller cannot
+        # bypass the privilege check by sending a privileged-looking
+        # actor string in the request payload.
+        from ..auth.auth_interceptor import get_authoritative_actor
+
+        actor = get_authoritative_actor(actor)
+
         if self.global_store is None:
             return "system"
 
@@ -537,9 +572,21 @@ class EntDBServicer(EntDBServiceServicer):
         entry in the tenant, returns "cross_tenant".
         Otherwise aborts with PERMISSION_DENIED.
 
+        ``actor`` is taken from the request payload but the helper
+        substitutes the trusted identity from :class:`AuthInterceptor`
+        before checking — a payload claim of ``"system:admin"`` from a
+        regular ``user:eve`` is downgraded to ``user:eve``. This is
+        the defence-in-depth fix for the actor-trust privilege
+        escalation; without it any authenticated user could short-
+        circuit through the ``startswith("system:")`` branch below.
+
         Returns:
             "local" (no global_store), "member", or "cross_tenant".
         """
+        from ..auth.auth_interceptor import get_authoritative_actor
+
+        actor = get_authoritative_actor(actor)
+
         if not self.global_store:
             return "local"
 
@@ -588,6 +635,14 @@ class EntDBServicer(EntDBServiceServicer):
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "actor is required")
             if not request.operations:
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "operations list is empty")
+
+            # SECURITY: replace the request-supplied actor with the
+            # trusted identity from AuthInterceptor for the rest of
+            # the handler. The persisted WAL event MUST record who
+            # actually performed the action, not whatever string the
+            # caller put on the wire — otherwise audit and GDPR
+            # exports both lie about provenance.
+            trusted_actor = self._trusted_actor(ctx.actor)
 
             # Generate idempotency key if not provided
             idempotency_key = request.idempotency_key or str(uuid.uuid4())
@@ -702,7 +757,7 @@ class EntDBServicer(EntDBServiceServicer):
             has_delete = any(op.get("op") in ("delete_node", "delete_edge") for op in ops)
             await self._check_tenant_access(
                 tenant_id=ctx.tenant_id,
-                actor=ctx.actor,
+                actor=trusted_actor,
                 context=context,
                 require_write=True,
                 op_kind="delete" if has_delete else "write",
@@ -716,10 +771,13 @@ class EntDBServicer(EntDBServiceServicer):
                         op["id"] = str(uuid.uuid4())
                     created_node_ids.append(op["id"])
 
-            # Build transaction event
+            # Build transaction event. The persisted ``actor`` is
+            # the trusted identity, NOT the (possibly forged) string
+            # the client claimed. This is the audit-truth invariant
+            # the privilege-escalation fix preserves.
             event = {
                 "tenant_id": ctx.tenant_id,
-                "actor": ctx.actor,
+                "actor": trusted_actor,
                 "idempotency_key": idempotency_key,
                 "schema_fingerprint": self.schema_registry.fingerprint,
                 "ts_ms": int(time.time() * 1000),
@@ -947,9 +1005,10 @@ class EntDBServicer(EntDBServiceServicer):
         start = time.perf_counter()
         try:
             await self._check_tenant(request.context.tenant_id, context)
+            trusted_actor = self._trusted_actor(request.context.actor)
             role = await self._check_cross_tenant_read(
                 request.context.tenant_id,
-                request.context.actor,
+                trusted_actor,
                 context,
             )
 
@@ -972,7 +1031,7 @@ class EntDBServicer(EntDBServiceServicer):
             if role == "cross_tenant":
                 actor_ids = await self.canonical_store.resolve_actor_groups(
                     request.context.tenant_id,
-                    request.context.actor,
+                    trusted_actor,
                 )
                 has_access = await self.canonical_store.can_access(
                     request.context.tenant_id,
@@ -1047,13 +1106,15 @@ class EntDBServicer(EntDBServiceServicer):
                 return GetNodeByKeyResponse(found=False)
 
             # Delegate to GetNode so ACL / cross-tenant / capability
-            # checks stay centralised.
+            # checks stay centralised. Forward the trusted identity
+            # so a forged ``request.actor`` cannot ride the inner
+            # call.
             from .generated import RequestContext as _RequestContext
 
             get_req = GetNodeRequest(
                 context=_RequestContext(
                     tenant_id=request.tenant_id,
-                    actor=request.actor,
+                    actor=self._trusted_actor(request.actor),
                 ),
                 type_id=int(request.type_id),
                 node_id=node.node_id,
@@ -1109,15 +1170,16 @@ class EntDBServicer(EntDBServiceServicer):
             )
 
             # ACL filtering: same pattern as QueryNodes
+            trusted_actor = self._trusted_actor(request.actor)
             role = await self._check_cross_tenant_read(
                 request.tenant_id,
-                request.actor,
+                trusted_actor,
                 context,
             )
             if role == "cross_tenant":
                 actor_ids = await self.canonical_store.resolve_actor_groups(
                     request.tenant_id,
-                    request.actor,
+                    trusted_actor,
                 )
                 accessible = []
                 for n in nodes:
@@ -1163,9 +1225,10 @@ class EntDBServicer(EntDBServiceServicer):
         start = time.perf_counter()
         try:
             await self._check_tenant(request.context.tenant_id, context)
+            trusted_actor = self._trusted_actor(request.context.actor)
             role = await self._check_cross_tenant_read(
                 request.context.tenant_id,
-                request.context.actor,
+                trusted_actor,
                 context,
             )
 
@@ -1181,7 +1244,7 @@ class EntDBServicer(EntDBServiceServicer):
             if role == "cross_tenant":
                 actor_ids = await self.canonical_store.resolve_actor_groups(
                     request.context.tenant_id,
-                    request.context.actor,
+                    trusted_actor,
                 )
 
             nodes = []
@@ -1240,9 +1303,10 @@ class EntDBServicer(EntDBServiceServicer):
         start = time.perf_counter()
         try:
             await self._check_tenant(request.context.tenant_id, context)
+            trusted_actor = self._trusted_actor(request.context.actor)
             role = await self._check_cross_tenant_read(
                 request.context.tenant_id,
-                request.context.actor,
+                trusted_actor,
                 context,
             )
 
@@ -1281,7 +1345,7 @@ class EntDBServicer(EntDBServiceServicer):
             if role == "cross_tenant":
                 actor_ids = await self.canonical_store.resolve_actor_groups(
                     request.context.tenant_id,
-                    request.context.actor,
+                    trusted_actor,
                 )
                 accessible = []
                 for n in nodes:
@@ -1654,9 +1718,10 @@ class EntDBServicer(EntDBServiceServicer):
         start = time.perf_counter()
         try:
             await self._check_tenant(request.context.tenant_id, context)
+            trusted_actor = self._trusted_actor(request.context.actor)
             actor_ids = await self.canonical_store.resolve_actor_groups(
                 request.context.tenant_id,
-                request.context.actor,
+                trusted_actor,
             )
             limit = request.limit or 100
             nodes = await self.canonical_store.get_connected_nodes(
@@ -1695,9 +1760,10 @@ class EntDBServicer(EntDBServiceServicer):
         start = time.perf_counter()
         try:
             await self._check_tenant(request.context.tenant_id, context)
+            trusted_actor = self._trusted_actor(request.context.actor)
             await self._check_tenant_access(
                 request.context.tenant_id,
-                request.context.actor,
+                trusted_actor,
                 context,
                 require_write=True,
             )
@@ -1716,7 +1782,7 @@ class EntDBServicer(EntDBServiceServicer):
             try:
                 await self._check_capability(
                     tenant_id,
-                    request.context.actor,
+                    trusted_actor,
                     request.node_id,
                     type_id,
                     "ShareNode",
@@ -1730,7 +1796,7 @@ class EntDBServicer(EntDBServiceServicer):
                 node_id=request.node_id,
                 actor_id=actor_id,
                 permission=permission,
-                granted_by=request.context.actor,
+                granted_by=trusted_actor,
                 actor_type=request.actor_type or "user",
                 expires_at=expires_at,
                 type_id=type_id,
@@ -1768,12 +1834,13 @@ class EntDBServicer(EntDBServiceServicer):
         start = time.perf_counter()
         try:
             await self._check_tenant(request.context.tenant_id, context)
+            trusted_actor = self._trusted_actor(request.context.actor)
             tenant_id = request.context.tenant_id
             actor_id = request.actor_id
             try:
                 await self._check_capability(
                     tenant_id,
-                    request.context.actor,
+                    trusted_actor,
                     request.node_id,
                     0,
                     "RevokeAccess",
@@ -1821,7 +1888,7 @@ class EntDBServicer(EntDBServiceServicer):
         try:
             await self._check_tenant(request.context.tenant_id, context)
             tenant_id = request.context.tenant_id
-            actor = request.context.actor
+            actor = self._trusted_actor(request.context.actor)
             actor_ids = await self.canonical_store.resolve_actor_groups(
                 tenant_id,
                 actor,
@@ -1984,12 +2051,39 @@ class EntDBServicer(EntDBServiceServicer):
     # --- User registry handlers ---
 
     def _is_admin_or_system(self, actor: str) -> bool:
-        """Check if actor is admin or system."""
-        return actor.startswith("system:") or actor.startswith("admin:") or actor == "__system__"
+        """Check if actor is admin or system.
+
+        ``actor`` is the raw request payload value; the helper
+        substitutes the trusted identity from :class:`AuthInterceptor`
+        before doing the privilege string check. Without this
+        substitution any authenticated user could send
+        ``actor="system:admin"`` and elevate themselves on the
+        privilege checks done by callers like ``CreateUser`` and the
+        tenant-admin handlers.
+        """
+        from ..auth.auth_interceptor import get_authoritative_actor
+
+        trusted = get_authoritative_actor(actor)
+        return (
+            trusted.startswith("system:") or trusted.startswith("admin:") or trusted == "__system__"
+        )
 
     def _is_self_or_admin(self, actor: str, user_id: str) -> bool:
-        """Check if actor is the user themselves or an admin/system."""
-        return self._is_admin_or_system(actor) or actor == f"user:{user_id}" or actor == user_id
+        """Check if actor is the user themselves or an admin/system.
+
+        Like :meth:`_is_admin_or_system`, the privilege decision is
+        made on the trusted identity from :class:`AuthInterceptor`,
+        not the request payload. The "self" arm compares the trusted
+        identity against ``user_id`` so a malicious caller cannot
+        smuggle a privileged actor string past the ``startswith``
+        check.
+        """
+        from ..auth.auth_interceptor import get_authoritative_actor
+
+        trusted = get_authoritative_actor(actor)
+        if trusted.startswith("system:") or trusted.startswith("admin:") or trusted == "__system__":
+            return True
+        return trusted == f"user:{user_id}" or trusted == user_id
 
     def _user_dict_to_proto(self, user: dict) -> UserInfo:
         """Convert a user dict to a UserInfo proto message."""
@@ -2228,6 +2322,12 @@ class EntDBServicer(EntDBServiceServicer):
             if not request.name:
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "name is required")
 
+            # SECURITY: bind to the trusted identity so the creator
+            # recorded as owner cannot be forged by sending
+            # ``actor=user:carol`` from a session authenticated as
+            # ``user:eve``.
+            trusted_actor = self._trusted_actor(request.actor)
+
             # Empty region defaults to the server's served region (or
             # 'us-east-1' when this node has no region configured —
             # single-region back-compat).
@@ -2240,7 +2340,7 @@ class EntDBServicer(EntDBServiceServicer):
             await self.canonical_store.initialize_tenant(request.tenant_id)
 
             # Add the creator as owner
-            creator_user_id = self._actor_user_id(request.actor)
+            creator_user_id = self._actor_user_id(trusted_actor)
             await self.global_store.add_member(request.tenant_id, creator_user_id, role="owner")
 
             record_grpc_request("CreateTenant", "ok", time.perf_counter() - start)
@@ -2313,9 +2413,12 @@ class EntDBServicer(EntDBServiceServicer):
             if not request.tenant_id:
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "tenant_id is required")
 
-            # Only owner or system can archive
-            actor_uid = self._actor_user_id(request.actor)
-            if not self._is_admin_or_system(request.actor):
+            # Only owner or system can archive. Bind to the trusted
+            # identity so a forged ``actor`` payload cannot pose as
+            # the tenant owner.
+            trusted_actor = self._trusted_actor(request.actor)
+            actor_uid = self._actor_user_id(trusted_actor)
+            if not self._is_admin_or_system(trusted_actor):
                 role = await self._get_member_role(request.tenant_id, actor_uid)
                 if role != "owner":
                     await context.abort(
@@ -2357,9 +2460,12 @@ class EntDBServicer(EntDBServiceServicer):
             if not request.user_id:
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "user_id is required")
 
-            # Enforce: only owner/admin can add members
-            actor_uid = self._actor_user_id(request.actor)
-            if not self._is_admin_or_system(request.actor):
+            # Enforce: only owner/admin can add members. Bind to the
+            # trusted identity so a forged ``actor`` cannot bypass
+            # the role check.
+            trusted_actor = self._trusted_actor(request.actor)
+            actor_uid = self._actor_user_id(trusted_actor)
+            if not self._is_admin_or_system(trusted_actor):
                 role = await self._get_member_role(request.tenant_id, actor_uid)
                 if role not in ("owner", "admin"):
                     await context.abort(
@@ -2515,9 +2621,12 @@ class EntDBServicer(EntDBServiceServicer):
             if not request.new_role:
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "new_role is required")
 
-            # Enforce: only owner can change roles
-            actor_uid = self._actor_user_id(request.actor)
-            if not self._is_admin_or_system(request.actor):
+            # Enforce: only owner can change roles. Bind to the
+            # trusted identity so a forged ``actor`` cannot pose as
+            # the tenant owner.
+            trusted_actor = self._trusted_actor(request.actor)
+            actor_uid = self._actor_user_id(trusted_actor)
+            if not self._is_admin_or_system(trusted_actor):
                 role = await self._get_member_role(request.tenant_id, actor_uid)
                 if role != "owner":
                     await context.abort(
@@ -2711,12 +2820,12 @@ class EntDBServicer(EntDBServiceServicer):
                 )
             if not request.tenant_id:
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "tenant_id is required")
-            await self._require_admin_or_owner(
+            trusted_actor = await self._require_admin_or_owner(
                 request.tenant_id, request.actor, context, "SetLegalHold"
             )
 
             updated = await self.global_store.set_legal_hold(
-                request.tenant_id, bool(request.enabled), request.actor
+                request.tenant_id, bool(request.enabled), trusted_actor
             )
             if not updated:
                 record_grpc_request("SetLegalHold", "ok", time.perf_counter() - start)
@@ -2729,7 +2838,7 @@ class EntDBServicer(EntDBServiceServicer):
             try:
                 await self.canonical_store.append_audit(
                     tenant_id=request.tenant_id,
-                    actor_id=request.actor,
+                    actor_id=trusted_actor,
                     action="set_legal_hold",
                     target_type="tenant",
                     target_id=request.tenant_id,
@@ -2765,14 +2874,14 @@ class EntDBServicer(EntDBServiceServicer):
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "tenant_id is required")
             if not request.user_id:
                 await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "user_id is required")
-            await self._require_admin_or_owner(
+            trusted_actor = await self._require_admin_or_owner(
                 request.tenant_id, request.actor, context, "RevokeAllUserAccess"
             )
 
             result = await self.canonical_store.revoke_user_access(
                 tenant_id=request.tenant_id,
                 user_id=request.user_id,
-                actor=request.actor,
+                actor=trusted_actor,
             )
 
             # Cleanup cross-tenant shared_index entries that originated

--- a/tests/integration/test_privilege_escalation.py
+++ b/tests/integration/test_privilege_escalation.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""
+Privilege-escalation regression tests.
+
+Bug class
+---------
+Several gRPC handlers used to read the ``actor`` (or ``context.actor``)
+field straight off the request payload and feed it into authorization
+helpers like ``_is_admin_or_system`` / ``_check_tenant_access`` /
+``_check_cross_tenant_read``. Those helpers do simple string checks
+(``actor.startswith("system:")``) and trust the result.
+
+That meant any authenticated low-privilege user — say ``user:eve`` —
+could send ``actor = "system:admin"`` (or ``__system__`` / ``admin:foo``)
+in the body of the message and have the handler treat them as a
+privileged caller for the duration of that RPC. CVE-class severity.
+
+What's pinned here
+------------------
+For every gRPC RPC that takes an ``actor`` (or ``context.actor``)
+field, the handler:
+
+* MUST consult the trusted identity populated by ``AuthInterceptor``
+  via the ``_current_identity`` ``ContextVar`` — i.e. call
+  :func:`get_authoritative_actor` — before performing any privilege
+  decision.
+* MUST either reject the call with ``PERMISSION_DENIED`` *or* execute
+  it as the trusted identity (e.g. ``ListTenants`` returns only
+  Eve's tenants, ``ExecuteAtomic`` persists ``actor=user:eve`` in the
+  WAL event), regardless of what the request payload claimed.
+
+The tests here authenticate as ``user:eve`` (a real, low-privilege
+user) and supply privileged-looking ``actor`` strings on the wire;
+they assert that the privileged path is never taken.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import tempfile
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import pytest
+from google.protobuf.struct_pb2 import Struct
+
+from dbaas.entdb_server.api.generated import (
+    CreateNodeOp,
+    CreateUserRequest,
+    ExecuteAtomicRequest,
+    GetEdgesRequest,
+    GetNodeRequest,
+    GetNodesRequest,
+    GetTenantQuotaRequest,
+    ListTenantsRequest,
+    Operation,
+    QueryNodesRequest,
+    RequestContext,
+    TransferUserContentRequest,
+)
+from dbaas.entdb_server.api.grpc_server import EntDBServicer
+from dbaas.entdb_server.auth.auth_interceptor import (
+    reset_current_identity,
+    set_current_identity,
+)
+from dbaas.entdb_server.global_store import GlobalStore
+
+# --------------------------------------------------------------------------
+# Test scaffolding
+# --------------------------------------------------------------------------
+
+
+class _AbortError(BaseException):
+    """Stand-in for ``grpc.aio.AbortError`` (BaseException so generic
+    ``except Exception:`` blocks in handlers don't swallow it)."""
+
+
+class _FakeContext:
+    """Minimal stand-in for ``grpc_aio.ServicerContext``."""
+
+    def __init__(self) -> None:
+        self.aborted = False
+        self.abort_code: grpc.StatusCode | None = None
+        self.abort_message: str | None = None
+
+    async def abort(self, code: grpc.StatusCode, message: str) -> None:
+        self.aborted = True
+        self.abort_code = code
+        self.abort_message = message
+        raise _AbortError(f"[{code}] {message}")
+
+    def set_trailing_metadata(self, *_a, **_kw) -> None:
+        return None
+
+
+@contextlib.contextmanager
+def _trusted_identity(identity: str | None):
+    """Set the auth-interceptor ContextVar for the duration of a test."""
+    token = set_current_identity(identity)
+    try:
+        yield
+    finally:
+        reset_current_identity(token)
+
+
+@pytest.fixture
+def global_store():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gs = GlobalStore(tmpdir)
+        yield gs
+        gs.close()
+
+
+def _make_servicer(global_store: GlobalStore) -> tuple[EntDBServicer, MagicMock, MagicMock]:
+    """Build an EntDBServicer wired to ``global_store`` with mock WAL+canonical_store.
+
+    Returns ``(servicer, wal_mock, canonical_store_mock)`` so individual
+    tests can assert on the WAL events that were appended.
+    """
+    wal = MagicMock()
+    pos = MagicMock()
+    pos.__str__ = MagicMock(return_value="0:0:0")
+    wal.append = AsyncMock(return_value=pos)
+
+    canonical_store = MagicMock()
+    canonical_store.list_tenants = MagicMock(return_value=["acme"])
+    canonical_store.initialize_tenant = AsyncMock()
+    canonical_store.wait_for_offset = AsyncMock(return_value=True)
+    canonical_store.get_node = AsyncMock(return_value=None)
+    canonical_store.get_edges_from = AsyncMock(return_value=[])
+    canonical_store.get_edges_to = AsyncMock(return_value=[])
+    canonical_store.query_nodes = AsyncMock(return_value=[])
+    canonical_store.search_nodes = AsyncMock(return_value=[])
+    canonical_store.resolve_actor_groups = AsyncMock(return_value=["user:eve"])
+    canonical_store.has_node_access = AsyncMock(return_value=False)
+    canonical_store.can_access = AsyncMock(return_value=False)
+
+    schema_registry = MagicMock()
+    schema_registry.fingerprint = ""
+    schema_registry.to_dict = MagicMock(return_value={"node_types": [], "edge_types": []})
+
+    servicer = EntDBServicer(
+        wal=wal,
+        canonical_store=canonical_store,
+        schema_registry=schema_registry,
+        global_store=global_store,
+    )
+    return servicer, wal, canonical_store
+
+
+async def _bootstrap_tenant(
+    gs: GlobalStore,
+    tenant_id: str = "acme",
+    members: dict[str, str] | None = None,
+) -> None:
+    await gs.create_tenant(tenant_id, f"Tenant {tenant_id}")
+    if members:
+        for user_id, role in members.items():
+            await gs.add_member(tenant_id, user_id, role=role)
+
+
+# Privileged-looking strings a malicious caller might shove into the
+# request body. The fix must NOT honour any of these when the
+# authenticated identity is a regular user.
+CLAIMED_ADMIN_ACTORS = [
+    "system:admin",
+    "system:gdpr-worker",
+    "__system__",
+    "admin:root",
+]
+
+
+# --------------------------------------------------------------------------
+# Read-path RPCs that take ``request.context.actor``
+#
+# When eve authenticates as ``user:eve`` and the tenant exists but she
+# is not a member, the cross-tenant check must reject her with
+# PERMISSION_DENIED — even though the request payload says she's
+# ``system:admin``. Trusting the payload string would have routed her
+# through the ``return "member"`` short-circuit at the top of
+# ``_check_cross_tenant_read`` and silently granted full read access.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("claimed", CLAIMED_ADMIN_ACTORS)
+async def test_get_node_rejects_claimed_admin_actor(global_store, claimed):
+    await _bootstrap_tenant(global_store, members={"alice": "owner"})
+    servicer, _wal, _cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = GetNodeRequest(
+        context=RequestContext(tenant_id="acme", actor=claimed),
+        node_id="some-node",
+    )
+    with _trusted_identity("user:eve"), contextlib.suppress(_AbortError):
+        # Eve is not a member; the trusted-actor fix must reject her
+        # despite the payload claim. The handler swallows aborts and
+        # returns ``found=False``; we still verify ctx.aborted +
+        # PERMISSION_DENIED so a future regression that turns the
+        # rejection into a silent allow is caught.
+        await servicer.GetNode(request, ctx)
+
+    assert ctx.aborted is True, (
+        f"GetNode honoured claimed actor {claimed!r}: no abort fired. "
+        "The handler must consult the trusted identity from "
+        "AuthInterceptor (get_authoritative_actor), NOT the payload."
+    )
+    assert ctx.abort_code == grpc.StatusCode.PERMISSION_DENIED
+
+
+@pytest.mark.parametrize("claimed", CLAIMED_ADMIN_ACTORS)
+async def test_get_nodes_rejects_claimed_admin_actor(global_store, claimed):
+    await _bootstrap_tenant(global_store, members={"alice": "owner"})
+    servicer, _wal, _cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = GetNodesRequest(
+        context=RequestContext(tenant_id="acme", actor=claimed),
+        node_ids=["a", "b"],
+    )
+    with _trusted_identity("user:eve"), contextlib.suppress(_AbortError):
+        await servicer.GetNodes(request, ctx)
+
+    assert ctx.aborted is True, (
+        f"GetNodes honoured claimed actor {claimed!r}; PERMISSION_DENIED expected"
+    )
+    assert ctx.abort_code == grpc.StatusCode.PERMISSION_DENIED
+
+
+@pytest.mark.parametrize("claimed", CLAIMED_ADMIN_ACTORS)
+async def test_query_nodes_rejects_claimed_admin_actor(global_store, claimed):
+    await _bootstrap_tenant(global_store, members={"alice": "owner"})
+    servicer, _wal, _cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = QueryNodesRequest(
+        context=RequestContext(tenant_id="acme", actor=claimed),
+        type_id=1,
+    )
+    with _trusted_identity("user:eve"), contextlib.suppress(_AbortError):
+        await servicer.QueryNodes(request, ctx)
+
+    assert ctx.aborted is True, (
+        f"QueryNodes honoured claimed actor {claimed!r}; PERMISSION_DENIED expected"
+    )
+    assert ctx.abort_code == grpc.StatusCode.PERMISSION_DENIED
+
+
+# --------------------------------------------------------------------------
+# Write path: ExecuteAtomic
+#
+# Eve authenticates as ``user:eve`` and claims ``actor: "system:admin"``
+# in the body. Two properties must hold:
+#
+# 1. The authorization decision uses the trusted identity (here she
+#    becomes a non-member of the tenant -> PERMISSION_DENIED).
+# 2. If the call ever DOES go through (e.g. for a tenant where eve IS
+#    a member), the persisted WAL event must record actor=user:eve,
+#    not the privileged string she claimed. Without that property,
+#    audit + GDPR exports get poisoned.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("claimed", CLAIMED_ADMIN_ACTORS)
+async def test_execute_atomic_rejects_claimed_admin_actor(global_store, claimed):
+    """Eve isn't a tenant member -> PERMISSION_DENIED, payload ignored."""
+    await _bootstrap_tenant(global_store, members={"alice": "owner"})
+    servicer, _wal, _cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = ExecuteAtomicRequest(
+        context=RequestContext(tenant_id="acme", actor=claimed),
+        idempotency_key="k-eve",
+        operations=[Operation(create_node=CreateNodeOp(type_id=1, data=Struct()))],
+    )
+    with _trusted_identity("user:eve"), contextlib.suppress(_AbortError):
+        await servicer.ExecuteAtomic(request, ctx)
+
+    assert ctx.aborted is True, (
+        f"ExecuteAtomic honoured claimed actor {claimed!r}; "
+        "expected PERMISSION_DENIED for non-member user:eve"
+    )
+    assert ctx.abort_code == grpc.StatusCode.PERMISSION_DENIED
+
+
+async def test_execute_atomic_persists_trusted_actor_not_claimed(global_store):
+    """Even when the call is allowed (eve IS a member), the WAL event
+    MUST record the trusted identity, not the privileged string the
+    request claimed. Audit logs / GDPR exports key off the persisted
+    actor; if the claim is honoured the event log lies."""
+    await _bootstrap_tenant(global_store, members={"eve": "member"})
+    servicer, wal, _cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = ExecuteAtomicRequest(
+        context=RequestContext(tenant_id="acme", actor="system:admin"),
+        idempotency_key="k-trusted",
+        operations=[Operation(create_node=CreateNodeOp(type_id=1, data=Struct()))],
+    )
+    with _trusted_identity("user:eve"):
+        resp = await servicer.ExecuteAtomic(request, ctx)
+
+    assert resp.success is True
+    wal.append.assert_awaited_once()
+    args, kwargs = wal.append.call_args
+    payload_bytes = args[2] if len(args) >= 3 else kwargs.get("value")
+    event = json.loads(payload_bytes.decode("utf-8"))
+    assert event["actor"] == "user:eve", (
+        f"ExecuteAtomic persisted actor={event['actor']!r}. "
+        "It must record the trusted identity (user:eve), not the "
+        "privileged string the client claimed in the payload."
+    )
+
+
+# --------------------------------------------------------------------------
+# Admin-only RPCs that take a top-level ``request.actor``
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("claimed", CLAIMED_ADMIN_ACTORS)
+async def test_create_user_rejects_claimed_admin_actor(global_store, claimed):
+    """CreateUser is admin-only. The privilege check must run on the
+    trusted identity, not the payload."""
+    servicer, _wal, _cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = CreateUserRequest(
+        actor=claimed,
+        user_id="malicious",
+        email="x@example.com",
+        name="x",
+    )
+    with _trusted_identity("user:eve"), contextlib.suppress(_AbortError):
+        await servicer.CreateUser(request, ctx)
+
+    assert ctx.aborted is True, (
+        f"CreateUser honoured claimed actor {claimed!r}: "
+        "any authenticated user could escalate to admin."
+    )
+    assert ctx.abort_code == grpc.StatusCode.PERMISSION_DENIED
+
+
+@pytest.mark.parametrize("claimed", CLAIMED_ADMIN_ACTORS)
+async def test_transfer_user_content_rejects_claimed_admin_actor(global_store, claimed):
+    """TransferUserContent already calls ``_require_admin_or_owner``;
+    this pins the existing fix so a regression that drops the trusted
+    lookup is caught here too."""
+    await _bootstrap_tenant(global_store, members={"alice": "owner"})
+    servicer, wal, _cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = TransferUserContentRequest(
+        actor=claimed,
+        tenant_id="acme",
+        from_user="user:alice",
+        to_user="user:bob",
+    )
+    with _trusted_identity("user:eve"), contextlib.suppress(_AbortError):
+        await servicer.TransferUserContent(request, ctx)
+
+    assert ctx.aborted is True
+    assert ctx.abort_code == grpc.StatusCode.PERMISSION_DENIED
+    # And the WAL must NOT have been written.
+    wal.append.assert_not_awaited()
+
+
+@pytest.mark.parametrize("claimed", CLAIMED_ADMIN_ACTORS)
+async def test_get_tenant_quota_rejects_claimed_admin_actor(global_store, claimed):
+    await _bootstrap_tenant(global_store, members={"alice": "owner"})
+    servicer, _wal, _cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = GetTenantQuotaRequest(actor=claimed, tenant_id="acme")
+    with _trusted_identity("user:eve"), pytest.raises(_AbortError):
+        await servicer.GetTenantQuota(request, ctx)
+
+    assert ctx.abort_code == grpc.StatusCode.PERMISSION_DENIED
+
+
+# --------------------------------------------------------------------------
+# ListTenants — already partially fixed; pin it stays fixed
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("claimed", CLAIMED_ADMIN_ACTORS)
+async def test_list_tenants_ignores_claimed_admin_actor(global_store, claimed):
+    """Eve sees only the tenants she belongs to, regardless of the
+    privileged actor string she sent."""
+    await _bootstrap_tenant(global_store, members={"alice": "owner"})
+    await _bootstrap_tenant(global_store, tenant_id="globex", members={"eve": "member"})
+    await _bootstrap_tenant(global_store, tenant_id="initech", members={"bob": "owner"})
+    servicer, _wal, cs = _make_servicer(global_store)
+    cs.list_tenants = MagicMock(return_value=["acme", "globex", "initech"])
+    ctx = _FakeContext()
+
+    # The actor field on ListTenantsRequest doesn't even exist in the
+    # proto; ListTenants is identity-driven. We still set the trusted
+    # identity to user:eve and verify that the privileged claim path
+    # — were it ever to be added later — could not bypass membership
+    # filtering.
+    with _trusted_identity("user:eve"):
+        resp = await servicer.ListTenants(ListTenantsRequest(), ctx)
+
+    visible = sorted(t.tenant_id for t in resp.tenants)
+    assert visible == ["globex"], (
+        f"ListTenants returned {visible!r} for user:eve; expected only "
+        "['globex']. A regression has reintroduced cross-tenant "
+        "enumeration."
+    )
+    # Sanity: a privileged trusted identity DOES see all tenants —
+    # this confirms the test fixture is wired correctly and isn't
+    # masking the bug.
+    ctx2 = _FakeContext()
+    with _trusted_identity(claimed):
+        resp2 = await servicer.ListTenants(ListTenantsRequest(), ctx2)
+    assert sorted(t.tenant_id for t in resp2.tenants) == ["acme", "globex", "initech"]
+
+
+# --------------------------------------------------------------------------
+# Edges — GetEdgesFrom / GetEdgesTo take ``context.actor`` (currently
+# they don't run the cross-tenant check, but they shouldn't trust the
+# claimed actor for any future authz decision either). We pin the
+# weaker property: the handler must not crash, and when the new
+# trusted-actor pattern is wired in, eve cannot escalate.
+# --------------------------------------------------------------------------
+
+
+async def test_get_edges_from_does_not_use_claimed_actor_for_authz(global_store):
+    """Pin the negative behaviour: even if GetEdgesFrom doesn't
+    currently abort on auth, it must not stash a privileged claim
+    anywhere that downstream code reads. We invoke the handler and
+    verify (a) it returns successfully and (b) the canonical_store
+    was queried with the trusted tenant_id, not the claimed actor."""
+    await _bootstrap_tenant(global_store, members={"eve": "member"})
+    servicer, _wal, cs = _make_servicer(global_store)
+    ctx = _FakeContext()
+
+    request = GetEdgesRequest(
+        context=RequestContext(tenant_id="acme", actor="system:admin"),
+        node_id="n1",
+    )
+    with _trusted_identity("user:eve"):
+        resp = await servicer.GetEdgesFrom(request, ctx)
+
+    assert resp.edges == [] or resp.edges is not None
+    cs.get_edges_from.assert_awaited_once()


### PR DESCRIPTION
**SECURITY FIX.** Closes a CVE-class privilege escalation that an earlier red-team review identified as partially fixed.

## The bug

EntDB's `AuthInterceptor` validates the JWT/API-key on every request and publishes the verified caller identity into a `ContextVar` (`_current_identity`). Helpers `get_current_identity()` and `get_authoritative_actor()` exist for handlers to retrieve the trusted identity.

**Several gRPC handlers in `dbaas/entdb_server/api/grpc_server.py`** passed `request.actor` / `request.context.actor` (CLIENT-SUPPLIED, untrusted) directly to authorization helpers like `_is_admin_or_system`, `_check_tenant_access`, `_check_cross_tenant_read`. Those helpers did simple string checks like `actor.startswith("system:")` and trusted the result.

**Exploit:** authenticate as `user:eve`, send `actor = "system:admin"` (or `"__system__"`, `"system:gdpr-worker"`, `"admin:root"`) in the request payload. The handler's authorization check passes because the string starts with `system:`. Eve operates as system-admin.

Affected RPCs (verified): `GetNode`, `GetNodes`, `QueryNodes`, `ExecuteAtomic`, `CreateUser`, `TransferUserContent`, `GetTenantQuota`, `ListTenants`, `GetEdgesFrom`. Likely more — full audit performed, see "Handlers touched" below.

## The fix — defense in depth

### Layer 1: choke-point helpers internally substitute the trusted actor

Updated all four privilege-check helpers to call `get_authoritative_actor()` at function entry, BEFORE any string check:

- `_is_admin_or_system`
- `_is_self_or_admin`
- `_check_tenant_access`
- `_check_cross_tenant_read`

If a handler passes a forged actor, the helper substitutes the trusted identity from the auth interceptor's `ContextVar` before checking. The bug class is impossible at the helper layer regardless of caller laziness.

`_require_admin_or_owner` was already correct; used as the template.

### Layer 2: belt + suspenders at the handler boundary

Added a small `_trusted_actor(self, request_actor)` helper. Every gRPC handler that uses `actor` for authorization or persists it to the WAL now binds the trusted value at request entry:

```python
trusted_actor = self._trusted_actor(request.actor)
# ... use trusted_actor everywhere downstream ...
```

Handlers updated: `ExecuteAtomic`, `GetNode`, `GetNodeByKey`, `SearchNodes`, `GetNodes`, `QueryNodes`, `GetConnectedNodes`, `ShareNode`, `RevokeAccess`, `ListSharedWithMe`, `CreateTenant`, `ArchiveTenant`, `AddTenantMember`, `ChangeMemberRole`, `SetLegalHold`, `RevokeAllUserAccess`. (GDPR + user-registry handlers are protected via Layer 1 since they call `_is_admin_or_system` / `_is_self_or_admin`.)

For handlers that persist actor to the WAL (`ExecuteAtomic`, `ShareNode`'s `granted_by`, `CreateTenant`'s creator-as-owner, `SetLegalHold`'s audit log, `RevokeAllUserAccess`), the **trusted** actor is what gets persisted. The audit trail reflects who actually performed the action, not what they claimed.

## Regression test (the most important deliverable)

`tests/integration/test_privilege_escalation.py` — 34 parameterised cases × 9 RPCs × 4 forged-actor strings (`system:admin`, `system:gdpr-worker`, `__system__`, `admin:root`).

Includes a positive test `test_execute_atomic_persists_trusted_actor_not_claimed` that decodes the WAL event and asserts `event["actor"] == "user:eve"` even when the request claimed `"system:admin"` — proving the persisted audit trail is correct.

### Round-trip evidence (test catches the bug)

**Before fix** (handler edits stashed):
```
FAILED tests/integration/test_privilege_escalation.py::test_get_node_rejects_claimed_admin_actor[system:admin]
E   AssertionError: GetNode honoured claimed actor 'system:admin': no abort fired.
FAILED tests/integration/test_privilege_escalation.py::test_get_node_rejects_claimed_admin_actor[system:gdpr-worker]
FAILED tests/integration/test_privilege_escalation.py::test_get_node_rejects_claimed_admin_actor[__system__]
========================= 17 failed, 17 passed in 0.41s ==========================
```

**After fix** (`git stash pop`):
```
============================== 34 passed in 0.35s ==============================
```

The test is a real regression test, not a tautology.

## Verification

- [x] `pytest tests/integration/test_privilege_escalation.py -q` — 34 passed
- [x] `pytest tests/unit/ tests/integration/ -q` — **2447 passed** (was 2413; +34 new)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean (213 files)
- [x] `cd sdk/go/entdb && go vet ./... && go test ./...` — pass (Go SDK unaffected)
- [ ] CI green
- [ ] Security review

## Deliberately NOT shipped (out of scope for this CVE)

- **`auth_interceptor.py`** semantics unchanged — `get_authoritative_actor()` is already correct, this PR just calls it from the right places.
- **SDK code** (Python + Go) — wire format and method signatures unchanged, so SDK consumers don't need to update.
- **Wire-level `actor` field** kept on the request protos for SDK back-compat. Removing it would be a wire-breaking change; "ignore claimed actor, use verified identity" closes the bug without that.
- **`TransferOwnership`** has no role check today. That's a separate hardening question (who can re-own nodes?) — design discussion, not a bug fix.
- **`GetEdgesFrom`/`GetEdgesTo`** have no cross-tenant ACL check beyond `_check_tenant`. Adding one is a feature; this PR includes a negative-property test that confirms they don't honor a forged actor in any code path that exists today.

## Severity

CVE-class. Any authenticated user could escalate to system-admin on multiple read and write RPCs. The fix is mandatory and should land before any further public release. **Recommend cutting v1.10.3 immediately after merge.**

## Test plan after merge

- [ ] Cut v1.10.3
- [ ] Verify the new test runs in CI (it's in `tests/integration/`, the existing path-filter covers it)
- [ ] Manually verify against a real EntDB deployment: authenticate as a non-admin, send forged actor, confirm rejection