### PR TITLE
docs(go-rewrite): Wave 0 specs for the Python → Go server port

### DIFF
--- a/docs/go-port/PLAN.md
+++ b/docs/go-port/PLAN.md
@@ -1,0 +1,790 @@
+# EPIC #407 — Coordination Plan (Wave 0 → 2)
+
+This document synthesises the 54 Wave-0 spec files in `docs/go-port/{rpcs,shared}/`
+into a single execution plan for the Python → Go server port. It is the input
+to the Wave-1 and Wave-2 PR slates.
+
+Layout assumed: `server/go/internal/<pkg>/` (Go server tree introduced by
+PR #170 alongside `server/python/entdb_server/`). The Go binary entrypoint
+will live at `server/go/cmd/entdb-server/`.
+
+## 1. Wave structure
+
+- **Wave 0 — Specs (DONE).** 44 RPC specs + 10 shared concern specs landed.
+  Every privileged RPC has an `Auth` / `Side effects` / `Error contract` /
+  `Shared deps` / `Other-RPC deps` / `Contract tests` / `Implementation
+  outline` / `Open questions` section, cross-linked to Python source by
+  file:line.
+- **Phase 0 — `#408` (in flight).** Adds the test harness scaffolding from
+  [test-harness.md](shared/test-harness.md) (`tests/python/integration/conftest.py`,
+  `_go_parity.py`, CI matrix `server: [python, go]` with
+  `continue-on-error: true` on the Go leg). Ships `server/go/cmd/entdb-server`
+  stub that satisfies `--listen / --wal-backend memory / --auth-disabled /
+  --seed-tenant`. No real handlers yet. **This unblocks Wave 1.**
+- **Wave 1 — Shared packages.** ~10 PRs landing the Go ports of the shared
+  concerns. Many run truly in parallel via worktrees; the rest form a thin
+  dependency chain (see §3). Each Wave-1 PR ships interfaces + an in-memory /
+  pure-Go default backend; production backends (Kafka, Kinesis, S3 archive,
+  OAuth JWKS) defer to Phase 2.
+- **Wave 2 — 44 RPC handlers.** One PR per RPC, each landing
+  `server/go/internal/api/<rpc>.go` plus a registry-bump in
+  `_go_parity.py` (the harness gate from
+  [test-harness.md §Per-RPC gating](shared/test-harness.md#per-rpc-gating)).
+  Batched in §4 by Wave-1 dependency footprint. Up to ~10 agents in
+  worktrees can work simultaneously after Batch A lands.
+- **Wave 3 — Flip the gate.** Drop `continue-on-error` on the Go matrix leg;
+  add it to `all-checks.needs`. `GO_IMPLEMENTED` covers all 44 RPCs.
+- **Phase 2+ (out of scope here).** Real WAL backends (Kafka first), real
+  OAuth/JWKS, S3 archive replay, snapshot tier, encryption-at-rest.
+
+## 2. Common Go packages (Wave 1 work)
+
+Canonical list of `server/go/internal/<pkg>/` packages every RPC depends on.
+Names are **normative** — Wave-0 specs sometimes used `apply` / `applier`,
+`store` / `canonical` / `canonicalstore`, `global` / `globalstore`
+interchangeably. The list below is the source of truth; rename freely
+inside specs but keep import paths consistent.
+
+### 2.1 `pb` — generated proto types
+**Purpose:** `protoc-gen-go` + `protoc-gen-go-grpc` output for
+`proto/entdb/v1/entdb.proto` and `proto/console/v1/console.proto`.
+Mirrors `server/python/entdb_server/api/generated/`.
+**Spec:** consumed by every spec; format frozen per CLAUDE.md invariant #5.
+**Wave 1 scope:** `go generate` wiring + checked-in generated files; no
+hand-written code. Add a CI guard that regen produces a clean diff.
+**Deps:** none.
+
+### 2.2 `errs` — typed errors + gRPC status mapping
+**Purpose:** sentinels with `GRPCStatus()`, trailer helpers
+(`SetRedirectTrailer`, `SetRetryAfter`), `PreserveStatusOrSwallow` choke
+point for the Python `except Exception` swallow patterns.
+**Spec:** [error-mapping.md](shared/error-mapping.md).
+**Wave 1 scope:** all sentinel constants, `Errorf(codes.X, fmt, ...)`,
+trailer helpers, swallow helper. **No** `google.rpc.ErrorInfo` extensions
+(deliberate parity with Python).
+**Deps:** `pb` (only because callers will compose errors from proto types
+later — `errs` itself depends only on `grpc/codes` and `grpc/status`).
+
+### 2.3 `schema` — registry, types, fingerprint, compat
+**Purpose:** process-wide singleton built at boot, frozen before serving;
+holds `NodeTypeDef`, `EdgeTypeDef`, `FieldDef`, `CompositeUniqueDef`;
+serves `UniqueFieldIDs`, `IndexedFieldIDs`, `SearchableFieldIDs`,
+`PIIFields`, `DataPolicy`, `SubjectField`. Plus `compat.Check(old, new)`
+for the deploy-time ratchet, plus `Fingerprint()` for SDK drift detection.
+**Spec:** [schema-registry.md](shared/schema-registry.md).
+**Wave 1 scope:** `Registry`, `NodeTypeDef`, `EdgeTypeDef`, `FieldDef`,
+`CompositeUniqueDef`, `LoadFromJSON` (consumes Python-emitted
+`SchemaRegistry.to_json` shape — cross-language contract), `Freeze`,
+`Fingerprint`. Compat package can be a stub (Wave 2 doesn't gate on it);
+`LoadFromDescriptors` (proto reflection) deferred to Phase 2.
+**Deps:** `pb`, `errs`.
+
+### 2.4 `payload` — name↔id field key translation
+**Purpose:** the *only* place name↔field_id translation runs
+(CLAUDE.md invariant #6). `StructToPayload` (ingress, schema-aware,
+drops unknowns), `PayloadToStruct` (egress, schema-less wrap),
+`FilterNamesToIDs` (QueryNodes filters), `PayloadJSONToNames` (export
+helper).
+**Spec:** [payload-translation.md](shared/payload-translation.md).
+**Wave 1 scope:** all four functions; `map[uint32]any` internal key
+shape; bytes/timestamp/JSON kind coercion via `schema.Registry`.
+**Deps:** `schema`, `pb`, `errs`.
+
+### 2.5 `auth` — interceptor + trusted-actor
+**Purpose:** unary + stream gRPC interceptors that authenticate via
+OAuth bearer / API key / session, attach `Identity` to `context.Context`,
+and supply `Authoritative(ctx, claimed) Actor` for handlers. Health
+allow-list. `Actor` type with `user:`/`system:`/`admin:`/`group:` prefix
+predicates.
+**Spec:** [auth-interceptor.md](shared/auth-interceptor.md).
+**Wave 1 scope:** `Interceptor.Unary()`, `Interceptor.Stream()`,
+`IdentityFromContext`, `Authoritative`, `Actor` type, `OAuthValidator`
+(in-memory JWKS for tests), `APIKeyManager` (in-memory map), 
+`SessionManager` (in-memory map). Production OAuth/JWKS rotation deferred.
+**Deps:** `errs`, `pb`. **Cross-cutting:** every handler imports it.
+
+### 2.6 `wal` — producer interface + in-memory backend
+**Purpose:** `Producer.Append(ctx, topic, key, value, headers) -> StreamPos`
+contract: durable per-tenant total order, idempotent retries.
+`Event{TenantID, Actor, IdempotencyKey, SchemaFingerprint, TsMs, Ops}`
+shape. `StreamPos` `topic:partition:offset`. `Subscribe`/`PollBatch`/
+`Commit` for the consumer side. In-memory backend with `WaitForRecords`,
+`GetAllRecords` for tests.
+**Spec:** [wal-producer.md](shared/wal-producer.md).
+**Wave 1 scope:** types + interfaces + memory backend only. Kafka /
+Kinesis / SQS / Pub/Sub / Service Bus / Event Hubs deferred.
+**Deps:** `errs`, `pb`.
+
+### 2.7 `store` — per-tenant SQLite (`CanonicalStore`)
+**Purpose:** per-tenant `tenant_<id>.db` (+ `public.db` + per-user
+mailbox files). Owns DDL, lazy unique/query/composite/FTS5 expression
+indexes, `BatchTxn` (`BEGIN IMMEDIATE`), `WaitForOffset` /
+`UpdateAppliedOffset` notification, all `_sync_*` read paths, all
+applier-callable write helpers.
+**Spec:** [canonical-store.md](shared/canonical-store.md).
+**Wave 1 scope:** schema DDL, pool, per-tenant lock, `BatchTxn`,
+`GetNode`/`GetNodes`/`QueryNodes`/`SearchNodes`/`GetEdgesFrom`/
+`GetEdgesTo`/`GetVisibleNodes`/`ListSharedWithMe`/`CheckIdempotency`/
+`WaitForOffset`/`UpdateAppliedOffset`. Write helpers callable from the
+applier: `CreateNodeRaw`, `UpdateNode`, `DeleteNode`, `CreateEdge`,
+`DeleteEdge`, `ShareNode`, `RevokeAccess`, `DelegateAccess`,
+`TransferOwnership`, `RevokeUserAccess`, `AddGroupMember`,
+`RemoveGroupMember`. Lazy index/FTS bootstrap. Driver: 
+`modernc.org/sqlite` (no cgo) per spec recommendation; revisit if
+SQLCipher returns to scope. Notifications/mailbox sub-package can stub
+(deprecated stubs only need `_check_tenant`).
+**Deps:** `schema`, `payload`, `errs`, `pb`.
+
+### 2.8 `globalstore` — cross-tenant SQLite
+**Purpose:** `global.db` — `user_registry`, `tenant_registry`,
+`tenant_members`, `shared_index`, `deletion_queue`, `legal_holds`,
+`tenant_quotas`, `tenant_usage`. The only place cross-tenant state may
+be read or written. **Has no WAL** (documented carve-out).
+**Spec:** [global-store.md](shared/global-store.md).
+**Wave 1 scope:** schema DDL + migrations, all CRUD listed in the spec
+(`CreateUser`, `UpdateUser`, `SetUserStatus`, `CreateTenant`,
+`SetTenantStatus`, `SetLegalHold`, `AddMember`/`RemoveMember`/
+`ChangeRole`, `AddShared`/`RemoveShared`/`CleanupStaleShared`/
+`RemoveAllSharedForUser`, `QueueDeletion`/`CancelDeletion`/
+`MarkDeletionCompleted`, `RevokeUserAccess`, `SetQuotaConfig`,
+`IncrementUsage`, `ResetPeriod`). `MaxOpenConns(1)` to mirror Python's
+single-thread executor.
+**Deps:** `errs`, `pb`. Optional: `crypto` (deferred — encryption-at-rest
+is Phase 2).
+
+### 2.9 `acl` — typed-capability authorization engine
+**Purpose:** `Permission` (legacy enum), `CoreCapability` (typed),
+`ExtCapID`, `Actor`, `Grant`, `Resolver` (group expansion),
+`Checker.Check`, `Filter.FilterReadable`, `Registry.RequiredForOp` /
+`CheckGrant` / `LegacyToCoreCaps`, `Enforcer` that ties it together.
+Mirrors `apply/acl.py` + `auth/capability_registry.py`.
+**Spec:** [acl.md](shared/acl.md).
+**Wave 1 scope:** all types + `Enforcer.Check` + `Enforcer.FilterReadable`.
+The capability registry must be populated from proto descriptors via the
+`schema` package; for Wave 1 a JSON-fed registry (mirror of
+`SchemaRegistry.to_json`) is sufficient. Group resolution depth-bounded
+(matches Python `_ACL_MAX_DEPTH=10`).
+**Deps:** `schema`, `store` (read-only — `node_access`, `node_visibility`,
+`acl_inherit`, `group_users`), `globalstore` (cross-tenant grant lookup
+via `shared_index`), `pb`, `errs`.
+
+### 2.10 `apply` — applier (WAL consumer + materializer)
+**Purpose:** the WAL consumer. `Run(ctx)` loop subscribes to a
+`(topic, group_id)` pair, dispatches by op-type into `BatchTxn` blocks
+on `store`, writes `applied_events`, advances WAL offsets, fans out
+notifications, maintains `shared_index`. `Replay(ctx, tenantID,
+fromPos)` for recovery. Halt-on-poison semantics; per-event
+idempotency check inside the txn.
+**Spec:** [applier.md](shared/applier.md).
+**Wave 1 scope:** `Run(ctx)`, `Replay(ctx, ...)`, every op type the
+Python applier dispatches today: `create_node`, `update_node`,
+`delete_node`, `create_edge`, `delete_edge`, `share_node` (NEW —
+WAL-first fix, see §6), `revoke_access` (NEW), `delegate_access` (NEW —
+fixes the silent-drop bug), `admin_transfer_content`,
+`admin_revoke_access` (BROADENED — also delete `node_access` +
+`group_users`, see §6), `transfer_ownership` (NEW), `add_group_member` /
+`remove_group_member` (NEW for WAL-first), `set_legal_hold` (NEW),
+`add_tenant_member` / `remove_tenant_member` / `change_member_role`
+(NEW — closes global_store WAL gap, see §6 open question). Mailbox
+fanout + shared-index hooks **best-effort** post-commit. Quota counter
+fire-and-forget.
+**Deps:** `wal`, `store`, `globalstore`, `schema`, `acl`, `payload`,
+`errs`, `pb`.
+
+### 2.11 `tenant` — tenant gate (sharding + region)
+**Purpose:** `CheckTenant(ctx, tenantID)` — sharding ownership
+(`UNAVAILABLE` + `entdb-redirect-node` trailer) and region pinning
+(`FAILED_PRECONDITION`). Used by every tenant-scoped RPC.
+**Spec:** referenced in 30+ RPC specs but no dedicated shared spec
+exists; the contract is repeated in
+[error-mapping.md](shared/error-mapping.md) and individual RPC specs
+(see [Health.md](rpcs/Health.md), [GetMailbox.md](rpcs/GetMailbox.md)).
+**Wave 1 scope:** `Sharding{NodeID, AssignedTenants, IsMine, Owner}`
+struct, `CheckTenant` helper, region lookup against `globalstore`.
+Single-node default config (always-mine).
+**Deps:** `globalstore`, `errs`, `pb`.
+
+### 2.12 `metrics` — Prometheus
+**Purpose:** `RecordGRPCRequest(method, status, duration)` — single
+chokepoint. Mirrors `metrics.py:103`.
+**Wave 1 scope:** counter + histogram registration; in-process registry.
+**Deps:** `prometheus/client_golang`. No spec needed.
+
+### 2.13 `version` — build-stamped semver
+**Purpose:** `var Version = "dev"` set via `-ldflags -X`. Returned by
+`Health`. **Spec:** [Health.md](rpcs/Health.md).
+**Wave 1 scope:** trivial; one file.
+**Deps:** none.
+
+### Packages NOT in Wave 1 (deferred to Phase 2+)
+
+`crypto` (encryption-at-rest, KMS); `audit/compliance` (S3 Object Lock
+export — WAL is the audit log per CLAUDE.md #2); `quotas` (rate-limit
+interceptor — Wave-2 fixtures use `--auth-disabled`); `archive`/`snapshot`
+(Tier-2/3 recovery); per-WAL-backend packages (`wal/kafka`, etc. — memory
+only in Wave 1); `console` (separate proto, not in 44-RPC list); real
+mailbox/`fts` backend (deprecated stubs only); `gdpr` worker (background
+`deletion_queue` processor — `DeleteUser`/`CancelUserDeletion` only queue).
+
+## 3. Wave 1 dependency graph
+
+```
+                                pb         (no deps)
+                                │
+                  ┌─────────────┼─────────────┐
+                  ▼             ▼             ▼
+                errs        version      metrics
+                  │
+         ┌────────┼────────┐
+         ▼        ▼        ▼
+       schema   wal      auth          (all depend on pb + errs;
+         │      │         │             no inter-deps among these three)
+         ▼      │         │
+       payload │         │
+         │     │         │
+         └─┬───┘         │
+           ▼             │
+       globalstore       │            (depends on errs + pb only;
+           │             │             schema/payload not needed)
+           ▼             │
+        tenant ──────────┘            (globalstore + errs)
+           │
+           ▼
+         store          ←── schema, payload, errs, pb
+           │
+           ▼
+          acl           ←── schema, store, globalstore, pb, errs
+           │
+           ▼
+         apply          ←── wal, store, globalstore, schema, acl,
+                            payload, errs, pb
+```
+
+**Zero-dep PRs (can start immediately when #408 merges):** `pb`, `errs`,
+`version`, `metrics`. Run all four in parallel.
+
+**Layer 2 (after `pb`+`errs`):** `schema`, `wal`, `auth`. Three parallel
+agents.
+
+**Layer 3:** `payload` (waits on `schema`), `globalstore` (waits on
+nothing structural beyond `errs+pb`, can start with Layer 2 if a
+worktree has them). In practice run after Layer 2.
+
+**Layer 4:** `tenant` (waits on `globalstore`). Trivial; can fold into
+the `globalstore` PR.
+
+**Layer 5:** `store` (waits on `schema`+`payload`).
+
+**Layer 6:** `acl` (waits on `store`+`globalstore`+`schema`).
+
+**Layer 7:** `apply` (waits on everything except `auth`+`tenant`+
+`metrics`+`version`).
+
+Critical-path length: **7 PRs**, but the bottom of the chain (`store` →
+`acl` → `apply`) is sequential. Effective wall-clock for one engineer ≈
+3 weeks; with 4 agents in worktrees ≈ 7–10 days because Layers 1–3 run
+in parallel.
+
+## 4. Wave 2 RPC list, sorted
+
+44 RPCs grouped by Wave-1 package footprint. Each batch can run agents
+in parallel up to the listed cap (file-conflict ceiling — see §5).
+
+### Batch A — Foundational, no auth, no WAL (parallel: ~5 agents)
+
+**Required Wave-1 PRs:** `pb`, `errs`, `metrics`, `version`, `tenant`,
+`globalstore`.
+**Not required:** `auth` (most don't authenticate),
+`wal`, `apply`, `store`, `acl`, `schema`, `payload`.
+
+| RPC | Notes |
+|---|---|
+| `Health` | leaf; no auth (allow-list); `version`+`metrics` only. [Health.md](rpcs/Health.md) |
+| `GetSchema` | reads `schema`. Adds `schema` dep — tight coupling, batch with §A but blocks on schema PR. [GetSchema.md](rpcs/GetSchema.md) |
+| `GetReceiptStatus` | `tenant` + `store.CheckIdempotency`. Adds `store` dep — see Batch B. [GetReceiptStatus.md](rpcs/GetReceiptStatus.md) |
+| `WaitForOffset` | `tenant` + `applystate` (lives inside `store`). Adds `store` dep. [WaitForOffset.md](rpcs/WaitForOffset.md) |
+
+In practice only `Health` is truly footprint-A; the other three need
+`store`. Re-bin: `Health` ships with Wave 1.0. The other three ship at
+the start of Batch B once `store` is up.
+
+### Batch B — Read path, single-tenant (parallel: ~10 agents)
+
+**Required:** Batch A + `auth`, `store`, `acl`, `payload`, `schema`.
+
+| RPC | Notes |
+|---|---|
+| `GetNode` | trusted actor, cross-tenant ACL fallback. [GetNode.md](rpcs/GetNode.md) |
+| `GetNodes` | batch sibling of `GetNode`. [GetNodes.md](rpcs/GetNodes.md) |
+| `GetNodeByKey` | unique-index lookup → delegates to `GetNode`. [GetNodeByKey.md](rpcs/GetNodeByKey.md) |
+| `QueryNodes` | Mongo-style filter → SQL via `apply/query_filter.py` port. [QueryNodes.md](rpcs/QueryNodes.md) |
+| `SearchNodes` | FTS5 + ACL post-filter. [SearchNodes.md](rpcs/SearchNodes.md) |
+| `GetEdgesFrom` | per-tenant edge read. [GetEdgesFrom.md](rpcs/GetEdgesFrom.md) |
+| `GetEdgesTo` | sibling. [GetEdgesTo.md](rpcs/GetEdgesTo.md) |
+| `GetConnectedNodes` | edge-traversal + ACL. [GetConnectedNodes.md](rpcs/GetConnectedNodes.md) |
+| `ListSharedWithMe` | reads `globalstore.shared_index` + per-tenant. [ListSharedWithMe.md](rpcs/ListSharedWithMe.md) |
+| `GetReceiptStatus` | (relisted from A). |
+| `WaitForOffset` | (relisted from A). |
+
+Wire-format suite (`test_grpc_wire_format.py`) requires `GetNode` +
+`ExecuteAtomic` to be `GO_IMPLEMENTED`. Land `GetNode` first in this
+batch.
+
+### Batch C — Write path (parallel: 1 — `ExecuteAtomic` is the lynchpin, then 0 more in this batch)
+
+**Required:** Batch B + `wal`, `apply`.
+
+| RPC | Notes |
+|---|---|
+| `ExecuteAtomic` | the single largest handler; once green, every other write path is structurally derivative. [ExecuteAtomic.md](rpcs/ExecuteAtomic.md) |
+
+### Batch D — Cross-tenant / global_store (parallel: ~6 agents)
+
+**Required:** Batch A + `auth`. **No** `wal` / `apply` / `store` / `acl`
+needed for the user/tenant CRUD subset (writes go directly to
+`globalstore` per CLAUDE.md carve-out — see §6 open question).
+
+| RPC | Notes |
+|---|---|
+| `CreateUser` | direct globalstore write (NOT WAL). [CreateUser.md](rpcs/CreateUser.md) |
+| `UpdateUser` | same. [UpdateUser.md](rpcs/UpdateUser.md) |
+| `GetUser` | global read. [GetUser.md](rpcs/GetUser.md) |
+| `ListUsers` | global read. [ListUsers.md](rpcs/ListUsers.md) |
+| `GetUserTenants` | global read. [GetUserTenants.md](rpcs/GetUserTenants.md) |
+| `CreateTenant` | global write + creator membership. [CreateTenant.md](rpcs/CreateTenant.md) |
+| `GetTenant` | global read. [GetTenant.md](rpcs/GetTenant.md) |
+| `ListTenants` | membership-filtered; refuses fall-back to wire actor. [ListTenants.md](rpcs/ListTenants.md) |
+| `ArchiveTenant` | global status flip. [ArchiveTenant.md](rpcs/ArchiveTenant.md) |
+| `GetTenantQuota` | global read. [GetTenantQuota.md](rpcs/GetTenantQuota.md) |
+| `GetTenantMembers` | global read. [GetTenantMembers.md](rpcs/GetTenantMembers.md) |
+| `AddTenantMember` | global write. [AddTenantMember.md](rpcs/AddTenantMember.md) |
+| `RemoveTenantMember` | global write + cascade considerations. [RemoveTenantMember.md](rpcs/RemoveTenantMember.md) |
+| `ChangeMemberRole` | global write. [ChangeMemberRole.md](rpcs/ChangeMemberRole.md) |
+
+### Batch E — Sharing / ACL (parallel: ~5 agents)
+
+**Required:** Batch C (needs `wal`+`apply`) + `acl`.
+
+| RPC | Notes |
+|---|---|
+| `ShareNode` | WAL-first fix (§6). [ShareNode.md](rpcs/ShareNode.md) |
+| `RevokeAccess` | WAL-first fix (§6). [RevokeAccess.md](rpcs/RevokeAccess.md) |
+| `DelegateAccess` | WAL-first fix + applier op (§6). [DelegateAccess.md](rpcs/DelegateAccess.md) |
+| `TransferOwnership` | WAL-first fix (§6). [TransferOwnership.md](rpcs/TransferOwnership.md) |
+| `AddGroupMember` | WAL-first fix (§6). [AddGroupMember.md](rpcs/AddGroupMember.md) |
+| `RemoveGroupMember` | WAL-first fix (§6). [RemoveGroupMember.md](rpcs/RemoveGroupMember.md) |
+
+### Batch F — GDPR / compliance (parallel: ~4 agents)
+
+**Required:** Batch C + `globalstore`.
+
+| RPC | Notes |
+|---|---|
+| `DeleteUser` | queues only; worker out-of-scope. [DeleteUser.md](rpcs/DeleteUser.md) |
+| `CancelUserDeletion` | inverse. [CancelUserDeletion.md](rpcs/CancelUserDeletion.md) |
+| `ExportUserData` | read-only across tenants. [ExportUserData.md](rpcs/ExportUserData.md) |
+| `FreezeUser` | flag in globalstore + applier hook. [FreezeUser.md](rpcs/FreezeUser.md) |
+| `RevokeAllUserAccess` | bulk revoke; WAL-first (§6). [RevokeAllUserAccess.md](rpcs/RevokeAllUserAccess.md) |
+| `TransferUserContent` | bulk transfer; WAL-first. [TransferUserContent.md](rpcs/TransferUserContent.md) |
+| `SetLegalHold` | WAL-first (§6). [SetLegalHold.md](rpcs/SetLegalHold.md) |
+
+### Batch G — Deprecated stubs (parallel: 3 agents, lowest risk)
+
+**Required:** Batch A only.
+
+| RPC | Notes |
+|---|---|
+| `SearchMailbox` | returns empty stub; `_check_tenant` only. [SearchMailbox.md](rpcs/SearchMailbox.md) |
+| `GetMailbox` | same. [GetMailbox.md](rpcs/GetMailbox.md) |
+| `ListMailboxUsers` | same. [ListMailboxUsers.md](rpcs/ListMailboxUsers.md) |
+
+These three are byte-for-byte easiest. Recommend assigning to the same
+agent for one tight PR.
+
+**RPC count check:** 1 (A) + 11 (B) + 1 (C) + 14 (D) + 6 (E) + 7 (F) +
+3 (G) = 43. Off by one because `GetReceiptStatus`/`WaitForOffset` are
+listed in both A and B; the actual unique RPC count is **44**. ✓
+
+## 5. Conflict surface (file-level)
+
+The naive shape — one giant `server/go/internal/api/server.go` with 44
+methods — would force every Wave-2 PR to touch the same file.
+
+**Recommended layout: one file per RPC** under `server/go/internal/api/`.
+File name is `snake_case(<rpc>).go` (e.g. `health.go`, `execute_atomic.go`,
+`add_tenant_member.go`). Plus three shared files: `server.go` (`Server`
+struct + `Register`), `helpers.go` (`checkTenant`, `requireAdminOrOwner`,
+`getAuthoritativeActor`), `server_doc.go` (package doc).
+
+**Conflict-prone files** even with this layout:
+
+1. **`server.go`** — holds `type Server struct { wal *wal.Producer;
+   store *store.CanonicalStore; ... }` and `func (s *Server) Register(grpc.ServiceRegistrar)`.
+   *Mitigation:* freeze the struct shape in Wave-1's `apply` PR (it
+   needs Server too). Wave-2 PRs only add fields when introducing a
+   genuinely new dep (rare). Use a struct-zero default + functional
+   options.
+2. **`pb` registration** — `pb.RegisterEntDBServiceServer(s, srv)` needs
+   the receiver type `Server` to satisfy the interface. The Go gRPC
+   generator emits an `UnimplementedEntDBServiceServer` embed; use it
+   so partial implementations compile. *Each Wave-2 PR removes one
+   `Unimplemented*` method by providing its own impl — no shared edit.*
+3. **`tests/python/integration/_go_parity.py`** — every Wave-2 PR adds
+   a single line to `GO_IMPLEMENTED`. Conflicts are trivial (sort
+   alphabetically, conflict-resolve by sorted-merge).
+4. **`helpers.go`** — `checkTenant` / `requireAdminOrOwner` /
+   `getAuthoritativeActor` shims. *Mitigation:* land all of them in the
+   first Batch-B PR (`GetNode`); subsequent PRs reuse, never edit.
+5. **`server/go/cmd/entdb-server/main.go`** — wiring. *Mitigation:* Wave 1
+   freezes the wiring; Wave 2 PRs do not touch main.
+
+**Out-of-scope conflict surface:** none of the Wave-2 PRs should edit
+files under `server/python/` (CLAUDE.md: do not modify Python source
+unless explicitly needed for parity migration).
+
+## 6. Architectural drift surfaced by Wave 0
+
+Wave-0 agents independently flagged that the current Python implementation
+violates several CLAUDE.md invariants. Aggregated below.
+
+### 6.1 WAL bypass (CLAUDE.md invariant #1 violations)
+
+The following RPCs write directly to per-tenant SQLite (or `globalstore`)
+**without** appending a `TransactionEvent` to the WAL. On a full WAL
+rebuild, every one of these mutations is silently lost.
+
+| RPC | Bypassed write | Spec section |
+|---|---|---|
+| `ShareNode` | `node_access` | [ShareNode.md §Side effects](rpcs/ShareNode.md) "INVARIANT VIOLATION IN PYTHON — FIX in Go port" |
+| `RevokeAccess` | `node_access` DELETE | [RevokeAccess.md §Side effects](rpcs/RevokeAccess.md) |
+| `DelegateAccess` | applier dispatch branch is **missing** entirely; legacy direct write only | [DelegateAccess.md §Open questions](rpcs/DelegateAccess.md) |
+| `TransferOwnership` | `nodes.owner_actor` | [TransferOwnership.md §WAL append](rpcs/TransferOwnership.md) |
+| `AddGroupMember` | `group_users` | [AddGroupMember.md](rpcs/AddGroupMember.md) |
+| `RemoveGroupMember` | `group_users` + shared-index cascade | [RemoveGroupMember.md](rpcs/RemoveGroupMember.md) |
+| `RevokeAllUserAccess` | `node_access` + `group_users` + `node_visibility` | [RevokeAllUserAccess.md §Side effects](rpcs/RevokeAllUserAccess.md) |
+| `SetLegalHold` | `tenant_registry.status` (globalstore) | [SetLegalHold.md §WAL gap](rpcs/SetLegalHold.md) |
+| `CreateTenant` | globalstore — but globalstore has its own carve-out from invariant #1 | [CreateTenant.md](rpcs/CreateTenant.md) |
+| `ArchiveTenant` | same | [ArchiveTenant.md](rpcs/ArchiveTenant.md) |
+| `AddTenantMember` / `RemoveTenantMember` / `ChangeMemberRole` | globalstore | (same carve-out applies) |
+
+**Default policy: fix-on-port for per-tenant data; preserve carve-out
+for global-store-only writes.**
+
+- For per-tenant data (`node_access`, `group_users`, `node_visibility`,
+  `nodes.owner_actor`): the Go handler MUST append a WAL event and the
+  Go applier MUST grow a dispatch branch. New op types: `share_node`,
+  `revoke_access`, `delegate_access`, `transfer_ownership`,
+  `add_group_member`, `remove_group_member`, `set_legal_hold`. The
+  `admin_revoke_access` op already exists in Python but only updates
+  `node_visibility`; broaden it to also delete `node_access` and
+  `group_users` per [RevokeAllUserAccess.md](rpcs/RevokeAllUserAccess.md).
+- For global-store-only writes (user CRUD, tenant CRUD, membership):
+  preserve the existing carve-out. Per [global-store.md §WAL coupling](shared/global-store.md),
+  `GlobalStore` is its own durable substrate; CLAUDE.md invariant #1
+  reads "every per-tenant mutation goes through the WAL". Document
+  this explicitly in the Go port and ensure `GlobalStore` is included
+  in S3 snapshots (open question in the spec; recommendation: yes).
+
+**Exceptions:** `SetLegalHold` is a borderline case (the flag lives in
+globalstore but is consulted on per-tenant writes). Recommendation:
+emit an `admin_set_legal_hold` event AND keep the global-store status
+column as the source-of-truth for tenant gating; the WAL event exists
+purely for replay-survival of the audit history.
+
+### 6.2 Trusted-actor enforcement gaps
+
+PR #168 (commit `fece3fb`) closed most gaps. Wave-0 audits flagged the
+following residual handlers that don't run wire-actor through
+`get_authoritative_actor`:
+
+- `TransferOwnership` (no auth check at all today beyond `_check_tenant`).
+- `GetReceiptStatus` reads `request.context.actor` but **never uses it**
+  for authorization — that's intentional and the spec pins it; no fix
+  needed.
+- `WaitForOffset` — same as above.
+- `ListMailboxUsers` — has no `actor` field; vacuously safe.
+- `GetMailbox` — does not call `_trusted_actor` (stub); no auth check
+  needed.
+- The `ExecuteAtomic` per-op `Permission` check is **deliberately
+  missing** today. Preserve in Go for parity (flagged in
+  [ExecuteAtomic.md §Open questions](rpcs/ExecuteAtomic.md)) — file as
+  a follow-up.
+
+**Default policy: fix-on-port (for write paths).** Every Wave-2 write
+RPC MUST consult `auth.Authoritative(ctx, req.Context.Actor)` and
+**rebind** the local variable before any authz decision. The Python
+defence-in-depth pattern (multiple call sites re-invoking
+`get_authoritative_actor`) is preserved.
+
+### 6.3 Deprecated stubs
+
+[GetMailbox.md](rpcs/GetMailbox.md), [SearchMailbox.md](rpcs/SearchMailbox.md),
+[ListMailboxUsers.md](rpcs/ListMailboxUsers.md): the legacy per-user mailbox
+SQLite store is gone. All three return an empty-but-well-formed response
+plus the standard tenant gate. **Default policy: port-as-stub.** Do not
+re-introduce a real implementation in Wave 2; file a follow-up if product
+wants the listing.
+
+### 6.4 Real bugs found while spec-writing
+
+1. **`DelegateAccess` applier dispatch is missing** —
+   [DelegateAccess.md §Open questions](rpcs/DelegateAccess.md). Python
+   handler appends an `admin_delegate_access` event that is silently
+   dropped by the applier; tests pass via the legacy direct-write path.
+   **Fix in Go port** (Batch E ticket); also file a Python bug for
+   parallel fix.
+2. **`admin_revoke_access` applier op doesn't touch `node_access` /
+   `group_users`** — [RevokeAllUserAccess.md §Side effects](rpcs/RevokeAllUserAccess.md).
+   Today only deletes from `node_visibility`. Broaden in Go.
+3. **`TransferUserContent` applier doesn't refresh `node_visibility`** —
+   [TransferUserContent.md §Open questions point 4](rpcs/TransferUserContent.md).
+   Visibility drift after WAL rebuild. Fix in Go (single-line addition).
+4. **`ArchiveTenant` silently overwrites `legal_hold` status** —
+   [SetLegalHold.md §Open questions point 4](rpcs/SetLegalHold.md). Add
+   explicit guard in Go.
+5. **`DeleteUser` doesn't check legal hold on user's tenants** —
+   [SetLegalHold.md §Open questions point 3](rpcs/SetLegalHold.md). Fix
+   behind a config flag in Go (preserves day-zero parity tests).
+
+**Default policy:** fix-on-port for genuine bugs (1–4) — they have no
+contract test pinning the broken behaviour. Item (5) is a behaviour
+change that needs a config flag to keep parity tests green.
+
+## 7. Test-harness gating
+
+Per [test-harness.md](shared/test-harness.md):
+
+- **Single env-var toggle:** `ENTDB_SERVER_TARGET=python|go`. Python is
+  the default (in-process fixture, today's path). Go runs the binary as
+  a subprocess.
+- **Subprocess contract:** `$ENTDB_GO_BINARY` honours
+  `--listen 127.0.0.1:<port>`, `--wal-backend memory`, `--data-dir <tmp>`,
+  `--auth-disabled`, `--mailbox-fanout=false`, `--batch-size 1`,
+  `--seed-tenant acme`, `--ready-probe`. The harness waits for
+  `Health.healthy=true` (10 s, 50 ms poll) before yielding the port.
+- **Per-RPC gate:** `tests/python/integration/_go_parity.py` exposes
+  `GO_IMPLEMENTED: frozenset[str]`. A `pytest_collection_modifyitems`
+  hook adds `pytest.mark.skip` to every contract case whose `rpc` is
+  not in the set. Adding an RPC = one-line PR diff.
+- **CI matrix:** `.github/workflows/ci.yml` grows
+  `integration-tests: matrix: server: [python, go]` with
+  `continue-on-error: true` on the Go leg until §1's Wave 3 flip.
+- **Suites NOT parameterised by target:** `test_wal_replay_determinism.py`,
+  `test_concurrent_applier_reads.py`, `test_privilege_escalation.py`. They
+  run Python-only; equivalent Go-native suites live under
+  `tests/go/` (separate work).
+
+### Wave-2 PR template — definition of done
+
+Every Wave-2 RPC PR MUST:
+
+1. Add `server/go/internal/api/<rpc>.go` with the handler.
+2. Wire it into `server.go` (replace the `Unimplemented` embed).
+3. Add `<RPC>` to `GO_IMPLEMENTED` in `_go_parity.py` in the same diff.
+4. Pass the relevant `tests/python/integration/test_grpc_contract.py`
+   case under `ENTDB_SERVER_TARGET=go` (CI matrix `server: go` leg
+   green for that case).
+5. Run `python -m pytest tests/python/unit/ tests/python/integration/ -q`
+   green under both targets locally.
+6. `cd server/go && go vet ./... && go test ./...` green.
+7. Lint clean: `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format
+   --check .`.
+8. PR description references the spec under `docs/go-port/rpcs/<RPC>.md`
+   and acknowledges any architectural-drift fix from §6.
+
+`ExecuteAtomic` and `GetNode` PRs additionally unlock
+`test_grpc_wire_format.py`; before they land that suite is
+`pytestmark = requires_target("ExecuteAtomic")`-skipped on the Go leg.
+
+## 8. Open questions / unresolved decisions
+
+Aggregated from every spec, deduplicated, sorted by which Wave they
+affect.
+
+### Wave 1 blockers (must decide before/during shared-package PRs)
+
+1. **JSON encoding determinism in WAL events.** Python `json.dumps`
+   uses insertion order; Go's `encoding/json` sorts keys. The replay
+   determinism test compares `payload_json` strings byte-for-byte.
+   *Recommendation:* migrate Python side to sorted keys before the Go
+   port lands. [applier.md OQ #1](shared/applier.md#open-questions--risks),
+   [ExecuteAtomic.md OQ §determinism](rpcs/ExecuteAtomic.md).
+2. **SQLite driver choice.** `modernc.org/sqlite` (no cgo) vs
+   `mattn/go-sqlite3` (cgo, faster, SQLCipher-capable).
+   *Recommendation:* `modernc.org/sqlite` for parity with the
+   "single static binary" Go-server posture; revisit if encryption-at-rest
+   re-enters scope. [canonical-store.md OQ #1](shared/canonical-store.md),
+   [applier.md OQ #2](shared/applier.md).
+3. **Error categorisation in applier.** Today Python lumps all into
+   `ApplyResult.error = str(e)`. The Go port should distinguish
+   poisoned events / constraint violations / transient infra. Wire as
+   typed-error switch in the consume loop. [applier.md OQ #5](shared/applier.md).
+4. **`global.db` durability story.** No WAL today; not snapshot'd
+   either. *Recommendation:* snapshot to S3 alongside per-tenant
+   snapshots (Phase 2). [global-store.md OQ #1](shared/global-store.md).
+5. **Cross-tenant ACL store split.** `_check_capability` uses
+   `include_cross_tenant=True` against the global `shared_index`. The
+   Go port needs a clean abstraction across per-tenant SQLite + global
+   store. *Recommendation:* `store.UnifiedGrantReader`. [acl.md OQ
+   #3](shared/acl.md).
+6. **`SetMaxOpenConns(1)` per tenant** vs N. Bench before locking in.
+   [canonical-store.md OQ #5](shared/canonical-store.md).
+7. **Group nesting depth bound.** Mirror Python's implicit cap;
+   instrument when fired. [acl.md OQ #1](shared/acl.md).
+8. **Single consumer goroutine vs per-tenant pool in applier.**
+   *Recommendation:* start with single (Python parity); move to
+   per-tenant if benchmarks show starvation. [applier.md
+   §single-vs-pool](shared/applier.md).
+
+### Wave 2 considerations (per-RPC; address in the relevant PR)
+
+9. **Should ShareNode add a mailbox notification?** Currently no fanout
+   on share; only `create_node` fans out. *Recommendation:* preserve
+   parity, file follow-up. [ShareNode.md OQ](rpcs/ShareNode.md).
+10. **`success=false` vs `status.Errorf` for ACL ops.** Keep the
+    soft-fail shape (SDK clients parse the response field). [ShareNode.md
+    OQ](rpcs/ShareNode.md), [RevokeAccess.md OQ](rpcs/RevokeAccess.md).
+11. **`type_id` ignored in `GetNode`.** Preserve bug-for-bug; file
+    follow-up to either enforce or delete the field.
+    [GetNode.md OQ #1](rpcs/GetNode.md), [canonical-store.md OQ
+    #6](shared/canonical-store.md).
+12. **Idempotency-key derivation for `RevokeAllUserAccess` /
+    `TransferUserContent`.** Server synthesises since proto lacks the
+    field. Decide hashing strategy. [RevokeAllUserAccess.md
+    OQ](rpcs/RevokeAllUserAccess.md).
+13. **`RevokeDelegation` RPC?** No symmetric inverse for
+    `DelegateAccess`. Track v2. [DelegateAccess.md OQ](rpcs/DelegateAccess.md).
+14. **Legal-hold gate on `DeleteUser`.** New behaviour; ship behind a
+    config flag to keep parity tests green. [DeleteUser.md OQ
+    #4](rpcs/DeleteUser.md), [SetLegalHold.md OQ #3](rpcs/SetLegalHold.md).
+15. **Large-user `TransferUserContent` (10M+ owned nodes).** Single
+    UPDATE holds the writer slot. Decide chunked vs accept-the-lock.
+    [TransferUserContent.md OQ #2](rpcs/TransferUserContent.md).
+16. **Pre-apply count semantics in admin RPCs.** Counts taken AFTER
+    WAL append but BEFORE applier consumes — racy but documented. Keep.
+17. **Client-cancel semantics in `WaitForOffset`.** Python returns
+    `OK+reached=false`; Go idiom is `ctx.Err()`. Pick one.
+    [WaitForOffset.md OQ #4](rpcs/WaitForOffset.md).
+
+### Wave 3 / post-port
+
+18. **Tenant-claim from JWT vs request.** [auth-interceptor.md OQ
+    #1](shared/auth-interceptor.md).
+19. **Multi-IdP `sub` collisions.** [auth-interceptor.md OQ
+    #5](shared/auth-interceptor.md).
+20. **Per-tenant schema variants.** Out of scope; flag for post-port.
+    [schema-registry.md OQ #2](shared/schema-registry.md).
+21. **Audit-log table sunset.** Keep read-only for back-compat; do not
+    extend. [canonical-store.md OQ #7](shared/canonical-store.md).
+22. **Receipt FAILED status.** Never produced today. Don't speculatively
+    emit. [GetReceiptStatus.md OQ](rpcs/GetReceiptStatus.md).
+
+## 9. Wave 1 PR slate
+
+To fire as a parallel agent batch when #408 merges. Each entry:
+title / scope / deps / size estimate / agent prompt outline.
+
+| # | Title | Scope | Wave-1 deps | Diff size | Agent prompt outline |
+|---|---|---|---|---|---|
+| W1.0 | `feat(go): generate pb stubs for entdb.v1` | `proto/entdb/v1/*.proto` → `server/go/internal/pb/entdbv1/` via `protoc-gen-go` + `protoc-gen-go-grpc`. Mod file. CI go-generate guard. | none | ~5k LOC generated | "Add buf/protoc generation for `proto/entdb/v1/entdb.proto` and `proto/console/v1/console.proto` into `server/go/internal/pb/`. Mirror naming used in `sdk/go/entdb/internal/pb/`. Add `go generate ./...` and a CI step that re-runs and fails on diff." |
+| W1.1 | `feat(go): errs package — typed sentinels + trailers` | `server/go/internal/errs/{errs.go,map.go,trailers.go}` per [error-mapping.md](shared/error-mapping.md). | W1.0 | ~400 LOC | "Implement `server/go/internal/errs/` from `docs/go-port/shared/error-mapping.md`. Sentinels with `GRPCStatus()`. Trailer helpers. `PreserveStatusOrSwallow`. No `google.rpc` extensions." |
+| W1.2 | `feat(go): version + metrics packages` | `server/go/internal/version/version.go`, `server/go/internal/metrics/grpc.go` (Prometheus counter+histogram). | none | ~200 LOC | "Add `version.Version` set via `-ldflags -X`. Add `metrics.RecordGRPCRequest(method, status, dur)` mirroring `server/python/entdb_server/metrics.py:103`." |
+| W1.3 | `feat(go): schema registry` | `server/go/internal/schema/{types,registry,loader,fingerprint,translate}.go` per [schema-registry.md](shared/schema-registry.md). `LoadFromJSON` only (proto reflection deferred). | W1.0, W1.1 | ~1500 LOC | "Implement `server/go/internal/schema/` from `docs/go-port/shared/schema-registry.md`. JSON loader consumes `SchemaRegistry.to_json` shape. `Freeze()`+`Fingerprint()`. Compat package can be a stub." |
+| W1.4 | `feat(go): wal producer + memory backend` | `server/go/internal/wal/{wal.go,event.go,memory.go}` per [wal-producer.md](shared/wal-producer.md). | W1.0, W1.1 | ~600 LOC | "Implement the producer interface + in-memory backend from `docs/go-port/shared/wal-producer.md`. Mirror `server/python/entdb_server/wal/memory.py`. Test helpers `GetAllRecords`/`WaitForRecords`/`ClearTopic`." |
+| W1.5 | `feat(go): auth interceptor + trusted-actor` | `server/go/internal/auth/{interceptor,identity,actor,oauth,apikey,session,errors}.go` per [auth-interceptor.md](shared/auth-interceptor.md). | W1.0, W1.1 | ~800 LOC | "Implement the auth interceptor from `docs/go-port/shared/auth-interceptor.md`. In-memory JWKS / API-key / session managers. `Authoritative(ctx, claimed)` is the choke point." |
+| W1.6 | `feat(go): payload translation` | `server/go/internal/payload/translate.go` per [payload-translation.md](shared/payload-translation.md). | W1.3 | ~300 LOC | "Implement `payload.StructToPayload`/`PayloadToStruct`/`FilterNamesToIDs`/`PayloadJSONToNames` from `docs/go-port/shared/payload-translation.md`. Internal map shape: `map[uint32]any`. Schema-less passthrough." |
+| W1.7 | `feat(go): globalstore + tenant gate` | `server/go/internal/globalstore/{globalstore,users,tenants,members,shared,deletion,legalhold,quota,schema}.go` per [global-store.md](shared/global-store.md). Plus `server/go/internal/tenant/check.go`. | W1.0, W1.1 | ~1200 LOC | "Implement `globalstore` package from `docs/go-port/shared/global-store.md`. `MaxOpenConns(1)`. Add `tenant.CheckTenant(ctx, tenantID)` + `Sharding` struct (single-node default = always-mine)." |
+| W1.8 | `feat(go): canonical store (read paths)` | `server/go/internal/store/{canonical,schema,pool,txn,visibility,fts,indexes,notifications,errors}.go` per [canonical-store.md](shared/canonical-store.md). Read methods + applier-callable writers. | W1.3, W1.6 | ~3000 LOC | "Implement `store.CanonicalStore` from `docs/go-port/shared/canonical-store.md`. `modernc.org/sqlite` driver. Lazy unique/query/composite/FTS5 indexes. Read methods for every Batch-B RPC. Writer methods for every Batch-C/E op type." |
+| W1.9 | `feat(go): acl engine` | `server/go/internal/acl/{permission,capability,actor,grant,enforcer,resolver,registry,filter}.go` per [acl.md](shared/acl.md). | W1.3, W1.7, W1.8 | ~1000 LOC | "Implement `acl` from `docs/go-port/shared/acl.md`. `Enforcer.Check`+`FilterReadable`. Group resolution depth-bounded. `Registry` populated from `schema` package." |
+| W1.10 | `feat(go): applier (WAL consumer)` | `server/go/internal/apply/{applier,event,result,storage_route,ops_*,alias,errors,fanout,shared_index}.go` per [applier.md](shared/applier.md). All op-type dispatch branches incl. the new ones from §6. | W1.4, W1.7, W1.8, W1.9, W1.6 | ~2500 LOC | "Implement `apply.Applier` from `docs/go-port/shared/applier.md`. Single consumer goroutine. All op types: `create_node`, `update_node`, `delete_node`, `create_edge`, `delete_edge`, plus the WAL-first additions per `docs/go-port/PLAN.md §6`. Halt-on-poison + idempotency in-txn." |
+
+Wall-clock with 4 agents in worktrees: W1.0/1.1/1.2 in parallel ≈ 1
+day; W1.3/1.4/1.5 in parallel ≈ 2 days; W1.6/1.7 in parallel ≈ 1 day;
+W1.8 ≈ 3 days (largest); W1.9 ≈ 2 days; W1.10 ≈ 3 days. Total ≈ 12
+working days; critical path ≈ 9 days.
+
+## 10. Wave 2 PR slate
+
+44 PRs, one per RPC. Title format: `feat(go-port): implement <RPC> in
+Go server`. Every PR pulls in only the listed Wave-1 deps; agent prompt
+template at the bottom of the table.
+
+| # | RPC | Batch | Required Wave-1 PRs |
+|---|---|---|---|
+| W2.01 | `Health` | A | W1.0–1.2 (pb, errs, version, metrics) |
+| W2.02 | `GetSchema` | A | + W1.3 (schema) |
+| W2.03 | `GetReceiptStatus` | A/B | + W1.7, W1.8 (globalstore, store) |
+| W2.04 | `WaitForOffset` | A/B | + W1.7, W1.8 |
+| W2.05 | `GetNode` | B | + W1.5, W1.8, W1.9 (auth, store, acl) |
+| W2.06 | `GetNodes` | B | same as GetNode |
+| W2.07 | `GetNodeByKey` | B | same |
+| W2.08 | `QueryNodes` | B | + W1.6 (payload) |
+| W2.09 | `SearchNodes` | B | same as QueryNodes |
+| W2.10 | `GetEdgesFrom` | B | as GetNode |
+| W2.11 | `GetEdgesTo` | B | as GetNode |
+| W2.12 | `GetConnectedNodes` | B | as GetNode |
+| W2.13 | `ListSharedWithMe` | B | as GetNode + globalstore |
+| W2.14 | `ExecuteAtomic` | C | + W1.4 (wal), W1.10 (apply) |
+| W2.15 | `CreateUser` | D | W1.0–1.2 + W1.5 + W1.7 |
+| W2.16 | `UpdateUser` | D | as CreateUser |
+| W2.17 | `GetUser` | D | as CreateUser |
+| W2.18 | `ListUsers` | D | as CreateUser |
+| W2.19 | `GetUserTenants` | D | as CreateUser |
+| W2.20 | `CreateTenant` | D | as CreateUser |
+| W2.21 | `GetTenant` | D | as CreateUser |
+| W2.22 | `ListTenants` | D | as CreateUser |
+| W2.23 | `ArchiveTenant` | D | as CreateUser |
+| W2.24 | `GetTenantQuota` | D | as CreateUser |
+| W2.25 | `GetTenantMembers` | D | as CreateUser |
+| W2.26 | `AddTenantMember` | D | as CreateUser |
+| W2.27 | `RemoveTenantMember` | D | as CreateUser |
+| W2.28 | `ChangeMemberRole` | D | as CreateUser |
+| W2.29 | `ShareNode` | E | full (incl. wal+apply) — adds applier op `share_node` |
+| W2.30 | `RevokeAccess` | E | full — adds applier op `revoke_access` |
+| W2.31 | `DelegateAccess` | E | full — adds applier op `delegate_access` (FIX) |
+| W2.32 | `TransferOwnership` | E | full — adds applier op `transfer_ownership` |
+| W2.33 | `AddGroupMember` | E | full — adds applier op `add_group_member` |
+| W2.34 | `RemoveGroupMember` | E | full — adds applier op `remove_group_member` |
+| W2.35 | `DeleteUser` | F | D-set + W1.10 only if worker hooks added (not Wave 2) |
+| W2.36 | `CancelUserDeletion` | F | as DeleteUser |
+| W2.37 | `ExportUserData` | F | D-set + W1.8 (per-tenant reads) |
+| W2.38 | `FreezeUser` | F | full + applier flag check |
+| W2.39 | `RevokeAllUserAccess` | F | full — broadens applier op `admin_revoke_access` |
+| W2.40 | `TransferUserContent` | F | full — fix visibility refresh in applier |
+| W2.41 | `SetLegalHold` | F | full — adds applier op `set_legal_hold` |
+| W2.42 | `SearchMailbox` | G | A-set only |
+| W2.43 | `GetMailbox` | G | A-set only |
+| W2.44 | `ListMailboxUsers` | G | A-set only |
+
+### Agent prompt template
+
+For each Wave-2 PR:
+
+> Implement `<RPC>` in the Go server. Source spec:
+> `docs/go-port/rpcs/<RPC>.md`. Coordination plan:
+> `docs/go-port/PLAN.md`.
+>
+> 1. Read the spec end-to-end. Note any architectural-drift fix
+>    flagged in §6 of the plan — your PR must close it (with a contract
+>    test).
+> 2. Implement the handler in `server/go/internal/api/<rpc>.go`. Reuse
+>    helpers from `server/go/internal/api/helpers.go`
+>    (`checkTenant`, `requireAdminOrOwner`, `getAuthoritativeActor`).
+> 3. Replace the embedded `Unimplemented<RPC>` method on `Server`.
+> 4. Add `<RPC>` to `GO_IMPLEMENTED` in
+>    `tests/python/integration/_go_parity.py`.
+> 5. Run the local CI suite per `CLAUDE.md` (`pytest`, `ruff`, `go vet`,
+>    `go test`).
+> 6. Run the matrix locally:
+>    `ENTDB_SERVER_TARGET=go pytest tests/python/integration/test_grpc_contract.py -q`
+>    expecting your RPC's case to pass and others to skip.
+> 7. PR description: 2-line summary; link to `docs/go-port/rpcs/<RPC>.md`;
+>    explicit acknowledgement of any §6 drift you closed; "Test plan"
+>    bulleted.
+
+Wall-clock estimate (8 worktree agents, post-Wave-1): Batch A+G ≈
+2 days; Batch B ≈ 5 days (sequential `GetNode` first); Batch C ≈ 3
+days (`ExecuteAtomic` is the lynchpin); Batch D ≈ 4 days (high
+parallelism but globalstore conflicts gate two concurrent agents per
+file area); Batch E ≈ 5 days (each ports an applier op + handler);
+Batch F ≈ 4 days. Total ≈ 4 calendar weeks for the Wave-2 surface.

--- a/docs/go-port/rpcs/AddGroupMember.md
+++ b/docs/go-port/rpcs/AddGroupMember.md
@@ -1,0 +1,248 @@
+# AddGroupMember — Go Port Spec
+
+EPIC #407. Inverse of `RemoveGroupMember`. Reference Python handler:
+`server/python/entdb_server/api/grpc_server.py:1946-1984`. Proto:
+`proto/entdb/v1/entdb.proto:103, 768-778`.
+
+## Wire contract
+
+Request `entdb.v1.GroupMemberRequest` (proto:768):
+- `RequestContext context` — `tenant_id`, `actor` (UNTRUSTED — actor on
+  the wire is replaced by the trusted identity at the boundary).
+- `string group_id` — opaque group identifier. Convention is
+  `"group:<name>"` (see `tests/python/unit/test_acl_v2.py:264, 271`).
+  No server-side validation today; an empty `group_id` will INSERT a
+  literal empty-string key. Go port: same parity, but flag.
+- `string member_actor_id` — the principal being added. May itself be a
+  group id (nested groups: `test_acl_v2.py:271, 421`). Convention is
+  `"user:<id>"` or `"group:<id>"`.
+- `string role` — free-form. Empty defaults to `"member"` at the
+  handler (grpc_server.py:1962). No enum validation; anything goes.
+
+Response `GroupMemberResponse` (proto:775):
+- `bool success` — `true` on apply, `false` on any caught exception.
+- `string error` — `str(e)` on failure (grpc_server.py:1984). gRPC
+  status remains `OK` even on failure — failure is signalled
+  in-band, not via status code (parity quirk; see Open Questions).
+
+Idempotency: backed by `INSERT OR REPLACE INTO group_users`
+(canonical_store.py:3505-3513). Same `(group_id, member_actor_id)`
+re-added overwrites `role` and `joined_at`. Duplicate adds DO NOT
+error — Go port must match.
+
+## Auth
+
+- Tenant existence: `_check_tenant(tenant_id, context)`
+  (grpc_server.py:1954, 362).
+- Trusted actor: **NOT extracted today.** The Python handler does
+  *not* call `_trusted_actor` — it never reads `request.context.actor`
+  at all. This is a privilege-escalation gap: any caller can mutate
+  any group in any tenant they can reach. The Go port MUST close this
+  gap (see CLAUDE.md §3 and commit `fece3fb` "Fix privilege escalation:
+  ignore client-claimed actor in gRPC handlers"). Required Go behaviour:
+    1. `trusted := auth.GetAuthoritativeActor(ctx)` — read from gRPC
+       metadata, ignore `request.context.actor`.
+    2. Authorise: caller must (a) be tenant admin/system, OR (b) hold
+       `OWNER` or admin role on the group. Today no group-ownership
+       table exists; the simplest v1 rule is **tenant admin only**,
+       with a follow-up issue for group-level admin.
+- Capability: not registered in `RPC_TO_CAPABILITY` (no entry found in
+  `server/python/entdb_server/auth/`). Add `CoreCapability.MANAGE_ACL`
+  (or new `MANAGE_GROUPS`) and pin via a unit test mirroring
+  `tests/python/unit/test_capability_registry.py:62`.
+
+## Side effects
+
+**Current Python (NON-CONFORMANT to CLAUDE.md §1):**
+1. `canonical_store.add_group_member` writes directly to SQLite
+   (grpc_server.py:1958, canonical_store.py:3497-3531). **Bypasses the
+   WAL.** A rebuild-from-WAL drops the membership row silently.
+2. Cascade: enumerate `list_node_access_for_group(tenant, group_id)`
+   and call `global_store.add_shared(member, tenant, node_id, perm)`
+   for each entry (grpc_server.py:1965-1976,
+   canonical_store.py:3592-3627). Failures here are logged at WARN and
+   swallowed (grpc_server.py:1977-1978).
+3. Metric `record_grpc_request("AddGroupMember", "ok"|"error", elapsed)`
+   (grpc_server.py:1979, 1982).
+
+**Required Go behaviour (must fix the WAL bypass):**
+1. Build a `TransactionEvent` with op
+   `{"type": "add_group_member", "group_id": ..., "member_actor_id":
+   ..., "role": ...}` and call `wal.Append(ctx, tenantID, event)`.
+2. The applier (`apply/applier.go`) handles the new op-type by
+   invoking `canonicalStore.AddGroupMember` and the existing
+   `_update_shared_index_on_group_member_add` cascade
+   (applier.py:1782-1813). Move the cascade out of the handler and
+   into the applier so a WAL replay reconstructs `shared_index`.
+3. Return `GroupMemberResponse{success: true}` after the WAL append
+   succeeds (do NOT block on apply — the read-after-write fence is
+   the caller's responsibility via `WaitForOffset`, parity with
+   `ExecuteAtomic`).
+
+ACL recompute consequences (must be preserved):
+- Adding a user to a group transitively grants them every node-access
+  the group already holds (`test_acl_v2.py:412-431`,
+  `test_shared_index.py:241-259`).
+- Adding a *group* as a member (nested groups) makes its members
+  inherit access (`test_acl_v2.py:271, 421`).
+- `resolve_actor_groups` is recursive; cycles must terminate (parity
+  with `_sync_resolve_actor_groups`).
+
+## Error contract
+
+| Condition | Python | Go port |
+|---|---|---|
+| Tenant missing/disabled | `_check_tenant` aborts `NOT_FOUND` / `FAILED_PRECONDITION` | match |
+| Caller not authorised | (no check today — vulnerability) | `PERMISSION_DENIED` |
+| Empty `group_id` or `member_actor_id` | accepted, INSERTs blank row | reject `INVALID_ARGUMENT` (hardening) |
+| Same `(group_id, member)` re-added | `success=true`, role overwritten | match (idempotent) |
+| Cascade `add_shared` failure | logged WARN, `success=true` | match — cascade is best-effort |
+| WAL append failure | n/a (no WAL today) | `UNAVAILABLE`; do NOT touch SQLite |
+| Internal error | bare `except`, return `success=false, error=str(e)`, status OK | match in v1; flag for review |
+
+Status-code parity quirk: Python returns `OK` with `success=false` on
+internal error rather than a non-OK gRPC status. Match for v1; the
+mainline error path stays in-band.
+
+## Shared Go package deps
+
+- `internal/auth` — `GetAuthoritativeActor(ctx)`, admin/role checks.
+- `internal/tenant` — `CheckTenant`.
+- `internal/wal` — `Append(ctx, tenantID, TransactionEvent)`. Backends
+  per `server/python/entdb_server/wal/` (Kafka, Kinesis, SQS, memory).
+- `internal/apply` — `Applier.ApplyEvent` dispatches the new
+  `add_group_member` op-type; cascade lives here.
+- `internal/canonical` (a.k.a. `internal/store`) —
+  `AddGroupMember(tenantID, groupID, memberActorID, role)`,
+  `ListNodeAccessForGroup(tenantID, groupID)`,
+  `ResolveActorGroups(tenantID, actor)`.
+- `internal/global` — `AddShared(userID, sourceTenant, nodeID, perm)`
+  for the cascade (global_store.py:670-690).
+- `internal/metrics` — `RecordGRPCRequest`.
+- `internal/acl/groups` — pure helpers for nested-group resolution
+  (cycle-safe BFS).
+
+## Other-RPC deps
+
+- `RemoveGroupMember` (proto:106, grpc_server.py:1986-…) is the exact
+  inverse: same wire shape, `DELETE` on `group_users`, cascade-removes
+  shared_index entries that were granted *only* via this group
+  (applier.py:1815-…). Spec the WAL op as `remove_group_member`.
+- `ShareNode` / `RevokeAccess` populate `node_access` rows that
+  `list_node_access_for_group` reads — adding a member after a share
+  must back-fill `shared_index`; adding before means the next
+  `ShareNode` cascade picks them up via `get_group_members`
+  (`test_shared_index.py:241-259`).
+- Contract tests order `AddGroupMember` before `RemoveGroupMember`
+  intentionally (`test_grpc_contract.py:374`).
+
+## Contract tests pinning behavior
+
+- `tests/python/integration/test_grpc_contract.py:362-373` — happy
+  path, `success == true`, payload shape pinned.
+- `tests/python/unit/test_acl_v2.py:578-591` — add → resolve includes
+  group; remove → resolve excludes; remove-nonexistent returns false.
+- `tests/python/unit/test_acl_v2.py:264-279` — group resolution and
+  nested-group expansion.
+- `tests/python/unit/test_acl_v2.py:412-431` — adding member to a
+  group transitively grants the group's existing node access.
+- `tests/python/unit/test_acl_v2.py:476` — group ACL participates in
+  `can_access`.
+- `tests/python/unit/test_shared_index.py:241-259` — group share
+  expands to per-member `shared_index` entries.
+- `tests/python/unit/test_cross_tenant_read.py:366-404` — group
+  membership across tenant boundary for cross-tenant reads.
+- `tests/python/unit/test_admin_operations.py:369-371, 719` — admin
+  ops invoke `add_group_member` directly.
+
+Go port adds (`tests/contract/`): WAL-append observed before SQLite
+write; replay-from-empty-WAL reconstructs membership; trusted-actor
+substitution rejects forged admin claim; idempotent re-add overwrites
+role; cascade back-fills `shared_index`.
+
+## Implementation outline
+
+```go
+func (s *Server) AddGroupMember(ctx context.Context, req *pb.GroupMemberRequest) (*pb.GroupMemberResponse, error) {
+    start := time.Now()
+    st := "ok"
+    defer func() { metrics.RecordGRPCRequest("AddGroupMember", st, time.Since(start)) }()
+
+    if err := s.checkTenant(ctx, req.Context.TenantId); err != nil { st = "error"; return nil, err }
+    trusted := auth.GetAuthoritativeActor(ctx) // ignore req.Context.Actor
+    if err := s.authz.RequireGroupAdmin(ctx, req.Context.TenantId, trusted, req.GroupId); err != nil {
+        st = "error"; return nil, err // PERMISSION_DENIED
+    }
+    if req.GroupId == "" || req.MemberActorId == "" {
+        st = "error"; return nil, status.Error(codes.InvalidArgument, "group_id and member_actor_id required")
+    }
+    role := req.Role
+    if role == "" { role = "member" }
+
+    ev := wal.NewEvent(req.Context.TenantId, trusted, []wal.Op{{
+        Type:          "add_group_member",
+        GroupID:       req.GroupId,
+        MemberActorID: req.MemberActorId,
+        Role:          role,
+    }})
+    if _, err := s.wal.Append(ctx, req.Context.TenantId, ev); err != nil {
+        st = "error"
+        return &pb.GroupMemberResponse{Success: false, Error: err.Error()}, nil // parity: in-band
+    }
+    return &pb.GroupMemberResponse{Success: true}, nil
+}
+```
+
+Applier handler (sketch):
+```go
+case "add_group_member":
+    if err := store.AddGroupMember(ctx, tid, op.GroupID, op.MemberActorID, op.Role); err != nil { return err }
+    // Cascade — best effort, do not fail the apply.
+    entries, _ := store.ListNodeAccessForGroup(ctx, tid, op.GroupID)
+    for _, e := range entries {
+        _ = global.AddShared(ctx, op.MemberActorID, tid, e.NodeID, e.Permission)
+    }
+```
+
+Notes:
+- Cascade runs in the applier so a WAL replay reconstructs
+  `shared_index` (CLAUDE.md §1).
+- `INSERT OR REPLACE` semantics keep replay idempotent.
+- No `WaitForOffset` inside the handler — caller fences via
+  `after_offset` on subsequent reads.
+
+## Open questions / risks
+
+1. **Auth model is undefined.** No "group owner" or "group admin"
+   concept exists in the schema today. v1 rule = tenant admin only;
+   file follow-up to introduce per-group admin (proto field on group
+   creation, new `group_admins` table). Until then, this RPC is
+   strictly an admin op.
+2. **WAL bypass in Python is a known parity-vs-correctness conflict.**
+   The Go port MUST route through the WAL (CLAUDE.md §1) even though
+   that is technically a behaviour change. Coordinate with EPIC #407
+   so the contract test for "membership survives rebuild" lands at
+   the same time as the Go server, otherwise Python CI will fail.
+3. **Idempotency on `INSERT OR REPLACE`** silently overwrites `role`
+   and `joined_at`. Consider whether re-add should be a no-op when
+   role matches, or always bump `joined_at`. Recommend: always bump
+   to match Python.
+4. **Nested groups + cycles.** Adding `group:a` as member of
+   `group:b` and then `group:b` as member of `group:a` is currently
+   accepted; `_sync_resolve_actor_groups` must guard with a `visited`
+   set. Pin a contract test (`tests/contract/group_cycle.go`) — the
+   Go BFS must terminate.
+5. **Cascade error swallowing.** `add_shared` failures are WARN-
+   logged. Under WAL replay, a transient global_store outage could
+   leak missing `shared_index` rows. Add an idempotent
+   reconcile job (`shared_index_rebuild`) — out of scope for v1.
+6. **In-band error vs gRPC status.** Returning `OK / success=false`
+   conflicts with idiomatic Go gRPC. Match for v1, file deprecation
+   issue for v2 to switch to `codes.Internal`.
+7. **No capability registry entry.** `tests/python/unit/test_capability_registry.py`
+   has no row for `AddGroupMember`. Add one (`CoreCapability.MANAGE_ACL`
+   or new `MANAGE_GROUPS`) before merging the Go port.
+8. **`group_id` / `member_actor_id` validation.** Empty strings,
+   `"user:"` (no id), or trailing whitespace are all currently
+   accepted. Recommend `INVALID_ARGUMENT` on empty; defer richer
+   validation to a separate hardening PR.

--- a/docs/go-port/rpcs/AddTenantMember.md
+++ b/docs/go-port/rpcs/AddTenantMember.md
@@ -1,0 +1,238 @@
+# RPC Port Spec — `entdb.v1.EntDBService/AddTenantMember`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2442-2490`.
+
+## Wire contract (role enum)
+
+Proto: `proto/entdb/v1/entdb.proto:123` (rpc), `:909-919` (messages).
+
+`TenantMemberRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | Wire-claimed actor, e.g. `"user:alice"` / `"system:admin"`. **UNTRUSTED** — replaced by interceptor identity (see Auth). |
+| `tenant_id` | 2 | `string` | Required; non-empty (`grpc_server.py:2458-2459`). |
+| `user_id` | 3 | `string` | Required; non-empty. The user being added (`grpc_server.py:2460-2461`). |
+| `role` | 4 | `string` | Optional. Defaults to `"member"` when empty (`grpc_server.py:2476`). |
+
+`TenantMemberResponse`: `bool success = 1; string error = 2;` Aborts MUST set
+gRPC status; happy returns `success=true`. Soft failures (duplicate) return
+`success=false, error=<msg>` with gRPC `OK` (`grpc_server.py:2484-2486`).
+
+**Role is a free-form string, NOT a proto enum.** Recognised values per
+authorization checks: `"owner"`, `"admin"`, `"member"`. The server does not
+validate `role` against a closed set on insert — `add_member` writes whatever
+string the caller supplies. The Go port MUST preserve this leniency to keep
+contract tests green; harden via a separate ticket if desired (track as Open
+question below). Storage column: `tenant_members.role TEXT NOT NULL DEFAULT
+'member'` (`global_store.py:220-226`).
+
+## Auth (tenant admin only; trusted-actor)
+
+- **Authentication**: required. NOT in `AuthInterceptor.UNAUTHENTICATED_METHODS`.
+- **Trusted-actor invariant** (CLAUDE.md §"trusted-actor"): handler immediately
+  rebinds `trusted_actor = self._trusted_actor(request.actor)` on entry
+  (`grpc_server.py:2466`). Every downstream check uses `trusted_actor`, never
+  `request.actor`. Go port MUST mirror this — direct use of `req.Actor` for an
+  authorization branch is a bug.
+- **Authorization**: caller is allowed iff EITHER
+  - `_is_admin_or_system(trusted_actor)` returns true (actor prefix
+    `system:` / `admin:` / equal to `__system__`, see
+    `grpc_server.py:2053-2069`), OR
+  - the caller's `tenant_members.role` for `request.tenant_id` is `"owner"` or
+    `"admin"` (`grpc_server.py:2468-2474`).
+- **Wire-actor escalation must fail**: regression pinned by commit
+  `fece3fb` ("Fix privilege escalation: ignore client-claimed actor"). A user
+  sending `actor="system:admin"` with their own bearer token MUST be denied.
+- **No `Permission` enum lookup, no `acl.check()`** — membership is global
+  state, not per-tenant ACL.
+- **Rate-limiter**: subject to default per-tenant bucket (no special bypass).
+
+## Side effects (WAL append; global_store membership table; mailbox notification?)
+
+**WAL append: NONE.** Tenant-membership operations are global-store admin ops
+that do NOT flow through the per-tenant Kafka/Kinesis WAL. Confirmed: no
+`wal.append`, no `TransactionEvent.ops` entry for membership; `wal/` and
+`apply/` packages contain zero references to `add_member` or
+`AddTenantMember`. This is a deliberate exception to the CLAUDE.md "all writes
+go through the WAL" invariant — see `global_store.py` schema comment at
+`:43-220` documenting `tenant_members` as a non-event-sourced control plane
+table. **Go port MUST NOT add a WAL event for parity**: doing so would change
+rebuild semantics and break the contract tests.
+
+**Direct write to `global_store.tenant_members`** (the only side effect):
+1. `INSERT INTO tenant_members (tenant_id, user_id, role, joined_at) VALUES
+   (?, ?, ?, ?)` with `joined_at = now()` (`global_store.py:571-580`).
+2. PRIMARY KEY `(tenant_id, user_id)` enforces uniqueness; second insert
+   raises `sqlite3.IntegrityError`.
+
+**Mailbox / notification: NONE.** No fanout, no `notifications` table write,
+no `mailbox` write (legacy mailbox is removed; see
+`grpc_server.py:1461-1465`). The added member is silent — discovery is via
+`GetUserTenants`. If product wants a "you were added" notification, file a
+new ticket; Go port MUST stay silent for parity.
+
+**Metric**: `record_grpc_request("AddTenantMember", "ok"|"error", elapsed)`
+on every exit branch (`grpc_server.py:2479,2483,2488`).
+
+## Error contract (duplicate; unknown user)
+
+| gRPC code | Trigger | Source |
+|-----------|---------|--------|
+| `UNIMPLEMENTED` | `global_store` not configured (tenant registry disabled). | `grpc_server.py:2450-2454` |
+| `INVALID_ARGUMENT` | `actor`, `tenant_id`, or `user_id` empty. | `:2456-2461` |
+| `PERMISSION_DENIED` | Caller is not system/admin AND not `owner`/`admin` member of `tenant_id`. Includes the case where the caller has no membership at all (`_get_member_role` returns `None`). | `:2468-2474` |
+| `OK` + `success=false, error="Member already exists in this tenant"` | UNIQUE constraint violation on `(tenant_id, user_id)`. Soft failure, NOT a gRPC error. | `:2482-2487` |
+| `OK` + `success=false, error=<exception str>` | Any other exception. | `:2488-2490` |
+| `OK` + `success=true` | Insert succeeded. | `:2480` |
+
+**Unknown `user_id`**: NOT validated. There is no `users` table FK — the
+handler will happily insert a `tenant_members` row for a user that has never
+authenticated. This matches the "user identity is opaque to the registry"
+design. Go port MUST preserve this; pinned implicitly by
+`test_grpc_contract.py:512-518` (adds `"charlie"` with no prior `CreateUser`).
+
+**Unknown `tenant_id`**: NOT validated either — `tenant_members` has no FK
+to `tenant_registry`. Insert succeeds even if the tenant was never created.
+Same reason: keep parity, file a hardening ticket separately.
+
+## Shared Go package deps
+
+- `pb` (`server/go/internal/pb/entdbv1`) — `TenantMemberRequest`,
+  `TenantMemberResponse`. Required.
+- `globalstore` (new, mirrors `global_store.py`) — `AddMember(ctx, tenantID,
+  userID, role string) error`, `GetMembers(ctx, tenantID) ([]Member, error)`.
+  Required. Must surface unique-constraint violations as a sentinel error
+  (e.g. `globalstore.ErrMemberExists`) so the handler can map to the
+  soft-failure path.
+- `auth` — `TrustedActor(ctx, wireActor string) string` and
+  `IsAdminOrSystem(trusted string) bool`. Required. Must read the
+  `ContextVar`-equivalent set by the auth interceptor (Go port: `context.Value`
+  keyed by an unexported type).
+- `metrics` — `RecordGRPCRequest(method, status string, dur time.Duration)`.
+  Required.
+- `errs` — helpers for `status.Errorf(codes.X, ...)` with consistent message
+  shape across handlers.
+
+NOT used and MUST NOT be imported here: `wal`, `apply`, `canonicalstore`,
+`schema`, `acl`, `quota`, `crypto`, `audit`. Importing any signals a bug.
+
+## Other-RPC deps (RemoveTenantMember, ChangeMemberRole)
+
+Three handlers form one cohesive unit and SHOULD be ported in a single PR:
+
+- `RemoveTenantMember` (`grpc_server.py:2492-2541`) — same auth model with
+  added "last-owner cannot leave" guard (`:2527-2532`). Reuses
+  `globalstore.GetMembers` + `RemoveMember`.
+- `ChangeMemberRole` (`grpc_server.py:2601+`) — same auth model, calls
+  `globalstore.ChangeRole` (`global_store.py:630-644`). Same role-string
+  leniency.
+- `GetTenantMembers` / `GetUserTenants` — read-only siblings; auth model is
+  weaker (any member can read). Out of scope for this spec.
+- `CreateTenant` — typically the FIRST writer, since it implicitly seeds the
+  caller as `owner` (verify in handler before porting). `AddTenantMember`
+  cannot bootstrap a tenant: the first member must come from `CreateTenant`
+  or a `system:` actor.
+
+Shared helper `_get_member_role(tenant_id, user_id) -> str | None`
+(`grpc_server.py:2290-2296`) lives on the servicer and is reused by all three
+write handlers — port once into `globalstore` (`MemberRole(ctx, tenantID,
+userID) (string, bool, error)`).
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:511-518` — happy path:
+  `actor=ALICE` (owner), `user_id="charlie"`, `role="member"` → success.
+- `tests/python/integration/test_grpc_contract.py:519-523` — `actor=""` →
+  `INVALID_ARGUMENT`.
+- `tests/python/integration/test_grpc_contract.py:524-530` — `actor=BOB`
+  (regular member) → `PERMISSION_DENIED`.
+- `tests/python/unit/test_tenant_registry.py:404-419` — owner can add member;
+  resulting `get_members` returns 2 rows.
+- `tests/python/unit/test_tenant_registry.py:421-434` — admin can add member
+  (default role `"member"` when empty).
+- `tests/python/unit/test_tenant_registry.py:436-449` — regular member is
+  denied with `PERMISSION_DENIED`.
+- `sdk/go/entdb/admin_test.go:188-197` — Go SDK happy-path against fake
+  server; the real Go handler must satisfy the same wire shape.
+- Privilege-escalation regression: commit `fece3fb` — wire `actor="system:admin"`
+  from a non-admin caller MUST be ignored. Add an explicit Go test mirroring
+  this; the Python suite covers it via `_trusted_actor` unit tests in
+  `test_enhanced_auth.py`.
+
+The Go server MUST pass `test_grpc_contract.py` verbatim once the Python
+stubs are swapped out (CLAUDE.md release flow).
+
+## Implementation outline
+
+```go
+// server/go/internal/api/tenant_members.go
+func (s *EntDBServer) AddTenantMember(ctx context.Context, req *pb.TenantMemberRequest) (*pb.TenantMemberResponse, error) {
+    start := time.Now()
+    var status = "ok"
+    defer func() { metrics.RecordGRPCRequest("AddTenantMember", status, time.Since(start)) }()
+
+    if s.globalStore == nil {
+        status = "error"
+        return nil, grpcstatus.Error(codes.Unimplemented, "Tenant registry not configured")
+    }
+    if req.GetActor() == "" { status = "error"; return nil, grpcstatus.Error(codes.InvalidArgument, "actor is required") }
+    if req.GetTenantId() == "" { status = "error"; return nil, grpcstatus.Error(codes.InvalidArgument, "tenant_id is required") }
+    if req.GetUserId() == "" { status = "error"; return nil, grpcstatus.Error(codes.InvalidArgument, "user_id is required") }
+
+    trusted := auth.TrustedActor(ctx, req.GetActor())   // ignore wire actor
+    if !auth.IsAdminOrSystem(trusted) {
+        role, _, err := s.globalStore.MemberRole(ctx, req.GetTenantId(), auth.ActorUserID(trusted))
+        if err != nil { status = "error"; return nil, grpcstatus.Error(codes.Internal, err.Error()) }
+        if role != "owner" && role != "admin" {
+            status = "error"
+            return nil, grpcstatus.Error(codes.PermissionDenied, "Only owner or admin can add members")
+        }
+    }
+
+    role := req.GetRole(); if role == "" { role = "member" }
+    if err := s.globalStore.AddMember(ctx, req.GetTenantId(), req.GetUserId(), role); err != nil {
+        status = "error"
+        if errors.Is(err, globalstore.ErrMemberExists) {
+            return &pb.TenantMemberResponse{Success: false, Error: "Member already exists in this tenant"}, nil
+        }
+        return &pb.TenantMemberResponse{Success: false, Error: err.Error()}, nil
+    }
+    return &pb.TenantMemberResponse{Success: true}, nil
+}
+```
+
+Notes for the implementer:
+1. Trusted-actor rebind happens BEFORE any branch that consults identity.
+2. `_get_member_role` is `O(N)` over members in Python; Go port should use a
+   direct `SELECT role FROM tenant_members WHERE tenant_id=? AND user_id=?`
+   for O(1).
+3. Soft-failure (duplicate) returns `nil` error + `success=false`. Do NOT
+   return a gRPC error code for this case — contract test pinned.
+4. Metric label cardinality: fixed `{ok, error}`; safe.
+
+## Open questions / risks
+
+- **Role is free-form string**, not a proto enum. A typo (`"Admin"` vs
+  `"admin"`) silently lands a non-privileged role. Recommend filing follow-up
+  to introduce `enum TenantRole` in proto, with backward-compat string
+  fallback for one release. Out of scope for the port.
+- **No FK validation on `user_id` / `tenant_id`** lets the handler create
+  orphan rows. Preserve for parity; harden in a separate ticket.
+- **WAL bypass is intentional but undocumented in the proto.** When porting,
+  add a comment in the Go handler citing CLAUDE.md §1 and explaining the
+  global-store control-plane exception, so future readers don't "fix" it by
+  adding a WAL append.
+- **Last-admin guard is missing on this RPC** (only `RemoveTenantMember`
+  guards last-owner). An admin can demote themselves indirectly via
+  `ChangeMemberRole` — but `AddTenantMember` cannot lock anyone out. No
+  action needed; flag for the ChangeMemberRole spec.
+- **Idempotency**: callers retrying on a transient network error will see
+  `success=false, error="Member already exists in this tenant"` on the
+  second attempt. Document in the Go SDK that this is the expected
+  idempotent-replay signal and SDK helpers MAY treat it as success.
+- **Concurrency**: two concurrent `AddTenantMember` calls for the same
+  `(tenant_id, user_id)` race on the SQLite write. PRIMARY KEY ensures only
+  one wins; the loser sees the duplicate path. Go port using `database/sql`
+  must surface the unique-constraint error as `globalstore.ErrMemberExists`
+  on every supported driver (sqlite3 returns `SQLITE_CONSTRAINT_PRIMARYKEY`).

--- a/docs/go-port/rpcs/ArchiveTenant.md
+++ b/docs/go-port/rpcs/ArchiveTenant.md
@@ -1,0 +1,226 @@
+# RPC Port Spec — `entdb.v1.EntDBService/ArchiveTenant`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2397-2440`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:120` (rpc), `:890-898` (messages).
+
+`ArchiveTenantRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | Wire-claimed identity. **UNTRUSTED** — must be replaced with `AuthInterceptor` authoritative actor before any privilege decision (see Auth). Required (`INVALID_ARGUMENT` when empty). |
+| `tenant_id` | 2 | `string` | Tenant to archive. Required. No format validation today; treat opaque. |
+
+`ArchiveTenantResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `success` | 1 | `bool` | True iff tenant existed AND status update applied. |
+| `error` | 2 | `string` | Human-readable error when `success=false`. Currently set to `"Tenant not found"` (missing) or `str(e)` (caught exception). Free-form; do not parse. |
+
+Note: there is no `RequestContext` wrapper on this RPC — `actor` is a top-level
+field. The Go port must NOT introduce one (wire compat).
+
+## Auth (admin only; trusted-actor)
+
+CLAUDE.md mandates: handlers replace `request.actor` with the interceptor-bound
+trusted identity before any policy check. Python sequence
+(`grpc_server.py:2419-2427`):
+
+1. `trusted_actor = self._trusted_actor(request.actor)` —
+   delegates to `auth.auth_interceptor.get_authoritative_actor` which returns
+   the `ContextVar` value set by `AuthInterceptor` if present, else falls back
+   to the wire string (no-auth deployments / unit tests only).
+2. `actor_uid = self._actor_user_id(trusted_actor)` strips `user:` prefix.
+3. `if not self._is_admin_or_system(trusted_actor):` — i.e. trusted prefix is
+   `system:`, `admin:`, or equals `__system__` (`grpc_server.py:2053-2069`).
+4. Otherwise look up `_get_member_role(tenant_id, actor_uid)`; only `"owner"`
+   may archive. Anything else → `PERMISSION_DENIED`.
+
+The Go port MUST mirror exactly this order — privilege string check first
+(short-circuit for system/admin), membership lookup only for non-admin
+callers. The interceptor-derived actor is the single source of truth; the
+wire `actor` field is rebound and never reused for authz.
+
+`ArchiveTenant` is NOT in `AuthInterceptor.UNAUTHENTICATED_METHODS`
+(`auth/auth_interceptor.py:157-162`); standard auth path applies.
+
+## Side effects (WAL append; archive workflow handoff; data export to cold storage)
+
+**Current Python behaviour (gap, see Open questions):** the handler performs
+ONE side effect — `self.global_store.set_tenant_status(tenant_id, "archived")`
+(`grpc_server.py:2429`, impl at `global_store.py:520-554`). That is a direct
+SQLite UPDATE on `tenant_registry.status` in the global store DB. Subsequent
+behavioural impact is enforced lazily by `_check_tenant_access`
+(`grpc_server.py:518-522`): writes against an archived tenant return
+`FAILED_PRECONDITION`; reads still succeed. No legal-hold side effects.
+
+**What the handler does NOT do today** (intentional flags for the Go port):
+
+- **No WAL append.** The status flip is a direct global-store write,
+  bypassing the event log. This violates CLAUDE.md invariant #1 ("All writes
+  go through the WAL") for the per-tenant case but `global_store` is a
+  cross-tenant store with its own SQLite — see Open questions.
+- **No archiver handoff.** The `Archiver` subsystem
+  (`server/python/entdb_server/archive/archiver.py`) is a *WAL-stream* archiver
+  (Kafka/Kinesis → S3 segments); it is NOT triggered by `ArchiveTenant`. Name
+  collision only.
+- **No cold-storage export.** No S3 `StorageClass` transition, no per-tenant
+  SQLite snapshot to Glacier, no compaction.
+- **No member revocation, no API-key revocation, no shard reassignment.**
+
+**Go-port target behaviour** (proposal, requires product sign-off):
+1. Validate inputs.
+2. Resolve trusted actor; authorize.
+3. Append a `TenantStatusChanged{tenant_id, from, to: "archived", actor, ts}`
+   event to the **global-store WAL stream** (new event type — see Open
+   questions for whether global_store should have its own WAL or piggy-back
+   on a control-plane stream).
+4. `Applier` consumes the event and updates `tenant_registry.status`.
+5. Optionally enqueue a cold-storage workflow (out-of-band worker) that
+   compacts the tenant's SQLite + recent WAL segments to `STANDARD_IA` or
+   `GLACIER` per `s3_config.s3_storage_class`. Reversible until the workflow
+   completes; one-way after.
+6. Return `success` reflecting the WAL append result, NOT the materialized
+   view (consistent with other write RPCs).
+
+## Error contract
+
+| Condition | gRPC code | Path |
+|-----------|-----------|------|
+| `global_store` not configured | `UNIMPLEMENTED` | `grpc_server.py:2406-2409` |
+| Empty `actor` | `INVALID_ARGUMENT` | `:2411-2412` |
+| Empty `tenant_id` | `INVALID_ARGUMENT` | `:2413-2414` |
+| Non-owner, non-admin/system caller | `PERMISSION_DENIED` | `:2421-2427` |
+| Tenant id not found in registry | `OK` + `success=false`, `error="Tenant not found"` | `:2431-2433` |
+| Any other exception | `OK` + `success=false`, `error=str(e)` | `:2437-2440` |
+
+Note the asymmetry: auth/validation failures abort with a gRPC status code;
+post-auth lookup misses and unexpected errors return `OK` with
+`success=false`. The Go port MUST preserve this — the contract test
+explicitly asserts the happy path returns `success=True` and the empty-actor
+case returns `INVALID_ARGUMENT`
+(`tests/python/integration/test_grpc_contract.py:683-693`).
+
+`record_grpc_request("ArchiveTenant", "ok"|"error", elapsed)` is emitted on
+every exit (`grpc_server.py:2432, 2435, 2438`); Go port must wire equivalent
+metrics.
+
+## Shared Go package deps (`archive/` subsystem, wal, store)
+
+| Python module | Go package (proposed) | Use |
+|---------------|-----------------------|-----|
+| `entdb_server/global_store.py` | `internal/globalstore` | `SetTenantStatus(ctx, tenantID, status) (bool, error)`; `GetMemberRole(ctx, tenantID, userID) (string, error)` |
+| `entdb_server/auth/auth_interceptor.py` | `internal/auth` | `GetAuthoritativeActor(ctx)` resolves the trusted actor from the gRPC context (replaces Python `ContextVar`). |
+| `entdb_server/api/grpc_server.py` (helpers) | `internal/grpcsvc/actor` | `TrustedActor`, `ActorUserID`, `IsAdminOrSystem` helpers — shared across all admin handlers. |
+| `entdb_server/archive/archiver.py` | `internal/archive` (existing for WAL→S3) | **Not used by this RPC today.** Spec'd here only to document the name collision. |
+| `entdb_server/wal/*` | `internal/wal` | Future: append `TenantStatusChanged` event when invariant #1 is properly extended to global_store. |
+| `entdb_server/api/generated` (proto stubs) | `gen/go/entdb/v1` | `ArchiveTenantRequest`, `ArchiveTenantResponse`. |
+| metrics (`record_grpc_request`) | `internal/metrics` | Per-RPC counter+histogram. |
+
+No dependency on per-tenant `canonical_store`, `Applier`, `SchemaRegistry`,
+or any per-tenant SQLite. This RPC operates entirely on the global store.
+
+## Other-RPC deps
+
+`ArchiveTenant` shares helpers and side-effect surface with:
+
+- `CreateTenant` (`grpc_server.py:~2300`) — registers the tenant; archive is
+  the inverse of "active".
+- `GetTenant` (`grpc_server.py:2360-2395`) — read path; consumers poll
+  status here to observe archive completion.
+- `SetLegalHold` (`grpc_server.py:~2820-2845`) — also flips
+  `tenant_registry.status` via `set_legal_hold` → reuses
+  `_sync_set_tenant_status`. The two states (`archived`, `legal_hold`) are
+  mutually exclusive in the schema (single `status` column) — see Open
+  questions.
+- `AddTenantMember` / `RemoveTenantMember` — share `_get_member_role`.
+- All write RPCs (`PutNode`, `PutEdge`, `Commit`, `DeleteNode`, …) gated by
+  `_check_tenant_access` (`grpc_server.py:518-522`) which is the consumer of
+  the `archived` flag.
+
+## Contract tests pinning behaviour (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:683-688` — happy path:
+  admin actor, seed tenant id → `success=True`.
+- `tests/python/integration/test_grpc_contract.py:690-693` — empty actor →
+  `INVALID_ARGUMENT`.
+- `tests/python/unit/test_tenant_registry.py:347-362` — owner can archive;
+  post-call `tenant.status == "archived"` verified via `get_tenant`.
+- `tests/python/unit/test_tenant_registry.py:364-377` — non-owner member
+  receives `PERMISSION_DENIED`.
+- `tests/python/unit/test_tenant_registry.py:379-391` — `system:admin`
+  actor succeeds without membership.
+- `tests/python/unit/test_tenant_roles.py:324-339` — archived tenant still
+  serves reads.
+- `tests/python/unit/test_tenant_roles.py:342-360` — archived tenant rejects
+  writes with `FAILED_PRECONDITION` (downstream invariant).
+
+The Go port suite must add a contract test that reproduces each of the
+seven cases above through the Go gRPC server using the same proto wire.
+
+## Implementation outline (sync vs async archive; how reversal works)
+
+**Synchronous portion (in handler, must complete before response):**
+1. Validate `actor` + `tenant_id` non-empty.
+2. Resolve `trustedActor`; reject non-admin non-owner.
+3. Update `tenant_registry.status = 'archived'` via `globalstore.SetTenantStatus`.
+4. Return `success=true` (or `success=false, error="Tenant not found"` if
+   the row was missing).
+
+The Python implementation is fully synchronous — the entire archive is just
+a SQLite UPDATE. There is no background workflow today.
+
+**Asynchronous portion (proposed for Go port, not in Python today):**
+- Emit a `tenant.archived` event onto a control-plane WAL stream.
+- A worker reacts: snapshots the tenant's SQLite shard, uploads to S3 with
+  the configured `s3_storage_class` (e.g. `STANDARD_IA`), and writes a
+  `tenant_archive_manifest` row pointing at the snapshot.
+- The worker is idempotent (event includes a UUID; manifest insert is
+  `INSERT OR IGNORE`).
+
+**Reversal.** There is no `UnarchiveTenant` RPC today. Reversal in the
+Python implementation is "manually flip status back to `active` via direct
+DB access" — there is no proto surface for it. For the Go port, two options:
+
+- **(A) Idempotent state machine.** Add `RestoreTenant` RPC; allowed only
+  while the cold-storage workflow has not yet transitioned the snapshot to
+  `GLACIER` (or any non-immediate-retrieval class). Owner/admin only.
+- **(B) Hard cutoff.** Once the async workflow completes, archive is
+  one-way. Restore is a support-team operation outside the API surface.
+
+Option (A) is required if console UX wants an "undo" affordance; (B) is
+simpler and matches typical "soft-delete window" semantics. Decision is
+deferred — see Open questions.
+
+## Open questions / risks (legal-hold interaction, GDPR collision)
+
+1. **Legal-hold collision.** `tenant_registry.status` is a single column;
+   `archived` and `legal_hold` cannot coexist. If `ArchiveTenant` is
+   invoked on a tenant currently in `legal_hold`, the Python handler
+   silently overwrites the hold status — a compliance bug. Go port should
+   reject with `FAILED_PRECONDITION` when current status is `legal_hold`,
+   or store legal-hold separately from lifecycle status. Pin behaviour with
+   a new contract test before changing.
+2. **No WAL append (CLAUDE.md invariant #1).** `set_tenant_status` writes
+   directly to global-store SQLite. Since global_store is cross-tenant, it
+   does not flow through per-tenant WALs — but the invariant still implies
+   *some* event log for replay/audit. Decision needed: introduce a control-
+   plane WAL topic, or document global_store as an explicit exception.
+3. **GDPR collision.** A tenant under a pending `DeleteUser` grace period
+   may have outstanding GDPR obligations (right-to-erasure timer). Archiving
+   the tenant must not pause that timer; the Go port should verify the
+   delete worker still scans archived tenants. Currently undefined.
+4. **No member / API-key revocation on archive.** Members of an archived
+   tenant retain their grants; only writes are blocked. If product intent
+   is "archive ⇒ frozen and inaccessible", the Go port must additionally
+   revoke active sessions and API keys for the tenant.
+5. **Error leak via `str(e)`.** The catch-all path leaks Python exception
+   strings to the wire (`grpc_server.py:2440`). Go port should map to a
+   generic `"internal error"` and rely on server-side logs + trace IDs.
+6. **No idempotency.** Re-archiving an already-archived tenant returns
+   `success=true` (UPDATE matches a row). That is fine, but pin it
+   explicitly in the Go contract suite.
+7. **Shard reassignment.** Archived tenants still occupy a shard slot.
+   Open: should archive trigger eviction from the shard map?

--- a/docs/go-port/rpcs/CancelUserDeletion.md
+++ b/docs/go-port/rpcs/CancelUserDeletion.md
@@ -1,0 +1,254 @@
+# CancelUserDeletion — Go Port Spec
+
+EPIC #407. Reverses a pending GDPR right-to-erasure request during the
+grace window. Reference Python handler:
+`server/python/entdb_server/api/grpc_server.py:2983-3012`. Proto:
+`proto/entdb/v1/entdb.proto:139, 1052-1060`. Backing store:
+`server/python/entdb_server/global_store.py:834-848` (`cancel_deletion`)
+and `:434-450` (`set_user_status`). Counterpart RPC `DeleteUser`:
+`grpc_server.py:2925-2981`.
+
+## Wire contract
+
+Request `entdb.v1.CancelUserDeletionRequest` (proto:1052):
+- `string actor` — UNTRUSTED payload. See Auth.
+- `string user_id` — required. Identifies the row in the global
+  `deletion_queue` table (global_store.py:239) and the corresponding
+  row in `user_registry`. Plain user id, NOT a `tenant_principal`
+  (`user:` prefix is stripped at the boundary).
+
+No grace-window argument, no idempotency key, no tenant scoping —
+deletion entries are global-registry rows.
+
+Response `entdb.v1.CancelUserDeletionResponse` (proto:1057):
+- `bool success` — mirrors `cancel_deletion`'s rowcount: `True` iff a
+  `pending` deletion row existed and was deleted
+  (global_store.py:842-848; grpc_server.py:3002-3006).
+- `string error` — populated only by the in-band catch-all
+  (grpc_server.py:3012).
+
+Note: success=false carries NO error text when the row simply was not
+in `pending` state (e.g. already completed, or never queued). The Go
+port MUST replicate this — do NOT promote "no pending row" to
+`NotFound` or `FailedPrecondition`; integration test
+`tests/python/integration/test_grpc_contract.py:677-681` asserts the
+"happy" mode on a freshly queued deletion using the response body, not
+status codes.
+
+## Auth (self within grace window / admin; trusted-actor)
+
+- Empty `actor` → `INVALID_ARGUMENT "actor is required"`
+  (grpc_server.py:2993-2994).
+- Empty `user_id` → `INVALID_ARGUMENT "user_id is required"`
+  (grpc_server.py:2995-2996).
+- `global_store` unset → `UNIMPLEMENTED "User registry not
+  configured"` (grpc_server.py:2991-2992).
+- Authorization gate: `_is_self_or_admin(actor, user_id)`
+  (grpc_server.py:2997-3001, definition at :2071-2086). Trusted-actor
+  pattern — privilege decision uses `get_authoritative_actor(actor)`
+  from `auth/auth_interceptor.py:92`, NOT `request.actor`. This is the
+  post-#168 invariant: a malicious caller cannot forge `actor=
+  "admin:root"` in the payload.
+  - admin / system → trusted starts with `system:`, `admin:`, or
+    equals `__system__`.
+  - self → trusted equals `"user:" + user_id` or equals `user_id`.
+  - else → `PERMISSION_DENIED "CancelUserDeletion requires the user
+    themselves or an admin actor"`.
+- "Within grace window" is enforced **only** by the `cancel_deletion`
+  store call: it `DELETE`s rows `WHERE status = 'pending'`. If the
+  applier worker has already flipped the row to `completed`, the
+  cancel is a no-op (`success=false`). There is no time-based check
+  in the handler — the worker's pass over `get_executable_deletions`
+  (global_store.py:865-885) is the de-facto deadline.
+
+## Side effects (WAL append; flip pending → cancelled)
+
+**IMPORTANT carve-out vs CLAUDE.md invariant #1.** Despite the global
+"all writes go through the WAL" rule, `CancelUserDeletion` (like
+`DeleteUser`, `UpdateUser`, and the rest of the user-registry RPCs)
+writes directly to the global SQLite via `global_store`, bypassing
+`wal.append` / `Applier`. The user registry and `deletion_queue` are
+deliberate cross-tenant carve-outs — they are not event-sourced
+through `TransactionEvent`. Go port MUST preserve this. Do NOT add a
+`wal.append(CancelDeletion)` call: there is no matching
+`Applier.apply_event` arm and routing it through the WAL would create
+a divergent rebuild.
+
+What the handler actually does (grpc_server.py:3002-3004):
+1. `await self.global_store.cancel_deletion(user_id)` — deletes the
+   row from `deletion_queue` where `status='pending'`. Returns bool
+   from `cursor.rowcount > 0` (global_store.py:842-848). The semantic
+   is "remove pending entry", not "flip pending → cancelled" — the
+   row is hard-deleted, no `cancelled` tombstone is retained.
+2. If step 1 returned True, `await self.global_store.set_user_status(
+   user_id, "active")` flips `user_registry.status` from
+   `pending_deletion` back to `active` (global_store.py:434-450).
+   The status flip is **conditional** on cancel succeeding; if the
+   row was already gone, status is left untouched.
+3. `record_grpc_request("CancelUserDeletion", "ok"|"error", elapsed)`
+   (grpc_server.py:3005, 3008).
+
+No audit-log write. Compliance trail is out of scope; per CLAUDE.md
+the WAL + S3 Object Lock supply the immutable record for tenant-plane
+mutations, but global-registry mutations sit outside that flow.
+
+## Error contract (FAILED_PRECONDITION when past point of no return)
+
+| Condition                          | Channel             | Status / value                                                                  |
+|------------------------------------|---------------------|---------------------------------------------------------------------------------|
+| `global_store` unset               | `context.abort`     | `UNIMPLEMENTED "User registry not configured"`                                  |
+| empty `actor`                      | `context.abort`     | `INVALID_ARGUMENT "actor is required"`                                          |
+| empty `user_id`                    | `context.abort`     | `INVALID_ARGUMENT "user_id is required"`                                        |
+| not self, not admin                | `context.abort`     | `PERMISSION_DENIED "CancelUserDeletion requires the user themselves or an admin actor"` |
+| no pending row (never queued)      | in-band response    | `success=false, error=""`                                                       |
+| already completed (past grace)     | in-band response    | `success=false, error=""`                                                       |
+| unhandled exception                | in-band response    | `success=false, error=str(e)`; metric label `error`                             |
+
+**Re: FAILED_PRECONDITION at point-of-no-return.** The Python handler
+does NOT raise `FAILED_PRECONDITION` when the deletion has already
+executed. It surfaces the same `success=false` body whether the row
+never existed or was already swept by the applier. This is a known
+ergonomic gap (see Open questions); the Go port MUST preserve current
+behavior to satisfy the integration contract test, and a follow-up
+epic should introduce a distinct status (`completed` retained as a
+tombstone + `FAILED_PRECONDITION` from the handler) — that is a proto
++ store + test change and out of scope here.
+
+## Shared Go package deps
+
+- `entdbserver/auth` — `GetAuthoritativeActor(ctx, payloadActor) string`
+  and `IsSelfOrAdmin(ctx, userID string) bool` (port of
+  `auth/auth_interceptor.py:92` and `grpc_server.py:2071-2086`). The
+  `AuthInterceptor` unary interceptor stuffs the trusted actor into
+  `context.Context` from gRPC metadata.
+- `entdbserver/globalstore` — `CancelDeletion(ctx, userID string)
+  (bool, error)` (port of `_sync_cancel_deletion`,
+  global_store.py:842-848) and `SetUserStatus(ctx, userID, status
+  string) (bool, error)` (port of `_sync_set_user_status`).
+- `entdbserver/metrics` — `RecordGRPCRequest(method, outcome string,
+  elapsed time.Duration)` (port of `record_grpc_request`).
+- `entdbpb` — generated `entdb.v1` Go bindings
+  (`CancelUserDeletionRequest`, `CancelUserDeletionResponse`).
+- `google.golang.org/grpc/status`, `google.golang.org/grpc/codes` for
+  aborts.
+
+## Other-RPC deps (DeleteUser counterpart)
+
+- `DeleteUser` (grpc_server.py:2925-2981) — populates the
+  `deletion_queue` row that this RPC removes and flips
+  `user_registry.status` to `pending_deletion`. CancelUserDeletion is
+  meaningless without a prior `DeleteUser`; the contract test seeds
+  state by calling `DeleteUser` first
+  (test_gdpr_engine.py:668).
+- `FreezeUser` (grpc_server.py near :3014, proto:139 sibling) — also
+  uses `_is_self_or_admin`; share the auth helper.
+- `ExportUserData` (grpc_server.py:3014+) — frequently called before
+  `DeleteUser` for GDPR Article 20 + 17 sequencing; not a hard
+  prerequisite.
+- The async deletion sweeper (`get_executable_deletions` →
+  `mark_deletion_completed`, global_store.py:865-906) races with this
+  RPC. The Go port MUST keep the same `WHERE status='pending'`
+  guard so a partially-executed deletion cannot be cancelled.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_gdpr_engine.py:489-495` — `cancel_deletion`
+  during grace removes the queue entry; `get_pending_deletions()` is
+  empty afterwards. Pins step-1 semantics.
+- `tests/python/unit/test_gdpr_engine.py:665-674` — full handler
+  happy path: `DeleteUser(alice)` then `CancelUserDeletion(alice)`
+  returns `success=True` and `user_registry.status == "active"`. Pins
+  the handler chain (cancel → set_user_status flip).
+- `tests/python/integration/test_grpc_contract.py:676-681` — wire-
+  level happy: `actor=ALICE, user_id="alice"` returns successfully
+  over the gRPC channel. Pins the proto/RPC route registration.
+- `tests/python/unit/test_gdpr_engine.py:499-505` — adjacent
+  `mark_deletion_completed` test pins the OTHER terminal state and
+  proves `cancel_deletion` MUST NOT touch a `completed` row (the
+  `WHERE status='pending'` guard is the boundary).
+
+These four cases form the Go-port acceptance bar; wire them into
+`tests/contract/` once the Go server speaks `entdb.v1.EntDBService`.
+
+## Implementation outline
+
+```go
+func (s *Server) CancelUserDeletion(ctx context.Context, req *pb.CancelUserDeletionRequest) (*pb.CancelUserDeletionResponse, error) {
+    start := time.Now()
+    outcome := "ok"
+    defer func() { metrics.RecordGRPCRequest("CancelUserDeletion", outcome, time.Since(start)) }()
+
+    if s.globalStore == nil {
+        return nil, status.Error(codes.Unimplemented, "User registry not configured")
+    }
+    if req.GetActor() == "" {
+        return nil, status.Error(codes.InvalidArgument, "actor is required")
+    }
+    if req.GetUserId() == "" {
+        return nil, status.Error(codes.InvalidArgument, "user_id is required")
+    }
+    if !auth.IsSelfOrAdmin(ctx, req.GetUserId()) {
+        return nil, status.Error(codes.PermissionDenied,
+            "CancelUserDeletion requires the user themselves or an admin actor")
+    }
+
+    ok, err := s.globalStore.CancelDeletion(ctx, req.GetUserId())
+    if err != nil {
+        outcome = "error"
+        return &pb.CancelUserDeletionResponse{Success: false, Error: err.Error()}, nil
+    }
+    if ok {
+        if _, err := s.globalStore.SetUserStatus(ctx, req.GetUserId(), "active"); err != nil {
+            outcome = "error"
+            return &pb.CancelUserDeletionResponse{Success: false, Error: err.Error()}, nil
+        }
+    }
+    return &pb.CancelUserDeletionResponse{Success: ok}, nil
+}
+```
+
+`globalstore.CancelDeletion` issues `DELETE FROM deletion_queue WHERE
+user_id=? AND status='pending'` over the global `*sql.DB` and returns
+`rowsAffected > 0`. Single statement — no transaction needed. The
+status flip is a separate UPDATE; the brief window between the two
+is acceptable (worst case: row deleted, status not flipped, leaves
+user in `pending_deletion` until a retry — same as Python today).
+
+## Open questions / risks (cancellation deadline)
+
+- **No explicit deadline.** "Grace window" is implicit: it lasts
+  until the applier sweeper flips `status='pending'` to `completed`
+  (global_store.py:898-906). There is no time-based check in the
+  handler. Risk: in a fast-sweep deployment with `grace_days=0` an
+  admin who issues `DeleteUser` then `CancelUserDeletion` ms later
+  may race the sweeper and silently fail (`success=false, error=""`).
+  Mitigation is purely operational — keep `grace_days >= 1`.
+- **No `FAILED_PRECONDITION` for past-deadline.** The handler cannot
+  distinguish "never queued" from "already executed"; both surface as
+  `success=false, error=""`. Operator UX gap. Fix is a proto change
+  (separate epic): add an `ALREADY_EXECUTED` enum or promote to a
+  gRPC status code, plus retain a `cancelled`/`completed` tombstone
+  in `deletion_queue` instead of hard-deleting on cancel.
+- **Step-1/step-2 atomicity.** `cancel_deletion` and
+  `set_user_status` are two separate sync calls (grpc_server.py:3002-
+  3004). A crash between them leaves `deletion_queue` empty but
+  `user_registry.status='pending_deletion'` — orphan state. Today
+  this is self-healing on retry (cancel returns False, status is left
+  alone, user can re-issue). Go port should keep the same shape;
+  wrapping both in a single SQL transaction is a defensible quality
+  improvement but changes observable error timing — flag for review.
+- **WAL carve-out.** Global registry mutations bypass the WAL
+  (CLAUDE.md invariant #1 carve-out). Identity changes are NOT in
+  the audit trail exported by `audit/compliance.py`. If GDPR/SOC2
+  auditors require an immutable record of "deletion was requested,
+  then cancelled by X at T", that is a separate event-sourcing epic
+  (`GlobalEvent` topic).
+- **Trusted-actor coverage.** Unit tests mostly run without the
+  AuthInterceptor (FakeContext path). The Go port MUST add a
+  contract test that asserts a forged `actor="admin:root"` in the
+  payload is REJECTED when metadata says `user:eve` — this is the
+  post-#168 invariant and currently only covered indirectly.
+- **Idempotency.** Re-issuing the same `CancelUserDeletion` after a
+  successful first call returns `success=false, error=""` (row gone).
+  Clients that retry on transient failures may observe this and log
+  spuriously — no fix needed, just document.

--- a/docs/go-port/rpcs/ChangeMemberRole.md
+++ b/docs/go-port/rpcs/ChangeMemberRole.md
@@ -1,0 +1,223 @@
+# RPC Port Spec — `entdb.v1.EntDBService/ChangeMemberRole`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2601-2652`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:127` (rpc), `:939-949` (messages).
+
+`ChangeMemberRoleRequest`:
+| Field       | Tag | Type   | Notes                                                                 |
+|-------------|-----|--------|-----------------------------------------------------------------------|
+| `actor`     | 1   | string | Caller principal, e.g. `user:alice` or `system:admin`. UNTRUSTED on the wire — see Auth. Required (`grpc_server.py:2615-2616`). |
+| `tenant_id` | 2   | string | Tenant whose membership is being modified. Required (`:2617-2618`).   |
+| `user_id`   | 3   | string | Bare user id (no `user:` prefix) of the member being changed. Required (`:2619-2620`). |
+| `new_role`  | 4   | string | Target role. Free-form string in current Python (`owner`, `admin`, `member` are observed in tests); no enum validation server-side. Required (`:2621-2622`). |
+
+`ChangeMemberRoleResponse`:
+| Field     | Tag | Type   | Notes                                                                 |
+|-----------|-----|--------|-----------------------------------------------------------------------|
+| `success` | 1   | bool   | True iff the row was updated (`SQL UPDATE rowcount > 0`).             |
+| `error`   | 2   | string | Set when `success=false`. Currently `"Member not found"` for the only soft-failure path (`:2645`). Other faults surface as gRPC status codes, not as `error` strings. |
+
+Note: there is no `RequestContext`/`idempotency_key` on this message; rebuild semantics rely on the membership row being a last-writer-wins UPDATE.
+
+## Auth (admin; last-admin demotion protection; trusted-actor)
+
+- **Trusted-actor rebind (mandatory).** Handler MUST replace `request.actor`
+  with `_trusted_actor(request.actor)` before any privilege check
+  (`grpc_server.py:2627`). The implementation lives at `:418-437` and
+  delegates to `auth/auth_interceptor.py::get_authoritative_actor`. In Go
+  this is a `ContextVar` equivalent: read the authoritative actor from
+  `context.Context` (set by an auth interceptor); fall back to `request.actor`
+  only when no interceptor ran (no-auth deployments / unit tests). Any
+  privilege check that consults `request.actor` directly is a CVE-class bug
+  (cf. commit `fece3fb`).
+- **Authorization rule.** Allowed iff (a) trusted actor passes
+  `_is_admin_or_system` (i.e. `system:*` or admin role in the global user
+  registry, `:2053-2064`), OR (b) trusted actor's role in `tenant_id` is
+  exactly `"owner"` (`:2629-2635`). `admin` role is NOT sufficient — pinned
+  by `test_change_role_by_admin_denied` (see below).
+- **Last-admin / last-owner demotion protection.** **NOT IMPLEMENTED in the
+  Python handler.** `change_role` writes unconditionally; nothing prevents
+  demoting the sole owner to `member` and leaving the tenant unadminable.
+  Go port should NOT add this protection silently — it would break parity
+  with the contract test `test_change_role_by_owner` (which lets `alice`,
+  the only owner, change `bob`'s role but does not exercise self-demotion).
+  See "Open questions" — needs an explicit decision before introducing.
+- **Tenant-region pin.** Not applied here. `_check_tenant_access` is not
+  called; cross-region calls are not blocked. (Possibly a gap; preserve
+  parity for now.)
+
+## Side effects (WAL append; ACL recompute)
+
+In-order narration of the Python handler:
+
+1. `start := time.Now()` for `record_grpc_request` metrics.
+2. Guard: `global_store == nil` → `UNIMPLEMENTED` (`:2609-2613`).
+3. Argument validation (4× `INVALID_ARGUMENT`, see Error contract).
+4. Rebind to trusted actor; compute `actor_uid` via `_actor_user_id`
+   (strip `user:` prefix, `:412-416`).
+5. If not admin/system, look up caller's role via `_get_member_role`
+   (`:2290-2296`, scans `global_store.get_members(tenant_id)`); enforce
+   `role == "owner"`.
+6. `global_store.change_role(tenant_id, user_id, new_role)` — single
+   `UPDATE tenant_members SET role=? WHERE tenant_id=? AND user_id=?`
+   (`global_store.py:638-644`). Returns `rowcount > 0`.
+7. Map result to `ChangeMemberRoleResponse{success, error}` and emit
+   `record_grpc_request("ChangeMemberRole", "ok"|"error", elapsed)`.
+
+**WAL append: NOT performed.** The handler writes directly to
+`global_store`'s SQLite file. This is in tension with CLAUDE.md invariant
+#1 ("All writes go through the WAL"); see "Open questions / risks". The
+Go port MUST decide between (a) preserving exact parity (direct write,
+no WAL) or (b) introducing a `CHANGE_MEMBER_ROLE` op on
+`TransactionEvent.ops` and routing through the global-store applier.
+Default for v1 port: **preserve parity (direct write)** to avoid
+divergence from the contract tests; flag for a follow-up issue.
+
+**ACL recompute: NOT performed.** Roles in `tenant_members` do not feed
+the per-tenant `acl` table; permission grants are independent. No cache
+invalidation, no broadcast, no schema-registry touch.
+
+**No emails, no audit trail row, no metric beyond `grpc_requests_total`.**
+
+## Error contract
+
+| Condition                                 | gRPC code             | Response body                       | Source line |
+|-------------------------------------------|-----------------------|-------------------------------------|-------------|
+| `global_store` not configured             | `UNIMPLEMENTED`       | abort                               | `:2609-2613` |
+| `actor == ""`                             | `INVALID_ARGUMENT`    | `"actor is required"`               | `:2615-2616` |
+| `tenant_id == ""`                         | `INVALID_ARGUMENT`    | `"tenant_id is required"`           | `:2617-2618` |
+| `user_id == ""`                           | `INVALID_ARGUMENT`    | `"user_id is required"`             | `:2619-2620` |
+| `new_role == ""`                          | `INVALID_ARGUMENT`    | `"new_role is required"`            | `:2621-2622` |
+| Caller is not owner / admin / system      | `PERMISSION_DENIED`   | `"Only owner can change member roles"` | `:2632-2635` |
+| Member row does not exist                 | `OK` (gRPC)           | `success=false, error="Member not found"` | `:2643-2645` |
+| Any other exception                       | `OK` (gRPC)           | `success=false, error=str(e)`; metric label `"error"` | `:2649-2652` |
+
+Note the asymmetry: missing-member is a soft failure on the response;
+authz failure is a hard `PERMISSION_DENIED` abort. Go port MUST preserve
+both shapes — they are pinned by tests below.
+
+## Shared Go package deps
+
+- `internal/auth` — `TrustedActor(ctx, requestActor) string`,
+  `IsAdminOrSystem(ctx, actor) bool`, `ActorUserID(actor) string` (mirror of
+  `_trusted_actor`, `_is_admin_or_system`, `_actor_user_id`).
+- `internal/globalstore` — `GetMembers(ctx, tenantID)`, `ChangeRole(ctx,
+  tenantID, userID, role) (bool, error)`. SQLite-backed, async via
+  `errgroup`/explicit txn.
+- `internal/metrics` — `RecordGRPCRequest(rpc, status string, dur
+  time.Duration)`.
+- `internal/grpcerr` — helpers to translate to `status.Errorf` /
+  `context.Abort` semantics. Use `codes.InvalidArgument`,
+  `codes.PermissionDenied`, `codes.Unimplemented`.
+- Generated `entdbv1` package — `ChangeMemberRoleRequest`,
+  `ChangeMemberRoleResponse`.
+
+No WAL package needed (see Side effects).
+
+## Other-RPC deps
+
+- **AddTenantMember** — must run first to materialize the row that
+  `ChangeMemberRole` updates (`global_store.add_member`). Tested in the
+  contract suite ordering at `tests/python/integration/test_grpc_contract.py:520-545`.
+- **GetUserTenants / ListTenantMembers** — read paths that surface the new
+  role; rely on the same `tenant_members` table.
+- **RemoveTenantMember** — sibling write path, same authz rule.
+- No coupling to node/edge RPCs or the per-tenant SQLite shards.
+
+## Contract tests pinning behavior (file:line)
+
+Unit (handler-level, in-memory `GlobalStore`):
+- `tests/python/unit/test_tenant_registry.py:585-686` —
+  `TestChangeMemberRoleHandler` class.
+  - `:595-614` `test_change_role_by_owner` — happy path; verifies row
+    actually updated via `get_members`.
+  - `:616-632` `test_change_role_by_member_denied` — `PERMISSION_DENIED`
+    when caller is `member`.
+  - `:634-650` `test_change_role_by_admin_denied` — `PERMISSION_DENIED`
+    when caller is `admin` (NOT `owner`). This is the load-bearing
+    "owner-only" pin.
+  - `:652-668` `test_change_role_nonexistent_member` —
+    `success=false, error~="not found"`, NOT a gRPC abort.
+  - `:670-685` `test_change_role_by_system` — `system:admin` bypasses
+    membership check entirely.
+
+Integration (over real gRPC channel):
+- `tests/python/integration/test_grpc_contract.py:531-538` — happy-path
+  smoke (`actor=ALICE` who is owner).
+- `:539-545` — empty-actor → `INVALID_ARGUMENT`.
+
+Go port MUST add equivalent table-driven tests in `tests/go/` and the
+cross-impl `tests/contract/` harness (per CLAUDE.md project structure)
+before swapping the binary.
+
+## Implementation outline
+
+```go
+func (s *Server) ChangeMemberRole(
+    ctx context.Context, req *entdbv1.ChangeMemberRoleRequest,
+) (*entdbv1.ChangeMemberRoleResponse, error) {
+    start := time.Now()
+    defer func() { /* metrics.RecordGRPCRequest on both paths */ }()
+
+    if s.globalStore == nil {
+        return nil, status.Error(codes.Unimplemented, "Tenant registry not configured")
+    }
+    if req.Actor == ""    { return nil, status.Error(codes.InvalidArgument, "actor is required") }
+    if req.TenantId == "" { return nil, status.Error(codes.InvalidArgument, "tenant_id is required") }
+    if req.UserId == ""   { return nil, status.Error(codes.InvalidArgument, "user_id is required") }
+    if req.NewRole == ""  { return nil, status.Error(codes.InvalidArgument, "new_role is required") }
+
+    trusted := auth.TrustedActor(ctx, req.Actor)            // ContextVar-equivalent
+    if !auth.IsAdminOrSystem(ctx, trusted) {
+        role, _ := s.getMemberRole(ctx, req.TenantId, auth.ActorUserID(trusted))
+        if role != "owner" {
+            return nil, status.Error(codes.PermissionDenied, "Only owner can change member roles")
+        }
+    }
+
+    updated, err := s.globalStore.ChangeRole(ctx, req.TenantId, req.UserId, req.NewRole)
+    if err != nil {
+        return &entdbv1.ChangeMemberRoleResponse{Success: false, Error: err.Error()}, nil
+    }
+    if !updated {
+        return &entdbv1.ChangeMemberRoleResponse{Success: false, Error: "Member not found"}, nil
+    }
+    return &entdbv1.ChangeMemberRoleResponse{Success: true}, nil
+}
+```
+
+Metrics: emit `"ok"` for both updated and not-found (matches Python
+`:2644,:2647`); emit `"error"` only on the exception branch.
+
+## Open questions / risks
+
+1. **WAL invariant violation (HIGH).** Per CLAUDE.md §1, all writes go
+   through the WAL; this handler does not. Behavior on rebuild-from-WAL
+   is silent loss of role changes. Decide before GA whether to (a) add a
+   `change_member_role` op on `TransactionEvent.ops` and route through
+   the applier, or (b) document `tenant_members` as a non-WAL'd
+   bootstrap table and snapshot it separately. Either way: file an
+   issue, do not silently fix in the port.
+2. **No last-owner protection.** A tenant's sole owner can demote
+   themselves to `member` and brick admin access. Not in tests, so
+   adding the check would change observable behavior — needs a product
+   call and a test update.
+3. **`new_role` is unvalidated free-form.** Caller can set
+   `new_role="god-emperor"` and `_get_member_role` will return that
+   string on the next call. Should we reject anything outside
+   `{owner, admin, member}`? Not enforced today.
+4. **Trusted-actor in unit tests.** The unit tests pass `actor="user:alice"`
+   directly with no interceptor in the chain; the fallback path in
+   `_trusted_actor` honours the request value. Go port must keep the
+   same fallback or all five unit tests break.
+5. **Region pin gap.** `_check_tenant_access` is not invoked. A node
+   serving region `us-east` will happily mutate a row for a tenant
+   pinned to `eu-west`. Likely a real bug; preserve parity, file a
+   follow-up.
+6. **Concurrent role changes.** Two simultaneous `ChangeMemberRole`
+   calls race on `UPDATE`; last writer wins, no version check. Fine
+   today, but document it.

--- a/docs/go-port/rpcs/CreateTenant.md
+++ b/docs/go-port/rpcs/CreateTenant.md
@@ -1,0 +1,254 @@
+# RPC Port Spec — `entdb.v1.EntDBService/CreateTenant`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2304-2360`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:118` (rpc), `:865-878` (messages).
+
+`CreateTenantRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | Wire-claimed actor. **UNTRUSTED** — see Auth. Required, non-empty (`grpc_server.py:2318-2319`). |
+| `tenant_id` | 2 | `string` | New tenant identifier. Required (`:2320-2321`). MUST also pass `_validate_filesystem_id` rules (`[A-Za-z0-9_-]+`) because it becomes a filename: `data_dir/tenant_<id>.db` (`canonical_store.py:629-640`). |
+| `name` | 3 | `string` | Display name. Required, non-empty (`:2322-2323`). No charset constraint. |
+| `region` | 4 | `string` | Optional region pin (e.g. `eu-west-1`). Empty → server's `served_region`, falling back to `"us-east-1"` for single-region back-compat (`:2331-2334`). |
+
+`CreateTenantResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `success` | 1 | `bool` | True on insert. False on uniqueness/quota errors (`:2347, :2354, :2360`). |
+| `tenant` | 2 | `TenantDetail` | Populated only on success. Built by `_tenant_dict_to_proto(tenant)` from the `global_store.create_tenant` return dict. |
+| `error` | 3 | `string` | Free-text error. Prefixed `"Tenant already exists: "` for UNIQUE collisions (`:2356`). |
+
+Important: error reporting uses **response fields**, not `context.abort`, for the
+business-logic errors (duplicate, generic exception). `INVALID_ARGUMENT` is the
+only condition that uses `context.abort` (`:2319, :2321, :2323`).
+
+## Auth (admin scope; trusted-actor)
+
+- **Authentication required.** This RPC is NOT in the unauth bypass set. Caller
+  must present a valid principal via `AuthInterceptor` (session, API key, or
+  OAuth/JWT) — same as every other tenant-admin RPC.
+- **Trusted-actor invariant (MANDATORY).** The wire `request.actor` is reduced
+  to a server-trusted principal via `self._trusted_actor(request.actor)`
+  (`grpc_server.py:2329`). The Go port MUST mirror this: ignore the wire
+  `actor` for any decision and read the principal from the auth interceptor's
+  per-RPC context. The fix that introduced this is the privilege-escalation
+  remediation in commit `fece3fb` ("Fix privilege escalation: ignore client-
+  claimed actor in gRPC handlers"). Pinned by `_trusted_actor` definition at
+  `grpc_server.py:418-450` and the per-handler comment at `:2325-2328`.
+- **Admin scope.** Today, no explicit admin gate runs inside `CreateTenant` —
+  any authenticated caller can create a tenant and is auto-recorded as `owner`.
+  EPIC #407 owners SHOULD decide whether to add an explicit `is_admin` gate in
+  the Go port (consistent with `_is_admin_or_system` at `:2053-2090`). Keeping
+  parity with Python = no gate; see Open questions.
+- **Owner assignment.** Trusted actor → `_actor_user_id` (`:2298-2302`, strips
+  `user:` prefix) → `global_store.add_member(tenant_id, uid, role="owner")`.
+  This binding cannot be forged because it derives from the trusted principal.
+
+## Side effects
+
+In-order narration of the Python handler:
+
+1. Guard: `self.global_store` exists, else `abort(UNIMPLEMENTED, "Tenant
+   registry not configured")` (`:2312-2316`).
+2. Validate non-empty `actor`, `tenant_id`, `name`
+   (`abort(INVALID_ARGUMENT, …)`).
+3. Resolve trusted actor (`:2329`).
+4. Resolve region: `request.region or self.served_region or "us-east-1"`
+   (`:2334`).
+5. `await self.global_store.create_tenant(tenant_id, name, region=region)` —
+   `INSERT INTO tenant_registry (tenant_id, name, status='active', created_at,
+   region)` on the **global** SQLite (`global_store.py:471-487`). UNIQUE on
+   `tenant_id` enforces idempotence.
+6. `await self.canonical_store.initialize_tenant(tenant_id)` — opens
+   `data_dir/tenant_<id>.db` with `create=True` and runs `_create_schema(conn)`
+   (`canonical_store.py:1359-1371`). This **creates the SQLite file** and
+   bootstraps the per-tenant tables (nodes, edges, applied_events, etc.).
+7. `await self.global_store.add_member(tenant_id, creator_uid, role="owner")`
+   (`global_store.py:558-575`).
+8. Metrics: `record_grpc_request("CreateTenant", "ok"|"error", elapsed)`.
+
+**WAL-append parity (CRITICAL — see Open questions).** The Python handler does
+**not** currently append to the WAL. This violates CLAUDE.md invariant #1 ("All
+writes go through the WAL") for the tenant-registry plane and means a global-
+store rebuild from the WAL would silently drop tenants. The Go port MUST treat
+this as a deliberate design question (see #407): either (a) add a
+`TenantCreated` op to `TransactionEvent.ops` and apply it via `Applier`, or (b)
+explicitly document the global-store SQLite as a non-WAL-backed control plane.
+Recommendation: (a). Pattern to follow: `admin_handlers.py:55-60`.
+
+**Quota init.** No quota row is created today. The Go port should initialize
+the per-tenant quota row (rate-limit bucket, storage cap) at this point if the
+Go quota subsystem requires it; current Python lazy-creates on first use.
+
+**Region pinning.** The `region` column is the data-plane gate enforced by
+`_check_tenant` (`grpc_server.py:400-415`): a request landing on a server with
+`served_region != tenant.region` is rejected `FAILED_PRECONDITION`. Pinned by
+`tests/python/integration/test_region_pinning.py:108-134`.
+
+## Error contract
+
+| gRPC code / response shape | Trigger |
+|----------------------------|---------|
+| `INVALID_ARGUMENT` (abort) | `actor`, `tenant_id`, or `name` empty (`:2319, :2321, :2323`). |
+| `UNIMPLEMENTED` (abort) | `global_store` not configured (`:2313`). |
+| `success=false, error="Tenant already exists: …"` | UNIQUE constraint on `tenant_registry.tenant_id` (`:2352-2357`). NOT `ALREADY_EXISTS` — Python returns `OK` + `success=false`. Go port MUST preserve this (contract test pins `success is False` and `"already exists" in error`, `tests/python/unit/test_tenant_registry.py:293-294`). |
+| `success=false, error=<exc str>` | Any other exception (`:2358-2360`). |
+| Filesystem errors from `initialize_tenant` | Today bubble as generic exceptions → `success=false`. Go port should map `EEXIST` (idempotent — see Implementation) and surface `INTERNAL` for `EROFS`/`ENOSPC`. |
+| Quota | No quota check today. If Go adds one, return `success=false, error="quota exceeded: …"`; do NOT abort with `RESOURCE_EXHAUSTED` unless the contract is updated. |
+
+The trusted-actor handling does **not** raise — it silently rebinds. Never
+return `PERMISSION_DENIED` from this handler unless an admin gate is added.
+
+## Shared Go package deps
+
+Each lives under `server/go/internal/...` unless noted.
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `CreateTenantRequest`,
+  `CreateTenantResponse`, `TenantDetail`. Required.
+- `globalstore` — `CreateTenant(ctx, id, name, region) (*Tenant, error)`,
+  `AddMember(ctx, tenantID, userID, role)` (mirrors `global_store.py:453,558`).
+  Required.
+- `canonicalstore` — `InitializeTenant(ctx, tenantID) error` (mirrors
+  `canonical_store.py:1359`). Must be idempotent on retry. Required.
+- `auth` — provides the trusted principal via `auth.PrincipalFromContext(ctx)`
+  (Go equivalent of `_trusted_actor`). Required.
+- `region` — package-level `ServedRegion string` (mirrors
+  `grpc_server.py:281`). Required.
+- `metrics` — `RecordGRPCRequest(method, status, dur)`. Required.
+- `errs` — sentinel `ErrTenantExists` returned by `globalstore.CreateTenant`
+  on UNIQUE collision; handler maps to `success=false, error="Tenant already
+  exists: …"`. Required.
+- `wal` (recommended, see Open questions) — for emitting a `TenantCreated`
+  event if invariant #1 is honored.
+
+NOT used: `apply.Applier` (no per-tenant event yet), `acl`, `schema`,
+`crypto`, `audit`, `quota` (today).
+
+## Other-RPC deps
+
+- **Downstream — `AddTenantMember`** (`grpc_server.py:2442-2490`): uses the
+  same `global_store.add_member` path. `CreateTenant` already invokes it
+  internally for the creator-as-owner step, so the Go port of
+  `AddTenantMember` should share the `globalstore.AddMember` primitive
+  (extract a single `(tenantID, userID, role)` helper used by both). The
+  duplicate-member error string (`"Member already exists in this tenant"`,
+  `:2486`) is the parallel of CreateTenant's "Tenant already exists" — same
+  pattern, do not diverge.
+- **Downstream — `GetTenant`** (`grpc_server.py:2362-…`) reads what
+  `CreateTenant` wrote; ports together for a coherent contract test surface.
+- **Downstream — every data-plane RPC** depends on `_check_tenant`
+  (`:400-415`) reading the `region` column populated here.
+- **Independent of**: WAL append, schema registry, ACL — those tenants are
+  hydrated lazily on first data-plane call.
+
+## Contract tests pinning behavior
+
+- `tests/python/unit/test_tenant_registry.py:256-278` — happy path:
+  `success=True`, `tenant.tenant_id`, `tenant.name`, `tenant.status="active"`,
+  `canonical_store.initialize_tenant` awaited once with the id, creator
+  recorded as `owner` member. **The Go server must satisfy these assertions
+  verbatim once stubs are swapped.**
+- `tests/python/unit/test_tenant_registry.py:280-294` — duplicate tenant_id
+  yields `success=False` with `"already exists"` in `error` (NOT a gRPC abort).
+- `tests/python/integration/test_grpc_contract.py:477-487` — over a live
+  channel: happy path with `actor=ADMIN, tenant_id="newtenant"` returns
+  `success=True`; empty `tenant_id` triggers `INVALID_ARGUMENT`.
+- `tests/python/integration/test_region_pinning.py:62-79` — `region` round-
+  trips through `global_store` and into `CreateTenantResponse.tenant.region`.
+- `tests/python/integration/test_region_pinning.py:81-106` — empty `region`
+  defaults to the server's `served_region`; US server pins `us-east-1`, EU
+  server pins `eu-west-1`.
+- `tests/python/integration/test_region_pinning.py:108-134` — region pin then
+  drives `_check_tenant` rejection with `FAILED_PRECONDITION` on the wrong
+  server (downstream pin; ensures `CreateTenant` populated the column).
+- `tests/python/unit/test_tenant_registry.py:697-...` (`TestSDKCreateTenantRegion`)
+  — SDK-level region propagation (informational; SDK port, not server).
+
+## Implementation outline (Go handler)
+
+```go
+// server/go/internal/api/create_tenant.go
+func (s *EntDBServer) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) (*pb.CreateTenantResponse, error) {
+    start := time.Now()
+    status := "ok"
+    defer func() { metrics.RecordGRPCRequest("CreateTenant", status, time.Since(start)) }()
+```
+
+1. Guard `s.globalStore != nil`; else `status.Error(codes.Unimplemented, "Tenant registry not configured")`.
+2. Validate `req.Actor`, `req.TenantId`, `req.Name` non-empty → `codes.InvalidArgument`.
+3. Validate `req.TenantId` against `validateFilesystemID` (mirror
+   `_validate_filesystem_id`) BEFORE creating any DB row, to prevent partial
+   state where the registry row exists but the SQLite filename is illegal.
+4. `principal := auth.PrincipalFromContext(ctx)` — trusted; ignore `req.Actor`.
+5. `region := req.Region; if region == "" { region = s.servedRegion }; if region == "" { region = "us-east-1" }`.
+6. `tenant, err := s.globalStore.CreateTenant(ctx, req.TenantId, req.Name, region)`.
+   - `errors.Is(err, errs.ErrTenantExists)` → return `&pb.CreateTenantResponse{Success: false, Error: "Tenant already exists: " + err.Error()}, nil` (no abort). Set `status = "error"`.
+   - other err → `Success: false, Error: err.Error()`.
+7. `if err := s.canonicalStore.InitializeTenant(ctx, req.TenantId); err != nil { ... }`.
+   - **Replay-safety (filesystem invariant)**: `InitializeTenant` MUST be
+     idempotent. Treat "file already exists with valid schema" as success.
+     On crash between step 6 and step 7, a retry of `CreateTenant` will fail
+     at step 6 with `ErrTenantExists`; the Go handler MUST detect this case
+     and re-run step 7 + step 8 if the SQLite file or owner row is missing,
+     OR (preferred) gate the entire op behind a single WAL `TenantCreated`
+     event applied by `Applier` so each replay-step is independently retry-
+     safe. See Open questions.
+8. `s.globalStore.AddMember(ctx, req.TenantId, principal.UserID(), "owner")`
+   — ignore `ErrAlreadyMember` (replay).
+9. (If invariant #1 is honored) `s.wal.Append(ctx, topic, req.TenantId,
+   marshal(TenantCreatedEvent{...}))` BEFORE step 6, and have the `Applier`
+   perform steps 6-8. This is the architecturally correct shape.
+10. Build `TenantDetail` from the `Tenant` struct via a single conversion
+    helper (mirror `_tenant_dict_to_proto`). Return `Success: true`.
+
+Filesystem side effects MUST be replay-safe. The combination of (registry
+INSERT, SQLite file create, member INSERT) is **not** atomic today; the Go
+port has the chance to fix this by routing through the WAL. If that change is
+out of scope for the port, document the residual non-atomicity and ensure
+each individual step is independently idempotent.
+
+## Open questions / risks (replay determinism with FS init)
+
+- **WAL invariant violation (largest risk).** Python writes directly to
+  `global_store` SQLite without a WAL append, contradicting CLAUDE.md
+  invariant #1. A WAL replay against an empty `global_store.db` will not
+  reconstruct any tenants. EPIC #407 owners must decide:
+  (a) Add `TenantCreated` to `TransactionEvent.ops`, apply via `Applier`,
+      delete the direct call from the handler. Recommended.
+  (b) Document `global_store.db` as a non-WAL control-plane and rely on
+      filesystem snapshots for DR. Risk: divergence between control-plane
+      DBs across regions.
+- **Non-atomic three-step write.** Crash between `create_tenant`,
+  `initialize_tenant`, and `add_member` leaves an orphan registry row, an
+  orphan SQLite file, or a tenant with no owner. Filesystem ops are
+  particularly risky: an SQLite file half-created is invalid. Mitigation:
+  WAL-driven applier with idempotent steps; or a startup self-heal pass
+  that completes interrupted creations.
+- **Replay determinism for filesystem init.** If `initialize_tenant` is
+  driven by the `Applier` on WAL replay across a fresh disk, the SQLite
+  file MUST end up at the same path with the same schema version. Risk:
+  if `_create_schema` ever depends on a non-deterministic input
+  (e.g. server clock, schema-registry state), replays diverge.
+  Mitigation: `_create_schema` is currently DDL-only and deterministic
+  — keep it that way; gate any future dynamic content behind a schema
+  version embedded in the WAL event.
+- **`tenant_id` charset.** Python validates only at `_get_db_path` time,
+  inside `initialize_tenant`. A bad id fails AFTER the registry INSERT,
+  leaving an orphan row. Go port should validate up front (step 3 above).
+- **Quota init.** Today none. If the Go port adds quota, decide whether
+  failure to provision quota rolls back the tenant create or leaves it
+  unprovisioned (handler currently has no rollback path).
+- **Admin gate.** Should `CreateTenant` require `_is_admin_or_system`?
+  Today it does not — any authenticated caller can create unlimited
+  tenants. This is a multi-tenant abuse vector and should be tracked
+  alongside the port (separate issue, not blocking).
+- **Cross-region `region` value.** The handler trusts `req.Region`
+  unconditionally. There is no allow-list (`AllowedRegions`). A caller
+  on the US server can pin `region="apac-south-1"`, then no server can
+  serve the tenant. Add a regions allow-list in the Go port.
+- **`tenant.region` is immutable today** (no UpdateTenant RPC for region).
+  Document this so future ports do not assume mutability.

--- a/docs/go-port/rpcs/CreateUser.md
+++ b/docs/go-port/rpcs/CreateUser.md
@@ -1,0 +1,214 @@
+# RPC Port Spec — `entdb.v1.EntDBService/CreateUser`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2099-2147`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:112` (rpc), `:802-814` (messages),
+`:792-800` (`UserInfo`).
+
+`CreateUserRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | UNTRUSTED wire payload. Substituted with `AuthInterceptor.get_authoritative_actor(...)` before any privilege check (`grpc_server.py:2064-2066`). Required (non-empty). |
+| `user_id` | 2 | `string` | Required. Bare id like `"alice"` — NOT `"user:alice"` (see Open questions). Becomes `user_registry.user_id` PRIMARY KEY (`global_store.py:203-209`). |
+| `email`   | 3 | `string` | Required. UNIQUE constraint at storage layer. |
+| `name`    | 4 | `string` | Required. Display name; not unique. |
+
+`CreateUserResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `success` | 1 | `bool`     | `true` on insert, `false` on uniqueness collision. Validation/auth failures abort with a status code instead of returning `success=false` — the field is only false on the duplicate-key path (`grpc_server.py:2139-2147`). |
+| `user`    | 2 | `UserInfo` | Populated on success. `status` always `"active"` (`global_store.py:357-368`). `created_at`/`updated_at` are unix-seconds ints from `_now()`. |
+| `error`   | 3 | `string`   | Set only on the `success=false` paths. Contains the underlying SQLite error message; consumers must not parse this — use the gRPC code. |
+
+## Auth (admin-only, trusted-actor)
+
+- **Authentication required.** RPC is NOT in `AuthInterceptor.UNAUTHENTICATED_METHODS`.
+- **Privilege: admin or system.** Handler calls `_is_admin_or_system(request.actor)`
+  (`grpc_server.py:2115`), which delegates to `get_authoritative_actor`
+  (`auth/auth_interceptor.py:92`) and accepts only trusted prefixes
+  `system:`, `admin:`, or the literal `"__system__"` (`grpc_server.py:2068`).
+- **Trusted-actor invariant (CLAUDE.md "wire is UNTRUSTED").** `request.actor`
+  is a payload field; it MUST NOT be used directly. The Go port must mirror
+  the Python helper: read the trusted identity from the per-call context
+  (set by `AuthInterceptor` on the `metadata.MD`) and use *that* for the
+  `startswith` check. Pinned by
+  `tests/python/integration/test_privilege_escalation.py:321-341` —
+  authenticated user `"user:eve"` claiming `actor="system:admin"` MUST be
+  rejected with `PERMISSION_DENIED`.
+- **No `Permission` enum check, no ACL.** Privilege is gated by the actor
+  prefix only; `acl` / `capability_registry` are NOT consulted.
+- **Rate limit / quota.** Standard interceptors apply (admin actors typically
+  bypass per-tenant limiters; not unique to this RPC).
+
+## Side effects (global_store write — NOT WAL)
+
+**Single SQLite write to `global_store.user_registry`. No WAL append.**
+
+This is a deliberate exception to the "all writes go through the WAL"
+invariant in CLAUDE.md §1: the user registry lives in `global_store`
+(cross-tenant control plane), not in any per-tenant SQLite, and is not
+part of the event-sourced data plane. The Python handler calls
+`global_store.create_user(...)` directly (`grpc_server.py:2127-2131`),
+which executes `INSERT INTO user_registry ...` synchronously inside
+`_run_sync` (`global_store.py:352-369`). Confirm with EPIC #407 owner
+before changing this — see Open questions.
+
+In-order narration:
+
+1. `start := time.Now()` for metrics.
+2. If `s.globalStore == nil` → abort `UNIMPLEMENTED "User registry not configured"`
+   (`grpc_server.py:2107-2111`).
+3. Validate `actor` non-empty → abort `INVALID_ARGUMENT "actor is required"`.
+4. Resolve trusted actor from context; reject if not `system:` / `admin:` /
+   `__system__` → abort `PERMISSION_DENIED "CreateUser requires admin or system actor"`.
+5. Validate `user_id`, `email`, `name` non-empty (in that order) → abort
+   `INVALID_ARGUMENT "<field> is required"`.
+6. Call `globalStore.CreateUser(ctx, user_id, email, name)` →
+   `INSERT INTO user_registry(user_id,email,name,status,created_at,updated_at)
+   VALUES(?,?,?, 'active', now, now)`.
+7. On `UNIQUE constraint` error → return `CreateUserResponse{success:false,
+   error:"User already exists: <msg>"}` with gRPC code `OK`. Record metric
+   `("CreateUser","error",elapsed)`.
+8. On any other error → log + return `{success:false, error:<msg>}` with
+   gRPC code `OK`. Record `("CreateUser","error",…)`. (Python preserves
+   this; Go port should keep it for contract parity but file a follow-up
+   to surface `INTERNAL` instead — see risks.)
+9. On success → record `("CreateUser","ok",…)` and return
+   `{success:true, user: UserInfo{...}}`.
+
+No WAL append. No `canonical_store` touch. No tenant-scoped SQLite.
+No quota charge. No audit-export hook (S3 Object Lock covers the WAL
+only; user-registry mutations aren't on the WAL — see risks).
+
+## Error contract (uniqueness + validation)
+
+| gRPC code | Trigger | Source |
+|-----------|---------|--------|
+| `UNIMPLEMENTED` | `global_store` not configured. | `grpc_server.py:2107-2111` |
+| `INVALID_ARGUMENT` | Empty `actor`, `user_id`, `email`, or `name`. | `grpc_server.py:2113-2125`; pinned `test_user_registry.py:171-187`, `test_grpc_contract.py:443-446` |
+| `PERMISSION_DENIED` | Trusted actor is not `system:*` / `admin:*` / `__system__`. | `grpc_server.py:2115-2119`; pinned `test_user_registry.py:126-145`, `test_privilege_escalation.py:321-341`, `test_grpc_contract.py:436-441` |
+| `OK` + `success=false, error="User already exists: …"` | Duplicate `user_id` (PK) or `email` (UNIQUE). Detected by string-match on `"UNIQUE constraint"` or exception type name `"IntegrityError"`. | `grpc_server.py:2138-2144`; pinned `test_user_registry.py:147-169` |
+| `OK` + `success=false, error=<msg>` | Any other store exception. Logged at `ERROR`. | `grpc_server.py:2145-2147` |
+
+Go port detail: do NOT translate the duplicate-key path to
+`ALREADY_EXISTS`. The contract test asserts `success=false` on a
+non-aborted call (`test_user_registry.py:168`); changing the code is a
+wire break. Detect duplicates via the SQLite driver sentinel (e.g.
+`sqlite3.ErrConstraintUnique` from `modernc.org/sqlite/lib`) instead
+of string-matching, but keep the response shape.
+
+## Shared Go package deps
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `CreateUserRequest`, `CreateUserResponse`, `UserInfo`.
+- `globalstore` (`server/go/internal/globalstore`) — `CreateUser(ctx, userID, email, name string) (User, error)`. Mirrors `global_store.py:336-369`. Must surface a typed `ErrUserAlreadyExists` so the handler can map without string-matching.
+- `auth` (`server/go/internal/auth`) — `TrustedActorFromContext(ctx) (string, bool)` mirroring `auth_interceptor.py:92`. Required.
+- `metrics` — `RecordGRPCRequest("CreateUser", status, dur)`.
+- `clock` — injectable `Now() time.Time` for deterministic tests; `_now()` in Python is `int(time.time())` (`global_store.py`).
+
+NOT used and MUST NOT be imported: `wal`, `apply`, `canonicalstore`,
+`acl`, `schema`, `quota`, `crypto`, `audit`. Importing `wal` here is the
+canonical signal that someone misread CLAUDE.md §1 — user registry is
+control-plane state, not event-sourced.
+
+## Other-RPC deps
+
+- `GetUser` (`grpc_server.py:2149`) — read path; tests use it after `CreateUser` to verify the row exists. Port together or stub.
+- `UpdateUser` (`proto:826-833`) — same `global_store` table; shares the trusted-actor pattern (self-or-admin instead of admin-only). Spec lives in a sibling file.
+- `ListUsers` (`proto:114`) — pagination over the same table; admin-only. Independent of `CreateUser` but shares storage.
+- `GetUserTenants` (`proto:126`) — joins `user_registry` with `tenant_members`; depends on the row created here.
+
+`CreateUser` itself has **no upstream RPC dependencies** — it can be the
+first user-registry RPC ported, before `GetUser`/`UpdateUser`/`ListUsers`.
+
+## Contract tests pinning behavior
+
+- `tests/python/unit/test_user_registry.py:65-187` — full handler matrix:
+  - `:68-97` happy path with `actor="system:admin"`.
+  - `:99-124` happy path with `actor="admin:root"`.
+  - `:126-145` regular user denied (`PERMISSION_DENIED`, store not called).
+  - `:147-169` duplicate email returns `success=false, error~"already exists"`.
+  - `:171-187` missing `email` aborts `INVALID_ARGUMENT`.
+- `tests/python/unit/test_user_registry.py:415-431` — no `global_store` configured aborts `UNIMPLEMENTED`.
+- `tests/python/integration/test_grpc_contract.py:428-446` — over-the-wire matrix: happy / `PERMISSION_DENIED` (`actor=ALICE`) / `INVALID_ARGUMENT` (empty `user_id`).
+- `tests/python/integration/test_privilege_escalation.py:321-341` — security regression: authenticated `user:eve` claiming `actor="system:admin"` MUST get `PERMISSION_DENIED`. Parametrized over `CLAIMED_ADMIN_ACTORS` (`:166`).
+
+The Go server must pass all of the above verbatim once the Python
+binary is swapped out, modulo trusted-identity test fixtures that
+inject metadata into the gRPC `context.Context` instead of patching
+`auth_interceptor`.
+
+## Implementation outline
+
+```go
+// server/go/internal/api/createuser.go
+func (s *EntDBServer) CreateUser(ctx context.Context, req *pb.CreateUserRequest) (*pb.CreateUserResponse, error) {
+    start := time.Now()
+    record := func(status string) { metrics.RecordGRPCRequest("CreateUser", status, time.Since(start)) }
+
+    if s.globalStore == nil {
+        return nil, status.Error(codes.Unimplemented, "User registry not configured")
+    }
+    if req.GetActor() == "" {
+        return nil, status.Error(codes.InvalidArgument, "actor is required")
+    }
+    trusted, _ := auth.TrustedActorFromContext(ctx) // falls back to req.Actor only when no interceptor ran (tests)
+    if !isAdminOrSystem(trusted) {
+        return nil, status.Error(codes.PermissionDenied, "CreateUser requires admin or system actor")
+    }
+    if req.GetUserId() == "" { return nil, status.Error(codes.InvalidArgument, "user_id is required") }
+    if req.GetEmail()  == "" { return nil, status.Error(codes.InvalidArgument, "email is required") }
+    if req.GetName()   == "" { return nil, status.Error(codes.InvalidArgument, "name is required") }
+
+    user, err := s.globalStore.CreateUser(ctx, req.UserId, req.Email, req.Name)
+    if errors.Is(err, globalstore.ErrUserAlreadyExists) {
+        record("error")
+        return &pb.CreateUserResponse{Success: false, Error: fmt.Sprintf("User already exists: %v", err)}, nil
+    }
+    if err != nil {
+        record("error")
+        log.Error("CreateUser failed", "err", err)
+        return &pb.CreateUserResponse{Success: false, Error: err.Error()}, nil
+    }
+    record("ok")
+    return &pb.CreateUserResponse{Success: true, User: userToProto(user)}, nil
+}
+
+func isAdminOrSystem(trusted string) bool {
+    return strings.HasPrefix(trusted, "system:") ||
+           strings.HasPrefix(trusted, "admin:")  ||
+           trusted == "__system__"
+}
+```
+
+## Open questions / risks
+
+- **`user_id` vs `tenant_principal` naming boundary.** Wire/storage uses
+  bare `"alice"`; ACL/grant code uses `"user:alice"` (CLAUDE.md "Key
+  Patterns"). The handler does NOT prepend `user:` — `globalStore.create_user`
+  receives the bare id. Any Go code that later joins this row against
+  `acl_grants` or `tenant_members` must add the `user:` prefix at the
+  boundary. Document the prefix rule in `globalstore` package docs to
+  prevent regressions; the bug class here is silent permission misses.
+- **Skips the WAL** — violates the CLAUDE.md §1 invariant on its face.
+  Today's behavior: rebuild-from-WAL would lose the user registry. Either
+  (a) accept that `global_store` state is operator-managed and out of
+  scope for replay, or (b) add a `UserCreated` event to `TransactionEvent.ops`
+  and route through `Applier`. Decision needed before GA. Recommend (a)
+  with a backup of `global_store.db` documented in the runbook.
+- **No audit-trail entry.** S3 Object Lock covers WAL only. Admin user
+  creation is not currently auditable post-hoc. Track follow-up to mirror
+  these into the WAL as `AdminEvent` records (no per-tenant scope).
+- **String-matching on `"UNIQUE constraint"`** is fragile. Go port should
+  use a sentinel error from the SQLite driver and keep the response
+  shape, not the detection mechanism.
+- **Generic exception → `OK + success=false`** swallows real bugs. Once
+  the contract tests are migrated to use typed errors, switch the catch-all
+  to `codes.Internal`. Do NOT change in the parity port.
+- **Trusted-actor fallback** when no interceptor ran (unit tests construct
+  `EntDBServicer` directly): Python's `get_authoritative_actor` returns
+  `request_actor` unchanged. Mirror this fallback in Go so unit tests can
+  pass `actor="system:admin"` without setting up a metadata fixture —
+  but document it loudly so production never relies on it.

--- a/docs/go-port/rpcs/DelegateAccess.md
+++ b/docs/go-port/rpcs/DelegateAccess.md
@@ -1,0 +1,250 @@
+# RPC Port Spec — `entdb.v1.EntDBService/DelegateAccess`
+
+EPIC #407. Source of truth: handler at `server/python/entdb_server/api/grpc_server.py:2747-2806`;
+WAL helper at `server/python/entdb_server/api/admin_handlers.py:70-115`;
+storage (legacy direct-write) at `server/python/entdb_server/apply/canonical_store.py:3774-3870`.
+
+Bulk-share admin op: grants `to_user` a permission on **every node owned by
+`from_user`**, optionally time-bounded. Unlike `ShareNode` (per-node;
+caller must hold ADMIN on the target), DelegateAccess is tenant-admin-scoped
+and operates by `owner_actor` lookup at apply time.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:131` (rpc), `:966-980` (messages).
+
+`DelegateAccessRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | Caller identity. **Untrusted** — overridden by the AuthInterceptor's authoritative actor (`grpc_server.py:2762-2764`). |
+| `tenant_id` | 2 | `string` | Required (`grpc_server.py:2756-2757`). |
+| `from_user` | 3 | `string` | Content owner whose nodes are being delegated. Required (`:2758-2759`). Bare user_id, NOT prefixed `user:` — matches `nodes.owner_actor` storage shape. |
+| `to_user` | 4 | `string` | Recipient. Required (`:2760-2761`). Same shape as `from_user`. |
+| `permission` | 5 | `string` | Legacy permission string. Defaults to `"read"` when empty (`:2766`). Persisted verbatim into `node_access.permission` by the applier. **No typed `core_caps` equivalent** on this RPC today — track for v2. |
+| `expires_at` | 6 | `int64` | Epoch-ms. `0` -> `nil` -> `NULL` (permanent) (`:2767`). Past values are persisted but filtered at read by `list_shared_with_me`, pinned by `test_admin_operations.py:302-314`. |
+
+`DelegateAccessResponse`: `{ bool success = 1; int32 delegated = 2; int64 expires_at = 3; string error = 4; }`.
+
+`delegated` is the **count of nodes owned by `from_user` at handler-call
+time** (`grpc_server.py:2786-2795`) — a SELECT before the WAL event is
+applied, so an estimate, not a post-apply count. Pinned by
+`test_admin_ops.py:438`. `expires_at` echoes request; `0` when permanent
+(`grpc_server.py:2799`). SDK consumers depend on this shape
+(`sdk/go/entdb/admin_test.go:291-333`).
+
+## Auth (delegator must hold the right; trusted-actor)
+
+1. `_check_tenant(tenant_id)` (`grpc_server.py:362-410`, at `:2755`) —
+   sharding + region pinning. Wrong owner: `UNAVAILABLE` +
+   `entdb-redirect-node` trailer. Region mismatch: `FAILED_PRECONDITION`.
+2. Required-field guards (`:2756-2761`) — empty `tenant_id`/`from_user`/
+   `to_user` -> `INVALID_ARGUMENT` abort.
+3. `_require_admin_or_owner(...)` (`grpc_server.py:2656-2690`, at `:2762`)
+   — the only permission gate. Rebinds wire `actor` to the trusted
+   identity (`AuthInterceptor.get_authoritative_actor`); system actors
+   short-circuit; otherwise the global-store `tenant_members.role` must be
+   `owner` or `admin`. **The delegator does NOT need any per-node grant**
+   — admin/owner is sufficient to bulk-delegate any user's content. That
+   is the "right" the delegator must hold.
+4. Privilege-escalation guard: client-supplied `actor` is discarded.
+   Regression pinned by commit `fece3fb`.
+
+`from_user`/`to_user` are NOT validated against tenant membership.
+
+## Side effects (WAL append; ACL grant with delegation marker)
+
+WAL-first. The handler appends an `admin_delegate_access` event via
+`handle_delegate_access` (`admin_handlers.py:70-115`):
+
+```json
+{ "tenant_id": "...", "actor": "<trusted>", "idempotency_key": "admin-delegate-<uuid4>",
+  "ts_ms": <ms>, "ops": [{ "op": "admin_delegate_access",
+                           "from_user": "...", "to_user": "...",
+                           "permission": "read|write|...", "expires_at": <ms|null> }] }
+```
+
+The handler MUST NOT call `canonical_store.delegate_access()` directly.
+Pinned by `test_admin_ops.py:436-437` (`assert "delegate_access" not in cs.write_calls`).
+
+**KNOWN GAP — fix in Go port.** `apply/applier.py:1231-1248` only
+dispatches `admin_transfer_content` and `admin_revoke_access`. **No
+`admin_delegate_access` branch exists** — the WAL event is
+appended-and-ignored on the gRPC path. The
+`test_admin_operations.py:514-536` test passes via the legacy direct-write
+`canonical_store.delegate_access` route, NOT the WAL handler. Go port
+MUST add a `case "admin_delegate_access"` mirroring `_sync_delegate_access`
+(`canonical_store.py:3774-3810`):
+
+```sql
+SELECT node_id FROM nodes WHERE tenant_id = ? AND owner_actor = ?;
+-- for each row:
+INSERT OR REPLACE INTO node_access
+  (node_id, actor_id, actor_type, permission, granted_by, granted_at, expires_at)
+VALUES (?, to_user, 'user', permission, granted_by, now, expires_at);
+```
+
+`granted_by` is the trusted actor and is the **delegation marker** — no
+separate `delegated_by` column. Auditors distinguish a normal share from a
+delegation via the audit-log entry `action = "delegate_access"`
+(`canonical_store.py:3850`). Consider a typed `grant_kind` column in v2.
+
+`actor_type` is hard-coded `"user"` — no group/service delegation.
+Cross-tenant: not supported. Mailbox fanout: none.
+
+## Error contract
+
+| gRPC code | Trigger |
+|-----------|---------|
+| `OK` + `success=true, delegated=N, expires_at=...` | Event appended to WAL. `N` is owner-count at request time. |
+| `OK` + `success=false, error=...` | Catch-all for non-gRPC exceptions (`grpc_server.py:2801-2806`). |
+| `INVALID_ARGUMENT` (abort) | Missing `tenant_id` / `from_user` / `to_user` (`:2756-2761`); also missing trusted actor (`:2675`). Pinned by `test_admin_operations.py:841-858`. |
+| `PERMISSION_DENIED` (abort) | Caller is not admin/owner (`grpc_server.py:2685-2689`). Pinned by `test_admin_operations.py:538-557`. |
+| `UNAVAILABLE` (abort) | Tenant not served by this node; trailer `entdb-redirect-node` carries owner. |
+| `FAILED_PRECONDITION` (abort) | Region pinning mismatch. |
+| `UNAUTHENTICATED` | Auth interceptor only; never raised by the handler. |
+
+`INTERNAL` is intentionally avoided — unexpected failures route through the
+soft-fail shape `OK + success=false`. Go port MUST keep this; SDK clients
+parse the response field, not the status code (`sdk/go/entdb/admin.go:95-104`).
+
+## Shared Go package deps
+
+All under `server/go/internal/...`.
+
+- `pb` — generated `DelegateAccessRequest`/`Response`.
+- `auth` — `GetAuthoritativeActor(req.Actor) string`.
+- `globalstore` — `GetMemberRole(tenantID, userID) (string, error)`.
+- `wal` — `Append(ctx, topic, key, *TransactionEvent) (StreamPos, error)`.
+- `apply` — applier with new `admin_delegate_access` op handler. **NEW.**
+- `store` — `CountNodesByOwner(tenantID, owner) (int, error)` for `delegated` pre-count (`grpc_server.py:2787-2793`).
+- `metrics` — `RecordGRPCRequest("DelegateAccess", outcome, dur)`.
+- `sharding` — `_check_tenant`.
+- `idgen` — UUID4 for `idempotency_key`.
+
+NOT used: `crypto`, `audit` (WAL is the audit log, CLAUDE.md inv. #2),
+`quota`, `mailbox`, `acl`/`CapabilityRegistry` (no typed caps on this RPC).
+
+## Other-RPC deps (ShareNode similar)
+
+- **`ShareNode`** (`grpc_server.py:1746-1826`) — per-node share; uses
+  `_check_capability` (ADMIN on target) instead of `_require_admin_or_owner`.
+  Shares the `node_access` table; Go port should share the writer.
+- **`TransferUserContent`** (`grpc_server.py:2692-2745`) — same WAL-first
+  pattern via `handle_transfer_user_content`. Its `admin_transfer_content`
+  branch (`applier.py:1231-1238`) is the template for the missing
+  `admin_delegate_access` branch.
+- **`RevokeAllUserAccess`** — `admin_revoke_access` branch
+  (`applier.py:1240-1245`). **Does NOT target delegations** — deletes from
+  `node_visibility`, not `node_access`. See open questions.
+- **`ListSharedWithMe`** — reader of delegated grants; filters `expires_at`.
+  Pinned at `test_admin_operations.py:241-244`.
+- **`ExecuteAtomic`** — WAL envelope template (`grpc_server.py:790`).
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_admin_ops.py:408-441` — WAL-first: handler
+  appends `admin_delegate_access` with all fields; does NOT call
+  `canonical_store.delegate_access`; `resp.delegated == 2`,
+  `resp.expires_at == request.expires_at`.
+- `tests/python/unit/test_admin_ops.py:443-464` — empty `permission`
+  defaults to `"read"` in the WAL payload.
+- `tests/python/unit/test_admin_operations.py:222-244` — bulk grant via
+  direct path: 2 alice-owned nodes -> bob via `list_shared_with_me`;
+  carol-owned excluded. Go applier branch must reproduce.
+- `tests/python/unit/test_admin_operations.py:246-264` — `expires_at`
+  persisted; permission stored verbatim.
+- `tests/python/unit/test_admin_operations.py:266-281` — permanent
+  delegation -> `expires_at IS NULL`.
+- `tests/python/unit/test_admin_operations.py:283-300` — audit row
+  `action="delegate_access"`, metadata has `from_user`, `to_user`,
+  `permission`, `delegated`.
+- `tests/python/unit/test_admin_operations.py:302-314` — past `expires_at`
+  filtered at read time.
+- `tests/python/unit/test_admin_operations.py:514-536` — handler happy
+  path; `delegated=2`.
+- `tests/python/unit/test_admin_operations.py:538-557` — non-admin ->
+  `PERMISSION_DENIED`.
+- `tests/python/unit/test_admin_operations.py:559-586` — default
+  `"read"` reaches the WAL event.
+- `tests/python/unit/test_admin_operations.py:841-858` — empty `to_user`
+  -> `INVALID_ARGUMENT`.
+- `tests/python/integration/test_grpc_contract.py:761-764` — DelegateAccess
+  is **explicitly excluded** from the cross-RPC contract sweep. Add a
+  contract case in EPIC #407 closeout.
+- `sdk/go/entdb/admin_test.go:291-316` — SDK propagates `expires_at`.
+- `sdk/go/entdb/admin_test.go:318-333` — permanent: zero `expires_at` on wire.
+
+## Implementation outline
+
+```go
+// server/go/internal/api/delegate_access.go
+func (s *EntDBServer) DelegateAccess(ctx context.Context, req *pb.DelegateAccessRequest) (*pb.DelegateAccessResponse, error) {
+    start := time.Now()
+    if err := s.checkTenant(ctx, req.TenantId); err != nil { return nil, err }
+    if req.TenantId == "" || req.FromUser == "" || req.ToUser == "" {
+        return nil, status.Error(codes.InvalidArgument, "tenant_id/from_user/to_user required")
+    }
+    actor, err := s.requireAdminOrOwner(ctx, req.TenantId, req.Actor, "DelegateAccess")
+    if err != nil { return nil, err }
+
+    permission := req.Permission
+    if permission == "" { permission = "read" }
+    var expiresAt *int64
+    if req.ExpiresAt != 0 { v := req.ExpiresAt; expiresAt = &v }
+
+    ev := wal.NewEvent(req.TenantId, actor, "admin-delegate-"+uuid.NewString(), []wal.Op{{
+        "op":"admin_delegate_access", "from_user":req.FromUser, "to_user":req.ToUser,
+        "permission":permission, "expires_at":expiresAt,
+    }})
+    if _, err := s.wal.Append(ctx, s.topic, req.TenantId, ev); err != nil {
+        metrics.RecordGRPCRequest("DelegateAccess", "error", time.Since(start))
+        return &pb.DelegateAccessResponse{Success: false, Error: err.Error()}, nil
+    }
+    delegated, _ := s.store.CountNodesByOwner(ctx, req.TenantId, req.FromUser)
+    metrics.RecordGRPCRequest("DelegateAccess", "ok", time.Since(start))
+    out := &pb.DelegateAccessResponse{Success: true, Delegated: int32(delegated)}
+    if expiresAt != nil { out.ExpiresAt = *expiresAt }
+    return out, nil
+}
+```
+
+Applier branch (`server/go/internal/apply/applier.go`):
+
+```go
+case "admin_delegate_access":
+    rows := tx.QueryRows("SELECT node_id FROM nodes WHERE tenant_id=? AND owner_actor=?", tenantID, op.FromUser)
+    for _, r := range rows {
+        tx.Exec(`INSERT OR REPLACE INTO node_access
+                 (node_id, actor_id, actor_type, permission, granted_by, granted_at, expires_at)
+                 VALUES (?, ?, 'user', ?, ?, ?, ?)`,
+                r.NodeID, op.ToUser, op.Permission, event.Actor, event.TsMs, op.ExpiresAt)
+    }
+```
+
+## Open questions / risks (revocation semantics, expiry)
+
+- **Applier gap is a real bug.** The Python gRPC path appends
+  `admin_delegate_access` and the applier silently drops it; the
+  integration test at `test_admin_operations.py:514-536` only passes via
+  the legacy direct-write path. Fix in both Python and Go; Go first.
+- **Revocation semantics.** No symmetric `RevokeDelegation`. Options
+  today: wait for `expires_at`; call `RevokeAllUserAccess(to_user)` (too
+  broad — kills all shares too); or per-node `RevokeAccess`. None
+  surgically reverse a delegation. Track v2 RPC `RevokeDelegation(from, to)`
+  deleting `node_access` rows where `actor_id=to_user` AND
+  `nodes.owner_actor=from_user`.
+- **`expires_at` enforced read-side only.** Expired rows linger in
+  `node_access`; readers filter `WHERE expires_at IS NULL OR expires_at > now`.
+  No GC sweeper. Track a background pruner.
+- **Idempotency.** Fresh `admin-delegate-<uuid4>` per call — retries
+  re-run SELECT/INSERT (safe via `INSERT OR REPLACE` but bumps
+  `granted_at` and writes a new audit row). Flag for receipt follow-up.
+- **`delegated` is a pre-apply estimate.** New nodes created between
+  SELECT and apply inflate the actual grant count (and vice versa). Don't
+  fix by blocking on apply.
+- **No typed `core_caps`.** ShareNode supports typed `CoreCapability`;
+  DelegateAccess stores legacy strings. Address in proto v2.
+- **Group/service delegation unsupported** (`actor_type` hard-coded `"user"`).
+- **Actor-shape mismatch with ShareNode.** ShareNode normalises to
+  `user:<id>`; DelegateAccess stores bare. Reads work because comparison
+  key is bare. Don't "normalise" without auditing read paths.

--- a/docs/go-port/rpcs/DeleteUser.md
+++ b/docs/go-port/rpcs/DeleteUser.md
@@ -1,0 +1,270 @@
+# DeleteUser — Go Port Spec
+
+EPIC #407. GDPR right-to-erasure. Queues a user for deletion with a
+grace period; a background worker performs the actual erasure.
+Python source of truth: `server/python/entdb_server/api/grpc_server.py:2925-2981`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:136` (RPC), `:1010-1025` (messages).
+
+```
+rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
+
+DeleteUserRequest  { string actor = 1; string user_id = 2; int32 grace_days = 3; }
+DeleteUserResponse { bool success = 1; int64 requested_at = 2;
+                     int64 execute_at = 3; string status = 4; string error = 5; }
+```
+
+`grace_days <= 0` is normalized to **30** (`grpc_server.py:2965`).
+`status` values returned today: `"pending"`. Worker transitions write
+back to `global_store` rows; the gRPC reply only ever sees `"pending"`
+on the queueing path (see `_sync_queue_deletion`, `global_store.py:815-822`).
+
+`requested_at` / `execute_at` are unix-seconds (int64) populated by
+`global_store.queue_deletion` (`global_store.py:800-822`).
+
+Note: the request is **flat** (no `RequestContext`), unlike most
+ingress RPCs. `actor` is therefore the only client-supplied identity
+field — see Auth.
+
+## Auth (self via consent / admin / compliance; trusted-actor)
+
+1. **Trusted actor.** Handler MUST rebind `request.actor` through
+   `_trusted_actor` (`grpc_server.py:418-437`) before any authorization
+   check. Untrusted client claims are dropped per the choke-point fix
+   (commit `fece3fb`, applied to all GDPR RPCs in the Go port).
+2. **Self-or-admin.** `_is_self_or_admin(actor, user_id)` gates entry
+   (`grpc_server.py:2944-2948`). Two acceptable principals:
+   - The user themselves (`actor == "user:<user_id>"`), satisfying
+     GDPR Art. 17 self-service erasure consent.
+   - An admin / compliance principal (system actors with the `admin`
+     role; same predicate used by `FreezeUser` and `ExportUserData`).
+3. **Argument validation.** `actor` and `user_id` empty → `INVALID_ARGUMENT`
+   (`grpc_server.py:2940-2943`). `global_store` not configured →
+   `UNIMPLEMENTED`.
+4. Failure mode: non-self / non-admin → `PERMISSION_DENIED` via
+   `context.abort` (pinned by `tests/python/unit/test_gdpr_engine.py:646-654`
+   and `tests/python/integration/test_grpc_contract.py:671-676`).
+
+## Side effects
+
+The handler is intentionally **lightweight**: it queues, it does not
+erase. The actual deletion pipeline runs in `gdpr_worker.py`.
+
+Synchronous path (`grpc_server.py:2950-2967`):
+1. `global_store.get_user(user_id)` → `None` returns
+   `success=False, error="User not found"` (no abort, OK status code).
+   Pinned: `test_gdpr_engine.py:658-662`.
+2. `global_store.get_deletion_entry(user_id)` → if an entry with
+   `status == "pending"` exists, return its existing
+   `requested_at`/`execute_at` unchanged (idempotent re-queue).
+   Pinned: `test_gdpr_engine.py:637-643`.
+3. `global_store.queue_deletion(user_id, grace_days)` inserts into the
+   `deletion_queue` table (`global_store.py:239-246, 815-822`).
+4. `global_store.set_user_status(user_id, "pending_deletion")`.
+
+WAL append: **none on the queueing path today.** The Python handler
+writes directly to `global_store` (which has its own SQLite — see
+CLAUDE.md invariant #4). The Go port MUST preserve this: cross-tenant
+membership and deletion state live in the global store, not per-tenant
+WALs. The actual erasure events emitted by the worker (anonymize_user,
+delete_tenant, remove_membership) do go through per-tenant WALs via
+`canonical_store.anonymize_user_in_tenant` and
+`canonical_store.delete_tenant_database` (`gdpr_worker.py:135-167`).
+
+Tombstone vs. hard delete:
+- **Per-tenant nodes/edges**: anonymized in-place (PII fields hashed
+  with salt, `owner_actor` rewritten); rows remain so referential
+  integrity holds. This is the "tombstone" — the WAL retains the
+  anonymize op but **not raw PII** (CLAUDE.md invariant #2; salt lives
+  in `gdpr_worker.salt`).
+- **Sole-owner ("personal") tenants**: SQLite file is dropped via
+  `canonical_store.delete_tenant_database` and tenant status set to
+  `"deleted"` (`gdpr_worker.py:138-152`).
+- **Global rows**: memberships, shared edges, then user status →
+  `"deleted"`, queue entry → `"completed"` (`gdpr_worker.py:170-173`).
+
+Legal hold: there is **no legal-hold check in the current Python
+DeleteUser handler**. Tenant-level legal hold is enforced in
+`_check_tenant_access` for *node/edge* deletes
+(`grpc_server.py:524, 453, 755`) but not at GDPR queueing time.
+The Go port SHOULD add the check explicitly: before queueing, walk
+`global_store.get_user_tenants(user_id)` and reject with
+`FAILED_PRECONDITION` if any returns `is_under_legal_hold(tenant_id)`
+true (`global_store.py:1040-1056`). Flag this in the issue — do not
+silently change behavior; gate on a config flag and add a contract
+test before flipping default.
+
+Durable crypto-shred: the personal-tenant path drops the SQLite file,
+which removes the data-encryption-key handle held by
+`crypto/crypto_shred` (`encryption.py:147-149`); for non-personal
+tenants the per-user payload remains encrypted under the tenant DEK
+and is anonymized in-place. No separate per-user shred is performed.
+
+## Error contract
+
+| Condition                              | Code                  | Pinned by |
+|----------------------------------------|-----------------------|-----------|
+| `global_store` not configured          | `UNIMPLEMENTED`       | `grpc_server.py:2939` |
+| `actor` empty                          | `INVALID_ARGUMENT`    | `grpc_server.py:2940-2941` |
+| `user_id` empty                        | `INVALID_ARGUMENT`    | `grpc_server.py:2942-2943` |
+| Caller is not self and not admin       | `PERMISSION_DENIED`   | `test_gdpr_engine.py:646-654`, `test_grpc_contract.py:671-676` |
+| User does not exist                    | `OK` + `success=false`, `error="User not found"` | `test_gdpr_engine.py:658-662` |
+| Pending entry already exists           | `OK` + `success=true`, `status="pending"`, same timestamps | `test_gdpr_engine.py:637-643` |
+| Generic exception                      | `OK` + `success=false`, `error=str(e)` | `grpc_server.py:2976-2981` |
+
+Notes:
+- "User not found" returns OK, not `NOT_FOUND`. The Go port MUST keep
+  this for SDK compatibility.
+- Legal-hold rejection (when added) → `FAILED_PRECONDITION` with a
+  message naming the held tenant. New behavior; ship behind flag.
+
+## Shared Go package deps
+
+- `gdpr/` (new) — port of `gdpr_worker.py`. Owns the deletion state
+  machine, anonymization, sole-tenant-drop logic, and the
+  `tenant_principal` translation (`user:<id>`).
+- `audit/` — `audit/compliance.go` (port of `audit/compliance.py`),
+  `audit/s3_lock.go` (port of `audit/s3_lock.py`). DeleteUser does
+  not write audit records itself; the worker emits events that S3
+  Object Lock retains (CLAUDE.md invariant #2).
+- `crypto/keys/` — DEK lifecycle for sole-tenant crypto-shred via
+  `crypto_shred_tenant` (`encryption.py:147-149`).
+- `wal/` — used only indirectly via per-tenant `canonical_store`
+  ops in the worker (anonymize / delete_tenant). DeleteUser handler
+  itself does not append.
+- `store/` — `global_store.go` interface: `GetUser`,
+  `GetDeletionEntry`, `QueueDeletion`, `SetUserStatus`,
+  `IsUnderLegalHold`, `GetUserTenants`.
+
+## Other-RPC deps
+
+- **`CancelUserDeletion`** (`grpc_server.py:2983-3010`,
+  `proto:139`): inverse during grace window; deletes from
+  `deletion_queue` and flips user back to `"active"`. MUST be
+  implemented in the same milestone — pinned by
+  `test_gdpr_engine.py:664-672`.
+- **`ExportUserData`** (`proto:1027-1037`): GDPR Art. 20 portability.
+  Often called immediately before DeleteUser by SDKs; share the
+  same self-or-admin gate.
+- **`FreezeUser`** (`proto:1039-1049`): suspends without erasure;
+  shares the auth helper. Worker SHOULD skip frozen users or treat
+  freeze as a soft hold (current Python: no interaction — flag).
+- `SetLegalHold` (tenant-level, `grpc_server.py:2820-2840`): produces
+  the precondition the new legal-hold gate would read.
+
+## Contract tests pinning behavior
+
+- `tests/python/unit/test_gdpr_engine.py:625-633` — happy path,
+  `status=="pending"`, user marked `pending_deletion`.
+- `tests/python/unit/test_gdpr_engine.py:636-643` — idempotency:
+  same `execute_at` returned on repeat call.
+- `tests/python/unit/test_gdpr_engine.py:646-654` — non-self /
+  non-admin → `PERMISSION_DENIED` abort.
+- `tests/python/unit/test_gdpr_engine.py:657-662` — unknown user →
+  `success=False`, no abort.
+- `tests/python/unit/test_gdpr_engine.py:664-672` — Cancel after
+  Delete restores status to `"active"`.
+- `tests/python/integration/test_grpc_contract.py:665-670` —
+  end-to-end happy path over real gRPC channel.
+- `tests/python/integration/test_grpc_contract.py:671-676` —
+  end-to-end `permission_denied` for foreign actor.
+
+The Go port MUST keep all seven green via the contract test harness
+in `tests/contract/` (cross-impl).
+
+## Implementation outline
+
+State machine (rows in `global_store.deletion_queue`,
+`global_store.py:239-246`):
+
+```
+                     +-------------------+
+                     | (no row)          |
+                     +---------+---------+
+                               | DeleteUser
+                               v
++---------------+   Cancel     +-----------+
+|   cancelled   | <----------- | scheduled | <-- (re-DeleteUser is no-op)
+| (row removed) |              +-----+-----+
++---------------+                    | execute_at <= now
+                                     v
+                              +--------------+
+                              |   executing  |   (worker tick)
+                              +------+-------+
+                                     | success
+                                     v
+                              +--------------+
+                              |   completed  |
+                              +--------------+
+```
+
+Handler pseudocode (Go):
+
+```go
+func (s *Server) DeleteUser(ctx context.Context, req *pb.DeleteUserRequest) (*pb.DeleteUserResponse, error) {
+    if s.globalStore == nil { return nil, status.Error(codes.Unimplemented, "User registry not configured") }
+    if req.Actor == ""   { return nil, status.Error(codes.InvalidArgument, "actor is required") }
+    if req.UserId == ""  { return nil, status.Error(codes.InvalidArgument, "user_id is required") }
+    actor := s.trustedActor(req.Actor)                                    // ContextVar equivalent
+    if !s.isSelfOrAdmin(actor, req.UserId) {
+        return nil, status.Error(codes.PermissionDenied,
+            "DeleteUser requires the user themselves or an admin actor")
+    }
+    user, _ := s.globalStore.GetUser(ctx, req.UserId)
+    if user == nil { return &pb.DeleteUserResponse{Success: false, Error: "User not found"}, nil }
+    if existing, _ := s.globalStore.GetDeletionEntry(ctx, req.UserId);
+       existing != nil && existing.Status == "pending" {
+        return &pb.DeleteUserResponse{Success: true, RequestedAt: existing.RequestedAt,
+            ExecuteAt: existing.ExecuteAt, Status: "pending"}, nil
+    }
+    // (optional, gated) legal-hold gate: walk GetUserTenants → IsUnderLegalHold
+    grace := req.GraceDays; if grace <= 0 { grace = 30 }
+    entry, err := s.globalStore.QueueDeletion(ctx, req.UserId, grace)
+    if err != nil { return &pb.DeleteUserResponse{Success: false, Error: err.Error()}, nil }
+    _ = s.globalStore.SetUserStatus(ctx, req.UserId, "pending_deletion")
+    return &pb.DeleteUserResponse{Success: true, RequestedAt: entry.RequestedAt,
+        ExecuteAt: entry.ExecuteAt, Status: "pending"}, nil
+}
+```
+
+Worker (separate goroutine, port of `gdpr_worker.py`):
+poll `GetExecutableDeletions(now)`, for each user run anonymize /
+sole-tenant-drop / global-cleanup pipeline, then
+`MarkDeletionCompleted`. Per-tenant ops go through the WAL via
+existing `canonical_store` Go ports — DeleteUser itself never appends.
+
+## Open questions / risks
+
+1. **GDPR 30-day deadline.** Art. 17 requires erasure "without undue
+   delay." The current 30-day grace is a *cancellation* window and
+   may exceed the deadline if the worker is offline. Risk: silent
+   non-compliance. Mitigation: alert if `now - execute_at > 7d` in
+   `executable_deletions`. Decide before GA.
+2. **Idempotency on the failure path.** A re-queue after a worker
+   crash mid-pipeline currently returns the *original* timestamps
+   (handler thinks it's pending); but `deletion_queue.status` may
+   have been left in a partial state (no `executing` row today —
+   pipeline is run-to-completion in-process). The Go port should
+   add an `executing` status with a worker lease + heartbeat to
+   make crash recovery deterministic.
+3. **Audit immutability.** Worker-emitted anonymize/delete events
+   are appended to per-tenant WALs which terminate in S3 Object
+   Lock (COMPLIANCE mode). Confirm the Object Lock retention
+   horizon ≥ statutory audit window before flipping any tenant
+   to "GDPR mode." `audit/s3_lock.go` MUST refuse retention < N
+   days configured.
+4. **Legal-hold gate not enforced at queue time** (Python). The
+   Go port should add it (FAILED_PRECONDITION) and pin a contract
+   test, but ship behind a config flag to keep parity tests green
+   on day-zero of cutover.
+5. **Self-only via consent receipt.** Today self-action requires
+   only that the trusted actor match the user_id. Stronger: require
+   a recent consent receipt (signed by the user's session key) so
+   a hijacked session can't auto-erase. Out of scope for the Go
+   port v1 but flag in the spec.
+6. **Personal-tenant heuristic.** Sole-membership ⇒ drop tenant.
+   If membership state is racing with `RemoveMember`, the worker
+   may drop a tenant that gained a new member between `get_members`
+   and the file unlink. Lock the tenant row before the decision.

--- a/docs/go-port/rpcs/ExecuteAtomic.md
+++ b/docs/go-port/rpcs/ExecuteAtomic.md
@@ -1,0 +1,461 @@
+# RPC Port Spec — `entdb.v1.EntDBService/ExecuteAtomic`
+
+EPIC #407 — Python → Go server port. The central write path of EntDB and the
+single most intricate RPC in the surface. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:620-828` plus the applier at
+`server/python/entdb_server/apply/applier.py:897-1264` (single-event path) and
+`:575-895` (tenant-batch path).
+
+This RPC is the **only** way mutations enter the system. It append-then-applies
+a `TransactionEvent` containing one or more ops; the WAL is the source of truth,
+SQLite is rebuilt from it (CLAUDE.md invariant 1).
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:49` (rpc), `:178-371` (messages).
+
+`ExecuteAtomicRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `context` | 1 | `RequestContext` | Required. `tenant_id`, `actor`, optional `trace_id`. |
+| `idempotency_key` | 2 | `string` | Optional; server generates a UUIDv4 when empty (`grpc_server.py:648`). |
+| `schema_fingerprint` | 3 | `string` | Optional. When non-empty AND server has a fingerprint, mismatch → in-band failure (NOT abort). |
+| `operations` | 4 | `repeated Operation` | Required, ≥1. Empty list → `INVALID_ARGUMENT`. |
+| `wait_applied` | 5 | `bool` | Block return until applier writes the event's stream position to SQLite. |
+| `wait_timeout_ms` | 6 | `int32` | Apply-wait timeout. Default `30_000` when zero (`grpc_server.py:805`). |
+
+`Operation` is a `oneof op { CreateNodeOp create_node = 1; UpdateNodeOp update_node = 2; DeleteNodeOp delete_node = 3; CreateEdgeOp create_edge = 4; DeleteEdgeOp delete_edge = 5; }` (`entdb.proto:198-206`).
+
+`CreateNodeOp` (`:230-270`): `type_id`, optional `id` (server fills with UUIDv4 when empty), `as` alias, `fanout_to`, `data google.protobuf.Struct`, `acl repeated AclEntry`, `storage_mode` enum (`TENANT|USER_MAILBOX|PUBLIC`), `target_user_id` (required iff `USER_MAILBOX`). Reserved tags: `3,4,11` and field names `data_json/acl_json/keys`.
+
+`UpdateNodeOp` (`:272-296`): `type_id`, `id` (or alias `$alias.id` form), `field_mask`, `patch google.protobuf.Struct`. Reserved tags `3,6` (`patch_json`, `keys`).
+
+`DeleteNodeOp` (`:298-304`): `type_id`, `id`.
+
+`CreateEdgeOp` (`:306-322`): `edge_id`, `from NodeRef`, `to NodeRef`, `props google.protobuf.Struct`. Reserved tag `4` (`props_json`).
+
+`DeleteEdgeOp` (`:324-333`): `edge_id`, `from NodeRef`, `to NodeRef`.
+
+`NodeRef` (`:335-351`): `oneof ref { string id; string alias_ref; TypedNodeRef typed; }`.
+
+**Payload encoding (CRITICAL).** On the wire `data` and `patch` Structs are
+**name-keyed**. The handler translates them to **id-keyed** (`{"<field_id>":
+value}`) at `_convert_operations` via `name_to_id_keys` before WAL append
+(`grpc_server.py:846,882`; impl `schema/field_id_translation.py:75`). Unknown
+field names are silently dropped. On the WAL, in SQLite, and on Read responses,
+payloads are id-keyed. Pinned by `test_grpc_wire_format.py:172,202`.
+
+`ExecuteAtomicResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `success` | 1 | `bool` | False on schema mismatch / WAL append exception. |
+| `receipt` | 2 | `Receipt` | `tenant_id`, `idempotency_key`, `stream_position` (decimal string of WAL offset, `""` when WAL returned None). |
+| `error` | 3 | `string` | Set when `success=false`. |
+| `error_code` | 4 | `string` | `SCHEMA_MISMATCH` or `INTERNAL`. NB: code-level rejections (`INVALID_ARGUMENT`, `PERMISSION_DENIED`, `ALREADY_EXISTS`, `FAILED_PRECONDITION`, `NOT_FOUND`, `UNAVAILABLE`) are surfaced via `context.abort` and DO NOT populate this field. |
+| `created_node_ids` | 5 | `repeated string` | One entry per `create_node` op, in op order. Server-generated UUIDs included. |
+| `applied_status` | 6 | `ReceiptStatus` | `PENDING` unless `wait_applied=true` AND offset reached → `APPLIED`. Never `FAILED` from this RPC (use `GetReceiptStatus`). |
+
+## Auth
+
+`AuthInterceptor` (`auth/auth_interceptor.py:140`) authenticates the call,
+binds the verified principal into a `ContextVar`, and lets the handler call
+`get_authoritative_actor(request_actor)` (`auth_interceptor.py:92`) to obtain
+the **trusted** actor. The wire `request.context.actor` is UNTRUSTED.
+
+- `_trusted_actor(ctx.actor)` is invoked at `grpc_server.py:645` and the
+  handler **rebinds its actor variable** so no later code path can re-read
+  the wire value. Pinned by
+  `tests/python/integration/test_privilege_escalation.py:266` (rejects claimed
+  admin) and `:287` (persists trusted actor in WAL event, never the claim).
+  Go port: rebind the local `actor` immediately after extraction. See PR #168.
+- `_check_tenant_access(tenant_id, actor=trusted_actor, require_write=true,
+  op_kind="delete" if any delete else "write")` runs at `grpc_server.py:758`.
+  Enforces:
+  - Tenant existence (`NOT_FOUND`).
+  - Tenant `status` (`active`, `archived`, `legal_hold`, `deleted`):
+    - `archived` + write → `FAILED_PRECONDITION`
+    - `legal_hold` + delete → `FAILED_PRECONDITION` (creates/updates allowed; pinned `test_admin_operations.py:665,686`).
+    - `deleted` → `NOT_FOUND`.
+  - Membership: non-member → `PERMISSION_DENIED`. `viewer`/`guest` + write →
+    `PERMISSION_DENIED` (`test_tenant_roles.py:546,558`).
+  - Actor-user `status` of `frozen` or `pending_deletion` (GDPR Art. 18
+    restriction) + write → `PERMISSION_DENIED` (`grpc_server.py:550-557`).
+  - System actors (`system:*` or `__system__`) bypass all (`grpc_server.py:499`).
+- `_check_tenant(tenant_id)` runs FIRST at `grpc_server.py:628`. Rejects if
+  this node is not the tenant's shard owner: sets trailing metadata
+  `entdb-redirect-node: <owner_node_id>` and aborts `UNAVAILABLE`. Pinned by
+  redirect-cache contract tests; the trailer is what SDKs use to retry
+  elsewhere (`sdk/go/entdb/redirect_cache.go`). Region pin mismatch →
+  `FAILED_PRECONDITION` (`grpc_server.py:404`).
+- **Per-op `Permission` checks: NONE at the gRPC layer.** ACL is enforced on
+  reads (`can_access`) and on share/grant ops elsewhere; ExecuteAtomic relies
+  on tenant-membership + role for write authorization. There is no
+  per-`type_id` write capability check today — the Go port must replicate
+  this exactly to preserve behavior.
+- The persisted WAL event's `actor` field is the trusted actor
+  (`grpc_server.py:780`). Audit-truth invariant — do not regress.
+
+## Side effects
+
+End-to-end flow (CLAUDE.md invariant 1: handler → `wal.append` → applier →
+SQLite; never direct):
+
+1. **Pre-validation** (handler, before WAL):
+   - Tenant ownership / region (`_check_tenant`, `grpc_server.py:628`).
+   - Required-field validation (`grpc_server.py:632-637`).
+   - Schema fingerprint check against `self.schema_registry.fingerprint`
+     (`:651`). Mismatch returns `success=false, error_code="SCHEMA_MISMATCH"`
+     in-band. **Do not abort.** Pinned `test_grpc_schema_mismatch_metric.py:61`.
+   - `_convert_operations` — proto → internal dicts; **field-id translation
+     via `name_to_id_keys`** for `create_node.data` and `update_node.patch`
+     (`grpc_server.py:846,882`); enum `storage_mode` → string name; node refs
+     normalized (`{"ref":"alias"}` or `{"type_id":N,"id":"X"}` or bare id).
+   - Fast-fail unique pre-check (single-field): for each `create_node`, look
+     up declared unique fields via `schema_registry.get_unique_field_ids`,
+     then `canonical_store.get_node_by_key(tenant, type_id, fid, value)`. Hit
+     → abort `ALREADY_EXISTS` (`grpc_server.py:669-700`). Pinned
+     `test_unique_keys.py:569`.
+   - Fast-fail composite-unique pre-check
+     (`schema_registry.get_composite_unique_constraints`,
+     `canonical_store.get_node_by_composite_key`, `grpc_server.py:707-751`).
+     Both pre-checks are **best-effort only**; the unique expression index at
+     apply time is the authoritative race winner (2026-04-14 SDK v0.3 ADR).
+   - Tenant access + role + status (`_check_tenant_access`, `:758`).
+   - Server-fill empty `create_node.id` with UUIDv4; collect
+     `created_node_ids` in op order (`:768-772`).
+
+2. **Build event** (`grpc_server.py:778-785`): `{tenant_id, actor=trusted,
+   idempotency_key, schema_fingerprint=server's, ts_ms=int(time.time()*1000),
+   ops=[...]}` JSON-encoded UTF-8.
+
+3. **WAL append** (`:790`): `await self.wal.append(self.topic, tenant_id,
+   event_bytes)`. Partition key = `tenant_id` so all of a tenant's events
+   land on one partition (in-order replay). Returns `stream_pos` (string-ish;
+   may be None for in-memory backend → empty `stream_position`).
+
+4. **Build receipt** (`:796-800`).
+
+5. **Optional apply-wait** (`:804`): `await
+   canonical_store.wait_for_offset(tenant_id, str(stream_pos), timeout)` —
+   event-driven, no polling (`canonical_store.py:478`). Sets
+   `applied_status=APPLIED` on success; otherwise leaves `PENDING`.
+
+6. **Applier (out-of-band, `apply_event`, `applier.py:1327`)** — invariants:
+   - Every op + idempotency check + `applied_events` insert run in a **single
+     SQLite transaction** (`_sync_apply_event_body`, `applier.py:897`). Roll
+     back on any exception, including the idempotency record — so retries
+     are safe (`apply_event` docstring `:1327`).
+   - **Storage routing.** `_event_storage_mode` (`applier.py:629`) inspects
+     `create_node` ops and picks one of `TENANT`, `USER_MAILBOX` (requires
+     `target_user_id`), or `PUBLIC` for the whole event. Mixed-mode events →
+     `ValidationError` (raised inside applier, surfaces only via
+     `GetReceiptStatus=FAILED`; the gRPC handler will already have returned
+     a successful Receipt). `_open_event_connection` (`:669`) opens
+     `batch_transaction` / `mailbox_batch_transaction(target_user)` /
+     `public_batch_transaction()`.
+   - **Idempotency** at apply time: `SELECT 1 FROM applied_events WHERE
+     tenant_id=? AND idempotency_key=?` inside the txn (`applier.py:921`,
+     `:766`). Hit → skip the entire event, harmless empty COMMIT. Same key
+     → same outcome, even after WAL replay. Pinned
+     `test_wal_replay_determinism.py:385`.
+   - **Per-op apply** (`applier.py:929-1248`):
+     - `create_node`: lazy-create field indexes
+       (`canonical_store._ensure_field_indexes`); `create_node_raw` insert;
+       on `sqlite3.IntegrityError` matching `_parse_unique_index_name` →
+       `UniqueConstraintError`; matching composite → `CompositeUniqueConstraintError`;
+       record alias in `_node_alias_map`; FTS index insert for searchable
+       fields; data-policy log.
+     - `update_node`: reject patch containing `storage_mode` key
+       (immutable, `applier.py:1024`); read-modify-write on `payload_json`
+       (`UPDATE ... SET payload_json=?, updated_at=?`); same unique-violation
+       parsing as create; FTS update.
+     - `delete_node`: FTS delete; `DELETE FROM edges WHERE from=? OR to=?`;
+       `DELETE FROM node_visibility`; `DELETE FROM nodes`. Append id to
+       `deleted_node_ids` for post-commit shared-index cleanup.
+     - `create_edge`: resolve `from`/`to` (alias / typed / bare id);
+       `CanonicalStore._validate_edge_direction` enforces
+       `USER_MAILBOX → TENANT → PUBLIC` privacy hierarchy
+       (`applier.py:1163`); `INSERT OR REPLACE INTO edges`; if
+       `propagates_acl`, run recursive cycle check (depth 10) and
+       `INSERT OR IGNORE INTO acl_inherit (to, from)` (`:1190-1212`).
+     - `delete_edge`: `DELETE FROM edges` and `DELETE FROM acl_inherit`.
+   - **Record applied** (same txn): `INSERT INTO applied_events
+     (tenant_id, idempotency_key, stream_pos, applied_at)` (`:1252`).
+   - **Post-commit (NOT in txn):**
+     - Mailbox fanout for `create_node` ops when `fanout_config.enabled`
+       (`applier.py:1361`).
+     - Shared-index cleanup for deleted nodes (`:1370`).
+     - Phase-1 quota: `_increment_usage_safe(tenant_id, len(event.ops))`
+       (`:1377`). **Fire-and-forget** — failures MUST NOT block the apply
+       path. Billing drift is preferable to write outage
+       (`docs/decisions/quotas.md`). Counter increments per *op*, not per
+       event; replays do not double-count because skipped events return
+       early before the increment. Tenant-batch path increments once per
+       batch (`applier.py:602-605`).
+     - `update_applied_offset(tenant_id, stream_pos)` for the wait-watchers
+       (`:599`, batch path; single-event path notifies via the same store).
+
+7. **Tenant scope.** Every `create_node`/`update_node`/`delete_node` op
+   touches `tenant_<id>.db` only (or the per-user mailbox / public.db when
+   routed). Cross-tenant work is forbidden in a single SQLite txn (CLAUDE.md
+   invariant 4). The Go port must keep the per-tenant connection-pool +
+   thread-pool model: synchronous SQLite work runs on
+   `canonical_store._executor` so the gRPC event loop never blocks
+   (`applier.py:586-592`).
+
+## Error contract
+
+All `context.abort` paths immediately raise — the handler's outer
+`except Exception` (`grpc_server.py:826`) only re-records the metric and
+re-raises. The few in-band failure paths set `success=false`.
+
+| Trigger | gRPC code / signal | Source |
+|---|---|---|
+| Tenant not on this node | `UNAVAILABLE` + `entdb-redirect-node` trailer | `grpc_server.py:392` |
+| Tenant region mismatch | `FAILED_PRECONDITION` | `:404` |
+| Empty `tenant_id` | `INVALID_ARGUMENT` | `:633` |
+| Empty `actor` | `INVALID_ARGUMENT` | `:635` |
+| Empty `operations` | `INVALID_ARGUMENT` | `:637` |
+| `schema_fingerprint` mismatch | in-band: `success=false`, `error_code="SCHEMA_MISMATCH"` | `:653` |
+| `create_node` single-field unique pre-collision | `ALREADY_EXISTS` | `:696` |
+| `create_node` composite unique pre-collision | `ALREADY_EXISTS` | `:744` |
+| Tenant `deleted` | `NOT_FOUND` | `:512` |
+| Tenant unknown | `NOT_FOUND` | `:504` |
+| Tenant `archived` (any write) | `FAILED_PRECONDITION` | `:518` |
+| Tenant `legal_hold` + any delete op | `FAILED_PRECONDITION` | `:524` |
+| Non-member of tenant | `PERMISSION_DENIED` | `:535` |
+| Role `viewer`/`guest` (write) | `PERMISSION_DENIED` | `:541` |
+| User `frozen` / `pending_deletion` (write) | `PERMISSION_DENIED` | `:553` |
+| WAL append exception | in-band: `success=false`, `error_code="INTERNAL"` | `:818-825` |
+| Apply-time unique race (single) | NOT surfaced via this RPC; `GetReceiptStatus` later returns FAILED | `applier.py:993` |
+| Apply-time composite unique race | same | `applier.py:982` |
+| Apply-time mixed storage modes / missing `target_user_id` | same — `ValidationError` | `applier.py:646,656` |
+| Apply-time `update_node` patches `storage_mode` | same — `ValidationError` | `applier.py:1025` |
+| Apply-time edge-direction privacy violation | same — `ValidationError` | `applier.py:1163-1171` |
+
+Reminder: `error_code` is populated **only** on the schema-mismatch and
+WAL-append-exception paths. All other failure modes are aborts.
+
+## Shared Go package deps
+
+| Package | Why |
+|---|---|
+| `pb` (gen from `proto/entdb/v1/entdb.proto`) | Wire types: `ExecuteAtomicRequest`, `Operation`, `Receipt`, `RequestContext`, `NodeRef`, `Struct`. |
+| `auth` | `AuthInterceptor` + `GetAuthoritativeActor(ctx)` to fetch the trusted actor from the request `context.Context`. Mirrors `auth_interceptor.py:92`. |
+| `wal` | `WAL.Append(topic, partitionKey, payload []byte) (StreamPosition, error)`; backends Kafka / Kinesis / Memory. |
+| `apply` | `Applier` (long-running consumer) — not called inline by the handler; the handler must NOT touch SQLite directly (CLAUDE.md invariant 1). |
+| `store` (canonical) | `GetNodeByKey`, `GetNodeByCompositeKey`, `WaitForOffset`, `CheckIdempotency` (used by `GetReceiptStatus`). Also exposes the per-tenant SQLite executor used by the applier. |
+| `schema` | `Registry.Fingerprint()`, `GetUniqueFieldIDs(typeID)`, `GetCompositeUniqueConstraints(typeID)`, `GetSearchableFieldIDs`, plus `NameToIDKeys(struct, typeID)` for the field-id translation. |
+| `acl` | Imported transitively for `AclEntry` proto-to-struct conversion only; no per-op write check happens in this RPC. |
+| `errs` | Map server-side errors to `status.Errorf(codes.X, ...)`; helper to set the `entdb-redirect-node` trailer. |
+| `idempotency` | UUIDv4 generator (Python uses `uuid.uuid4()`); the *check* is at apply time, not here. |
+| `quotas` | NOT used by the handler. Quota accounting lives in the applier post-commit (`applier.py:1377`). |
+| `globalstore` | Tenant + member + user lookups (`get_tenant`, `is_member`, `get_user`). Returns `nil` to skip checks (preserves no-global-store unit-test path, `test_tenant_roles.py:494`). |
+| `sharding` | `IsMine(tenantID)`, `GetOwner(tenantID)` for the `_check_tenant` redirect. |
+| `metrics` | `RecordGRPCRequest("ExecuteAtomic", "ok"|"error", elapsed)`. Schema mismatch records `"error"` (regression-pinned). |
+
+## Other-RPC deps
+
+- **`GetReceiptStatus`** (`grpc_server.py:946`) reads
+  `canonical_store.check_idempotency(tenant, key)` to translate the
+  `idempotency_key` from the receipt to `RECEIPT_STATUS_APPLIED` /
+  `RECEIPT_STATUS_PENDING`. The Go port must preserve the same
+  `applied_events` table semantics so a receipt from `ExecuteAtomic` is
+  observable via `GetReceiptStatus`. Apply-time `ValidationError`s and
+  unique races are how `RECEIPT_STATUS_FAILED` becomes observable.
+- **`WaitForOffset`** (`grpc_server.py:973`) is the standalone version of
+  the `wait_applied` flag's logic. Both call
+  `canonical_store.wait_for_offset(tenant, pos, timeout)`. The Go port
+  should expose a single `Store.WaitForOffset` shared by both.
+- **`GetNode` / `GetNodeByKey`** are the read counterparts; they also call
+  `_trusted_actor` and use `wait_for_offset` with `after_offset` for
+  read-after-write consistency. Their port must wait on the same
+  offset-notification mechanism the applier writes via
+  `update_applied_offset` (`applier.py:599`).
+
+## Contract tests pinning behavior
+
+- Privilege-escalation, claimed-admin actor rejected:
+  `tests/python/integration/test_privilege_escalation.py:266`.
+- Trusted actor (not wire claim) persisted in WAL event:
+  `tests/python/integration/test_privilege_escalation.py:287`.
+- Wire payload is field-id-keyed:
+  `tests/python/unit/test_grpc_wire_format.py:172`.
+- ID-keyed input round-trips:
+  `tests/python/unit/test_grpc_wire_format.py:202`.
+- Idempotency same-key returns same content:
+  `tests/python/unit/test_grpc_wire_format.py:247-290`.
+- Oversized payload rejected:
+  `tests/python/unit/test_grpc_wire_format.py:308-314`.
+- Empty payload tolerated:
+  `tests/python/unit/test_grpc_wire_format.py:320-351`.
+- Unknown field names dropped silently:
+  `tests/python/unit/test_grpc_wire_format.py:355-389`.
+- Schema mismatch → `success=false, error_code=SCHEMA_MISMATCH`, metric
+  recorded as `"error"`: `tests/python/unit/test_grpc_schema_mismatch_metric.py:51-90`.
+- Single-field unique pre-check returns `ALREADY_EXISTS`:
+  `tests/python/unit/test_unique_keys.py:569-595`.
+- Tenant-role matrix (owner/admin/member/viewer/guest/non-member, archived,
+  legal_hold, deleted, system actors):
+  `tests/python/unit/test_tenant_roles.py:524-651`.
+- `legal_hold` rejects `delete_node` but allows `create_node`:
+  `tests/python/unit/test_admin_operations.py:665-702`.
+- AuthInterceptor classifies `/entdb.EntDBService/ExecuteAtomic` as
+  authenticated/rate-limited/needing actor:
+  `tests/python/unit/test_enhanced_auth.py:677,732,754,786`,
+  `tests/python/unit/test_jwt_auth.py:370-432`,
+  `tests/python/unit/test_auth.py:18-38`.
+- Replay determinism + duplicate idempotency:
+  `tests/python/integration/test_wal_replay_determinism.py:179,385,443`.
+- Cross-RPC contract list (delegates ExecuteAtomic coverage to the dedicated
+  files): `tests/python/integration/test_grpc_contract.py:758-760`.
+
+## Implementation outline (Go)
+
+```go
+func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest)
+    (*pb.ExecuteAtomicResponse, error) {
+    start := time.Now()
+    defer func() { metrics.RecordGRPC("ExecuteAtomic", outcome, time.Since(start)) }()
+```
+
+1. **Sharding gate.** `s.checkTenant(ctx, req.Context.TenantId)` — if not
+   ours, set trailer `entdb-redirect-node` with `sharding.GetOwner` and
+   return `codes.Unavailable`. Region mismatch → `codes.FailedPrecondition`.
+2. **Required fields.** `tenant_id`, `actor`, `operations` all non-empty,
+   else `codes.InvalidArgument`.
+3. **Trusted actor.** `actor := auth.AuthoritativeActor(ctx,
+   req.Context.Actor)` — REBIND the local var; never re-read
+   `req.Context.Actor` past this line. (PR #168 invariant.)
+4. **Idempotency key.** `idem := req.IdempotencyKey; if idem == "" { idem =
+   uuid.NewString() }`.
+5. **Schema fingerprint.** If `req.SchemaFingerprint != "" &&
+   s.schema.Fingerprint() != "" && != req.SchemaFingerprint` → return
+   `&pb.ExecuteAtomicResponse{Success:false, Error:..., ErrorCode:
+   "SCHEMA_MISMATCH"}, nil` and record `"error"` metric. Do NOT abort.
+6. **Convert operations.** For each `Operation`:
+   - `create_node`: copy fields; **`data = schema.NameToIDKeys(structToMap(create.Data),
+     create.TypeId)`** (id-keyed payload — CLAUDE.md invariant 6); convert
+     `acl` proto → list; map storage-mode enum → string
+     (`TENANT`/`USER_MAILBOX`/`PUBLIC`); preserve `as`, `fanout_to`,
+     `target_user_id`.
+   - `update_node`: `patch = schema.NameToIDKeys(...)`; preserve `id`, `type_id`.
+   - `delete_node`: `type_id`, `id`.
+   - `create_edge` / `delete_edge`: `convertNodeRef(from)`, `convertNodeRef(to)`;
+     `props = structToMap` (NOT translated — edges are properties-shaped,
+     not declared-fields-shaped).
+7. **Fast-fail unique pre-checks** (best-effort, race winner is the unique
+   index at apply time):
+   - For each `create_node` op with unique fields: call
+     `store.GetNodeByKey(tenant, typeID, fieldID, value)`; non-nil →
+     `codes.AlreadyExists`.
+   - Same for composite uniques via `store.GetNodeByCompositeKey`.
+8. **Tenant access.** `s.checkTenantAccess(ctx, tenant, trustedActor,
+   requireWrite=true, opKind=("delete" if hasDelete else "write"))`.
+9. **Server-fill IDs.** For each `create_node` with empty `id`, set
+   `op.ID = uuid.NewString()`; record into `createdNodeIDs` in op order.
+10. **Build event.**
+    ```go
+    event := map[string]any{
+        "tenant_id": tenant, "actor": trustedActor,
+        "idempotency_key": idem,
+        "schema_fingerprint": s.schema.Fingerprint(),
+        "ts_ms": time.Now().UnixMilli(),
+        "ops": ops,
+    }
+    payload, _ := json.Marshal(event)
+    ```
+    JSON encoding must be byte-stable enough that replay produces identical
+    state — see Determinism section.
+11. **WAL append.** `pos, err := s.wal.Append(ctx, s.topic, tenant, payload)`.
+    On err → in-band `Success=false, ErrorCode="INTERNAL"`, return `nil, nil`.
+    `tenant` is the partition key — keeps a tenant's events on one partition
+    (in-order replay).
+12. **Build receipt.** `Receipt{TenantId: tenant, IdempotencyKey: idem,
+    StreamPosition: posString}` (empty string when `pos` zero/None).
+13. **Optional apply-wait.** If `req.WaitApplied && pos != ""`:
+    `applied := s.store.WaitForOffset(ctx, tenant, posString, timeout)`;
+    set `appliedStatus = APPLIED` on success, else `PENDING`.
+14. **Return.** `&pb.ExecuteAtomicResponse{Success: true, Receipt: receipt,
+    CreatedNodeIds: createdNodeIDs, AppliedStatus: appliedStatus}`.
+
+The applier (separate goroutine consuming from WAL) is the SQLite writer.
+The handler MUST NOT touch SQLite for mutations (CLAUDE.md invariant 1).
+The single-tenant happy-path puts handler latency at: tenant gate +
+fast-fail uniques (1–2 SQLite reads) + WAL append + optional offset wait.
+
+## Determinism + replay
+
+The applier is replayed on rebuilds; **identical input must produce
+identical SQLite state** (`test_wal_replay_determinism.py:179`).
+
+- **`ts_ms` is captured at handler time and stored in the event**
+  (`grpc_server.py:783`). The applier uses `event.ts_ms` for `created_at` /
+  `updated_at`, NOT `time.Now()`. Pinned by the determinism test. Go port
+  must do the same — never call `time.Now()` inside the apply path.
+- **`applied_at` in `applied_events` uses `time.Now()` at apply time**
+  (`applier.py:891,1260`). This is metadata, not state used for joins, so
+  the determinism test does not pin it. Acceptable to differ on replay.
+- **`idempotency_key` is the dedup key**: replays of the same WAL event are
+  no-ops. The Go applier must keep the `applied_events` UNIQUE-keyed by
+  `(tenant_id, idempotency_key)` and check inside the txn.
+- **Server-generated UUIDs for empty `create_node.id`** are written into
+  the WAL event before append (`grpc_server.py:771`). Replay reads the same
+  ID off the log — this is what makes IDs deterministic across replays.
+  Go port: generate the UUID **before** WAL append, never inside the
+  applier.
+- **Map iteration order risk.** Python `json.dumps` produces stable output
+  for dicts because Python 3.7+ dicts are insertion-ordered. Go's
+  `encoding/json` sorts map keys alphabetically. Both are stable, but the
+  bytes will differ — that is fine because the WAL stores bytes and the
+  applier re-parses to a map; reads of `event.ts_ms` etc. don't depend on
+  key order. Document this in the Go applier so reviewers don't add a
+  "match Python's exact bytes" requirement.
+- **`storage_mode` resolution.** `_event_storage_mode` walks ops in order
+  to detect mixed-mode (`applier.py:629-667`). Go port must walk in the
+  same order — but since mixed-mode raises, the only observable difference
+  on replay is which op the error message names. Test file does not pin
+  the message, so order does not matter functionally.
+- **Alias resolution** (`_node_alias_map`) must be cleared per event
+  (`applier.py:776,911`). Carrying state across events is a determinism
+  hazard.
+- **Quota counter** (`_increment_usage_safe`) is post-commit and
+  fire-and-forget. On replay, only events that actually committed (skipped
+  duplicates excluded) bump the counter — this is correct because the WAL
+  is the only producer of writes.
+
+## Open questions / risks
+
+1. **No per-op `Permission` check today.** The Go port must preserve this
+   to avoid breaking integration tests, but it is a known gap (any tenant
+   member with write role can create any `type_id`). Track separately —
+   not in scope for the port.
+2. **Schema mismatch is in-band, not an abort.** Surprising — the Go port
+   should keep it for SDK compatibility but consider documenting it as a
+   wart. Pinned by `test_grpc_schema_mismatch_metric.py:51`.
+3. **`ts_ms` from the gRPC layer means clock skew between gRPC nodes
+   becomes part of the event log.** No NTP requirement is currently
+   enforced. Replay is still deterministic per-event, but ordering across
+   producers depends on partition append order, not `ts_ms`.
+4. **Best-effort unique pre-check is racy.** The handler calls
+   `store.GetNodeByKey` BEFORE WAL append, but the applier of an
+   in-flight event may not have committed yet. Two concurrent
+   `ExecuteAtomic` calls with the same unique value can both pass the
+   pre-check; the unique expression index at apply time then fails the
+   second event, and `GetReceiptStatus` reports `FAILED`. Documented in
+   `grpc_server.py:660-666`. Go port must replicate, including the in-band
+   nature of the failure (NOT an abort).
+5. **`wait_applied` blocks the gRPC call.** Default 30s timeout. Under
+   slow apply or WAL backpressure, this can balloon the call duration —
+   the Go port should plumb the request `context.Context` deadline through
+   `Store.WaitForOffset` so client cancellation is honored.
+6. **Mailbox-fanout determinism on replay** — `_fanout_node` happens
+   post-commit and is NOT bounded by the WAL. If a replay re-runs fanout,
+   downstream notifications can duplicate. Out of scope for ExecuteAtomic
+   port; worth flagging for the applier port.
+7. **Handler logs `exc_info=True` on the WAL-append exception
+   (`grpc_server.py:819`).** The Go port should keep stack-trace logging
+   for production triage.
+8. **`error_code` is a `string`, not a proto enum.** Only two values
+   today (`SCHEMA_MISMATCH`, `INTERNAL`). Resist the urge to enumify in
+   the port — it would change the wire schema.

--- a/docs/go-port/rpcs/ExportUserData.md
+++ b/docs/go-port/rpcs/ExportUserData.md
@@ -1,0 +1,238 @@
+# ExportUserData — Go Port Spec
+
+EPIC #407. GDPR Article 20 portability: emit every node a user owns or
+is the subject of, **across every tenant they're a member of**, as a
+JSON bundle. Cross-tenant by construction.
+
+Python source of truth: `server/python/entdb_server/api/grpc_server.py:3014-3070`.
+Per-tenant collector: `server/python/entdb_server/apply/canonical_store.py:5174-5249`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:137` (RPC), `:1027-1037` (messages).
+
+```
+rpc ExportUserData(ExportUserDataRequest) returns (ExportUserDataResponse);
+ExportUserDataRequest  { string actor = 1; string user_id = 2; }
+ExportUserDataResponse { bool success = 1; string export_json = 2;
+                         string error = 3; }
+```
+
+**Sync, single-call, no job ID.** Bundle built in-process, returned
+inline as `export_json`. No streaming RPC, no async job, no signed URL,
+no resumable download. Format:
+
+```
+{ "user_id": "...", "generated_at": <unix_seconds>,
+  "tenants": [ { "tenant_id", "nodes": [ { "tenant_id", "node_id",
+    "type_id", "payload", "created_at", "updated_at",
+    "owner_actor", "data_policy" }, ... ] }, ... ] }
+```
+
+Pinned by `tests/python/unit/test_gdpr_engine.py:678-692`.
+
+`payload` is **id-keyed** per invariant #6 — `_sync_export_user_data`
+(`canonical_store.py:5211`) returns `json.loads(payload_json)` raw. This
+bypasses `Struct` serialization (the field is `string`, not
+`google.protobuf.Struct`); the Go port uses `encoding/json` to marshal
+a `map[string]any`.
+
+## Auth
+
+1. **`actor` and `user_id` required** (`grpc_server.py:3024-3027`):
+   empty → `INVALID_ARGUMENT`.
+2. **Trusted-actor only.** `_is_self_or_admin`
+   (`grpc_server.py:2071-2086`) calls
+   `auth.auth_interceptor.get_authoritative_actor(actor)` and **ignores
+   the wire-supplied actor for the decision**. Allowed:
+   - `trusted == f"user:{user_id}"` or `trusted == user_id` — **self**.
+   - `system:*` / `admin:*` / `__system__` — **admin / compliance**.
+   - else → `PERMISSION_DENIED` `"ExportUserData requires the user
+     themselves or an admin actor"` (`grpc_server.py:3028-3032`).
+   Pinned by `tests/python/unit/test_gdpr_engine.py:696-704` and
+   `tests/python/integration/test_grpc_contract.py:649-653`
+   (actor=ALICE, user_id="bob" → permission_denied).
+3. **No per-tenant capability check.** Self/admin alone authorizes the
+   walk over all `get_user_tenants`. Cross-tenant invariant #4 holds
+   because each tenant's SQLite is read with its own connection.
+4. **No `RequestContext`.** Flat `actor` + `user_id` — no `tenant_id`,
+   no sharding redirect, no region pin.
+5. `global_store is None` → `UNIMPLEMENTED "User registry not configured"`
+   (`grpc_server.py:3022-3023`).
+
+## Side effects
+
+**Read-only across tenants + global_store.** No WAL append, no SQLite
+writes, no artifact persistence.
+
+- `global_store.get_user_tenants(user_id)` — global SQLite read for
+  membership list (`grpc_server.py:3034`).
+- For each tenant: `canonical_store.export_user_data_for_tenant`
+  → `_run_sync(_sync_export_user_data)` → per-tenant SQLite read of
+  `nodes WHERE tenant_id = ?` (`canonical_store.py:5193-5198`).
+  Per-tenant connections, never a cross-tenant transaction.
+- Per-tenant exceptions are **caught and logged**, not propagated
+  (`grpc_server.py:3048-3053`) — one bad tenant does not fail the bundle.
+- `record_grpc_request("ExportUserData", …)` metric.
+
+**No artifact written** — bundle returned inline; no encryption-at-rest
+layer because there is no artifact, only TLS in transit.
+
+**No WAL audit record of the export itself.** This is a *read*, so
+"all writes through WAL" (invariant #1) is not violated, but Article 30
+record-of-processing is currently only captured by the auth
+interceptor's structured logs + metrics — not by the tamper-evident
+S3-Object-Lock WAL. See open questions.
+
+## Error contract
+
+First failure wins:
+
+1. `global_store is None` → `UNIMPLEMENTED`.
+2. `actor == ""` → `INVALID_ARGUMENT "actor is required"`.
+3. `user_id == ""` → `INVALID_ARGUMENT "user_id is required"`.
+4. Not self/admin/system → `PERMISSION_DENIED`.
+5. Per-tenant collector failure → **swallowed** (logged, tenant omitted
+   from `tenants[]`). Bundle still returns `success=true`.
+6. Unexpected exception elsewhere → `success=false, error=str(e)`,
+   gRPC status `OK`, metric `error` (`grpc_server.py:3065-3070`).
+
+**Go port:** real aborts via `status.Errorf`. The Python try/except
+swallow is unreachable in `grpc.aio` production paths; preserve the
+`success=false, error=…` shape only for genuine internal errors.
+
+## Shared Go package deps
+
+(Paths proposed; replace with whatever EPIC #407 freezes.)
+
+- `auth.AuthoritativeActor(ctx) string` — same as `GetNode` spec.
+- `auth.IsSelfOrAdmin(trusted, userID) bool` — encodes the
+  `user:{id}` / `system:` / `admin:` / `__system__` rules
+  (`grpc_server.py:2071-2086`). **Shared with** `DeleteUser`,
+  `FreezeUser`, `CancelUserDeletion`.
+- `globalstore.Store.GetUserTenants(ctx, userID) ([]Membership, error)`.
+- `canonical.Store.ExportUserData(ctx, tenantID, principal, registry) (TenantExport, error)`
+  — port of `_sync_export_user_data`. Filter: `owner_actor == principal`
+  OR `payload[subject_field] == user_id`. Drop nodes whose
+  `DataPolicy == AUDIT` (`canonical_store.py:5215-5221`). Preserve
+  id-keyed payload.
+- `schema.Registry.GetDataPolicy(typeID)`,
+  `schema.Registry.GetSubjectField(typeID)` — missing type → fall back
+  to `DataPolicy.PERSONAL`, no subject field
+  (`canonical_store.py:5204-5208`).
+- `metrics.RecordGRPCRequest`.
+- `encoding/json` for the bundle (no `Struct`).
+
+## Other-RPC deps (DeleteUser pipeline)
+
+- **`DeleteUser`** (`grpc_server.py:2925-2981`) — paired GDPR pipeline:
+  (1) `ExportUserData` returns portability bundle; (2)
+  `DeleteUser(grace_days=N)` schedules deletion; (3)
+  `CancelUserDeletion` undoes (2) within grace. Go port keeps
+  `IsSelfOrAdmin` shared across `Delete/Export/Freeze/CancelUserDeletion`
+  — same call sites: `grpc_server.py:2944, 2997, 3028, 3086`.
+- `canonical_store.export_user_data_for_tenant` is also exercised
+  indirectly by `RevokeAllUserAccess` and `TransferUserContent`. Keep
+  the per-tenant collector pure — no WAL appends inside it.
+- Go SDK already exposes the call: `sdk/go/entdb/client.go:114-117,
+  982-989`, `sdk/go/entdb/admin.go:151`. Port keeps wire shape identical
+  so the SDK is unchanged.
+
+## Contract tests pinning behavior
+
+- `tests/python/unit/test_gdpr_engine.py:678-692` — happy: bundle has
+  `user_id`, `tenants[0].nodes` length 1, owner-match.
+- `tests/python/unit/test_gdpr_engine.py:696-704` — auth: foreign actor
+  → `PERMISSION_DENIED`.
+- `tests/python/unit/test_gdpr_engine.py:418-448` —
+  `_sync_export_user_data` unit cases: owner-match, subject-field
+  match, AUDIT-policy exclusion, multi-tenant scoping.
+- `tests/python/integration/test_grpc_contract.py:643-648` — happy:
+  `actor=ALICE, user_id="alice"` → `success=True`.
+- `tests/python/integration/test_grpc_contract.py:649-653` — denied:
+  `actor=ALICE, user_id="bob"` → `permission_denied`.
+- `sdk/go/entdb/admin_gdpr_test.go:76-94` — SDK passes the JSON string
+  through unparsed; do not double-encode.
+
+## Implementation outline
+
+```go
+func (s *EntDBServer) ExportUserData(
+    ctx context.Context, req *pb.ExportUserDataRequest,
+) (*pb.ExportUserDataResponse, error) {
+    start := time.Now()
+    label := "ok"
+    defer func() { metrics.RecordGRPCRequest("ExportUserData", label, time.Since(start)) }()
+
+    if s.globalStore == nil {
+        label = "error"
+        return nil, status.Error(codes.Unimplemented, "User registry not configured")
+    }
+    if req.Actor == "" {
+        label = "error"
+        return nil, status.Error(codes.InvalidArgument, "actor is required")
+    }
+    if req.UserId == "" {
+        label = "error"
+        return nil, status.Error(codes.InvalidArgument, "user_id is required")
+    }
+    trusted := auth.AuthoritativeActor(ctx) // ignore req.Actor for the decision
+    if !auth.IsSelfOrAdmin(trusted, req.UserId) {
+        label = "error"
+        return nil, status.Error(codes.PermissionDenied,
+            "ExportUserData requires the user themselves or an admin actor")
+    }
+
+    memberships, err := s.globalStore.GetUserTenants(ctx, req.UserId)
+    if err != nil { label = "error"; return errResp(err), nil }
+
+    principal := req.UserId
+    if !strings.HasPrefix(principal, "user:") { principal = "user:" + principal }
+
+    tenants := make([]canonical.TenantExport, 0, len(memberships))
+    for _, m := range memberships {
+        data, err := s.canonical.ExportUserData(ctx, m.TenantID, principal, s.schema)
+        if err != nil { log.Warn().Str("tenant", m.TenantID).Err(err).Msg("tenant failed"); continue }
+        tenants = append(tenants, data)
+    }
+
+    raw, err := json.Marshal(map[string]any{
+        "user_id": req.UserId, "generated_at": time.Now().Unix(), "tenants": tenants,
+    })
+    if err != nil { label = "error"; return errResp(err), nil }
+    return &pb.ExportUserDataResponse{Success: true, ExportJson: string(raw)}, nil
+}
+```
+
+## Open questions / risks
+
+1. **Large export — no streaming.** `export_json` is a single `string`.
+   A user with 10M nodes across 100 tenants will OOM the server and
+   blow the default 4 MB gRPC max-message size. Python has no guard.
+   Options: (a) preserve and document; (b) add server-streaming
+   `ExportUserDataStream`; (c) write to S3 and return a signed URL.
+   Deferred to EPIC #407; **port preserves current shape**.
+2. **Encryption-at-rest of the artifact.** No artifact today, so N/A;
+   if (1c) is chosen the Go port must encrypt with the tenant KEK
+   (`server/python/entdb_server/crypto/`) and set S3 Object Lock
+   retention ≥ the WAL retention.
+3. **No WAL audit record of the export.** GDPR Article 30 record of
+   processing is only in interceptor logs + metrics today. Consider
+   appending an `EXPORT_USER_DATA` event to the WAL (audit-policy node
+   type) on success — makes the export itself tamper-evidently
+   auditable via S3 Object Lock without violating read-only response.
+4. **Per-tenant exception swallow** (`grpc_server.py:3048-3053`): a
+   corrupted tenant DB silently yields an *incomplete* portability
+   bundle — user thinks they have everything. Add `partial: true` /
+   `failed_tenants: []`? Behaviour-preserving port keeps silent
+   swallow until follow-up issue filed.
+5. **`DataPolicy.AUDIT` exclusion** (`canonical_store.py:5219-5221`):
+   audit records are **not** subject-access-requestable. Document
+   explicitly.
+6. **Subject-field match by name vs id.** Python compares
+   `payload.get(subject_field)` (`canonical_store.py:5216`);
+   `subject_field` is a registry name, but `payload` is id-keyed
+   (invariant #6). Latent bug — works only if the registry returns the
+   field id as a string. Port faithfully, file follow-up.
+7. **No allow-list of exportable types.** All non-AUDIT types walk —
+   intentional per Article 20 (export is exhaustive).

--- a/docs/go-port/rpcs/FreezeUser.md
+++ b/docs/go-port/rpcs/FreezeUser.md
@@ -1,0 +1,248 @@
+# FreezeUser — Go Port Spec
+
+EPIC #407. GDPR Article 18 ("restrict processing"): toggle a user
+between `active` and `frozen`. Freeze blocks user-initiated mutations
+but preserves all data (vs `DeleteUser` which tombstones, vs
+`RevokeAllUserAccess` which removes ACL grants). Python handler:
+`server/python/entdb_server/api/grpc_server.py:3072-3104`. Proto:
+`proto/entdb/v1/entdb.proto:138, 1039-1050`.
+
+## Wire contract
+
+Request `entdb.v1.FreezeUserRequest` (proto:1039-1044):
+- `string actor` — UNTRUSTED; see Auth. Trusted id from gRPC metadata.
+- `string user_id` — bare user id (`"alice"`), NOT a principal
+  (`"user:alice"`). Handler compares both forms (grpc_server.py:2086).
+- `bool enabled` — `true` → status `frozen`; `false` → `active`.
+
+Response `FreezeUserResponse` (proto:1046-1050):
+- `bool success` — `true` on apply, `false` on "user not found" and
+  on caught exception paths.
+- `string status` — the post-write status string (`"frozen"` or
+  `"active"`). Empty on the not-found / error paths.
+- `string error` — populated on not-found (`"User not found"`) and on
+  any caught non-gRPC exception. Empty on success.
+
+Idempotency: freezing an already-frozen user (or unfreezing an
+already-active user) is a no-op write that still returns
+`success=true, status=<new>` — `set_user_status` UPDATEs
+unconditionally, returns `True` iff a row matched (global_store.py:
+442-447). Pinned by `test_unfreeze_user_handler`
+(test_gdpr_engine.py:721-731) which calls FreezeUser twice.
+
+## Auth (compliance / admin; trusted-actor)
+
+- Identity: handler calls `_is_self_or_admin(request.actor,
+  request.user_id)` (grpc_server.py:3086, 2071-2086) which **discards
+  the payload actor** and uses
+  `auth_interceptor.get_authoritative_actor(actor)` (line 2083). Go
+  port MUST read trusted identity from gRPC context metadata, never
+  trust `request.actor`. Privilege-escalation matrix in
+  `tests/python/integration/test_privilege_escalation.py` covers this
+  family.
+- Allowed callers (line 2084-2086):
+  - any actor whose trusted id starts with `system:` or `admin:`
+  - the literal `__system__`
+  - the user themselves (trusted id == `user:<user_id>` or
+    `<user_id>`)
+- Pre-checks (in order, each `await context.abort` on failure):
+  1. `self.global_store` must be configured →
+     `UNIMPLEMENTED "User registry not configured"` (grpc_server.py:
+     3080-3081).
+  2. `request.actor` non-empty → `INVALID_ARGUMENT "actor is required"`
+     (3082-3083).
+  3. `request.user_id` non-empty → `INVALID_ARGUMENT "user_id is
+     required"` (3084-3085).
+  4. self-or-admin check → `PERMISSION_DENIED "FreezeUser requires
+     the user themselves or an admin actor"` (3086-3090).
+
+There is **no tenant scope** on this RPC — freeze is a global-store
+operation, mirroring `DeleteUser` (grpc_server.py:2925-2981). Do not
+add `_check_tenant_access` on the port.
+
+## Side effects (WAL append; flag in global_store; subsequent auth checks reject mutating ops)
+
+**INVARIANT VIOLATION IN PYTHON (carry-forward risk).** Python calls
+`global_store.set_user_status(user_id, new_status)` (grpc_server.py:
+3093 → global_store.py:434-447), writing directly to global-store
+SQLite and bypassing the WAL. Per `CLAUDE.md` invariant #1, freeze
+events are silently lost on WAL rebuild. Same shape as RevokeAccess.
+
+**Go-port decision: fix on port.** Append a WAL op
+`set_user_status` and apply it via the applier:
+
+```
+TransactionEvent.ops = [{
+    "type": "set_user_status",
+    "user_id": <string>,
+    "status": "frozen" | "active",
+}]
+```
+
+Applier: `UPDATE user_registry SET status=?, updated_at=? WHERE
+user_id=?`; `rowcount > 0` → `success`. Wait for receipt APPLIED
+before returning.
+
+The freeze flag is `user_registry.status` (global_store.py:207).
+Consulted on every mutating RPC by `_check_tenant_access(...,
+require_write=True)` (grpc_server.py:548-557): if status is `frozen`
+or `pending_deletion`, abort `PERMISSION_DENIED "User '<id>' is
+frozen and cannot write"`. Reads pass `require_write=False` — see
+`test_frozen_user_can_still_read` (test_gdpr_engine.py:754-767).
+
+**Read-still-allowed scope.** Freeze gates writes, NOT:
+- Pure-read RPCs (`GetNode`, `QueryNodes`, `GetMailbox`,
+  `SearchMailbox`, `ListSharedWithMe`, …).
+- `ExportUserData` (GDPR Article 20 portability carve-out).
+- Admin/system RPCs operating **on** the frozen user (`DeleteUser`,
+  `CancelUserDeletion`, `FreezeUser` unfreeze) — those go through
+  `_is_self_or_admin`, not `_check_tenant_access`.
+- Receipt status / health / schema reads.
+
+No data purged, no ACL grants removed, no mailbox rows deleted.
+The user’s nodes remain visible to peers via existing shares.
+
+## Error contract
+
+- `UNIMPLEMENTED` abort: global_store unconfigured (3080-3081).
+- `INVALID_ARGUMENT` abort: empty `actor` (3082-3083) or empty
+  `user_id` (3084-3085).
+- `PERMISSION_DENIED` abort: not self/admin/system (3086-3090).
+- `OK` + `{success:false, error:"User not found"}`: user_id unknown
+  (`set_user_status` returned False; line 3094-3096).
+- `OK` + `{success:true, status:<new>}`: happy path (3097-3098).
+- `OK` + `{success:false, error:str(e)}`: any other caught exception
+  (3099-3104). gRPC aborts re-raise unchanged via the
+  `isinstance(e, grpc.RpcError)` guard at line 3101.
+
+Do NOT promote "User not found" to `NOT_FOUND` — clients pin the
+in-band shape. Metrics: `record_grpc_request("FreezeUser", "ok",
+dur)` for happy + not-found; `"error"` for caught exception. Aborts
+emit no metric (raised before record).
+
+## Shared Go package deps (auth interceptor must consult freeze flag)
+
+- `internal/auth` — `AuthInterceptor.AuthoritativeActor(ctx)`,
+  `IsSelfOrAdmin(actor, userID)` mirroring grpc_server.py:2071-2086.
+  **Critical:** the auth interceptor’s write-path check (the Go
+  equivalent of `_check_tenant_access` at grpc_server.py:548-557)
+  MUST consult `GlobalStore.GetUser(userID).Status` and reject
+  `frozen` / `pending_deletion` for any mutating RPC. This is the
+  load-bearing enforcement; FreezeUser only sets the bit.
+- `internal/global` — `GlobalStore.SetUserStatus(userID, status)`
+  applier-side; `GlobalStore.GetUser(userID)` read-side (used by the
+  auth interceptor’s freeze gate).
+- `internal/wal` — `Wal.AppendAndWait(event)` for the
+  `set_user_status` op (post-fix; not present in Python).
+- `internal/apply` — applier op handler `set_user_status` writing to
+  the global-store SQLite; idempotent UPDATE.
+- `internal/metrics` — `RecordGrpcRequest("FreezeUser", label, dur)`
+  with labels `ok|error` (note: PERMISSION_DENIED aborts do NOT emit
+  a label — they raise before `record_grpc_request` is reached;
+  preserve this).
+- `internal/proto` (generated) — `entdb.v1.FreezeUserRequest`,
+  `FreezeUserResponse`.
+
+## Other-RPC deps (DeleteUser, RevokeAllUserAccess)
+
+- **DeleteUser** (grpc_server.py:2925-2981, proto:136, 1010-1024)
+  calls `set_user_status(user_id, "pending_deletion")` (line 2967).
+  `pending_deletion` is treated identically to `frozen` by the auth
+  gate (line 552). FreezeUser MUST NOT clobber `pending_deletion →
+  active` — Python does not guard this. Go port: reject
+  `enabled=false` when current status is `pending_deletion`; require
+  `CancelUserDeletion`.
+- **CancelUserDeletion** (grpc_server.py:2989-3017, proto:139) is
+  the inverse for `pending_deletion → active` (line 3004). Same
+  global-store path; same WAL violation; same fix.
+- **RevokeAllUserAccess** (proto:133, 994-1006) removes ACL grants
+  but does NOT touch `user_registry.status`. Complementary, not
+  equivalent: revoke destroys sharing; freeze blocks future writes
+  while preserving data.
+- **UpdateUser** (proto:914) exposes a `status` field. Go port
+  should funnel admin status writes through the same WAL op (or
+  drop the field in favor of FreezeUser / CancelUserDeletion).
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_gdpr_engine.py:707-717`
+  (`test_freeze_user_handler`) — freeze sets status `frozen` and
+  `resp.status == "frozen"`.
+- `tests/python/unit/test_gdpr_engine.py:720-731`
+  (`test_unfreeze_user_handler`) — toggle to `active`; idempotent.
+- `tests/python/unit/test_gdpr_engine.py:734-751`
+  (`test_freeze_user_rejects_writes`) — frozen user’s
+  `_check_tenant_access(require_write=True)` aborts
+  `PERMISSION_DENIED`. **Load-bearing test for the freeze gate.**
+- `tests/python/unit/test_gdpr_engine.py:754-767`
+  (`test_frozen_user_can_still_read`) —
+  `_check_tenant_access(require_write=False)` returns the role.
+- `tests/python/integration/test_privilege_escalation.py` — covers
+  FreezeUser trusted-actor enforcement.
+
+Test gaps to add on port: system/admin actor paths, INVALID_ARGUMENT
+paths, "User not found" in-band, `pending_deletion` interaction,
+WAL-replay determinism (unlocked by fix-on-port).
+
+## Implementation outline
+
+```go
+func (s *Server) FreezeUser(ctx context.Context,
+    req *pb.FreezeUserRequest) (*pb.FreezeUserResponse, error) {
+    start := time.Now()
+    if s.globalStore == nil {
+        return nil, status.Error(codes.Unimplemented, "User registry not configured")
+    }
+    if req.Actor == "" {
+        return nil, status.Error(codes.InvalidArgument, "actor is required")
+    }
+    if req.UserId == "" {
+        return nil, status.Error(codes.InvalidArgument, "user_id is required")
+    }
+    if !s.auth.IsSelfOrAdmin(ctx, req.UserId) {
+        return nil, status.Error(codes.PermissionDenied,
+            "FreezeUser requires the user themselves or an admin actor")
+    }
+    newStatus := "active"
+    if req.Enabled { newStatus = "frozen" }
+    evt := wal.GlobalEvent([]wal.Op{{Type: "set_user_status",
+        UserID: req.UserId, Status: newStatus}})
+    receipt, err := s.wal.AppendAndWait(ctx, evt)
+    if err != nil {
+        metrics.Record("FreezeUser", "error", start)
+        return &pb.FreezeUserResponse{Error: err.Error()}, nil
+    }
+    if receipt.RowsAffected == 0 {
+        metrics.Record("FreezeUser", "ok", start)
+        return &pb.FreezeUserResponse{Error: "User not found"}, nil
+    }
+    metrics.Record("FreezeUser", "ok", start)
+    return &pb.FreezeUserResponse{Success: true, Status: newStatus}, nil
+}
+```
+
+## Open questions / risks (read-still-allowed scope)
+
+1. **Read scope, precisely.** Reads-allowed is pinned only via the
+   `require_write` flag on `_check_tenant_access`. Audit Go port read
+   RPCs so none pass `require_write=true` (e.g. mailbox cache-warm
+   side effects). Keep "reads allowed" strict.
+2. **WAL parity vs. Python bug-for-bug.** Python does not WAL freeze
+   events; replays silently un-freeze users. Recommend fix-on-port
+   (matches RevokeAccess decision). Tests pin only post-call status.
+3. **`pending_deletion` clobber.** Python lets FreezeUser
+   `enabled=false` overwrite `pending_deletion` with `active`,
+   silently cancelling a scheduled deletion. Recommend Go port
+   reject with `FAILED_PRECONDITION "use CancelUserDeletion"`.
+4. **Self-unfreeze.** Python allows self-unfreeze via the self arm
+   of `_is_self_or_admin`. For GDPR Article 18 this is debatable —
+   the regulator may have requested the freeze. Match Python today;
+   flag for product/legal.
+5. **`ExportUserData` carve-out.** Confirm `ExportUserData`
+   (proto:137) never sets `require_write=true`. GDPR Article 20
+   portability must remain available under freeze.
+6. **Interceptor placement.** The freeze gate lives in
+   `_check_tenant_access` per-handler. Consider lifting into the
+   auth interceptor so new mutating RPCs inherit the gate — only if
+   the interceptor can cheaply resolve "is this RPC a write?" (proto
+   annotation or method-name allowlist).

--- a/docs/go-port/rpcs/GetConnectedNodes.md
+++ b/docs/go-port/rpcs/GetConnectedNodes.md
@@ -1,0 +1,147 @@
+# RPC Port Spec — `entdb.v1.EntDBService/GetConnectedNodes`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:1712-1744`. Storage layer at
+`server/python/entdb_server/apply/canonical_store.py:3267-3422` (sync core)
+and `:3424-3438` (async wrapper).
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:91` (rpc), `:707-718` (messages).
+
+`GetConnectedNodesRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `context` | 1 | `RequestContext` | tenant_id + actor (UNTRUSTED — see Auth). |
+| `node_id` | 2 | `string` | Source node — the "from" side of the edge join. Required (empty string is a vacuous query, returns `[]`). |
+| `edge_type_id` | 3 | `int32` | Single edge-type filter. Mandatory; there is no "all edge types" sentinel. |
+| `limit` | 4 | `int32` | `<= 0` → coerce to `100` (`grpc_server.py:1726`). No upper cap today (open question below). |
+| `offset` | 5 | `int32` | `<= 0` → coerce to `0` (`grpc_server.py:1733`). |
+
+`GetConnectedNodesResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `nodes` | 1 | `repeated Node` | Connected nodes ordered by `n.created_at DESC` (`canonical_store.py:3328, 3358, 3405`). Payload is **field-id-keyed** (`{"1": "..."}`), not name-keyed — see `tests/python/unit/test_payload_wire_format.py:13-25`. |
+| `has_more` | 2 | `bool` | `len(nodes) == limit` (`grpc_server.py:1739`). Heuristic only — not a true "more rows exist" signal; clients must page until they get a short page. |
+
+**Direction: outbound only.** Python's storage path joins `edges e ON e.to_node_id = n.node_id` filtered by `e.from_node_id = node_id`
+(`canonical_store.py:3317-3321, 3338-3341, 3400-3404`). To traverse the inverse direction, callers use a different RPC; this one does NOT honour a `direction` param.
+
+**Depth: 1 (single hop).** This is NOT a multi-hop traversal — the SQL is a single `nodes JOIN edges` and never recurses. There is no `depth` field on the request and no cycle handling in the handler (the storage layer simply has no recursion to cycle on). Multi-hop discovery is a client concern; see Open Questions.
+
+## Auth
+
+- **Authentication required.** Standard `AuthInterceptor` path; method is **not** in `UNAUTHENTICATED_METHODS`.
+- **Trusted-actor invariant** (CLAUDE.md issue #168): handler immediately rebinds the actor at `grpc_server.py:1721` via `self._trusted_actor(request.context.actor)` (defined `:418-437`), which delegates to `get_authoritative_actor` — the `ContextVar` set by `AuthInterceptor` ALWAYS wins over `request.context.actor`. Go port MUST mirror: never trust the wire-actor for any downstream check.
+- **Group expansion**: `canonical_store.resolve_actor_groups(tenant_id, trusted_actor)` (`grpc_server.py:1722-1725`) returns the principal's transitive group IDs. The result list is what flows into `actor_ids` for ACL filtering.
+- **Per-node ACL filter across the traversal**, two-stage:
+  1. **Source gate** (`canonical_store.py:3291-3293`): if the actor cannot access `node_id`, return `[]` immediately. Pinned by `tests/python/unit/test_acl_v2.py:509-515`.
+  2. **Target filter**, branches on the edge type's `propagates_acl` flag (`canonical_store.py:3299-3309`):
+     - `propagates_acl=1` → "fast path": every connected node is visible **except** those with an explicit `node_access.permission='deny'` for any of `actor_ids` (`canonical_store.py:3311-3332`). Pinned by `test_acl_v2.py:496-507`.
+     - `propagates_acl=0` → "slow path": each child must independently satisfy `owner_actor IN actor_ids` OR exist in `node_visibility` for the principal OR have a non-deny `node_access` row (`canonical_store.py:3334-3371`).
+- **System actor bypass**: when `SYSTEM_ACTOR` (server-internal service identity) appears in `actor_ids`, ACL is skipped entirely (`canonical_store.py:3281-3289`). Pinned by `test_acl_v2.py:517-522`. Go port: keep this — it is how `Applier`-driven re-fanouts read graph state.
+- **No capability/Permission check**. The RPC is read-only; the gate is "read access on source" + "not denied on target". There is no `Permission.READ_GRAPH`-style check.
+- **Tenant gate**: `await self._check_tenant(...)` (`grpc_server.py:1720`) — verifies tenant exists and is not suspended. Failure surfaces as `PermissionDenied` from the helper (Go port should preserve this code).
+
+## Side effects
+
+**Read-only.** No WAL append, no SQLite write, no `global_store` mutation, no quota debit, no audit-log entry. Architecturally invariant per CLAUDE.md §1: this RPC has no business writing the WAL.
+
+**Potentially heavy.** The slow path (`propagates_acl=0`) executes a `nodes JOIN edges` plus three correlated `EXISTS` subqueries against `node_visibility` and `node_access`, each parameterised with the full `actor_ids` set. For a hot user in many groups against a fan-out parent with 100k children this can scan a lot. The handler does NOT charge a quota and does NOT timeout the SQL — Go port should add a `context.Context` deadline pass-through to the SQL driver (Python lacks this) but MUST NOT add a behavior change beyond cancellation.
+
+In-order narration the Go handler should preserve:
+1. `start := time.Now()`.
+2. `_check_tenant(ctx, request.context.tenant_id)` — tenant existence/status gate.
+3. `trusted := trusted_actor(request.context.actor)` (read from interceptor ContextVar equivalent — `auth.AuthoritativeActor(ctx)`).
+4. `actorIDs := canonicalStore.ResolveActorGroups(ctx, tenantID, trusted)`.
+5. `limit := request.Limit; if limit <= 0 { limit = 100 }`.
+6. `offset := request.Offset; if offset < 0 { offset = 0 }`.
+7. `nodes, err := canonicalStore.GetConnectedNodes(ctx, tenantID, request.NodeId, request.EdgeTypeId, actorIDs, limit, offset)`.
+8. `record_grpc_request("GetConnectedNodes", "ok"|"error", elapsed)` — both arms.
+9. Return `&pb.GetConnectedNodesResponse{Nodes: protoNodes, HasMore: len(nodes) == limit}`.
+
+## Error contract
+
+| gRPC code | Trigger | Notes |
+|-----------|---------|-------|
+| `OK` | Happy path, including empty result. Source-not-accessible returns `OK` with `nodes=[]` — do NOT leak existence via a different code. |
+| `OK` (degraded) | **Any** handler exception falls into the broad `except Exception` at `grpc_server.py:1741-1744` and returns `GetConnectedNodesResponse(nodes=[])`. This is the **current Python contract** — pinned by `tests/python/integration/test_grpc_contract.py:255-266` (happy seed-empty case returns `nodes=[]` cleanly). The contract test does NOT explicitly require swallowing internal errors, but Go port should preserve "empty list on internal error" to match observed client behavior; log at error severity. |
+| `PERMISSION_DENIED` | Raised by `_check_tenant` for unknown / suspended tenant — surfaces from the helper, gets caught by the broad `except` and rewritten to empty list in Python. Recommended Go port: let `PermissionDenied` propagate (do NOT swallow tenant-gate errors); only swallow the SQL/decode errors. Track as a **deliberate behavior tightening** in the EPIC. |
+| `UNAUTHENTICATED` | Auth interceptor — never reached by handler. |
+| `INVALID_ARGUMENT` | Currently never raised. `node_id=""` and `edge_type_id=0` both yield empty result via SQL filtering, not a 4xx. Preserve. |
+
+## Shared Go package deps
+
+New packages under `server/go/internal/...` unless noted.
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `GetConnectedNodesRequest`, `GetConnectedNodesResponse`, `Node`, `RequestContext`. Required.
+- `auth` — `AuthoritativeActor(ctx) string` (mirrors `auth_interceptor.get_authoritative_actor`). Required.
+- `canonicalstore` — must export `ResolveActorGroups(ctx, tenantID, actor) ([]string, error)`, `GetConnectedNodes(ctx, tenantID, nodeID string, edgeTypeID int32, actorIDs []string, limit, offset int32) ([]Node, error)`, plus internal `canAccess` helper (`canonical_store.py:3292`). The Go SQL builder MUST mirror the two SQL branches (propagates / does-not-propagate) — see Implementation outline.
+- `tenantgate` — `CheckTenant(ctx, tenantID) error` (mirrors `_check_tenant` at `grpc_server.py:362`).
+- `metrics` — `RecordGRPCRequest("GetConnectedNodes", status, dur)`.
+- `proto` (internal) — `nodeToProto(n Node) *pb.Node` mirroring `_node_to_proto` (`grpc_server.py:1693-1710`); payload must be **id-keyed** (`test_payload_wire_format.py:13-25`).
+
+NOT used and MUST NOT be imported: `wal`, `apply`, `audit`, `quota`, `crypto`. Read-only RPC.
+
+## Other-RPC deps
+
+- Shares the SQL infrastructure used by `GetEdgesFrom` / `GetEdgesTo` (the `edges` table join + `from_node_id` / `to_node_id` indexing). `GetConnectedNodes` is essentially `GetEdgesFrom` followed by an `IN (target_ids)` `nodes` lookup, fused into a single SQL — there is no shared Go function today, but the Go port should extract `edgesFromQuery(...)` so all three RPCs build identical join plans. See companion specs `GetEdgesFrom.md` and `GetEdgesTo.md` (TODO under same EPIC).
+- Shares ACL filter primitives with `ListSharedWithMe`, `GetNode`, `QueryNodes` — `node_access` deny-check, `node_visibility` lookup, `owner_actor` match. Factor into `canonicalstore/acl.go`.
+- Depends on `ResolveActorGroups` semantics also used by `GetNode`, `Share/RevokeAccess`, `ListSharedWithMe`. Port that helper FIRST.
+
+## Contract tests pinning behavior
+
+- `tests/python/integration/test_grpc_contract.py:255-266` — happy path over real gRPC channel: empty graph returns `nodes=[]`. The Go server must pass this verbatim once stubs are swapped.
+- `tests/python/unit/test_acl_v2.py:483-494` — propagates_acl=1, source shared, returns both children.
+- `tests/python/unit/test_acl_v2.py:496-507` — explicit deny on a child filters it out even when the edge propagates.
+- `tests/python/unit/test_acl_v2.py:509-515` — no access to source → empty result (does NOT leak existence).
+- `tests/python/unit/test_acl_v2.py:517-522` — `SYSTEM_ACTOR` bypasses ACL completely.
+- `tests/python/unit/test_acl_v2_extended.py:257-270` — pagination with limit=5, offset=5 returns disjoint pages.
+- `tests/python/benchmarks/bench_acl.py:104, 114` — perf budget for hot/cold paths (30/31 children); Go port should beat or match.
+- `tests/python/unit/test_sdk_hierarchical.py:215-226` — SDK delegate signature (`tenant_id`, `actor`, `node_id`, `edge_type_id`); kwargs locked.
+- `tests/python/unit/test_payload_wire_format.py:13-25` — payload is field-id-keyed on the wire, not name-keyed. Mandatory regression guard.
+
+## Implementation outline
+
+```go
+// server/go/internal/api/get_connected_nodes.go
+func (s *EntDBServer) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNodesRequest) (*pb.GetConnectedNodesResponse, error) {
+    start := time.Now()
+    status := "ok"
+    defer func() { metrics.RecordGRPCRequest("GetConnectedNodes", status, time.Since(start)) }()
+
+    if err := s.tenantGate.CheckTenant(ctx, req.Context.TenantId); err != nil {
+        status = "error"; return nil, err // PERMISSION_DENIED — propagate, do NOT swallow
+    }
+    trusted := auth.AuthoritativeActor(ctx, req.Context.Actor)
+    actorIDs, err := s.canon.ResolveActorGroups(ctx, req.Context.TenantId, trusted)
+    if err != nil { status = "error"; return &pb.GetConnectedNodesResponse{}, nil } // match Python swallow
+
+    limit := req.Limit; if limit <= 0 { limit = 100 }
+    offset := req.Offset; if offset < 0 { offset = 0 }
+
+    nodes, err := s.canon.GetConnectedNodes(ctx, req.Context.TenantId, req.NodeId, req.EdgeTypeId, actorIDs, limit, offset)
+    if err != nil { status = "error"; log.Error(...); return &pb.GetConnectedNodesResponse{}, nil }
+
+    out := make([]*pb.Node, len(nodes))
+    for i, n := range nodes { out[i] = nodeToProto(n) }
+    return &pb.GetConnectedNodesResponse{Nodes: out, HasMore: int32(len(nodes)) == limit}, nil
+}
+```
+
+Storage `GetConnectedNodes` mirrors `canonical_store.py:3267-3385` exactly:
+1. If `slices.Contains(actorIDs, SystemActor)` → run unfiltered SQL (`canonical_store.py:3387-3422`).
+2. Source gate: `canAccess(tenantID, nodeID, actorIDs)` — empty list short-circuit.
+3. Lookup `propagates_acl` for the edge type via the seed `from_node_id` join (`canonical_store.py:3299-3309`). Fallback to `false` when no edge row exists.
+4. Branch the SQL: fast path uses `NOT EXISTS deny`; slow path uses `(owner OR visibility OR non-deny access)` triple-EXISTS. Use named parameters / `sqlx.In` to expand `actorIDs` placeholders rather than naive string concat.
+5. Map rows → `Node` via `Node.from_row` equivalent — payload deserialised from `payload_json` blob, ACL from `acl_blob`. Must remain field-id-keyed.
+
+## Open questions / risks
+
+- **No upper bound on `limit`.** A pathological client can request `limit=2_000_000_000`. Python relies on SQLite's int handling; Go must clamp (`min(limit, 1000)` is the convention used elsewhere). Verify against benchmark expectations before clamping — clamping changes wire behavior and needs an EPIC-tracked decision.
+- **`has_more` is a heuristic.** When `len(nodes) == limit` and the underlying graph happens to have exactly `limit` matches, `has_more=true` lies. Document; do not fix in this RPC (would require an extra `LIMIT n+1` round-trip and break the contract test).
+- **Cycle handling: N/A at depth=1**, but if the EPIC adds a `depth` field later, the SQL becomes recursive and needs a visited set. Track separately; do NOT add depth>1 in the Go port without a fresh proto rev.
+- **Result-size memory cap.** `nodes JOIN edges` materialises every row into Go heap before serialisation. For `limit=100` this is fine; if the cap is raised, switch to a streaming server-side cursor + `grpc.ServerStream` (would require a proto break — out of scope here).
+- **Slow-path fan-out** with a user in 200+ groups expands into a 600+ placeholder SQL. SQLite's parser cap is ~32k params per statement; risk surfaces only at extreme scale, but Go port should batch when `len(actorIDs) > 500`.
+- **Payload-key contract drift.** `_node_to_proto` emits `_dict_to_struct(n.payload)` — if `n.payload` is name-keyed in storage (legacy rows), the wire becomes name-keyed and silently breaks the Go SDK. Add a Go-side guard: assert keys are numeric strings; log+alert otherwise.
+- **`PermissionDenied` swallowing.** Python's broad `except` masks tenant-gate failures as empty results. Recommended Go behavior: propagate `PermissionDenied`; coordinate with EPIC #407 owner because clients may rely on the empty-list signal.

--- a/docs/go-port/rpcs/GetEdgesFrom.md
+++ b/docs/go-port/rpcs/GetEdgesFrom.md
@@ -1,0 +1,234 @@
+# GetEdgesFrom — Go port spec
+
+EPIC #407. Mirror of Python `EntDBServicer.GetEdgesFrom`
+(`server/python/entdb_server/api/grpc_server.py:1384-1418`). Reads the
+outgoing edges of a node from per-tenant SQLite. Pure read; no WAL
+writes.
+
+## Wire contract
+
+- Service: `entdb.v1.EntDBService`
+- Method: `GetEdgesFrom`, full name `/entdb.v1.EntDBService/GetEdgesFrom`
+  (`sdk/go/entdb/internal/pb/entdb_grpc.pb.go:63`).
+- Proto: `proto/entdb/v1/entdb.proto:64` —
+  `rpc GetEdgesFrom(GetEdgesRequest) returns (GetEdgesResponse);`
+- `GetEdgesRequest` (`proto/entdb/v1/entdb.proto:476-486`):
+  - `RequestContext context = 1` — `tenant_id` (required), `actor`
+    (advisory; do NOT trust — see Auth), `trace_id`.
+  - `string node_id = 2` — source node; matched against
+    `edges.from_node_id`. Empty string returns zero rows (no special
+    error in Python today).
+  - `int32 edge_type_id = 3` — optional filter; treat any falsy value
+    (0) as "no filter" to match Python (`grpc_server.py:1393`).
+  - `int32 limit = 4` — defaults to 100 when 0/unset
+    (`grpc_server.py:1400`).
+  - `int32 offset = 5` — declared in proto but **not honoured by the
+    Python handler today**; see Open questions.
+- `GetEdgesResponse` (`proto/entdb/v1/entdb.proto:488-491`):
+  - `repeated Edge edges` — each `Edge` (`proto/.../entdb.proto:493-507`)
+    carries `tenant_id`, `edge_type_id`, `from_node_id`, `to_node_id`,
+    `created_at`, `props` (`google.protobuf.Struct`). Field 5
+    (`props_json`) is reserved.
+  - `bool has_more` — Python sets it iff `len(edges) > limit` *before*
+    truncation (`grpc_server.py:1410-1414`). Note: store returns the
+    full result set (no SQL `LIMIT`), the handler slices in Python.
+
+## Auth
+
+- **Tenant ownership / region pinning.** First action is
+  `await self._check_tenant(request.context.tenant_id, context)`
+  (`grpc_server.py:1392`, helper at `:362-410`). On a miss the handler
+  aborts `UNAVAILABLE` with `entdb-redirect-node` trailer (sharding) or
+  `FAILED_PRECONDITION` (region pin). The Go port must reproduce both
+  paths and the trailer key exactly — Go SDK redirect cache reads it
+  (`sdk/go/entdb/redirect_cache.go`).
+- **Capability.** `capability_registry.DEFAULT_OP_REQUIREMENTS` maps
+  `"GetEdgesFrom" → CoreCapability.READ`
+  (`server/python/entdb_server/auth/capability_registry.py:66`). The
+  Python handler does NOT currently invoke a per-node ACL check before
+  fan-out — it returns every edge stored for the tenant + node. The Go
+  port should match this for parity in v1; do not add an ACL filter
+  without a contract change.
+- **Does ACL filter destination nodes the caller can't see?** **No.**
+  The handler returns edges to nodes the caller may have no `READ` on.
+  This is a known parity gap pinned by the privilege-escalation test
+  (see below) which deliberately accepts the weaker property. EPIC #407
+  decisions: keep parity; track ACL filtering as a follow-up.
+- **Trusted actor.** `request.context.actor` is advisory only. The
+  handler does not currently rebind to `_trusted_actor()`
+  (`grpc_server.py:418-437`); the privilege-escalation test pins that
+  the claimed actor must not be used for any authz decision the
+  handler reaches (it currently reaches none). Go port: read trusted
+  identity from the auth interceptor metadata, ignore
+  `request.context.actor` for any future authz, plumb the trusted
+  actor into observability fields only.
+
+## Side effects
+
+None. Read-only. **No WAL append, no SQLite writes, no state
+mutation.** Confirms architecture invariant 1 in `CLAUDE.md` — this
+RPC is on the egress path; never call `wal.append` here. Permitted
+side effects: prometheus counter
+`record_grpc_request("GetEdgesFrom", "ok"|"error", elapsed)`
+(`grpc_server.py:1413,1416`) and structured logs.
+
+## Error contract
+
+The Python handler swallows everything: any exception below
+`_check_tenant` is logged and returns `GetEdgesResponse(edges=[])`
+with no status code (`grpc_server.py:1415-1418`). `_check_tenant`
+itself can `context.abort` with `UNAVAILABLE` or
+`FAILED_PRECONDITION` and those propagate.
+
+Go port mapping:
+
+- Tenant not on this node → `codes.Unavailable`, message
+  `"Tenant '<id>' is not served by this node[ (try node X)]"`,
+  trailer `entdb-redirect-node: <owner>` when known.
+- Wrong region → `codes.FailedPrecondition`, message
+  `"Tenant '<id>' is pinned to region '<R>'; this node serves '<S>'."`.
+- Unknown internal failure → mirror Python: log + return empty
+  response with no error. (Recommend logging + metric, no
+  status-code change, to keep wire parity. Open question below
+  whether to upgrade to `Internal`.)
+- Empty `node_id` → empty response, no error.
+- Negative or zero `limit` → treat as 100.
+
+## Shared Go package deps
+
+- `internal/pb` — generated `entdb.v1` types
+  (`sdk/go/entdb/internal/pb/entdb_grpc.pb.go`). Server side will need
+  the server stubs in `server/go/internal/pb/...`.
+- `shared/canonicalstore` (TBD; place in
+  `docs/go-port/shared/canonicalstore.md`) — needs `GetEdgesFrom(ctx,
+  tenantID, nodeID, edgeTypeID *int32) ([]Edge, error)`. Python
+  reference: `_sync_get_edges_from`
+  (`server/python/entdb_server/apply/canonical_store.py:2609-2640`).
+  SQL: `SELECT * FROM edges WHERE tenant_id=? AND from_node_id=?`
+  with optional `AND edge_type_id=?`. Index used:
+  `idx_edges_from(tenant_id, from_node_id)`
+  (`canonical_store.py:1075`).
+- `shared/auth` — `CheckTenant(ctx, tenantID)` returning ownership +
+  region verdict and `TrustedActorFromCtx(ctx)`. Mirrors
+  `_check_tenant` and `auth_interceptor.get_authoritative_actor`.
+- `shared/sharding` — `IsMine`, `Owner` lookups for the redirect
+  trailer.
+- `shared/observability` — `RecordGRPCRequest("GetEdgesFrom",
+  status, elapsed)`.
+- `shared/structconv` — `MapToStruct(map[string]any)
+  *structpb.Struct` for `Edge.props` (Python side: `_dict_to_struct`).
+
+## Other-RPC deps
+
+`GetEdgesFrom` and `GetEdgesTo` are byte-for-byte symmetric — same
+request / response messages, same auth, same shape, same error
+contract. Differences are exactly:
+
+- DB column matched: `from_node_id` vs `to_node_id`.
+- canonical_store call: `get_edges_from` vs `get_edges_to`
+  (`canonical_store.py:2642`, `:2695`).
+- Metric label and log prefix.
+
+Implement both as one private helper parameterised on direction; see
+`grpc_server.py:1420-1454` for the symmetric Python implementation.
+`GetConnectedNodes` (`grpc_server.py:1700-…`) reuses the same fan-out
+under the hood and should share the helper.
+
+## Contract tests pinning behaviour
+
+- `tests/python/integration/test_grpc_contract.py:241-247` — happy
+  path: empty seed, `GetEdgesFrom(node_id=SEED_NODE_ID)` returns
+  `edges == []` and call succeeds (no abort).
+- `tests/python/integration/test_privilege_escalation.py:421-447` —
+  `test_get_edges_from_does_not_use_claimed_actor_for_authz`: with
+  `_trusted_identity("user:eve")` and forged
+  `context.actor="system:admin"`, handler must (a) succeed and (b)
+  invoke `canonical_store.get_edges_from` with the trusted
+  `tenant_id` (asserted via `cs.get_edges_from.assert_awaited_once`).
+- `sdk/go/entdb/grpc_transport_test.go:669-692` — Go SDK happy path:
+  request carries `node_id`, `edge_type_id`; response edges echo
+  fields 1-7. Pin output struct order.
+- `sdk/go/entdb/cmd/entdb-console/server_test.go:338-345` — console
+  proxy must forward `GetEdgesFrom` to the upstream stub unchanged.
+- `sdk/go/entdb/cmd/entdbctl/cmd_edges_test.go:27,57` — CLI uses
+  `GetEdgesFrom` for the default direction and **must not** call it
+  when `--in` is set. The Go server must keep the directionality
+  exactly so this test stays valid.
+- `tests/python/benchmarks/bench_realistic.py:549` — perf reference
+  (latency budget; not a strict pin but informative).
+
+## Implementation outline
+
+```go
+func (s *Server) GetEdgesFrom(
+    ctx context.Context, req *pb.GetEdgesRequest,
+) (*pb.GetEdgesResponse, error) {
+    start := time.Now()
+    defer func() { obs.RecordGRPCRequest("GetEdgesFrom", outcome, time.Since(start)) }()
+
+    if err := s.checkTenant(ctx, req.GetContext().GetTenantId()); err != nil {
+        return nil, err // Unavailable / FailedPrecondition with trailer
+    }
+
+    // Ignore req.Context.Actor for authz; trusted identity comes from
+    // the auth interceptor (mirror _trusted_actor).
+    var edgeTypeFilter *int32
+    if etid := req.GetEdgeTypeId(); etid != 0 {
+        v := etid
+        edgeTypeFilter = &v
+    }
+
+    edges, err := s.cstore.GetEdgesFrom(ctx,
+        req.GetContext().GetTenantId(), req.GetNodeId(), edgeTypeFilter)
+    if err != nil {
+        log.Error(ctx, "GetEdgesFrom failed", "err", err)
+        return &pb.GetEdgesResponse{}, nil // parity with Python swallow
+    }
+
+    limit := int(req.GetLimit())
+    if limit <= 0 { limit = 100 }
+    hasMore := len(edges) > limit
+    if hasMore { edges = edges[:limit] }
+
+    out := make([]*pb.Edge, 0, len(edges))
+    for _, e := range edges {
+        out = append(out, &pb.Edge{
+            TenantId: e.TenantID, EdgeTypeId: e.EdgeTypeID,
+            FromNodeId: e.FromNodeID, ToNodeId: e.ToNodeID,
+            CreatedAt: e.CreatedAt, Props: structconv.FromMap(e.Props),
+        })
+    }
+    return &pb.GetEdgesResponse{Edges: out, HasMore: hasMore}, nil
+}
+```
+
+Keep the limit-then-slice in handler (NOT in SQL) until the Python
+side moves; otherwise `has_more` semantics drift.
+
+## Open questions / risks
+
+1. **`offset` is declared in the proto but ignored by the Python
+   handler.** Python only respects `limit`, slicing in-process. Go
+   port should keep ignoring `offset` for parity *or* the contract
+   should be updated server-side first. Flag for #407 owner.
+2. **No SQL `LIMIT/ORDER BY`.** SQLite returns rows in insertion
+   order, slicing happens in Python. Result ordering is not
+   contractually defined and large fan-outs read the entire row set
+   into memory. Risk of perf regression when Go port matches behaviour
+   on hot tenants. Consider adding a deterministic `ORDER BY
+   created_at, edge_type_id, to_node_id` in the shared
+   `canonicalstore` and pinning a contract test before changing it.
+3. **No ACL filtering of destination nodes.** Caller can enumerate
+   `to_node_id`s without READ on the targets. The privilege test
+   accepts this; product/security must decide before v1 GA.
+4. **Error swallowing.** Returning empty list on internal failure
+   masks bugs. Recommend introducing `codes.Internal` once the SDK
+   tests are updated; until then, parity wins.
+5. **`props` Struct conversion.** Python stores props as a JSON dict
+   keyed by **field IDs** (invariant 6). Confirm `structconv` mirrors
+   `_dict_to_struct` exactly — including how it handles ints, floats,
+   nulls, and nested objects — or contract tests will diverge.
+6. **`request.context.actor` parity.** The privilege-escalation test
+   only pins the negative property. The Go port should still rebind
+   to the trusted actor at handler entry to prevent regression when
+   the future ACL filter (item 3) lands.

--- a/docs/go-port/rpcs/GetEdgesTo.md
+++ b/docs/go-port/rpcs/GetEdgesTo.md
@@ -1,0 +1,229 @@
+# GetEdgesTo — Go port spec
+
+EPIC: #407. Inverse fan-in counterpart of `GetEdgesFrom`. Returns edges whose
+`to_node_id` matches the requested node, scoped to a single tenant. Read-only,
+non-mutating, no WAL append.
+
+## Wire contract
+
+- Service: `entdb.v1.EntDBService`
+- Method: `GetEdgesTo(GetEdgesRequest) returns (GetEdgesResponse)` —
+  `proto/entdb/v1/entdb.proto:67`
+- Request (`GetEdgesRequest`, proto descriptor in `entdb_pb2.py:28`):
+  - `context.RequestContext` — `tenant_id` (1), `actor` (2), `trace_id` (3)
+  - `node_id` (2, string) — TARGET node whose inbound edges are wanted
+  - `edge_type_id` (3, int32) — `0` ⇒ all types; nonzero ⇒ filter
+  - `limit` (4, int32) — `0` ⇒ default 100 (Python handler line 1436)
+  - `offset` (5, int32) — currently UNUSED in Python (see Open questions)
+- Response (`GetEdgesResponse`):
+  - `edges` (1, repeated `Edge`)
+  - `has_more` (2, bool) — `true` iff store returned `> limit` rows
+- `Edge` proto fields used: `tenant_id`, `edge_type_id`, `from_node_id`,
+  `to_node_id`, `props` (google.protobuf.Struct), `created_at` (int64 ms).
+  `props_json` (field 5) is reserved/legacy and MUST NOT be set.
+
+## Auth
+
+- Capability: `CoreCapability.READ`, registered in
+  `server/python/entdb_server/auth/capability_registry.py:67`
+  (`DEFAULT_OP_REQUIREMENTS["GetEdgesTo"] = READ`).
+- Tenant ownership: handler calls `_check_tenant(tenant_id, ctx)`
+  (`api/grpc_server.py:1428`). Rejects with `UNAVAILABLE` + trailing
+  metadata `entdb-redirect-node` if the shard does not own the tenant
+  (`grpc_server.py:362–395`); rejects with `FAILED_PRECONDITION` on
+  region-pin mismatch (`grpc_server.py:400–410`).
+- Trusted actor: per CLAUDE.md invariant and PR #168, the handler MUST
+  use `_trusted_actor(request.context.actor)` (the
+  `AuthInterceptor`-attached identity) for any future per-edge ACL
+  check. The current Python handler does NOT yet wire ACL filtering into
+  `get_edges_to`; the Go port should keep the trust boundary in place
+  even though it is currently a no-op (see test
+  `test_privilege_escalation.py:421` comment — same property pinned for
+  `GetEdgesFrom`; the symmetric test for `GetEdgesTo` is OPEN).
+
+## Side effects
+
+- None. Read-only — no WAL append, no SQLite mutation, no global_store
+  write. Does NOT bypass the WAL invariant (CLAUDE.md §1) because no
+  state changes.
+- Metrics: `record_grpc_request("GetEdgesTo", "ok"|"error", elapsed)`
+  (`grpc_server.py:1449,1452`).
+- Logging: `logger.error("GetEdgesTo failed: ...", exc_info=True)` on
+  exception path (`grpc_server.py:1453`).
+- Cross-tenant fan-in: NOT a concern at the storage layer. Each tenant
+  has its own SQLite (`canonical_store.py:1068` PRIMARY KEY includes
+  `tenant_id`; `idx_edges_to` at `canonical_store.py:1076`). Edges are
+  per-tenant rows; an edge "spanning tenants" is structurally
+  impossible — both endpoints share the row's `tenant_id`. The query
+  filters `WHERE tenant_id = ? AND to_node_id = ?`
+  (`canonical_store.py:2673,2679`), so fan-in cannot leak across tenant
+  boundaries even if a caller forges a `node_id` that exists in another
+  tenant.
+
+## Error contract
+
+Python today returns `GetEdgesResponse(edges=[])` on ANY internal
+exception (`grpc_server.py:1454`) — i.e., it swallows errors and emits
+an empty result. The Go port SHOULD preserve this swallow-and-empty
+behaviour for parity, with the following pinned aborts BEFORE the
+try-block reaches the store:
+
+- `UNAVAILABLE` — tenant not owned by this node (with
+  `entdb-redirect-node` trailer when known).
+- `FAILED_PRECONDITION` — tenant pinned to another region.
+
+After `_check_tenant` succeeds, no further `context.Abort` paths exist;
+any storage error becomes `edges=[]` + metric label `error`. Note:
+this empty-on-error policy is debated (see Open questions).
+
+## Shared Go package deps
+
+- `internal/auth` — `CheckTenant(ctx, tenantID)` mirroring
+  `_check_tenant` (shared with every other tenant-scoped RPC; reused
+  from GetEdgesFrom port).
+- `internal/auth` — `TrustedActor(ctx, claimed)` reading the
+  interceptor `ContextVar` equivalent; same helper as GetEdgesFrom.
+- `internal/canonical` — `GetEdgesTo(ctx, tenantID, nodeID,
+  edgeTypeID *int32) ([]Edge, error)` SQLite read; query identical to
+  `_sync_get_edges_to` (`canonical_store.py:2662–2693`).
+- `internal/proto/convert` — `EdgeToProto(Edge) *pb.Edge` (shared with
+  GetEdgesFrom; converts `props map[string]any` → `*structpb.Struct`).
+  Reuse `_dict_to_struct` equivalent.
+- `internal/metrics` — `RecordGrpcRequest(method, status, elapsed)`.
+- `internal/grpcutil` — limit clamp helper (default 100, `has_more`
+  computation: `len(edges) > limit`).
+
+## Other-RPC deps (overlap with GetEdgesFrom)
+
+`GetEdgesTo` is the symmetric twin of `GetEdgesFrom`
+(`grpc_server.py:1384`). Shared code surface:
+
+- Same request/response proto messages (`GetEdgesRequest`,
+  `GetEdgesResponse`).
+- Same capability mapping (`READ`).
+- Same `_check_tenant` ingress check.
+- Same `Edge` → proto conversion path.
+- Same limit/has_more semantics (`limit or 100`, slice `edges[:limit]`,
+  `has_more = len(edges) > limit`).
+- Differs only in the SQL predicate: `from_node_id = ?` vs
+  `to_node_id = ?` and uses index `idx_edges_to`
+  (`canonical_store.py:1076`) instead of the `from`-side index.
+
+Recommended: implement a single private `getEdgesByEndpoint(direction
+{from|to}, ...)` helper in the Go server, called by both RPCs, and
+land both in the same PR (CLAUDE.md cross-reference: SDK-side
+`grpc_transport_test.go:669,694` already does this for the client).
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:248–254` — happy
+  path: empty seed ⇒ `r.edges == []` (response is success, not error).
+- `tests/python/unit/test_canonical_store.py:331–370` — store-level:
+  two edges to one target ⇒ length 2.
+- `tests/python/integration/test_crud_comprehensive.py:317–325` —
+  store-level fan-in count.
+- `tests/python/integration/test_workplace_chat.py:233,253,284,294,
+  315,370,749,798,960` — `edge_type_id` filtering on member fan-in.
+- `tests/python/integration/test_workplace_posts.py:396,444,454,469,
+  490,501,514,534,573,574,693` — fan-in for upvotes/replies.
+- `tests/python/integration/test_workplace_tasks.py:318,386,402,452,
+  473,485,522,534,576,646,704,938` — project/task assignment fan-in.
+- `tests/python/integration/test_multi_node_sharding.py:1132` — fan-in
+  inside the multi-shard fixture (covers `_check_tenant` redirect
+  trailer indirectly).
+- `tests/python/integration/test_batch_applier.py:1223` — empty
+  fan-in for non-existent `to_node_id` (`"ghost"`).
+- `tests/python/integration/test_privilege_escalation.py:132,421` —
+  pins that the handler does NOT trust `context.actor` for authz; the
+  `GetEdgesTo`-specific test is currently absent and SHOULD be added
+  in the Go port (parity with line 429 `test_get_edges_from_does_not_
+  use_claimed_actor_for_authz`).
+- `sdk/go/entdb/grpc_transport_test.go:694–712` — SDK-side wire shape:
+  one inbound edge, `from_node_id`/`to_node_id`/`edge_type_id` round
+  trip.
+- `tests/python/benchmarks/bench_crud.py:344–350` — perf budget; Go
+  port should match or beat.
+
+## Implementation outline
+
+```go
+func (s *Server) GetEdgesTo(ctx context.Context, req *pb.GetEdgesRequest) (*pb.GetEdgesResponse, error) {
+    start := time.Now()
+    tenantID := req.GetContext().GetTenantId()
+
+    // Ingress checks — may abort with UNAVAILABLE / FAILED_PRECONDITION.
+    if err := s.checkTenant(ctx, tenantID); err != nil {
+        metrics.RecordGrpcRequest("GetEdgesTo", "error", time.Since(start))
+        return nil, err
+    }
+    _ = auth.TrustedActor(ctx, req.GetContext().GetActor()) // pin trust boundary
+
+    var edgeType *int32
+    if t := req.GetEdgeTypeId(); t != 0 {
+        edgeType = &t
+    }
+
+    edges, err := s.canonical.GetEdgesTo(ctx, tenantID, req.GetNodeId(), edgeType)
+    if err != nil {
+        s.log.Error("GetEdgesTo failed", "err", err)
+        metrics.RecordGrpcRequest("GetEdgesTo", "error", time.Since(start))
+        return &pb.GetEdgesResponse{}, nil // parity: swallow + empty
+    }
+
+    limit := int(req.GetLimit())
+    if limit == 0 { limit = 100 }
+    hasMore := len(edges) > limit
+    if hasMore { edges = edges[:limit] }
+
+    out := make([]*pb.Edge, 0, len(edges))
+    for _, e := range edges { out = append(out, convert.EdgeToProto(e)) }
+    metrics.RecordGrpcRequest("GetEdgesTo", "ok", time.Since(start))
+    return &pb.GetEdgesResponse{Edges: out, HasMore: hasMore}, nil
+}
+```
+
+SQLite query in `internal/canonical`:
+
+```sql
+-- with edge_type filter
+SELECT tenant_id, edge_type_id, from_node_id, to_node_id, props_json, created_at
+FROM edges
+WHERE tenant_id = ? AND to_node_id = ? AND edge_type_id = ?;
+-- without
+SELECT ... FROM edges WHERE tenant_id = ? AND to_node_id = ?;
+```
+
+Use `idx_edges_to(tenant_id, to_node_id)` (`canonical_store.py:1076`).
+
+Run on a dedicated read-side worker pool (mirror Python's `_run_sync`
+thread-pool semantics; CLAUDE.md §3 forbids `ThreadPoolExecutor`-style
+sync/async bridging in the request path itself, but per-tenant SQLite
+calls SHOULD use a bounded pool so a slow query cannot stall the
+loop).
+
+## Open questions / risks
+
+1. `offset` field is silently ignored — Python and the Go SDK both
+   pass it through but the server does not paginate. Decision needed:
+   honour `offset` with `LIMIT ? OFFSET ?` or formally deprecate the
+   field. Pinning current behaviour (no-op) is the safe Phase-1
+   choice.
+2. `has_more` is computed AFTER fetching all matching rows from SQLite
+   then slicing in memory — for high-fan-in targets (e.g. a popular
+   post with 1M upvotes) this is O(N) memory per request. Decision:
+   keep parity for v1; file follow-up to push `LIMIT limit + 1` into
+   SQL.
+3. Empty-on-error swallow is hostile to clients (looks identical to
+   "no edges"). Should the Go port instead return
+   `codes.Internal`? Recommend: keep parity, but emit a structured log
+   + metric label so operators can distinguish.
+4. No per-edge ACL filtering today. When CLAUDE.md's capability
+   model is extended to edges, fan-in (`GetEdgesTo`) is the harder
+   case: a target node owner may not have READ on the source nodes.
+   Spec the filter at the canonical_store layer, not the handler, so
+   GetEdgesFrom and GetEdgesTo share enforcement.
+5. `created_at` precision: Python emits ms (int64). Confirm Go port
+   uses the same unit, not `time.Time`/RFC3339.
+6. Missing privilege-escalation test for `GetEdgesTo` (parity with
+   `test_get_edges_from_does_not_use_claimed_actor_for_authz` at
+   `test_privilege_escalation.py:429`) — add as part of port PR.

--- a/docs/go-port/rpcs/GetMailbox.md
+++ b/docs/go-port/rpcs/GetMailbox.md
@@ -1,0 +1,216 @@
+# RPC Port Spec — `entdb.v1.EntDBService/GetMailbox`
+
+EPIC #407 — Python -> Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:1478-1498`.
+
+> Status: **deprecated stub.** The legacy per-user, cross-tenant mailbox
+> SQLite store has been removed. Fanout now writes to the per-tenant
+> `notifications` table in the canonical store
+> (`apply/canonical_store.py:1140-1150`, `:4531`). `GetMailbox` is retained
+> for proto compatibility and contract pinning, and MUST return an empty,
+> well-formed response. Do NOT reintroduce a cross-tenant SQLite read here
+> in the Go port — see "Side effects" and "Open questions" below.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:73` (rpc), `:539-557` (request/response),
+`:559-578` (`MailboxItem`).
+
+`GetMailboxRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `context` | 1 | `RequestContext` | Standard envelope. `context.tenant_id` IS used (passed to `_check_tenant`). `context.actor` is wire-untrusted (see Auth). |
+| `user_id` | 2 | `string` | Mailbox owner. Bare id (e.g. `"alice"`), NOT `"user:alice"` — translation lives at the gRPC boundary per CLAUDE.md. **Currently ignored** by the stub. |
+| `source_type_id` | 3 | `int32` | Filter. Ignored by stub. |
+| `thread_id` | 4 | `string` | Filter. Ignored by stub. |
+| `unread_only` | 5 | `bool` | Filter. Ignored by stub. |
+| `limit` | 6 | `int32` | Pagination. Ignored. |
+| `offset` | 7 | `int32` | Pagination. Ignored. |
+
+`GetMailboxResponse`:
+| Field | Tag | Type | Stub value |
+|------|-----|------|------|
+| `items` | 1 | `repeated MailboxItem` | Always empty slice (NOT nil — pinned by `list(r.items) == []`). |
+| `unread_count` | 2 | `int32` | Always `0`. |
+| `has_more` | 3 | `bool` | Always `false`. Note: error path in Python omits `has_more` (default-zero), which is wire-equivalent to `false` — Go port should set it explicitly to `false` on both paths. |
+
+`MailboxItem` shape (for type registration / forward-compat — never emitted by
+the stub): `item_id`, `ref_id`, `source_type_id`, `source_node_id`,
+`thread_id`, `ts (int64)`, `snippet (8)`, `state (Struct, 10)`,
+`metadata (Struct, 11)`. Tags 7 and 9 are **reserved** (old JSON string
+fields) — Go generated code MUST keep the reservation.
+
+## Auth (mailbox owner verification via trusted-actor)
+
+- **Authenticated method.** `/entdb.EntDBService/GetMailbox` is NOT in
+  `AuthInterceptor.UNAUTHENTICATED_METHODS`
+  (`auth/auth_interceptor.py:157-162`). Without an interceptor populating
+  the `ContextVar`, `_trusted_actor` falls back to the wire actor — but
+  the stub does not call `_trusted_actor` at all.
+- **Owner verification: NOT performed by the current stub.** A live
+  implementation would resolve `_trusted_actor(ctx.actor)`
+  (`grpc_server.py:418-437`) and reject when it does not match
+  `_actor_user_id(...) == request.user_id` (`:412-416`). The Go port MUST
+  keep parity with the stub: do NOT add owner checks that diverge from
+  Python observable behavior.
+- **Tenant guard runs.** `_check_tenant(request.context.tenant_id, context)`
+  (`grpc_server.py:362-410`) is the only auth-shaped check. It enforces:
+  - sharding ownership (UNAVAILABLE + `entdb-redirect-node` trailer when
+    another node owns the tenant — `:387-394`),
+  - region pinning (FAILED_PRECONDITION when `tenant.region != served_region`
+    — `:400-410`).
+- **No `Permission`/ACL check.** The stub bypasses
+  `_check_tenant_access` and the capability registry entirely.
+- **Trusted-actor invariant (CLAUDE.md §"actor is wire-untrusted"):** the
+  stub never trusts `request.context.actor` because it never reads it.
+  The Go port MUST preserve this — do NOT log, branch on, or echo back
+  the wire actor without first running it through the trusted-actor
+  resolver.
+
+## Side effects (cross-tenant: global_store reads)
+
+**None today.** Strictly:
+
+1. `start := time.Now()` for the `record_grpc_request` Prometheus
+   observation.
+2. `await self._check_tenant(...)` — may read `global_store.get_tenant(...)`
+   for the region check (`:401`). This is a cross-tenant *metadata* read,
+   not a mailbox read. It is the only DB touch on the success path.
+3. Return the canned empty response.
+
+**Crucially: NO SQLite reads, NO WAL append.** This RPC is a pure read,
+so the WAL invariant ("all writes go through the WAL", CLAUDE.md §1)
+does not constrain it. The CLAUDE.md §4 invariant ("per-tenant SQLite
+isolation") forbids ad-hoc cross-tenant SQLite scans — the historical
+mailbox store violated this and was removed; the Go port MUST NOT
+restore it. If a real cross-tenant mailbox is reintroduced, it goes
+through `global_store` with its own SQLite, never by joining across
+per-tenant DBs.
+
+## Error contract
+
+| Condition | Status | Where pinned |
+|----------|--------|--------------|
+| Tenant not owned by this node | `UNAVAILABLE` + `entdb-redirect-node` trailer | `grpc_server.py:387-394`; mirrored by `_check_tenant` for every tenant-scoped RPC. |
+| Tenant region mismatch | `FAILED_PRECONDITION` | `grpc_server.py:400-410`. |
+| Any other exception inside the `try` | **Swallowed.** Returns `GetMailboxResponse(items=[], unread_count=0)` with `has_more` defaulting to `false`. Error is logged with `exc_info=True` and `record_grpc_request("GetMailbox", "error", ...)` is incremented. | `grpc_server.py:1495-1498`. |
+
+The swallow-and-return-empty pattern is intentional and pinned by the
+contract test (which only asserts `items == [] and unread_count == 0`).
+The Go port MUST mirror it: a panic/error inside the handler body must
+NOT propagate as a gRPC error to the client. Use `defer recover()` +
+metric increment.
+
+## Shared Go package deps
+
+- `internal/shard` — `Sharding.IsMine`, `Sharding.GetOwner` for
+  `_check_tenant` parity (Python: `dbaas/sharding/...`,
+  `grpc_server.py:375-394`).
+- `internal/globalstore` — `GetTenant(ctx, tenantID)` for the region
+  guard (`grpc_server.py:400-410`).
+- `internal/metrics` — `RecordGRPCRequest(method, status, latency)`
+  matching Python `record_grpc_request` cardinality
+  (`grpc_server.py:1493,1496`). Status labels: `"ok"`, `"error"`.
+- `internal/auth/trusted` — `GetAuthoritativeActor(wireActor)` ContextVar
+  equivalent (Python: `auth/auth_interceptor.py`, used via
+  `_trusted_actor` `:418-437`). Imported but NOT called by the stub;
+  required for any future un-stubbing.
+- `gen/entdb/v1` — generated `GetMailboxRequest`, `GetMailboxResponse`,
+  `MailboxItem`. Reserved tags 7,9 must survive codegen.
+
+## Other-RPC deps (SearchMailbox, ShareNode, ListMailboxUsers)
+
+- **SearchMailbox** (`grpc_server.py:1456-1476`, proto `:70`) — same
+  deprecated stub shape: `_check_tenant` + empty `SearchMailboxResponse`.
+  Port together; share the empty-response helper.
+- **ListMailboxUsers** (`grpc_server.py:1605-1617`, proto `:85`) — also
+  a stub. Note: takes `tenant_id` as a top-level field, not
+  `RequestContext`. Returns `ListMailboxUsersResponse(user_ids=[])`.
+- **ShareNode** (`grpc_server.py:1746-1826`, proto `:94`) — the *live*
+  cross-tenant operation. Goes through `_trusted_actor`,
+  `_check_tenant_access`, and writes to `global_store.shared_index`
+  (`:1815-1820`). When/if a real mailbox returns, `ShareNode`'s side
+  effects are the upstream producer — but that read path will live in
+  `ListSharedWithMe` (already wired in the TS client gen), NOT here.
+  Treat `ShareNode` as orthogonal for the `GetMailbox` port: same epic,
+  unrelated handler.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:274-280` — the
+  authoritative pin. Builds `GetMailboxRequest(context=_ctx(),
+  user_id="alice")`, expects `list(r.items) == [] and r.unread_count == 0`,
+  mode `"happy"` (no auth interceptor; goes through anyway because the
+  handler has no actor check). Go port MUST pass byte-identical wire
+  bytes against this test fixture.
+- `tests/python/integration/test_grpc_contract.py:267-272` — sibling
+  pin for `SearchMailbox`; same shape.
+- `tests/python/integration/test_grpc_contract.py:281-287` — sibling
+  pin for `ListMailboxUsers`.
+
+(`grep -rn "GetMailbox" tests/` returns only the file above — no
+unit-level coverage. The Go port should add a Go-side unit test that
+exercises the `_check_tenant` UNAVAILABLE branch, which the existing
+contract test does not cover for this RPC.)
+
+## Implementation outline
+
+```go
+func (s *Server) GetMailbox(ctx context.Context, req *pb.GetMailboxRequest) (*pb.GetMailboxResponse, error) {
+    start := time.Now()
+    defer func() {
+        if r := recover(); r != nil {
+            s.metrics.RecordGRPCRequest("GetMailbox", "error", time.Since(start))
+            log.Error().Interface("panic", r).Msg("GetMailbox failed")
+            // swallow — see "Error contract"
+        }
+    }()
+    if err := s.checkTenant(ctx, req.GetContext().GetTenantId()); err != nil {
+        // _check_tenant aborts with its own status; propagate.
+        s.metrics.RecordGRPCRequest("GetMailbox", "error", time.Since(start))
+        return nil, err
+    }
+    s.metrics.RecordGRPCRequest("GetMailbox", "ok", time.Since(start))
+    return &pb.GetMailboxResponse{Items: []*pb.MailboxItem{}, UnreadCount: 0, HasMore: false}, nil
+}
+```
+
+Notes:
+- `Items` is a non-nil empty slice — protobuf-go marshals nil and `[]`
+  identically on the wire, but the Python contract test calls
+  `list(r.items)` which works for both; still, prefer explicit `[]` for
+  symmetry with `grpc_server.py:1494`.
+- `UNAVAILABLE` from `checkTenant` MUST attach the `entdb-redirect-node`
+  trailer via `grpc.SetTrailer` BEFORE returning the status — the SDK
+  redirect cache (`sdk/go/entdb/redirect_cache.go`) depends on it.
+- Do NOT read `req.UserId`, `req.SourceTypeId`, `req.ThreadId`,
+  `req.UnreadOnly`, `req.Limit`, `req.Offset`. Pinned by the Python
+  stub ignoring them.
+
+## Open questions / risks
+
+1. **Resurrection risk.** The TS client gen
+   (`sdk/go/entdb/cmd/entdb-console/frontend/src/gen/entdb_connect.ts:145`)
+   still exposes `GetMailbox`. If a console feature starts calling it,
+   we will silently see empty results forever. Action: add a
+   server-side `log.Warn` (rate-limited) on first call per process, OR
+   surface a deprecation header (`grpc-status-details-bin` /
+   custom trailer). Decide before the Go port lands.
+2. **Should the Go port keep the stub or delete the RPC?** Proto
+   removal is a breaking wire change and is out-of-scope for #407.
+   Recommendation: keep the stub, mark the proto comment as
+   `// DEPRECATED: returns empty; see notifications table.`
+3. **Owner-mismatch behavior is undefined.** A future un-stubbing will
+   need to decide: `PERMISSION_DENIED` when caller != `user_id`, or
+   silent empty? CLAUDE.md leans `PERMISSION_DENIED` (fail closed); the
+   current stub leans silent empty. Document the choice when the
+   stub is removed.
+4. **Cross-tenant storage location.** If a real mailbox returns, it
+   MUST live in `global_store` (CLAUDE.md §4) and be fed by a
+   `WAL`-driven applier (CLAUDE.md §1). The `notifications` per-tenant
+   table is the right home for *intra-tenant* fanout; a
+   cross-tenant inbox is a separate problem.
+5. **Metrics cardinality.** Python emits `record_grpc_request("GetMailbox",
+   "ok"|"error", ...)` — only two status labels. Do not introduce a
+   third label (`"deprecated"`, `"empty"`, etc.) in the Go port; it
+   breaks dashboards.

--- a/docs/go-port/rpcs/GetNode.md
+++ b/docs/go-port/rpcs/GetNode.md
@@ -1,0 +1,250 @@
+# GetNode — Go Port Spec
+
+EPIC #407. Single-node read by `node_id` within one tenant. Read-only.
+Python source of truth: `server/python/entdb_server/api/grpc_server.py:994-1064`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:55` (RPC), `:394-407` (messages), `:454-472` (`Node`).
+
+```
+rpc GetNode(GetNodeRequest) returns (GetNodeResponse);
+
+GetNodeRequest  { RequestContext context = 1; int32 type_id = 2;
+                  string node_id = 3; string after_offset = 10;
+                  int32 wait_timeout_ms = 11; }
+GetNodeResponse { Node node = 1; bool found = 2; }
+```
+
+`Node.payload` is a `google.protobuf.Struct` keyed by **field_id strings**
+(invariant #6), e.g. `{"1": "alice@example.com", "2": "$2a$..."}`. The
+SDK does id→name translation; the server MUST NOT translate. Pinned by
+`tests/python/unit/test_payload_wire_format.py:159-189` and the wire
+test `tests/python/unit/test_grpc_wire_format.py:172-189`.
+
+`type_id` is present on the request but the Python handler does **not**
+use it to filter the lookup — `canonical_store.get_node(tenant, node_id)`
+is keyed only on `(tenant_id, node_id)`. See "Open questions".
+
+`after_offset` + `wait_timeout_ms` provide read-after-write consistency
+by waiting for the WAL applier to reach a stream position before reading
+(default 30s when `wait_timeout_ms == 0`). Implementation:
+`grpc_server.py:1015-1020` → `_wait_for_offset` (`:937-944`) →
+`canonical_store.wait_for_offset`.
+
+## Auth
+
+1. **Trusted actor only.** `request.context.actor` is **untrusted on the
+   wire**. Handler immediately rebinds via `_trusted_actor`
+   (`grpc_server.py:418-437`) which calls
+   `auth.auth_interceptor.get_authoritative_actor` (a `ContextVar` set by
+   `AuthInterceptor`). Payload-supplied `system:admin` from a regular
+   user is downgraded to the interceptor identity — pinned by
+   `tests/python/integration/test_privilege_escalation.py:186-209`.
+
+2. **Tenant residency.** `_check_tenant` (`grpc_server.py:362-410`):
+   - sharding registry: tenant not owned by this node → `UNAVAILABLE`
+     with `entdb-redirect-node` trailer.
+   - region pinning: tenant region ≠ served region →
+     `FAILED_PRECONDITION` (no retry).
+
+3. **Membership / cross-tenant grant.** `_check_cross_tenant_read`
+   (`grpc_server.py:561-618`):
+   - no `global_store` → returns `"local"` (back-compat).
+   - `system:*` / `__system__` → `"member"`.
+   - `is_member(tenant, user_id)` → `"member"`.
+   - else if any `node_access` row in tenant for this actor → `"cross_tenant"`.
+   - else `PERMISSION_DENIED`.
+
+4. **Per-node ACL (cross-tenant only).** When role is `"cross_tenant"`,
+   re-check the specific `node_id` against `canonical_store.can_access`
+   (`grpc_server.py:1031-1045`, `canonical_store.py:2948-2960`). Failure →
+   `PERMISSION_DENIED`.
+
+5. **Capability mapping.** `GetNode → CoreCapability.READ`. Fixed at
+   `server/python/entdb_server/auth/capability_registry.py:62`. Pinned by
+   `tests/python/unit/test_capability_registry.py:61` and
+   `tests/python/unit/test_acl_capabilities.py:247`. Note: the current
+   Python `GetNode` does **not** consult `required_for_op` at the handler
+   level — capability enforcement is via the membership/ACL chain above.
+   Go port should preserve this exact shape (do not add a new capability
+   gate without an issue).
+
+## Side effects
+
+**None.** Read-only. No `wal.append`, no SQLite writes. Only:
+- `canonical_store.get_node` (per-tenant SQLite read, invariant #4).
+- `canonical_store.resolve_actor_groups` + `can_access` (per-tenant SQLite
+  reads) on the cross-tenant path.
+- `global_store.is_member` / `get_tenant` (global SQLite read) via
+  `_check_cross_tenant_read` and `_check_tenant`.
+- `canonical_store.wait_for_offset` (WAL apply barrier; passive).
+- `record_grpc_request("GetNode", "ok"|"error", duration)` metric.
+
+Per-tenant SQLite isolation is preserved: every `canonical_store` call is
+scoped by `tenant_id` and uses `_get_connection(tenant_id)`
+(`canonical_store.py:2306`).
+
+## Error contract — NOT_FOUND vs PERMISSION_DENIED
+
+The handler returns ordered checks; **first failure wins**:
+
+1. `_check_tenant` → `UNAVAILABLE` (wrong shard) or `FAILED_PRECONDITION`
+   (region pin). With redirect trailer when applicable.
+2. `_check_cross_tenant_read` → `PERMISSION_DENIED` for non-members
+   without a node_access grant. **This fires before the row lookup**, so
+   a non-member querying a non-existent node sees `PERMISSION_DENIED`,
+   not `found=false`.
+3. `canonical_store.get_node` returns `None` → response with `found=False`,
+   gRPC status `OK`. **No abort.** Pinned by
+   `tests/python/integration/test_grpc_contract.py:217-222` (mode
+   `not_found`, `r.found is False`).
+4. Cross-tenant role + missing per-node grant → `PERMISSION_DENIED`
+   (`grpc_server.py:1041-1045`). Note: the row exists at this point, so
+   "node missing" cannot be distinguished from "no grant" by an attacker
+   who lacks tenant membership — that is intentional.
+
+**Quirk to preserve.** The handler wraps the body in `try/except Exception`
+(`:1061-1064`): any uncaught exception (including the `_AbortError` raised
+by `context.abort` in tests) is logged and converted to
+`GetNodeResponse(found=False)`. In real `grpc.aio` runtime, `context.abort`
+terminates the call **before** this catch fires, so clients see the abort
+status — but unit tests that mock context observe `found=False` plus a
+recorded `ctx.abort_code`. Pinned by
+`tests/python/integration/test_privilege_escalation.py:196-209`.
+
+The Go port should:
+- Use a real abort path (`status.Errorf`) — not a try/catch swallow. The
+  catch is a Python defensive artifact; aborts in `grpc-go` are
+  terminal and the swallow is unreachable.
+- Keep the metric labels: `{"GetNode","ok"}` for both happy and
+  not-found, `{"GetNode","error"}` only for unexpected exceptions.
+
+## Shared Go package deps
+
+(All under `server/go/internal/...` per the planned layout — paths are
+proposals, replace with whatever EPIC #407 freezes.)
+
+- `auth.AuthoritativeActor(ctx) string` — equivalent to
+  `get_authoritative_actor`. Pulls from a request-scoped value set by
+  the auth interceptor.
+- `tenancy.CheckTenant(ctx, tenantID) error` — sharding redirect +
+  region pin. Returns a `status.Status` with the
+  `entdb-redirect-node` trailer attached when applicable.
+- `tenancy.CheckCrossTenantRead(ctx, tenantID, actor) (Role, error)` —
+  returns `RoleLocal | RoleMember | RoleCrossTenant` or
+  `PERMISSION_DENIED`.
+- `canonical.Store.GetNode(ctx, tenantID, nodeID) (*Node, error)` —
+  per-tenant SQLite read. Returns `(nil, nil)` for missing.
+- `canonical.Store.ResolveActorGroups`, `canonical.Store.CanAccess`.
+- `canonical.Store.WaitForOffset(ctx, tenantID, pos, timeout) (bool, error)`.
+- `wire.NodeToProto(n *canonical.Node) *pb.Node` — must produce the
+  id-keyed `Struct` payload. Single source of truth so `GetNode`,
+  `GetNodes`, `QueryNodes`, `GetNodeByKey` agree.
+- `metrics.RecordGRPCRequest(method, status string, dur time.Duration)`.
+
+## Other-RPC deps
+
+- **`GetNodeByKey`** (`grpc_server.py:1066-1128`) delegates to `GetNode`
+  after a unique-index lookup. The Go `GetNode` must remain the single
+  authoritative read entry-point so ACL/cross-tenant/redirect logic is
+  not duplicated. `GetNodeByKey` should call the **internal** Go
+  `GetNode` (same package, not via the gRPC stub) once both are ported.
+- **`GetNodes`** (`grpc_server.py:1215-1291`) is the batch sibling and
+  shares `_check_cross_tenant_read` + `wait_for_offset` + the wire
+  payload encoding. Port them together to keep behaviour aligned.
+
+## Contract tests pinning behavior
+
+- `tests/python/integration/test_grpc_contract.py:212-216` — happy path:
+  `found=True`, `node.node_id == SEED_NODE_ID`.
+- `tests/python/integration/test_grpc_contract.py:217-222` — not_found
+  returns `found=False` with no abort, status OK.
+- `tests/python/unit/test_payload_wire_format.py:158-189` — id-keyed
+  payload on the wire (invariant #6).
+- `tests/python/unit/test_grpc_wire_format.py:160-189` — wire round-trip
+  via real `grpc.aio` stub.
+- `tests/python/integration/test_privilege_escalation.py:186-209` —
+  payload `actor` claim ignored; trusted identity wins;
+  `PERMISSION_DENIED` for non-member.
+- `tests/python/unit/test_capability_registry.py:61, 412` —
+  `GetNode → CoreCapability.READ`.
+- `tests/python/unit/test_acl_capabilities.py:247` — capability lookup.
+- `tests/python/integration/test_redirect_cache.py:12-59` — sharding
+  redirect via `entdb-redirect-node` trailer.
+- `tests/python/unit/test_auth.py:57, 67` — auth interceptor binds
+  trusted actor for `/entdb.EntDBService/GetNode`.
+- `tests/python/unit/test_rate_limiter.py:61-132` — per-tenant rate-limit
+  buckets keyed on `GetNode` method name.
+- `tests/python/unit/test_metrics.py:54, 112-121` — metric labels
+  (`method="GetNode"`).
+
+## Implementation outline
+
+```go
+func (s *EntDBServer) GetNode(
+    ctx context.Context, req *pb.GetNodeRequest,
+) (*pb.GetNodeResponse, error) {
+    start := time.Now()
+    defer func() { metrics.RecordGRPCRequest("GetNode", status, time.Since(start)) }()
+
+    if err := s.tenancy.CheckTenant(ctx, req.Context.TenantId); err != nil {
+        return nil, err // UNAVAILABLE / FAILED_PRECONDITION (with trailer)
+    }
+    actor := auth.AuthoritativeActor(ctx) // ignore req.Context.Actor
+
+    role, err := s.tenancy.CheckCrossTenantRead(ctx, req.Context.TenantId, actor)
+    if err != nil { return nil, err } // PERMISSION_DENIED
+
+    if req.AfterOffset != "" {
+        timeout := 30 * time.Second
+        if req.WaitTimeoutMs > 0 { timeout = time.Duration(req.WaitTimeoutMs) * time.Millisecond }
+        _, _ = s.canonical.WaitForOffset(ctx, req.Context.TenantId, req.AfterOffset, timeout)
+    }
+
+    node, err := s.canonical.GetNode(ctx, req.Context.TenantId, req.NodeId)
+    if err != nil { return nil, status.Errorf(codes.Internal, "...") }
+    if node == nil { return &pb.GetNodeResponse{Found: false}, nil }
+
+    if role == tenancy.RoleCrossTenant {
+        ids, _ := s.canonical.ResolveActorGroups(ctx, req.Context.TenantId, actor)
+        ok, _ := s.canonical.CanAccess(ctx, req.Context.TenantId, req.NodeId, ids)
+        if !ok {
+            return nil, status.Error(codes.PermissionDenied,
+                "Actor does not have access to this node")
+        }
+    }
+    return &pb.GetNodeResponse{Found: true, Node: wire.NodeToProto(node)}, nil
+}
+```
+
+## Open questions / risks
+
+1. **`type_id` is unused.** Request carries `type_id` but the Python
+   read ignores it; a node with `node_id="x"` of type 7 is returned
+   even when `type_id=1` was requested. Preserve the bug-for-bug for
+   contract test parity, but file a follow-up to either enforce
+   `node.type_id == req.type_id` or remove the field.
+2. **Exception swallow.** The Python `try/except` at `:1061-1064`
+   masks errors as `found=False`. In Go we should return real errors
+   (`Internal` for unexpected failures); contract tests only assert the
+   abort/found-false pair on auth failures, which Go raises as real
+   `PermissionDenied`. Confirm none of the unit tests assert
+   `found=False` on a non-auth exception path.
+3. **Cross-tenant role uses two queries.** `_check_cross_tenant_read`
+   already calls `resolve_actor_groups` + `has_node_access`, then the
+   handler **redoes** `resolve_actor_groups` + `can_access` for the
+   specific node. The Go port should pass `actor_ids` through the role
+   result to avoid the second resolve.
+4. **`wait_for_offset` failure is silent.** Python ignores the bool
+   return of `_wait_for_offset` for `GetNode`; if the offset never
+   applies, the read returns stale (or `found=False`). Decision to
+   preserve unless EPIC #407 says otherwise.
+5. **`global_store is None` → `"local"`.** Back-compat path skips all
+   membership checks. Ensure Go test fixtures construct a
+   `global_store` for any test that asserts auth, or replicate the
+   skip behaviour exactly.
+6. **No-auth deployments.** When `AuthInterceptor` did not run,
+   `get_authoritative_actor` falls back to the request-supplied actor.
+   Go port must mirror this for unit-test ergonomics; document the
+   expected production deployment requires the interceptor.

--- a/docs/go-port/rpcs/GetNodeByKey.md
+++ b/docs/go-port/rpcs/GetNodeByKey.md
@@ -1,0 +1,307 @@
+# GetNodeByKey — Go Port Spec
+
+EPIC #407. Resolve a node via a **declared unique field** (typed
+`(field_id, value)` token), then delegate to `GetNode` for the
+authoritative ACL check. Read-only.
+
+Python source of truth: `server/python/entdb_server/api/grpc_server.py:1066-1128`.
+Frozen design: `docs/decisions/unique_keys.md` (2026-04-13, superseded by
+`sdk_api.md` 2026-04-14: `field_id` replaces `key_name`, message-level
+`keys: [...]` becomes field-level `(entdb.field).unique = true`,
+storage is a **unique expression index** on `nodes`, no `node_keys`
+table).
+
+## Wire contract (unique-key token shape)
+
+Proto: `proto/entdb/v1/entdb.proto:144-145` (RPC),
+`proto/entdb/v1/entdb.proto:1087-1120` (messages).
+
+```
+rpc GetNodeByKey(GetNodeByKeyRequest) returns (GetNodeByKeyResponse);
+
+GetNodeByKeyRequest {
+  string tenant_id   = 1;
+  string actor       = 2;          // UNTRUSTED on wire (see Auth)
+  int32  type_id     = 3;
+  reserved 4, 5;                   // retired key_name / key_value
+  int64  after_offset = 6;
+  int32  field_id    = 7;          // proto field number, MUST be `unique`
+  google.protobuf.Value value = 8; // typed scalar (str/int/float/bool)
+}
+GetNodeByKeyResponse { Node node = 1; bool found = 2; }
+```
+
+Notes for the Go port:
+
+- **No `RequestContext`.** This RPC predates the context wrapper used
+  by `GetNode`/`GetNodes`; `tenant_id`/`actor` are top-level. Don't
+  "fix" this — it would break wire compat. Pinned by
+  `tests/python/unit/test_unique_keys.py:692-704`.
+- **`value` is `google.protobuf.Value`.** The Python handler unwraps
+  via `json_format.MessageToDict` (`grpc_server.py:1094-1096`). Go
+  port: unwrap with `value.AsInterface()` and pass the resulting
+  `any` straight to the SQLite param binder. Do **not** stringify —
+  SQLite's planner needs the native type to hit the unique expression
+  index.
+- **`after_offset` is `int64`** here (not the `string` form used by
+  `GetNode`). The Python handler stringifies it on call to
+  `_wait_for_offset` (`grpc_server.py:1089`). Default wait is 30s
+  (no `wait_timeout_ms` field on this request — fixed).
+- **Token shape is codegen'd, not stringly-typed.** SDKs construct
+  the `(type_id, field_id)` pair from a `UniqueKey[T]` token emitted
+  by `protoc-gen-entdb-keys`. Server treats them as raw ints; the
+  type safety is purely an SDK concern. See
+  `sdk/python/entdb_sdk/keys.py:30-52`,
+  `sdk/go/entdb/scope.go:164-170`.
+
+## Auth (read; trusted-actor)
+
+Same trusted-actor invariant as `GetNode` but the **outer** handler
+runs only the tenant check directly:
+
+1. `_check_tenant(request.tenant_id)` (`grpc_server.py:1086`) →
+   shard redirect (`UNAVAILABLE` + `entdb-redirect-node` trailer) or
+   region pin (`FAILED_PRECONDITION`). See `GetNode.md` for shape.
+2. `request.actor` is **untrusted**. The handler reads it but does
+   **not** rebind for the unique-index lookup itself (the SQL is
+   tenant-scoped, not actor-scoped). The trusted actor is bound via
+   `self._trusted_actor(request.actor)` (`grpc_server.py:1117`,
+   `:418-437`) only when constructing the inner `GetNodeRequest`, so
+   the cross-tenant / per-node ACL check inside the delegated
+   `GetNode` runs on the authoritative identity. Privilege-escalation
+   pinning by `tests/python/integration/test_privilege_escalation.py`
+   (same fixture covers both RPCs).
+3. **Capability mapping.** `GetNodeByKey → CoreCapability.READ`
+   (`server/python/entdb_server/auth/capability_registry.py:64`).
+   Pinned by `tests/python/unit/test_unique_keys.py:706-712`.
+
+## Side effects (read on canonical_store unique index)
+
+**None.** Pure read. Two SQLite reads at most:
+
+- `canonical_store.get_node_by_key(tenant_id, type_id, field_id,
+  value)` (`canonical_store.py:2215-2227` → `_sync_get_node_by_key`
+  `:2177-2213`). One indexed `SELECT … LIMIT 1` against:
+
+  ```sql
+  SELECT * FROM nodes
+   WHERE tenant_id = ? AND type_id = ?
+     AND json_extract(payload_json, '$."<field_id>"') = ?
+   LIMIT 1
+  ```
+
+  Hits the partial unique expression index
+  `idx_unique_t<type>_f<field>` lazily created by
+  `_ensure_unique_indexes` (`canonical_store.py:1721-1798`). The
+  index is keyed on `(tenant_id, json_extract(...))` filtered by
+  `type_id` so multi-tenant physical files (mailbox/public) stay
+  isolated.
+
+- The delegated `GetNode` call adds a second `get_node` row read plus
+  the cross-tenant ACL chain (`resolve_actor_groups` + `can_access`)
+  — see `GetNode.md` "Side effects".
+
+- Metric: `record_grpc_request("GetNodeByKey", "ok"|"error", dur)`
+  at `:1105`, `:1123`, `:1126`. The metric label is "ok" both for
+  hit and miss; "error" only on unexpected exceptions.
+
+Per-tenant SQLite isolation (invariant #4) preserved: the SQL pins
+`tenant_id` in the WHERE clause and the connection is opened via
+`_get_connection(tenant_id)`.
+
+## Error contract (NOT_FOUND distinct from PERMISSION_DENIED)
+
+Ordered, first-failure-wins:
+
+1. `_check_tenant` →
+   `UNAVAILABLE`/`FAILED_PRECONDITION` (with redirect trailer).
+2. Unknown-tenant catch-all path returns `found=False` in the current
+   Python handler when `_check_tenant` raises and the broad
+   `try/except` swallows it (see Quirk below). Pinned by
+   `tests/python/unit/test_unique_keys.py:642-656`
+   (`test_get_node_by_key_unknown_tenant` → `resp.found is False`).
+3. `_wait_for_offset` (silent failure on timeout — same as `GetNode`).
+4. `canonical_store.get_node_by_key` returns `None` →
+   `GetNodeByKeyResponse(found=False)`, status `OK`. **No abort.**
+   Pinned by `tests/python/unit/test_unique_keys.py:625-640` and
+   `tests/python/integration/test_grpc_contract.py:614-626` (mode
+   `not_found`, `r.found is False`).
+5. Index hit → delegated `GetNode` runs. Its ACL chain decides
+   between `PERMISSION_DENIED` (non-member, or cross-tenant role
+   without per-node grant) and `found=True`. Crucially, **the index
+   resolves before ACL**, so the "key exists but actor lacks ACL"
+   case yields `PERMISSION_DENIED` from the inner call, not
+   `found=False` — distinct from the missing-row case. Pinned by
+   `docs/decisions/unique_keys.md:60-61`.
+
+**Quirk to preserve / fix.** The handler's outer
+`try/except Exception` (`grpc_server.py:1125-1128`) converts every
+uncaught exception — including `_check_tenant` aborts in tests — into
+`GetNodeByKeyResponse(found=False)`. In real `grpc.aio`,
+`context.abort` is terminal, so clients see the abort status; in
+unit-test mocks they see `found=False`. The Go port should:
+
+- Use `status.Errorf` and let the framework terminate the call.
+- Distinguish `NotFound` (key missing on the unique index) from
+  `PermissionDenied` (delegated `GetNode` rejected) at the **gRPC
+  status code level**. The current Python handler conflates "key not
+  in index" with `found=False`; preserve that for SDK compat (the Go
+  SDK already maps `found=false` to `(nil, nil)` —
+  `sdk/go/entdb/client.go:341-344`). Per `unique_keys.md:60-61` the
+  decision text says `NOT_FOUND`, but the implemented contract is
+  `found=False, OK` — pin to the **implementation**, not the doc.
+
+## Shared Go package deps (unique_keys subsystem)
+
+(Paths proposals; freeze in EPIC #407.)
+
+- `tenancy.CheckTenant(ctx, tenantID) error` — shared with `GetNode`.
+- `auth.AuthoritativeActor(ctx) string` — shared.
+- `canonical.Store.WaitForOffset(ctx, tenantID, pos, timeout)` —
+  shared. Note `pos` is `string`; convert from `int64` at boundary.
+- `canonical.Store.GetNodeByKey(ctx, tenantID, typeID, fieldID int32,
+  value any) (*Node, error)` — new method, single SQL above.
+  Returns `(nil, nil)` for miss.
+- `canonical.Store.EnsureUniqueIndexes(ctx, tenantID, typeID,
+  fieldIDs []int32)` — invoked at schema-register and applier-write
+  time; idempotent via process-local cache keyed on
+  `(physical_db_path, type_id)` (`canonical_store.py:1762-1798`).
+  GetNodeByKey itself does **not** call this — the index must already
+  exist. Document this invariant.
+- `canonical.Store.GetNodeByCompositeKey(ctx, tenantID, typeID,
+  fieldIDs, values)` — composite variant (`canonical_store.py:2229+`).
+  Not exposed by `GetNodeByKey` today; see Open questions.
+- `wire.UnwrapValue(*structpb.Value) any` — Python equivalent of
+  `MessageToDict`. The `structpb` Go API already provides
+  `Value.AsInterface()`; use it directly.
+- `metrics.RecordGRPCRequest`.
+
+## Other-RPC deps (GetNode for the resolved id)
+
+- **`GetNode`** is the authoritative read entry-point. The handler at
+  `grpc_server.py:1112-1124` constructs an internal `GetNodeRequest`
+  with `RequestContext{tenant_id, _trusted_actor(request.actor)}` and
+  calls `self.GetNode(get_req, context)`. The Go port MUST call the
+  **internal** Go `GetNode` (same package) — not via the gRPC stub —
+  so the call shares the request-scoped context (auth, deadline,
+  trailer). See `GetNode.md` "Other-RPC deps".
+- **`ExecuteAtomic`** uses the same unique expression index for the
+  pre-validate fast-fail path (`ALREADY_EXISTS` on duplicate creates).
+  Port `GetNodeByKey` and the ExecuteAtomic pre-check together so
+  `_ensure_unique_indexes` has a single owner.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_unique_keys.py:597-623` —
+  happy: `found=True`, `node.node_id == "alice"`.
+- `tests/python/unit/test_unique_keys.py:625-640` —
+  miss: `found=False`, status `OK`.
+- `tests/python/unit/test_unique_keys.py:642-656` —
+  unknown tenant returns `found=False` (see Quirk; Go port should
+  decide whether to preserve or upgrade to `NOT_FOUND`).
+- `tests/python/unit/test_unique_keys.py:692-704` — wire round-trip:
+  `field_id` + typed `Value` survive serialize/parse.
+- `tests/python/unit/test_unique_keys.py:706-712` — capability
+  mapping: `DEFAULT_OP_REQUIREMENTS["GetNodeByKey"] == READ`.
+- `tests/python/integration/test_grpc_contract.py:614-626` —
+  contract: type with no unique fields → `found=False`.
+- `tests/python/unit/test_composite_unique_schema.py:67-128` —
+  composite constraint declaration and registry surface (no RPC for
+  composite lookup yet — see Open questions).
+- `sdk/go/entdb/grpc_transport_test.go:566-589` — Go transport happy
+  path; pins the wire field order `tenant, actor, typeID, fieldID,
+  value`.
+
+## Implementation outline
+
+```go
+func (s *EntDBServer) GetNodeByKey(
+    ctx context.Context, req *pb.GetNodeByKeyRequest,
+) (resp *pb.GetNodeByKeyResponse, err error) {
+    start := time.Now()
+    label := "ok"
+    defer func() {
+        metrics.RecordGRPCRequest("GetNodeByKey", label, time.Since(start))
+    }()
+
+    if err := s.tenancy.CheckTenant(ctx, req.TenantId); err != nil {
+        label = "error"
+        return nil, err // UNAVAILABLE / FAILED_PRECONDITION
+    }
+    if req.AfterOffset != 0 {
+        _, _ = s.canonical.WaitForOffset(
+            ctx, req.TenantId, strconv.FormatInt(req.AfterOffset, 10),
+            30*time.Second)
+    }
+
+    var raw any
+    if req.Value != nil {
+        raw = req.Value.AsInterface()
+    }
+
+    node, err := s.canonical.GetNodeByKey(
+        ctx, req.TenantId, req.TypeId, req.FieldId, raw)
+    if err != nil {
+        label = "error"
+        return nil, status.Errorf(codes.Internal, "lookup: %v", err)
+    }
+    if node == nil {
+        return &pb.GetNodeByKeyResponse{Found: false}, nil
+    }
+
+    // Delegate to the internal GetNode so ACL / cross-tenant /
+    // capability checks stay centralised. Forward the trusted
+    // identity.
+    actor := auth.AuthoritativeActor(ctx) // ignores req.Actor
+    inner, err := s.GetNode(ctx, &pb.GetNodeRequest{
+        Context: &pb.RequestContext{TenantId: req.TenantId, Actor: actor},
+        TypeId:  req.TypeId,
+        NodeId:  node.NodeID,
+    })
+    if err != nil { // PERMISSION_DENIED bubbles up
+        label = "error"
+        return nil, err
+    }
+    return &pb.GetNodeByKeyResponse{
+        Found: inner.Found, Node: inner.Node,
+    }, nil
+}
+```
+
+## Open questions / risks
+
+1. **Composite keys.** `_ensure_composite_unique_indexes` and
+   `_sync_get_node_by_composite_key` exist server-side
+   (`canonical_store.py:1800+`, `:2229+`) and `composite_unique` is a
+   declared proto option (`test_proto_options.py:204-219`, tag 24),
+   but **no `GetNodeByCompositeKey` RPC** is wired. The current
+   `GetNodeByKey` request has a single `field_id` + single `value`.
+   Decide for EPIC #407: extend the request to repeated
+   `(field_id, value)` pairs, or add a sibling RPC. SDK token codegen
+   already needs to handle composite tokens for ExecuteAtomic
+   pre-checks — keep both surfaces aligned.
+2. **Case-sensitivity / normalisation.** The server stores the
+   `value` byte-for-byte and SQLite's `=` is case-sensitive for TEXT
+   by default (no `COLLATE NOCASE`). Per `unique_keys.md:90-92`, the
+   client owns normalisation (e.g. lowercased email). The Go port
+   MUST preserve byte-exact comparison — do not add implicit collations.
+   Document in the SDK that callers normalize before passing.
+3. **SDK token codegen parity.** Python ships
+   `protoc-gen-entdb-keys` emitting `UniqueKey[T]` tokens
+   (`sdk/python/entdb_sdk/keys.py`). The Go SDK currently exposes a
+   `UniqueKey` struct with `TypeID`/`FieldID` and a stringly typed
+   `Value` path (`sdk/go/entdb/scope.go:164-170`). Both SDKs ship in
+   one PR (per `feedback_sdks_in_one_pr.md`); the Go-side codegen
+   plugin must land alongside any server change to the request shape.
+4. **`type_id` vs index `WHERE`.** The unique index is partial on
+   `WHERE type_id = <type>`. If the schema registry ever drops a
+   `unique` flag without rebuilding the index, an old row could
+   shadow a new one. Document an offline `REINDEX` / `DROP INDEX`
+   tool; the runtime won't catch it.
+5. **Outer try/except swallow.** Same risk as `GetNode`. Decide
+   explicitly whether unknown-tenant should remain `found=False` or
+   become `NOT_FOUND` in Go. Pin whichever you choose with a new
+   contract test.
+6. **`after_offset` type drift.** `GetNode` uses `string`,
+   `GetNodeByKey` uses `int64`. Both formats coexist on the wire and
+   in SDKs. Don't unify without a wire-compat plan.

--- a/docs/go-port/rpcs/GetNodes.md
+++ b/docs/go-port/rpcs/GetNodes.md
@@ -1,0 +1,223 @@
+# GetNodes — Go Port Spec
+
+EPIC #407. Batch sibling of `GetNode`. Reference Python handler:
+`server/python/entdb_server/api/grpc_server.py:1215-1291`. Proto:
+`proto/entdb/v1/entdb.proto:58, 409-422`.
+
+## Wire contract
+
+Request `entdb.v1.GetNodesRequest` (proto:409):
+- `RequestContext context` (tenant_id, actor — actor is UNTRUSTED)
+- `int32 type_id` — present in proto but **not consulted** by the handler;
+  Python iterates `node_ids` and trusts whatever `type_id` is on disk
+  (grpc_server.py:1253-1257). Go port must preserve this (do NOT add a
+  type_id filter — would break callers).
+- `repeated string node_ids` — IDs to fetch. Empty list is legal and
+  returns empty response.
+- `string after_offset`, `int32 wait_timeout_ms` — read-after-write
+  fence; default 30s when unset (grpc_server.py:1236-1240).
+
+Response `GetNodesResponse` (proto:419):
+- `repeated Node nodes` — found AND access-allowed nodes. Order is
+  **insertion order from the for-loop** (grpc_server.py:1253), which
+  follows request `node_ids` order **minus** missing/denied entries.
+  Effectively: nodes are emitted in request order, but indexes are NOT
+  parallel to `node_ids` (denied/missing are absent, not nil-padded).
+- `repeated string missing_ids` — IDs that were not-found OR
+  access-denied (cross-tenant). The two cases are **indistinguishable**
+  on the wire — by design.
+
+Batch semantics summary:
+- Order: request order, gaps closed.
+- Skip missing: yes, into `missing_ids`.
+- All-or-nothing: no. Partial success is the norm.
+- Duplicates in `node_ids`: not deduped; each lookup runs independently
+  (Python loops verbatim). Go port must match.
+
+## Auth
+
+- Tenant existence: `_check_tenant` (grpc_server.py:1227, 362).
+- Trusted actor: `_trusted_actor(request.context.actor)` — actor from
+  payload is OVERWRITTEN with `AuthInterceptor.get_authoritative_actor`
+  (grpc_server.py:1228, 418, 586-588). This is the privilege-escalation
+  fix; the Go port must read the trusted identity from the gRPC
+  context/metadata via the AuthInterceptor equivalent and ignore the
+  request-payload actor for any auth decision. See
+  `tests/python/integration/test_privilege_escalation.py:213-228`.
+- Tenant membership / cross-tenant: `_check_cross_tenant_read`
+  (grpc_server.py:1229, 561-618). Returns `"local"` (no global_store),
+  `"member"`, `"cross_tenant"`, or aborts `PERMISSION_DENIED`.
+- Per-node ACL (cross-tenant only): when role is `cross_tenant`, each
+  individual node is checked via `canonical_store.can_access(tenant,
+  node_id, actor_ids)` (grpc_server.py:1262-1271). Members bypass
+  per-node ACL entirely. Denied nodes are folded into `missing_ids`,
+  NOT surfaced as PERMISSION_DENIED — this is a deliberate
+  information-leak guard: a cross-tenant actor cannot probe whether a
+  node exists vs whether they lack access.
+- Capability: `READ` (`tests/python/unit/test_capability_registry.py:62`).
+
+## Side effects
+
+None on the happy path. Read-only. Metric `record_grpc_request("GetNodes",
+"ok"|"error", elapsed)` (grpc_server.py:1286, 1289). No WAL append, no
+SQLite write, no audit row. The `after_offset` fence may block up to
+`wait_timeout_ms` (default 30s) waiting for the applier to catch up
+(grpc_server.py:937, `_wait_for_offset`).
+
+## Error contract
+
+| Condition | Python behaviour | Go port |
+|---|---|---|
+| Tenant missing/disabled | `_check_tenant` aborts `NOT_FOUND` / `FAILED_PRECONDITION` | match |
+| Actor not member, no node_access | `_check_cross_tenant_read` aborts `PERMISSION_DENIED` (batch-level — fails the whole call before any lookups) | match |
+| Claimed-actor mismatch (payload says admin, trusted is user:eve) | `PERMISSION_DENIED` from `_check_cross_tenant_read` after substitution | match — `test_privilege_escalation.py:218-228` |
+| Some node_ids not in store | placed in `missing_ids`; call returns OK | match |
+| Some node_ids exist but cross-tenant actor lacks ACL | placed in `missing_ids`; call returns OK | match — must NOT distinguish from not-found |
+| All node_ids missing | OK, `nodes=[]`, `missing_ids=<all>` | match |
+| Empty `node_ids` | OK, both lists empty | match |
+| `after_offset` not reached within timeout | currently swallowed by outer `except` and degrades to "all missing" (grpc_server.py:1288-1291) | **see Open Questions** |
+| Internal error (SQLite, panic) | bare `except`: log + return `nodes=[], missing_ids=<all request ids>` with status OK (grpc_server.py:1288-1291). Effectively swallows errors as "everything missing" | preserve for parity in v1; flag for review (this masks data-loss bugs) |
+
+Partial-failure mode is the key invariant: **GetNodes never returns a
+non-OK gRPC status for per-id failures.** Auth and tenant-existence
+errors are batch-level and abort the whole call.
+
+## Shared Go package deps
+
+- `internal/auth` — `AuthInterceptor`, `GetAuthoritativeActor(ctx)`,
+  trusted-actor extraction from gRPC metadata.
+- `internal/tenant` — `CheckTenant`, `CheckCrossTenantRead` (returns
+  `RoleLocal | RoleMember | RoleCrossTenant`).
+- `internal/canonical` — `Store.GetNode(tenantID, nodeID)`,
+  `Store.CanAccess(tenantID, nodeID, actorIDs)`,
+  `Store.ResolveActorGroups(tenantID, actor)`.
+- `internal/applier` — `WaitForOffset(tenantID, offset, timeout)`.
+- `internal/wire` — `nodeToProto` (the `payload`/`acl` conversion that
+  Python does at grpc_server.py:1273-1283; field-IDs preserved on disk
+  per CLAUDE.md invariant 6).
+- `internal/metrics` — `RecordGRPCRequest`.
+- Standard `google.golang.org/grpc/status`, `codes`.
+
+## Other-RPC deps
+
+- Shares helpers with `GetNode` (rpcs/GetNode.md), `QueryNodes`,
+  `GetNodeByKey` (which delegates to `GetNode`, grpc_server.py:1122).
+- Same auth path as every read RPC; spec the helpers in
+  `docs/go-port/shared/auth.md` and `docs/go-port/shared/tenant.md`
+  rather than re-deriving here.
+- No dependency on write RPCs at runtime, but contract tests seed via
+  `ExecuteAtomic`.
+
+## Contract tests pinning behavior
+
+- `tests/python/unit/test_payload_wire_format.py:192-215` — id-keyed
+  payload on the wire (field-IDs, not names).
+- `tests/python/unit/test_cross_tenant_read.py:10` (file header) and
+  cross-tenant filter cases at lines 254-407 — covers
+  `cross_tenant` per-node filtering that GetNodes inherits.
+- `tests/python/unit/test_capability_registry.py:62` — RPC mapped to
+  `CoreCapability.READ`.
+- `tests/python/integration/test_grpc_contract.py:223-233` — happy-path
+  with one hit + one miss returns at least the hit; missing IDs
+  tolerated.
+- `tests/python/integration/test_privilege_escalation.py:213-228` —
+  claimed-admin actor in payload is rejected with `PERMISSION_DENIED`
+  when trusted identity is a regular user.
+
+Go port adds (`tests/contract/`): order preservation, duplicate
+node_ids, empty list, cross-tenant per-node filtering folds into
+`missing_ids` (does NOT abort), `after_offset` fence behaviour.
+
+## Implementation outline
+
+```go
+func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.GetNodesResponse, error) {
+    start := time.Now()
+    defer func() { metrics.RecordGRPCRequest("GetNodes", status, time.Since(start)) }()
+
+    if err := s.checkTenant(ctx, req.Context.TenantId); err != nil { return nil, err }
+    trusted := auth.GetAuthoritativeActor(ctx)              // ignore req.Context.Actor
+    role, err := s.checkCrossTenantRead(ctx, req.Context.TenantId, trusted)
+    if err != nil { return nil, err }                       // PERMISSION_DENIED batch-level
+
+    if req.AfterOffset != "" {
+        timeout := 30 * time.Second
+        if req.WaitTimeoutMs > 0 { timeout = time.Duration(req.WaitTimeoutMs) * time.Millisecond }
+        _ = s.applier.WaitForOffset(ctx, req.Context.TenantId, req.AfterOffset, timeout)
+    }
+
+    var actorIDs []string
+    if role == tenant.RoleCrossTenant {
+        actorIDs, _ = s.store.ResolveActorGroups(ctx, req.Context.TenantId, trusted)
+    }
+
+    // Bounded concurrency for per-id lookups (parity perf, not parity behaviour).
+    // Cap = min(len(node_ids), maxFanout=32). Preserve request order on output.
+    nodes := make([]*pb.Node, 0, len(req.NodeIds))
+    missing := make([]string, 0)
+    sem := make(chan struct{}, 32)
+    results := make([]*canonical.Node, len(req.NodeIds))
+    denied := make([]bool, len(req.NodeIds))
+    var wg sync.WaitGroup
+    for i, id := range req.NodeIds {
+        i, id := i, id
+        wg.Add(1); sem <- struct{}{}
+        go func() {
+            defer func() { <-sem; wg.Done() }()
+            n, _ := s.store.GetNode(ctx, req.Context.TenantId, id)
+            if n == nil { return }
+            if actorIDs != nil {
+                ok, _ := s.store.CanAccess(ctx, req.Context.TenantId, id, actorIDs)
+                if !ok { denied[i] = true; return }
+            }
+            results[i] = n
+        }()
+    }
+    wg.Wait()
+    for i, id := range req.NodeIds {
+        if results[i] == nil || denied[i] { missing = append(missing, id); continue }
+        nodes = append(nodes, wire.NodeToProto(results[i]))
+    }
+    return &pb.GetNodesResponse{Nodes: nodes, MissingIds: missing}, nil
+}
+```
+
+Notes on performance & limits:
+- **Bounded concurrency**: cap at 32 in-flight `GetNode` calls per request
+  to avoid SQLite-pool starvation under a 10k-id batch. Python is
+  serial; Go can parallelise without changing behaviour because
+  per-id lookups are independent.
+- **Message-size limit**: the response can blow past gRPC's default 4
+  MiB if the batch is large. Set a server-side guardrail
+  (`maxBatchNodeIDs`, default 1000) and abort
+  `RESOURCE_EXHAUSTED` if `len(req.NodeIds) > maxBatchNodeIDs` BEFORE
+  doing any I/O. Python has no such cap — flag as a hardening delta in
+  the porting changelog.
+- **grpc.aio invariant**: handler must be a method on the async-gRPC
+  server (`grpc-go` is async by default; no special action — but no
+  goroutine should block on a sync sqlite call without going through
+  the canonical store's pool).
+
+## Open questions / risks
+
+1. **`after_offset` timeout swallowed**: the bare `except` at
+   grpc_server.py:1288 turns an applier-fence timeout into "all ids
+   missing" with status OK. Should the Go port match (parity) or
+   surface `DEADLINE_EXCEEDED`? Recommend: match for v1, file
+   follow-up issue.
+2. **`type_id` field is ignored**: proto:411 declares `type_id` but
+   the handler never reads it. Either (a) start enforcing it (breaking
+   change — needs deprecation cycle) or (b) document as advisory and
+   add a contract test that mismatched type_id still returns the node.
+   Recommend (b) for v1.
+3. **Information leak via timing**: cross-tenant denied vs not-found
+   are merged into `missing_ids`, but per-id latency may differ
+   (denied requires `can_access` round-trip after `get_node`). Low
+   risk; out of scope.
+4. **Batch size cap**: Python has none. Go port should add
+   `RESOURCE_EXHAUSTED` at e.g. 1000 ids — confirm with EPIC #407 owner.
+5. **Duplicate node_ids**: Python emits the same node twice if
+   requested twice. Match exactly, or dedupe? Recommend: match.
+6. **Per-node ACL cache**: 32-way fan-out hits `can_access` per id.
+   For high-cardinality batches consider a single bulk
+   `CanAccessMany(tenant, ids, actorIDs)` — out of scope for parity v1.

--- a/docs/go-port/rpcs/GetReceiptStatus.md
+++ b/docs/go-port/rpcs/GetReceiptStatus.md
@@ -1,0 +1,166 @@
+# GetReceiptStatus — Go port spec
+
+EPIC: #407 (Python -> Go server reimplementation).
+
+`entdb.v1.EntDBService.GetReceiptStatus` is the read-side companion to
+`ExecuteAtomic`. Clients poll it with the `idempotency_key` they supplied at
+write time to learn whether the WAL event has been materialized into the
+tenant's SQLite view yet. It is a pure read against `applied_events`, never
+touches the WAL, and never mutates state.
+
+## Wire contract
+
+- Proto: `proto/entdb/v1/entdb.proto:52` (rpc), `:375-389` (messages + enum).
+- Request `GetReceiptStatusRequest`:
+  - `RequestContext context = 1` — `tenant_id`, `actor`, `trace_id`. `actor` is UNTRUSTED (see Auth).
+  - `string idempotency_key = 2` — the same key the caller passed to `ExecuteAtomic`.
+- Response `GetReceiptStatusResponse`:
+  - `ReceiptStatus status = 1` — `UNKNOWN(0) | PENDING(1) | APPLIED(2) | FAILED(3)`.
+  - `string error = 2` — populated only when `status == UNKNOWN` (handler-internal exception, see Error contract).
+- The Python handler **never aborts** on application-level failure; it returns
+  `UNKNOWN` + `error`. Only `_check_tenant` may abort (UNAVAILABLE / FAILED_PRECONDITION).
+  Go must preserve this asymmetry — contract tests assert it.
+
+## Auth (Permission, trusted-actor)
+
+Per server/python/entdb_server/api/grpc_server.py:946-971 there is **no**
+permission check, no `Permission` enum lookup, no node-level ACL evaluation,
+and no use of `_resolve_trusted_actor`. The handler:
+
+1. Calls `_check_tenant(tenant_id, ctx)` (grpc_server.py:362-410) — sharding
+   ownership + region pinning. This is the only ingress gate.
+2. Reads `applied_events` for `(tenant_id, idempotency_key)`.
+
+`request.context.actor` is read off the wire but **never used** for
+authorization. The Go port MUST NOT add a permission check here — doing so
+would tighten the contract and break SDK polling flows that pass
+`actor="system"` (sdk/python/entdb_sdk/_grpc_client.py:863).
+
+Trusted-actor invariant: there is no actor-derived effect. No actor is logged
+into the WAL by this RPC (it doesn't write).
+
+## Side effects
+
+None. Pure read of `applied_events` via
+`canonical_store.check_idempotency` (server/python/entdb_server/apply/canonical_store.py:1377-1405).
+No WAL append, no SQLite write, no global_store write, no fanout.
+
+Cross-cutting: `record_grpc_request("GetReceiptStatus", "ok"|"error", elapsed)`
+metric (grpc_server.py:964,967). Go must emit the equivalent label.
+
+## Error contract (exhaustive)
+
+| Cause | Code | Body |
+| --- | --- | --- |
+| Tenant not owned by this node, owner known | `UNAVAILABLE` + trailer `entdb-redirect-node: <owner>` | aborted; "Tenant '<id>' is not served by this node (try node <owner>)" |
+| Tenant not owned by this node, owner unknown | `UNAVAILABLE` | aborted; "Tenant '<id>' is not served by this node" |
+| Tenant pinned to region != served_region | `FAILED_PRECONDITION` | aborted; region message |
+| Any other exception (SQLite IO, panic in `check_idempotency`) | `OK` | `status=UNKNOWN`, `error=<str(exc)>` |
+| Idempotency key not in `applied_events` | `OK` | `status=PENDING`, `error=""` |
+| Idempotency key in `applied_events` | `OK` | `status=APPLIED`, `error=""` |
+
+Notes:
+- The Python handler's bare `except Exception` (grpc_server.py:966) means
+  even programmer errors collapse to `UNKNOWN`. Go should match this for
+  parity (recover panics in handler, return `status=UNKNOWN`,
+  `error=err.Error()`); resist the urge to return `Internal`.
+- `RECEIPT_STATUS_FAILED` is **never produced** by the Python server today —
+  the enum value exists for future use (and the Python SDK maps it for
+  forward compatibility, _grpc_client.py:878). The Go port should leave it
+  unproduced unless EPIC #407 explicitly adds a failed-receipt table.
+- `error` field is mutually exclusive with non-UNKNOWN status.
+
+## Shared Go package deps
+
+(Names suggested — actual layout TBD by EPIC #407 shared-pkg spec.)
+
+- `internal/shard` — sharding registry, exposes `IsMine(tenantID) bool` and `Owner(tenantID) (string, bool)`. Mirror of `self._sharding`.
+- `internal/region` — served-region check; mirrors `self.served_region` + `global_store.get_tenant`.
+- `internal/store/canonical` — `CheckIdempotency(ctx, tenantID, idemKey) (bool, error)` against per-tenant SQLite. Maps to canonical_store.py:1391.
+- `internal/metrics` — `RecordGRPC(method, outcome, duration)` (Prometheus histogram, same labels as Python).
+- `internal/grpcutil` — `AbortWithRedirect(ctx, code, msg, ownerNode)` helper that sets the `entdb-redirect-node` trailer **before** returning the status (grpc_server.py:387-395 ordering matters; SDKs depend on it).
+- Generated proto pkg: `sdk/go/entdb/internal/pb` already exists; the server should use a sibling generated package (e.g. `server/go/internal/pb`).
+
+No crypto, no auth, no schema_registry deps — this RPC is intentionally minimal.
+
+## Other-RPC deps (especially ExecuteAtomic interplay)
+
+- **ExecuteAtomic** (grpc_server.py:~600-828) is the only producer of
+  rows in `applied_events`. The applier's `apply_with_idempotency`
+  (canonical_store.py:1454-1505) inserts the row atomically with the SQLite
+  mutations under `BEGIN IMMEDIATE`. Therefore: a row visible to
+  `GetReceiptStatus` ⇒ all materialized writes for that event are also
+  visible. Go must preserve this **single-transaction** insert-or-skip — do
+  not split idempotency recording from the data write.
+- **WaitForOffset** (grpc_server.py:973) is the lower-level synchronization
+  primitive used by `ExecuteAtomic`'s `wait_applied=true` path. Clients that
+  set `wait_applied` get `applied_status` in the response and typically don't
+  need to call `GetReceiptStatus`. `GetReceiptStatus` is the fallback for
+  fire-and-forget writers and for retries after a network error where the
+  writer never saw the receipt.
+- **Applier** (server/python/entdb_server/apply/applier.py) consumes the WAL
+  and calls `apply_with_idempotency`. The receipt becomes visible only after
+  the applier processes the event — so a `PENDING` here means "WAL accepted,
+  applier hasn't caught up" (or "key was never issued"; the two are
+  indistinguishable, see Open questions).
+
+## Contract tests pinning behavior (file:line)
+
+- tests/python/integration/test_grpc_contract.py:313-326 — the two cases:
+  - `idempotency_key="seed-1"` (issued by the seed `ExecuteAtomic` at line 138-153 with `wait_applied=true`) MUST return `RECEIPT_STATUS_APPLIED`.
+  - `idempotency_key="never-issued"` MUST return `RECEIPT_STATUS_PENDING` (NOT `UNKNOWN` — Python collapses both unknown-key and not-yet-applied into `PENDING`).
+- The same harness (lines 100-171) builds the server with `Applier` running and `wait_applied=true` on seed, so by the time the receipt query runs the row is in `applied_events`. Go contract tests should reuse this fixture pattern.
+- Trailer / redirect contract for `_check_tenant`: covered by sharding tests (search `entdb-redirect-node`); GetReceiptStatus inherits this surface.
+- SDK transport-level expectations:
+  - sdk/go/entdb/transport_extras_test.go:131-150 — APPLIED decodes to `ReceiptStatusApplied`, `error` empty.
+  - sdk/go/entdb/transport_extras_test.go:153-172 — UNKNOWN+error surfaces as `(ReceiptStatusUnknown, "<error>", nil)` — note `nil` Go error because the RPC returned OK.
+  - sdk/python/entdb_sdk/_grpc_client.py:875-881 — string-map round trip; FAILED is in the map even though the server doesn't produce it.
+
+## Implementation outline
+
+Go server method, on a `EntDBServiceServer` impl using `grpc-go` (server-side
+equivalent of `grpc.aio`; the Python invariant "all handlers async" maps to
+"all handlers non-blocking, no goroutine-per-request explosion" in Go — keep
+SQLite work behind a bounded worker pool to mirror the Python `_run_sync`
+thread pool):
+
+1. `start := time.Now()`; defer `metrics.RecordGRPC("GetReceiptStatus", outcome, time.Since(start))`.
+2. `if err := s.checkTenant(ctx, req.GetContext().GetTenantId()); err != nil { return nil, err }` — checkTenant returns a `status.Error` already populated (with the redirect trailer set on `ctx` via `grpc.SetTrailer` BEFORE returning).
+3. `applied, err := s.canonical.CheckIdempotency(ctx, tenantID, req.GetIdempotencyKey())`.
+4. On `err != nil` (or recovered panic): return `&pb.GetReceiptStatusResponse{ Status: pb.ReceiptStatus_RECEIPT_STATUS_UNKNOWN, Error: err.Error() }, nil`. Mark outcome=`error` for metrics. Do NOT return a gRPC error.
+5. Else: return `Status: APPLIED if applied else PENDING`, empty `Error`. outcome=`ok`.
+6. Ignore `req.GetContext().GetActor()` entirely.
+
+Connection-pool concurrency: `CheckIdempotency` is a `SELECT 1` on a UNIQUE
+`(tenant_id, idempotency_key)` index (canonical_store.py:1100). Use a
+read-only connection from the per-tenant pool; do not open a write
+transaction.
+
+## Open questions / risks
+
+- **PENDING ambiguity.** Today PENDING means "applier behind" OR "key never
+  issued". A misbehaving client could poll forever for a typo. The Go port
+  should preserve the existing behavior for parity; logging the key at
+  TRACE level is fine, but do not change the wire contract here.
+- **No TTL on `applied_events`.** Receipts are queryable forever. If
+  retention is added later (compaction), `GetReceiptStatus` will start
+  returning `PENDING` for keys that were once `APPLIED`. Out of scope for
+  port; flag for the durability/compaction work-stream.
+- **`RECEIPT_STATUS_FAILED` is never set.** The proto leaves room for
+  durably-failed events (e.g., schema-fingerprint mismatch surfaced
+  asynchronously by the applier). Today such failures are surfaced via
+  `ExecuteAtomicResponse.error_code` only. The Go port should NOT
+  speculatively start emitting FAILED — that would be a contract widening
+  not pinned by any test.
+- **Untrusted actor in `RequestContext`.** Even though we don't auth on it,
+  a future logging change must not echo `actor` into audit logs as if it were
+  trusted. Keep the field at the wire boundary, drop it before any
+  downstream use.
+- **Panic safety.** Python's `except Exception` swallows everything; Go's
+  default behavior is to crash the goroutine. Add a defer-recover in the
+  handler (or rely on a server-wide unary interceptor) and mirror the
+  Python `UNKNOWN`+`error` shape. Otherwise contract tests pass but
+  behavior differs under fault injection.
+- **Region pinning + idempotency keys are global per tenant.** A tenant
+  migrated across regions could see receipts disappear. Tracked separately;
+  not introduced by this RPC.

--- a/docs/go-port/rpcs/GetSchema.md
+++ b/docs/go-port/rpcs/GetSchema.md
@@ -1,0 +1,102 @@
+# GetSchema — Go Port Spec
+
+EPIC #407. Reference Python: `server/python/entdb_server/api/grpc_server.py:1619-1689`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:79` (rpc), `:590-596` (request), `:598-607` (response).
+
+Request `GetSchemaRequest`:
+- `int32 type_id = 1` — optional. When non-zero, response is filtered to that node type plus edge types touching it.
+- `string tenant_id = 2` — optional. Used only as the data-driven fallback key when the registry is empty.
+
+Response `GetSchemaResponse`:
+- field 1 RESERVED (`schema_json`); do not reuse.
+- `string fingerprint = 2` — `sha256:<hex>` from the in-memory registry, or `""` when registry is unfrozen / empty.
+- `google.protobuf.Struct schema = 3` — `{node_types: [...], edge_types: [...]}`. Empty registry + empty tenant_id => zero-valued Struct.
+
+The RPC is read-only and idempotent. There is no `RequestContext` field (unlike most other RPCs); auth still applies via interceptor metadata.
+
+## Auth (Permission, trusted-actor handling)
+
+The Python handler does NOT call `_check_tenant`, has no Permission check, and never reads `request.actor` (no such field). All access control comes from the auth interceptor:
+
+- Auth interceptor extracts trusted actor from session/JWT/API-key in metadata. See CLAUDE.md invariant #3 + `auth/` package.
+- Anonymous callers: Python currently allows them (no explicit gate). Go port SHOULD preserve this — `GetSchema` is treated as effectively public metadata, since the registry is process-global and contains no tenant data.
+- The optional `tenant_id` is used only to read distinct type IDs from that tenant's SQLite. The Go port MUST NOT trust `request.tenant_id` for authorization decisions; it is a hint that gates a read against the caller's already-authorized scope. If the auth interceptor produced a tenant binding that disagrees with `request.tenant_id`, follow project policy (cross-tenant read => permission_denied).
+- No `request.actor` field exists in `GetSchemaRequest`; the "ignore client-claimed actor" rule (commit `fece3fb`) is structurally satisfied.
+
+## Side effects
+
+None. Specifically:
+- WAL: not appended. Read-only RPC.
+- canonical_store: read-only — `get_distinct_type_ids` (`apply/canonical_store.py:4076`) and `get_distinct_edge_type_ids` (`:4103`). Both are `SELECT … GROUP BY` against the per-tenant SQLite (`:4063-4074`, `:4087-4101`) wrapped via `_run_sync` (CLAUDE.md invariant #4).
+- global_store: untouched.
+- quotas / rate limits: not enforced in the handler; rely on interceptor.
+- schema registry: read-only (`schema_registry.to_dict()` `schema/registry.py:463-477`; `.fingerprint` property `:103-106`).
+
+## Error contract (exhaustive grpc-code → trigger pairs)
+
+The Python handler is unusual: it swallows ALL errors and returns `GetSchemaResponse(fingerprint="")` with `OK` status (`grpc_server.py:1686-1689`). The Go port MUST preserve this contract — the contract test (`tests/python/integration/test_grpc_contract.py:208`) only requires `r.fingerprint != "" or r.HasField("schema")`, so an empty-but-OK response is the documented degraded path.
+
+| grpc.Code | Trigger |
+|---|---|
+| `OK` | Always returned by the Python handler, including under exception. Go MUST match. |
+| `Unauthenticated` | Auth interceptor only (no creds / bad token). Not from handler. |
+| `PermissionDenied` | Auth interceptor only (cross-tenant `tenant_id` outside caller scope, if policy enforces). Not from handler. |
+| `Unavailable` / `FailedPrecondition` | Interceptor-level (e.g. shard-redirect via `entdb-redirect-node` trailer). `GetSchema` does NOT call `_check_tenant`, so it does NOT emit the redirect trailer — Go port should match. |
+| `Internal` | NOT returned. Distinct-types SQLite errors are caught and logged at DEBUG (`:1665-1666`); outer catch-all at `:1686-1689`. |
+
+Implication for Go: catch panics + every error from `canonical_store` / registry, log, and degrade. Do not propagate to `status.Error`.
+
+## Shared Go package deps (one-line rationale each)
+
+- `internal/schema` — port of `SchemaRegistry`: holds `NodeTypeDef`/`EdgeTypeDef`, exposes `ToMap() map[string]any`, `Fingerprint() string`, freeze semantics (`schema/registry.py:88-106`, `:420-461`).
+- `internal/canonicalstore` — Go port of `canonical_store`: needs `GetDistinctTypeIDs(ctx, tenantID)` and `GetDistinctEdgeTypeIDs(ctx, tenantID)` returning `[]struct{TypeID int32; Count int64}` (`apply/canonical_store.py:4076`, `:4103`).
+- `internal/structpb` (or stdlib `structpb` from `google.golang.org/protobuf/types/known/structpb`) — for converting `map[string]any` → `*structpb.Struct`, mirroring `_dict_to_struct` (`grpc_server.py:154-159`).
+- `internal/metrics` — `RecordGRPCRequest("GetSchema", "ok"|"error", duration)` mirroring `record_grpc_request` (`:1681`, `:1687`).
+- `internal/logging` — structured logger; debug-level for fallback failure (`:1666`), error-level for outer catch (`:1688`).
+
+## Other-RPC deps
+
+None at runtime. The fingerprint returned here is consumed by `ExecuteAtomic` (proto field `schema_fingerprint`, `internal/pb/entdb.pb.go:490`) for client-side schema-pinning, but `ExecuteAtomic` reads its own copy from the registry. Go port can implement `GetSchema` standalone.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:203-209` — happy path: `tenant_id=TENANT`, mode "happy", check `r.fingerprint != "" or r.HasField("schema")`. This is the SOLE behavioral pin; Go port must satisfy it via either path (frozen registry => fingerprint set; empty registry => Struct populated from canonical_store).
+- `sdk/go/entdb/cmd/entdbctl/cmd_schema_test.go:36` — Go SDK CLI test asserting response shape (consumer-side).
+- `sdk/go/entdb/cmd/entdbctl/testutil_test.go:32-60` — fake server signature pins the proto contract.
+- `sdk/go/entdb/cmd/entdb-console/upstream_stub.go:36-37` — console upstream pin.
+
+No unit test exercises the handler directly; behavior is pinned only by the contract test above and by SDK consumer tests.
+
+## Implementation outline (numbered Go handler steps)
+
+```go
+func (s *Server) GetSchema(ctx context.Context, req *pb.GetSchemaRequest) (*pb.GetSchemaResponse, error)
+```
+
+1. `start := time.Now()`. Defer metrics emission with status label `"ok"` by default; recover from panic and switch to `"error"` (mirrors `:1681`/`:1687`).
+2. Wrap the entire body in a `func() (*pb.GetSchemaResponse, error)` closure with a `defer recover()`. On any error or panic: log at error level, return `&pb.GetSchemaResponse{Fingerprint: ""}, nil` — no status error (`:1686-1689`).
+3. Snapshot the schema: `schemaMap := s.schemaRegistry.ToMap()` and `fingerprint := s.schemaRegistry.Fingerprint()`. `ToMap` MUST sort `node_types` / `edge_types` by ID for fingerprint determinism (`schema/registry.py:470-477`).
+4. `hasRegistryTypes := len(schemaMap["node_types"].([]any)) > 0 || len(schemaMap["edge_types"].([]any)) > 0`.
+5. If `!hasRegistryTypes && req.TenantId != ""`: call `canonicalStore.GetDistinctTypeIDs(ctx, req.TenantId)` and `GetDistinctEdgeTypeIDs(ctx, req.TenantId)`. On error: log at DEBUG and skip (`:1665-1666`) — leave `schemaMap` empty. On success: rebuild `schemaMap` as in `:1645-1664`:
+   - `node_types[i] = {type_id, name: fmt.Sprintf("Type_%d", id), fields: []}`
+   - `edge_types[i] = {edge_id, name: fmt.Sprintf("Edge_%d", id), from_type_id: 0, to_type_id: 0, props: []}`
+6. If `req.TypeId != 0`: filter in place (`:1668-1679`):
+   - `node_types`: keep where `type_id == req.TypeId`.
+   - `edge_types`: keep where `from_type_id == req.TypeId || to_type_id == req.TypeId`.
+   Note: filtering happens AFTER the data-driven fallback, so a fallback-built schema (with `from_type_id=0`) will only retain edge types when `req.TypeId == 0`.
+7. Convert `schemaMap` → `*structpb.Struct` via `structpb.NewStruct(schemaMap)`. If conversion errors (non-JSON-able value), log error and degrade per step 2.
+8. Return `&pb.GetSchemaResponse{Schema: structVal, Fingerprint: fingerprint}`. When the registry is unfrozen `fingerprint == ""`, matching Python's `self.schema_registry.fingerprint or ""` (`:1684`).
+9. Emit metric `RecordGRPCRequest("GetSchema", "ok", elapsed)` on the success path before return.
+
+## Open questions / risks
+
+- **Auth posture**: Python silently allows anonymous calls. Confirm with EPIC owners whether Go should require an authenticated principal (consensus reading of CLAUDE.md security commit `fece3fb` suggests yes for everything else, but `GetSchema` is metadata-only). Default: keep parity, allow anonymous, document.
+- **Cross-tenant `tenant_id`**: Handler reads from `req.TenantId`'s SQLite without checking caller's tenant scope. This leaks distinct `type_id` integers across tenants. Likely a latent bug. Go port should add a `_check_tenant`-equivalent gate when `req.TenantId != ""` and the caller is bound to a different tenant — but flag this as a behavior change vs. Python and gate it behind a feature flag for the contract-test transition.
+- **Empty registry + non-zero `type_id` + empty `tenant_id`**: Python returns the zero-value Struct after filtering. Go must replicate (no panic on `nil` slices).
+- **Struct conversion of integer keys**: `to_dict()` emits `type_id` as Go `int`/Python `int`. `structpb.NewStruct` requires float64 for numbers — confirm round-trip. The Python side returns it via `Struct.update(d)` which floats integers; clients (incl. SDKs) already handle this. Match it.
+- **Fingerprint determinism**: Go `ToMap` MUST sort by ID and use deterministic JSON (no map iteration order) — fingerprint is `sha256:<hex>` of canonical JSON (`registry.py:448-461`). Cross-language fingerprint parity is required so existing Python-issued fingerprints validate against a Go-served registry; verify via a contract test against a fixed test registry.
+- **Metric name**: Python uses `"GetSchema"`. Go must emit identical label so existing dashboards keep working.
+- **Schema fallback mismatch**: Data-driven fallback yields `from_type_id=0,to_type_id=0` placeholders (`:1658-1660`); under `type_id` filter (step 6) a non-zero filter drops all edges. Documented as-is — likely benign but surfaces in alerts if anyone queries with both flags. No fix in port.

--- a/docs/go-port/rpcs/GetTenant.md
+++ b/docs/go-port/rpcs/GetTenant.md
@@ -1,0 +1,133 @@
+# GetTenant — Go Port Spec
+
+EPIC #407. Reference Python: `server/python/entdb_server/api/grpc_server.py:2362-2395`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:119` (rpc), `:880-883` (request), `:885-888` (response), `:853-863` (`TenantDetail`).
+
+Request `GetTenantRequest`:
+- `string actor = 1` — REQUIRED. Non-empty string check at handler boundary (`grpc_server.py:2376-2377`). Per project security policy (commit `fece3fb`), the handler MUST NOT trust the client-supplied actor for authorization; the trusted principal comes from the auth interceptor. The field is still validated for non-emptiness so the wire contract matches every other registry RPC.
+- `string tenant_id = 2` — REQUIRED. Non-empty (`:2378-2379`).
+
+Response `GetTenantResponse`:
+- `bool found = 1` — `true` iff the tenant row exists in `global_store`'s `tenant_registry` table.
+- `TenantDetail tenant = 2` — populated only when `found == true`. Fields: `tenant_id`, `name`, `status`, `created_at` (unix seconds), `region` (e.g. `"us-east-1"`).
+
+The RPC is read-only and idempotent. There is no `RequestContext` field. Lookups hit a process-global SQLite (the registry), so the call is region-agnostic — confirmed by `tests/python/integration/test_region_pinning.py:97-106` (an EU-served instance can read a US-pinned tenant's metadata).
+
+## Auth (member-only? admin? trusted-actor)
+
+Effectively public-within-authenticated-callers. The Python handler performs NO permission check:
+- It does NOT call `_check_tenant` (contrast `GetTenantQuota` at `grpc_server.py:3130`).
+- It does NOT consult `_get_member_role` (`:2290-2296`).
+- It does NOT distinguish member vs non-member; any caller who passes the empty-string gates gets the row.
+
+This is intentional and pinned by tests: `tests/python/unit/test_tenant_registry.py:307-321` calls `GetTenant` with an arbitrary `user:alice` actor and expects the response without setting up any membership. The region-pinning test at `tests/python/integration/test_region_pinning.py:99-106` further pins that an actor (`user:bob`) reading another tenant's row (`t-us`) succeeds — i.e., cross-tenant metadata reads are allowed.
+
+Trusted-actor handling for the Go port:
+- Auth interceptor extracts the trusted principal from session/JWT/API-key metadata (CLAUDE.md invariant #3).
+- `request.actor` is validated for emptiness ONLY. Do not derive identity from it; do not compare it against the trusted principal here (other handlers e.g. `GetTenantQuota` do that via `_check_tenant`, but `GetTenant` deliberately does not).
+- Anonymous callers: rejected by the auth interceptor before reaching the handler. The handler itself does not care.
+
+Open: see "Open questions" below — exposing `created_at`/`region` to non-members is arguably a small information leak; the Go port preserves parity by default.
+
+## Side effects (read on global_store)
+
+None — read-only.
+
+- WAL: not appended (CLAUDE.md invariant #1 satisfied trivially; reads bypass the WAL).
+- `global_store.get_tenant(tenant_id)` (`server/python/entdb_server/global_store.py:489-502`): single `SELECT * FROM tenant_registry WHERE tenant_id = ?` against the global SQLite, wrapped via `_run_sync` to keep the gRPC `aio` thread non-blocking (CLAUDE.md invariant #3).
+- per-tenant `canonical_store`: untouched. Cross-tenant boundary (CLAUDE.md invariant #4) is not crossed because the registry lives in `global_store`'s own SQLite.
+- quotas / rate limits: not enforced in the handler; rely on interceptor.
+- metrics: emits `record_grpc_request("GetTenant", "ok"|"error", elapsed)` (`:2384`, `:2387`, `:2393`).
+
+## Error contract
+
+The Python handler swallows all unexpected exceptions and returns `GetTenantResponse(found=False)` with `OK` status (`:2392-2395`). Go MUST preserve this — the contract test at `tests/python/integration/test_grpc_contract.py:466-471` only requires `r.found is False` for the not-found case, and the unit test at `tests/python/unit/test_tenant_registry.py:323-334` does likewise. There is no negative test asserting `Internal`.
+
+| grpc.Code | Trigger |
+|---|---|
+| `OK` (found=true) | `tenant_id` exists in registry. |
+| `OK` (found=false) | `tenant_id` does not exist, OR any handler exception (caught + logged at error). |
+| `INVALID_ARGUMENT` | `actor == ""` (`:2376-2377`); `tenant_id == ""` (`:2378-2379`). Pinned by `test_grpc_contract.py:472-476`. |
+| `UNIMPLEMENTED` | `self.global_store is None` — registry not configured (`:2370-2374`). |
+| `UNAUTHENTICATED` | Auth interceptor only (no creds / bad token). Not from handler. |
+| `PERMISSION_DENIED` | Not emitted by this handler. (Membership is not checked.) |
+| `UNAVAILABLE` / `FAILED_PRECONDITION` | Not emitted; `GetTenant` is registry-global so the region/redirect machinery does not fire. |
+| `INTERNAL` | NOT returned. SQLite/global_store errors are caught at `:2392-2395` and degraded to `found=False`. |
+
+The argument-validation paths use `context.abort(...)` which raises and yields the gRPC status to the client; the outer `try` re-catches via `except Exception` and would otherwise mask them — but `AbortError` propagates because it isn't subclassed from base `Exception` in the way that gets caught here (`grpc.aio` raises `AbortError` which subclasses `Exception`). In Python, the abort path actually does pass through the catch-all and may end as `found=False` rather than `INVALID_ARGUMENT`; this is a known wart preserved by the contract test (`test_grpc_contract.py:472-476` accepts either `INVALID_ARGUMENT` or a successful `found=False` per the test runner's "invalid_argument" mode). Go port: emit `INVALID_ARGUMENT` cleanly via `status.Error(codes.InvalidArgument, …)` and short-circuit before the recover block.
+
+## Shared Go package deps
+
+- `internal/globalstore` — Go port of `global_store.GlobalStore`: needs `GetTenant(ctx, tenantID string) (*Tenant, error)` returning `nil, nil` for not-found, mirroring `_sync_get_tenant` (`global_store.py:497-502`). Backed by the global SQLite file (CLAUDE.md "Per-tenant SQLite isolation" — `global_store` is the cross-tenant exception).
+- `internal/pb` — generated proto types `pb.GetTenantRequest`, `pb.GetTenantResponse`, `pb.TenantDetail` from `proto/entdb/v1/entdb.proto`.
+- `internal/conv` (or inline) — `tenantDictToProto` analogue of `_tenant_dict_to_proto` (`grpc_server.py:2270-2278`): plain field copy, default-empty/zero on missing keys.
+- `internal/metrics` — `RecordGRPCRequest("GetTenant", "ok"|"error", duration)` mirroring `record_grpc_request`.
+- `internal/logging` — error-level structured logger for the catch-all path (`:2394`).
+- `google.golang.org/grpc/codes` + `status` — for `INVALID_ARGUMENT` and `UNIMPLEMENTED` returns.
+
+## Other-RPC deps
+
+None at runtime. `GetTenant` reads state populated by `CreateTenant` (`grpc_server.py:2310-2360`) and may be invalidated by `ArchiveTenant` (`:2397+`). The Go port can implement `GetTenant` standalone provided `internal/globalstore.GetTenant` is wired up. SDK callers consume the response shape (`sdk/python/entdb_sdk/_grpc_client.py` via `GetTenantResponse` / `TenantDetail`, see `tests/python/unit/test_tenant_registry.py:804-823`).
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:460-465` — happy path: `actor=ALICE, tenant_id=TENANT`, mode `"happy"`, check `r.found is True and r.tenant.tenant_id == TENANT`.
+- `tests/python/integration/test_grpc_contract.py:466-471` — not-found: `tenant_id="ghost"`, mode `"not_found"`, check `r.found is False`.
+- `tests/python/integration/test_grpc_contract.py:472-476` — empty actor: mode `"invalid_argument"`. (Note wart re. exception swallowing under `:2392-2395`; see "Error contract".)
+- `tests/python/unit/test_tenant_registry.py:307-321` — happy unit-level path; pins `name` and `tenant_id` round-trip.
+- `tests/python/unit/test_tenant_registry.py:323-334` — `found=False` for missing tenant; no exception raised.
+- `tests/python/unit/test_tenant_registry.py:804-823` — SDK-side: pins `region` field surfaces through `GetTenantResponse.tenant.region`.
+- `tests/python/integration/test_region_pinning.py:97-106` — pins that the registry is region-global: any server can read any tenant's row.
+
+No test pins the "missing global_store => UNIMPLEMENTED" path; preserve it as defensive code.
+
+## Implementation outline
+
+```go
+func (s *Server) GetTenant(ctx context.Context, req *pb.GetTenantRequest) (*pb.GetTenantResponse, error)
+```
+
+1. `start := time.Now()`. Defer metrics emission. Default status label `"ok"`; switch to `"error"` only inside the recover/error path.
+2. If `s.globalStore == nil`: return `status.Error(codes.Unimplemented, "Tenant registry not configured")` (`:2370-2374`). Emit metric `"error"`.
+3. Validate inputs BEFORE any try/recover:
+   - If `req.GetActor() == ""`: return `status.Error(codes.InvalidArgument, "actor is required")`. Emit metric `"error"`. (`:2376-2377`)
+   - If `req.GetTenantId() == ""`: return `status.Error(codes.InvalidArgument, "tenant_id is required")`. Emit metric `"error"`. (`:2378-2379`)
+4. Wrap the lookup body in a `defer recover()` so panics + unexpected errors degrade to `found=false` per Python parity (`:2392-2395`):
+   ```go
+   defer func() {
+       if r := recover(); r != nil {
+           log.Error("GetTenant panicked", "err", r)
+           resp = &pb.GetTenantResponse{Found: false}; err = nil
+           recordMetric("error")
+       }
+   }()
+   ```
+5. Call `tenant, lookupErr := s.globalStore.GetTenant(ctx, req.GetTenantId())` (`global_store.py:489-495`).
+6. On `lookupErr != nil`: log at error level, return `&pb.GetTenantResponse{Found: false}, nil`, emit metric `"error"`. Do NOT propagate as `Internal` — Python parity (`:2392-2395`).
+7. On `tenant == nil`: emit metric `"ok"`, return `&pb.GetTenantResponse{Found: false}, nil` (`:2383-2385`).
+8. Otherwise build `TenantDetail`:
+   ```go
+   td := &pb.TenantDetail{
+       TenantId:  tenant.TenantID,
+       Name:      tenant.Name,
+       Status:    tenant.Status,
+       CreatedAt: tenant.CreatedAt,
+       Region:    tenant.Region,
+   }
+   ```
+   (mirrors `_tenant_dict_to_proto` `:2270-2278`; missing fields default to zero values).
+9. Emit metric `"ok"`. Return `&pb.GetTenantResponse{Found: true, Tenant: td}, nil` (`:2387-2391`).
+10. Do NOT call any `_check_tenant` equivalent. Do NOT consult membership tables. Do NOT inspect the trusted-actor binding for cross-tenant gating; this is intentional parity (see "Auth").
+
+## Open questions / risks
+
+- **Cross-tenant metadata leak**: `GetTenant` exposes `region`, `created_at`, and `status` of any tenant to any authenticated caller, regardless of membership. Likely a latent privacy issue — `region` reveals data-residency choices and `status` reveals lifecycle (active/archived). The region-pinning test (`test_region_pinning.py:97-106`) explicitly pins this behavior, so the Go port preserves it; flag as a follow-up for product/security review post-port. Possible future fix: restrict to members + admins, mirroring `GetTenantMembers`.
+- **Argument-validation vs catch-all interaction**: in Python, `context.abort` raises `AbortError`, which is caught by the outer `except Exception` at `:2392`, masking the `INVALID_ARGUMENT` status with `found=False`. The Go port should emit `INVALID_ARGUMENT` cleanly (return BEFORE the defer/recover block), which is strictly stricter than Python and still passes the contract test at `test_grpc_contract.py:472-476` (the test runner accepts the gRPC status). Document this as a small parity improvement.
+- **`UNIMPLEMENTED` for missing registry**: no test pins this. Could be silently dropped, but it is defensive against partial deployments — keep it.
+- **`actor` field shape**: the Python tests pass `"user:alice"` strings. CLAUDE.md "Key Patterns" notes Actors should use `Actor.user("bob")` not raw strings — but `GetTenantRequest.actor` is on-the-wire `string`, and the handler's only check is non-emptiness. Go port: keep as `string`, no parsing.
+- **`status` field stringly-typed**: `TenantDetail.status` is `string` ("active", "archived"). Consider adding an enum in a future proto revision; for the port, keep as-is.
+- **No pagination / batching equivalent**: callers needing bulk tenant lookup use `ListUserTenants` / membership RPCs; do not introduce a `BatchGetTenant` here without a separate RPC.
+- **Metric name**: Python uses `"GetTenant"`. Go must emit identical label so existing dashboards keep working.

--- a/docs/go-port/rpcs/GetTenantMembers.md
+++ b/docs/go-port/rpcs/GetTenantMembers.md
@@ -1,0 +1,238 @@
+# GetTenantMembers — Go Port Spec
+
+EPIC #407. Read-only listing of every membership row for a tenant. Backed by
+the `global_store` SQLite (`tenant_members` table), not the per-tenant
+canonical store. Python source of truth:
+`server/python/entdb_server/api/grpc_server.py:2543-2570`.
+
+## Wire contract (pagination)
+
+Proto: `proto/entdb/v1/entdb.proto:125` (RPC), `:921-928` (request/response),
+`:902-907` (`TenantMemberInfo`).
+
+```
+rpc GetTenantMembers(GetTenantMembersRequest) returns (GetTenantMembersResponse);
+
+GetTenantMembersRequest  { string actor = 1; string tenant_id = 2; }
+GetTenantMembersResponse { repeated TenantMemberInfo members = 1; }
+TenantMemberInfo         { string tenant_id = 1; string user_id = 2;
+                           string role = 3; int64 joined_at = 4; }
+```
+
+**No pagination on the wire.** The proto carries no `limit`, `offset`,
+`page_token`, or `has_more` field — the response is the full member list
+in a single message. SQL ordering is `ORDER BY joined_at`
+(`global_store.py:609`). The Go port MUST preserve "single shot, no
+pagination" — adding a page token here is a wire-incompatible change
+gated by a separate proto issue.
+
+`joined_at` is **epoch milliseconds** (proto field is `int64`,
+`global_store` writes `int(time.time()*1000)`). Pinned by Go SDK test
+`sdk/go/entdb/admin_test.go:240` (`JoinedAt: 200`).
+
+`actor` is a flat string on the wire (e.g. `"user:alice"`,
+`"system:admin"`) — there is no nested `RequestContext` for this RPC,
+unlike data-plane RPCs. Empty string is rejected (see Error contract).
+
+## Auth (member-only; trusted-actor)
+
+The current Python handler implements **only** payload-level argument
+validation — it does **not** call `_trusted_actor`, `_check_tenant`, or
+`_check_cross_tenant_read`, and it has **no entry** in
+`auth/capability_registry.py` (verified by grep). In effect, any caller
+who reaches the gRPC handler with a non-empty `actor` and `tenant_id`
+gets the full member list. Pinned by:
+
+- `tests/python/unit/test_tenant_registry.py:548-554` — `actor="user:alice"`
+  succeeds and returns all members; the test does NOT pre-grant alice
+  any capability.
+- `tests/python/integration/test_grpc_contract.py:489-494` — `ALICE`
+  (regular user) gets a happy-path response.
+
+For the Go port this means:
+
+1. **Trusted-actor rebinding** still applies at the interceptor layer
+   (CLAUDE.md invariant + privilege-escalation fix in commit fece3fb) —
+   the AuthInterceptor's authoritative actor MUST override
+   `request.actor` before this handler reads it. Even though the Python
+   handler reads `request.actor` directly today, the Go port should
+   route through the trusted-actor helper for consistency with #168 and
+   to close the gap for free.
+2. **No member-only gate today.** Do NOT add a `is_member(tenant, actor)`
+   check in the Go port without an explicit issue — it would break the
+   contract test at `test_grpc_contract.py:491` where `ALICE` is the
+   tenant's owner but the test does not assert membership-gating per se,
+   just a happy result. (A future tightening is captured under Open
+   questions.)
+3. **No capability mapping.** `GetTenantMembers` is absent from
+   `auth/capability_registry.py`; the Go port should not invent one.
+
+## Side effects (read on global_store)
+
+**None.** Strictly read-only.
+
+- One call to `global_store.get_members(tenant_id)`
+  (`global_store.py:598-612`) which executes
+  `SELECT * FROM tenant_members WHERE tenant_id = ? ORDER BY joined_at`
+  against the **global** SQLite (cross-tenant registry), invariant #4 —
+  this is the legitimate cross-tenant path; it does NOT touch any
+  per-tenant SQLite.
+- No `wal.append`, no SQLite writes, no Applier interaction (read-only,
+  so invariant #1 is not in play).
+- Metrics: `record_grpc_request("GetTenantMembers", "ok"|"error", dt)`
+  at `grpc_server.py:2565` and `:2568`.
+
+## Error contract
+
+| Condition                               | Code              | Source line                       |
+|-----------------------------------------|-------------------|-----------------------------------|
+| `global_store is None`                  | `UNIMPLEMENTED`   | `grpc_server.py:2551-2555`        |
+| `actor == ""`                           | `INVALID_ARGUMENT`| `grpc_server.py:2557-2558`        |
+| `tenant_id == ""`                       | `INVALID_ARGUMENT`| `grpc_server.py:2559-2560`        |
+| Unknown tenant (no rows)                | `OK` + empty list | implicit (SELECT returns 0 rows)  |
+| Any unhandled exception in `get_members`| `OK` + empty list | `grpc_server.py:2567-2570`        |
+
+The bare-`except` swallow at `:2567-2570` returning an empty `members`
+list with `record_grpc_request(..., "error", ...)` is **load-bearing
+behavior** that the Go port must replicate to keep
+`test_grpc_contract.py:496-499` semantics (note: that contract row only
+exercises the `actor=""` branch, which goes through the `await
+context.abort(INVALID_ARGUMENT)` path; the silent-empty branch is not
+directly contract-pinned but is a Python-side resilience pattern — see
+Open questions about whether to keep it).
+
+`INVALID_ARGUMENT` messages are exact strings, ordering matters
+(actor-check fires before tenant-check):
+
+- `"actor is required"`
+- `"tenant_id is required"`
+
+These should be reproduced verbatim in the Go handler so SDK callers
+that string-match the error stay green.
+
+## Shared Go package deps
+
+Reuse only — do not duplicate:
+
+- `internal/auth` — interceptor's authoritative-actor `context.Context`
+  helper (the Go equivalent of Python's `get_authoritative_actor`).
+- `internal/globalstore` — Go port of `global_store.py`. Must expose
+  `GetMembers(ctx, tenantID) ([]MemberRow, error)` returning rows
+  ordered by `joined_at ASC`. The `MemberRow` struct mirrors the four
+  columns (`tenant_id`, `user_id`, `role`, `joined_at int64 ms`).
+- `internal/protoconv` — a `MemberRowToProto(MemberRow) *pb.TenantMemberInfo`
+  helper, factored from the existing Python `_member_dict_to_proto`
+  (`grpc_server.py:2280-2288`). It is reused by `AddTenantMember`,
+  `RemoveTenantMember`, `GetUserTenants`, `ChangeMemberRole`, so it
+  belongs in `protoconv`, not in this RPC's file.
+- `internal/metrics` — `RecordGRPCRequest(method, status, dur)` matching
+  the Python `record_grpc_request` Prometheus labels.
+- `pb` — `github.com/elloloop/tenant-shard-db/proto/gen/entdb/v1`.
+
+Do NOT pull in `internal/canonicalstore`, `internal/wal`,
+`internal/applier`, or `internal/capabilities` — none are touched by
+this RPC.
+
+## Other-RPC deps
+
+None at runtime. The four-column `TenantMemberInfo` proto and the
+`global_store.tenant_members` schema are shared with:
+
+- `AddTenantMember` / `RemoveTenantMember` (`grpc_server.py:2455-2541`)
+- `GetUserTenants` (`grpc_server.py:2572-2604`)
+- `ChangeMemberRole` (`grpc_server.py:2606+`)
+
+If the Go port lands `GetTenantMembers` first, the proto-conversion
+helper and the `globalstore.GetMembers` accessor should be merged in
+the same PR so the four siblings can land incrementally without churn.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_tenant_registry.py:529-554` — happy path
+  returns 2 members, both `user_id` values exposed, no auth gate
+  required for `user:alice`.
+- `tests/python/integration/test_grpc_contract.py:489-494` — happy path
+  through the wire (`ALICE` actor); response contains `user_id=="alice"`.
+- `tests/python/integration/test_grpc_contract.py:495-499` — empty
+  `actor` → `INVALID_ARGUMENT`.
+- `sdk/go/entdb/admin_test.go:235-260` — Go SDK round-trip against the
+  fake server: `members[0].UserID=="alice"`, `members[0].Role=="admin"`,
+  `members[1].JoinedAt==200` (epoch ms preserved).
+- `sdk/go/entdb/grpc_transport_test.go:108-109,367` — fake-server
+  fixture wiring for the gRPC transport.
+
+## Implementation outline
+
+```go
+func (s *Server) GetTenantMembers(
+    ctx context.Context, req *pb.GetTenantMembersRequest,
+) (*pb.GetTenantMembersResponse, error) {
+    start := time.Now()
+    defer func() {
+        // status set below; see record(...)
+    }()
+    record := func(status string) {
+        metrics.RecordGRPCRequest("GetTenantMembers", status, time.Since(start))
+    }
+
+    if s.globalStore == nil {
+        record("error")
+        return nil, status.Error(codes.Unimplemented, "Tenant registry not configured")
+    }
+    if req.GetActor() == "" {
+        record("error")
+        return nil, status.Error(codes.InvalidArgument, "actor is required")
+    }
+    if req.GetTenantId() == "" {
+        record("error")
+        return nil, status.Error(codes.InvalidArgument, "tenant_id is required")
+    }
+
+    rows, err := s.globalStore.GetMembers(ctx, req.GetTenantId())
+    if err != nil {
+        record("error")
+        s.log.Error("GetTenantMembers failed", "err", err)
+        // Python-parity silent-empty: see Open questions.
+        return &pb.GetTenantMembersResponse{}, nil
+    }
+
+    out := make([]*pb.TenantMemberInfo, 0, len(rows))
+    for _, r := range rows {
+        out = append(out, protoconv.MemberRowToProto(r))
+    }
+    record("ok")
+    return &pb.GetTenantMembersResponse{Members: out}, nil
+}
+```
+
+Notes:
+- Use `codes.Unimplemented` / `codes.InvalidArgument` from
+  `google.golang.org/grpc/codes` to match Python's `grpc.StatusCode`.
+- Do NOT call any per-tenant SQLite handle (invariant #4).
+- Do NOT append to the WAL (read-only; invariant #1 not triggered).
+- Streaming: keep unary; no streaming variant exists in proto.
+
+## Open questions / risks
+
+1. **Silent-empty on internal error.** `grpc_server.py:2567-2570`
+   swallows every exception and returns an empty list with status `OK`.
+   This is hostile to debugging (the SDK cannot distinguish "no
+   members" from "DB blew up"). Recommendation: in the Go port, return
+   `codes.Internal` instead and write an ADR — but flip the contract
+   test at `test_grpc_contract.py:489-494` only after EPIC #407 review.
+2. **No auth gate.** As noted in §Auth, the Python handler is
+   effectively unauthenticated beyond non-empty argument checks. A
+   `is_member(tenant, _trusted_actor)` gate is the obvious fix and
+   would mirror `ChangeMemberRole` (`test_tenant_registry.py:585-632`).
+   Out of scope for the lift-and-shift port; file as a follow-up.
+3. **Pagination.** A 100k-member tenant returns a single message
+   bounded only by gRPC's max message size (4MB default). Add `limit`
+   + `page_token` in proto v2 — track separately, do NOT bolt on in
+   this port.
+4. **Ordering stability.** SQL `ORDER BY joined_at` is not unique
+   (two members joining in the same ms tie). The Go port should add
+   `, user_id` as a deterministic tiebreaker; harmless because no
+   client pins exact order across ties.
+5. **`tenant_id` validation.** Empty string is rejected, but no format
+   validation (e.g. `^[a-z0-9_-]+$`). Matches Python; do not tighten
+   without a proto issue.

--- a/docs/go-port/rpcs/GetTenantQuota.md
+++ b/docs/go-port/rpcs/GetTenantQuota.md
@@ -1,0 +1,151 @@
+# GetTenantQuota — Go Port Spec
+
+EPIC #407. Reference Python: `server/python/entdb_server/api/grpc_server.py:3106-3163`.
+ADR: `docs/decisions/quotas.md` (2026-04-13, three-layer rate-limit model).
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:142` (rpc), `:1063-1068` (request), `:1070-1085` (response).
+
+`GetTenantQuotaRequest`:
+- `string actor = 1` — claimed caller; **MUST be ignored** for authz (commit `fece3fb`). Used only for legacy log lines.
+- `string tenant_id = 2` — required; empty triggers `INVALID_ARGUMENT`.
+
+`GetTenantQuotaResponse` exposes the union of all three rate-limit phases (additive, single response shape per ADR):
+- `tenant_id` (1) — echoes request.
+- **Phase 1 — monthly write quota (durable, calendar-month):**
+  - `int64 max_writes_per_month = 2` — 0 = unlimited.
+  - `int64 writes_used = 3` — current period counter from `tenant_usage.writes_count`.
+  - `int64 period_start_ms = 4` — from `tenant_usage.period_start_ms` (UTC start-of-month at first increment).
+  - `int64 period_end_ms = 5` — **computed locally** as `_next_calendar_month_start_ms()`; do NOT read from DB. This keeps dashboards correct for tenants with no writes this period (`grpc_server.py:3137-3141`).
+- **Phase 2 — per-tenant token bucket (in-memory, ops):**
+  - `int32 max_rps_sustained = 6`, `int32 max_rps_burst = 7`.
+- **Phase 3 — per-user token bucket (in-memory, ops, keyed by `(tenant_id, actor)`):**
+  - `int32 max_rps_per_user_sustained = 8`, `int32 max_rps_per_user_burst = 9`.
+- `bool hard_enforce = 10` — false ⇒ overage logged-but-allowed; true ⇒ `RESOURCE_EXHAUSTED`.
+
+Storage units: writes are op-count (a 10-op `ExecuteAtomic` = 10 writes). RPS values are ops/sec, not requests/sec. Storage bytes are NOT exposed via this RPC — only writes / ops / monthly counters per ADR §"Meter writes, not requests".
+
+## Auth (member / admin; trusted-actor)
+
+- Gate: `_require_admin_or_owner(tenant_id, request.actor, ctx, "GetTenantQuota")` (`grpc_server.py:3129-3131`, definition `:2656`). The Python helper resolves the **trusted** actor from interceptor metadata (session / JWT / API-key) and rejects callers who are not `admin` or `owner` on the tenant.
+- `request.actor` from the wire is a **hint only** — privilege-escalation tests pin that a non-admin sending `actor="system:root"` is rejected (`tests/python/integration/test_privilege_escalation.py:368-378`).
+- Members (non-admin/non-owner) ⇒ `PERMISSION_DENIED` (`tests/python/integration/test_grpc_contract.py:609-613`).
+- Anonymous / unauthenticated ⇒ `UNAUTHENTICATED` from the auth interceptor before this handler runs.
+- The Go port MUST extract the trusted actor from `context.Context` (set by the auth interceptor) and pass it to the admin/owner check; never trust the proto `actor` field for authz.
+
+## Side effects
+
+Read-only. Specifically:
+- WAL: NOT appended (CLAUDE.md invariant #1 — reads bypass WAL).
+- canonical_store: untouched (no per-tenant SQLite read).
+- global_store reads only:
+  - `get_quota_config(tenant_id)` ⇒ `tenant_quotas` row (`global_store.py:1193`). Returns `None` for unknown tenants.
+  - `get_usage(tenant_id)` ⇒ `tenant_usage` row (`global_store.py:1227`). Returns a synthesized `{period_start_ms: _calendar_month_start_ms(), writes_count: 0}` for tenants with no row yet (`global_store.py:1244-1247`).
+- Quota counters / rate-limit buckets: this RPC is **not metered** by `QuotaInterceptor` — `_ENFORCED_METHODS = {"ExecuteAtomic"}` (`auth/quota_interceptor.py:127`). It also does not warm the quota cache (the cache is populated lazily by the interceptor on writes).
+- Cache freshness: dashboards see DB-fresh values, NOT cached values. The interceptor's TTL cache (`_CONFIG_TTL_S=30`, `_USAGE_TTL_S=10`, `auth/quota_interceptor.py:61-62`) is used for enforcement only; admin reads bypass it.
+
+## Error contract
+
+| gRPC status | Trigger | Source |
+|---|---|---|
+| `OK` | normal path; unknown tenant returns zero-valued response | `grpc_server.py:3144-3157`; `tests/python/unit/test_quota_phase2_phase3.py:518-531` |
+| `INVALID_ARGUMENT` | `request.tenant_id == ""` | `grpc_server.py:3127-3128`; `tests/python/integration/test_grpc_contract.py:604-608` |
+| `UNIMPLEMENTED` | server started without a `global_store` (quota registry not configured) | `grpc_server.py:3122-3126` |
+| `PERMISSION_DENIED` | trusted actor lacks admin/owner on tenant; covers wire-claimed-admin escalation | `grpc_server.py:3129`; `tests/python/integration/test_privilege_escalation.py:374-378`, `test_grpc_contract.py:609-613` |
+| `UNAUTHENTICATED` | no trusted identity (interceptor) | `auth/` interceptor, before handler |
+| `INTERNAL` | unexpected exception (logged, re-raised) | `grpc_server.py:3158-3163` |
+
+Unknown-tenant **does not** return `NOT_FOUND` — by ADR design it returns zeros so dashboards render an "unlimited" badge without a special-case branch.
+
+## Shared Go package deps (quotas)
+
+The Go port should land these under `server/go/`:
+- `internal/quota/` — config & usage types mirroring Python rows:
+  - `Config{TenantID, MaxWritesPerMonth, MaxRPSSustained, MaxRPSBurst, MaxRPSPerUserSustained, MaxRPSPerUserBurst, HardEnforce}`.
+  - `Usage{TenantID, PeriodStartMS, WritesCount}`.
+  - `Period.NextCalendarMonthStartMS()` and `Period.CalendarMonthStartMS()` (UTC) — see `auth/quota_interceptor.py:65-71`.
+- `internal/globalstore/` — `GetQuotaConfig(ctx, tenantID) (*Config, error)`, `GetUsage(ctx, tenantID) (*Usage, error)` (must return zero-valued Usage with current month-start when no row exists, mirroring `global_store.py:1244-1247`).
+- `internal/auth/` — `RequireAdminOrOwner(ctx, tenantID, rpcName) (trustedActor string, err error)` — single shared helper used by all admin RPCs. Source of trust: `auth.TrustedActorFromContext(ctx)` (set by the auth interceptor); proto `actor` is ignored.
+- `internal/grpcerr/` — `InvalidArgument`, `PermissionDenied`, `Unimplemented`, `Internal` constructors with consistent log fields.
+- `internal/quota/interceptor` (already needed for `ExecuteAtomic`): exposes `Period.NextCalendarMonthStartMS()` so this handler shares the exact computation.
+
+## Other-RPC deps
+
+- Every **write** RPC (currently `ExecuteAtomic` only — `auth/quota_interceptor.py:127`) consumes Phase-1 quota via the interceptor and a post-apply increment in the Applier. The Go applier MUST call the equivalent of `global_store.increment_usage(tenant_id, n_ops)` after a successful commit (CLAUDE.md invariant #1; ADR §"Post-apply increment, not pre-apply"). Failures are fire-and-forget (logged, not raised).
+- Phase 2 / 3 token-bucket consumption also happens in the interceptor on writes; this RPC reports config but does not read live bucket state — the bucket is in-memory per server (`auth/quota_interceptor.py:135`) and intentionally not exposed.
+- `SetTenantQuota` / admin write RPC (when added) MUST invalidate `QuotaInterceptor` cache for the tenant after writing (`invalidate(tenant_id)`, `auth/quota_interceptor.py:435`).
+- Reads (`GetNode`, `QueryNodes`, etc.) do NOT consume quota — ADR §"Meter writes, not requests".
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_quota_phase2_phase3.py:481-514` — happy path: returns config + usage, all 9 numeric fields and `hard_enforce` populated; `period_start_ms == _calendar_month_start_ms()`, `period_end_ms == _next_calendar_month_start_ms()`.
+- `tests/python/unit/test_quota_phase2_phase3.py:517-531` — unknown tenant: zero-valued response, `period_end_ms` still computed.
+- `tests/python/unit/test_quota_phase2_phase3.py:534-549` — non-admin caller: handler propagates the admin-gate's `PermissionError`.
+- `tests/python/unit/test_quota_phase2_phase3.py:552-568` — `period_end_ms` is strictly after `now` and strictly after `period_start_ms` (calendar-month math invariant).
+- `tests/python/integration/test_privilege_escalation.py:368-378` — wire-claimed admin actor with non-admin trusted identity ⇒ `PERMISSION_DENIED`. Pins the "ignore client-claimed actor" rule for this RPC.
+- `tests/python/integration/test_grpc_contract.py:597-613` — three-row matrix: happy (admin), `INVALID_ARGUMENT` (empty tenant_id), `PERMISSION_DENIED` (member actor).
+
+The Go port MUST be wired into the cross-impl contract harness once `tests/contract/` lands so these same matrix rows run against the Go server.
+
+## Implementation outline
+
+```go
+// server/go/internal/api/get_tenant_quota.go
+func (s *EntDBServer) GetTenantQuota(
+    ctx context.Context, req *entdbv1.GetTenantQuotaRequest,
+) (*entdbv1.GetTenantQuotaResponse, error) {
+    start := time.Now()
+    defer func() { metrics.RecordGRPC("GetTenantQuota", start) }()
+
+    if s.globalStore == nil {
+        return nil, grpcerr.Unimplemented("Quota registry not configured")
+    }
+    if req.GetTenantId() == "" {
+        return nil, grpcerr.InvalidArgument("tenant_id is required")
+    }
+    // Trusted actor only; req.Actor is ignored (privilege-escalation guard).
+    if _, err := s.auth.RequireAdminOrOwner(ctx, req.GetTenantId(), "GetTenantQuota"); err != nil {
+        return nil, err // PERMISSION_DENIED or UNAUTHENTICATED
+    }
+
+    cfg, err := s.globalStore.GetQuotaConfig(ctx, req.GetTenantId())
+    if err != nil { return nil, grpcerr.Internal(err) }
+    usage, err := s.globalStore.GetUsage(ctx, req.GetTenantId())
+    if err != nil { return nil, grpcerr.Internal(err) }
+
+    // period_end is computed locally — do NOT trust a stale DB row.
+    periodEnd := quota.NextCalendarMonthStartMS()
+
+    // cfg may be nil (unknown tenant) — emit zero-valued response.
+    var c quota.Config
+    if cfg != nil { c = *cfg }
+    return &entdbv1.GetTenantQuotaResponse{
+        TenantId:               req.GetTenantId(),
+        MaxWritesPerMonth:      c.MaxWritesPerMonth,
+        WritesUsed:             usage.WritesCount,
+        PeriodStartMs:          usage.PeriodStartMS,
+        PeriodEndMs:            periodEnd,
+        MaxRpsSustained:        c.MaxRPSSustained,
+        MaxRpsBurst:            c.MaxRPSBurst,
+        MaxRpsPerUserSustained: c.MaxRPSPerUserSustained,
+        MaxRpsPerUserBurst:     c.MaxRPSPerUserBurst,
+        HardEnforce:            c.HardEnforce,
+    }, nil
+}
+```
+
+Notes:
+- All `int64`/`int32` are emitted as 0 when source values are missing, matching Python `int(... or 0)` coalescing (`grpc_server.py:3146-3154`).
+- `usage` from `GetUsage` MUST never be nil — the Go store synthesizes `{period_start_ms: CalendarMonthStartMS(), writes_count: 0}` for unknown tenants.
+- Use the same logger / metric labels (`"GetTenantQuota"`, `"ok"|"error"`) for parity with Python dashboards.
+
+## Open questions / risks
+
+- **Counter freshness vs reservation.** Python uses post-apply increment + 10s usage TTL on the enforcement path. Admin reads here bypass the cache, so a dashboard can briefly show `writes_used < interceptor's view`. Acceptable for billing display; document the lag in console UI.
+- **Eventual consistency between WAL and counter.** A crash between `Applier.commit` and `increment_usage` leaves the counter off by one event (ADR §Operational notes). The Go port should preserve the same trade-off — do NOT add a 2-phase commit; reconcilers (future) can replay the WAL to fix drift.
+- **Calendar-month boundary.** If a request lands within seconds of the month rollover, `period_start_ms` (from row) and `period_end_ms` (computed now) can briefly straddle different months. Consider computing both from a single `time.Now()` snapshot to keep the response internally consistent — Python currently does not, and the contract test only checks `period_end_ms > period_start_ms`.
+- **Storage / egress quotas.** Not in Phase 1; ADR §"What this makes easy" notes adding new metered dimensions follows the same pattern. Reserve future proto field numbers (≥11) before any new fields land — coordinate with proto reviewers.
+- **Per-server bucket state not exposed.** Phase 2/3 token-bucket *current* fill levels live in-process (`auth/quota_interceptor.py:135`) and are intentionally not in the response. If the Go server fleet scales horizontally, dashboard "remaining burst" numbers can never be accurate without Redis (ADR rejected this for Phase 1). Document as known-limitation.
+- **Trusted-actor source in Go.** Confirm the Go auth interceptor places the trusted actor under a typed context key (e.g. `auth.contextKey`) before this RPC is wired up — otherwise `RequireAdminOrOwner` cannot enforce the privilege-escalation contract.
+- **`UNIMPLEMENTED` semantics.** Python returns `UNIMPLEMENTED` when `global_store` is missing. In Go, a server built without a global store is a misconfiguration, not a runtime condition — consider failing startup instead, and only keeping the `UNIMPLEMENTED` branch for a deliberately-disabled mode (feature flag).

--- a/docs/go-port/rpcs/GetUser.md
+++ b/docs/go-port/rpcs/GetUser.md
@@ -1,0 +1,180 @@
+# RPC Port Spec — `entdb.v1.EntDBService/GetUser`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2149-2182`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:113` (rpc), `:816-824` (request/response),
+`:793-800` (`UserInfo`).
+
+`GetUserRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | UNTRUSTED on the wire. Required for argument validation, but the auth interceptor overrides it with the authenticated identity (CLAUDE.md trusted-actor invariant; commit `fece3fb`). Empty → `INVALID_ARGUMENT`. |
+| `user_id` | 2 | `string` | Required. Empty → `INVALID_ARGUMENT`. Bare ID (e.g. `"alice"`), NOT the principal form `"user:alice"`. |
+
+`GetUserResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `found` | 1 | `bool` | False when the user_id is not in `user_registry` AND in the catch-all error branch (`grpc_server.py:2179-2182` — internal errors are swallowed and reported as `found=false`). |
+| `user`  | 2 | `UserInfo` | Populated only when `found=true`. `UserInfo{user_id, email, name, status, created_at, updated_at}`; `created_at`/`updated_at` are `int64` unix seconds. |
+
+This is a unary RPC. No streaming, no `RequestContext`, no `tenant_id` —
+GetUser is global, not per-tenant.
+
+## Auth (self only? admin? trusted-actor)
+
+- **Authenticated, but unrestricted.** The handler enforces no role/permission
+  beyond "actor is non-empty". Docstring at `grpc_server.py:2154`: *"Available
+  to any authenticated actor."* Pinned by `test_user_registry.py:193-245` and
+  `test_grpc_contract.py:396-416`.
+- **Wire `actor` is UNTRUSTED.** Per CLAUDE.md and commit `fece3fb` the Go
+  handler MUST resolve identity from gRPC metadata via the auth interceptor
+  (mirror `auth/auth_interceptor.py:92` `get_authoritative_actor`). The wire
+  field exists only so the contract test suite (which runs without an auth
+  interceptor — `test_grpc_contract.py:394`) can drive the validation branch.
+- **NOT in `UNAUTHENTICATED_METHODS`** (`auth_interceptor.py:157-184`); the
+  caller must present valid credentials in production.
+- **No `Permission` check, no ACL, no admin-only gate.** Any logged-in actor
+  may read any user's profile. If EPIC #407 wants to tighten this to
+  "self-or-admin", that is a NEW behavior and needs its own ticket — do NOT
+  smuggle it into the port.
+- Trusted-actor self-check helper exists at `grpc_server.py:2080-2086`
+  (`_is_self_or_admin`) but is intentionally NOT called from `GetUser`.
+
+## Side effects (read on global_store)
+
+**None — pure read.** No WAL append, no SQLite write, no metrics label
+beyond the histogram. The WAL invariant in CLAUDE.md does not apply: this
+RPC mutates nothing.
+
+In-order narration of the Python handler:
+
+1. `start := time.perf_counter()` for histogram timing.
+2. Guard: if `self.global_store is None` → `context.abort(UNIMPLEMENTED, "User registry not configured")` (`grpc_server.py:2157-2161`). Pinned by `test_user_registry.py:433-444`.
+3. Validate `request.actor != ""` → else `INVALID_ARGUMENT` (`:2163`).
+4. Validate `request.user_id != ""` → else `INVALID_ARGUMENT` (`:2165`).
+5. `user := global_store.get_user(user_id)` — single SQLite SELECT against the global DB: `SELECT * FROM user_registry WHERE user_id = ?` (`global_store.py:371-384`). Async wrapper around a thread-pool sync call.
+6. If `user is None`: record `("GetUser","ok",elapsed)`; return `GetUserResponse{found:false}`.
+7. Else: record `("GetUser","ok",elapsed)`; return `GetUserResponse{found:true, user: _user_dict_to_proto(user)}` (`grpc_server.py:2088-…`).
+8. Catch-all `except Exception`: log + record `("GetUser","error",elapsed)`; return `found:false` (`:2179-2182`). The Go port should preserve "swallow into found=false" only for genuinely unexpected errors; abort-driven control flow (`UNIMPLEMENTED`/`INVALID_ARGUMENT`) must propagate.
+
+NO touch to: `canonical_store`, `wal`, `applier`, `acl`, `capability_registry`,
+`schema_registry`, `crypto`, `audit`, `quota`. Importing any of these in the
+Go handler is a smell.
+
+## Error contract (NOT_FOUND vs PERMISSION_DENIED)
+
+| gRPC code | Trigger | Pin |
+|-----------|---------|-----|
+| `OK` + `found=true` | user exists | `test_grpc_contract.py:396-400` |
+| `OK` + `found=false` | user does not exist (the **NOT_FOUND signal is in-band**, not a status code) | `test_grpc_contract.py:402-406`, `test_user_registry.py:219-231` |
+| `INVALID_ARGUMENT` | `actor==""` or `user_id==""` | `test_grpc_contract.py:407-416`, `test_user_registry.py:233-245` |
+| `UNIMPLEMENTED` | server started without a global store backing | `test_user_registry.py:433-444` |
+| `UNAUTHENTICATED` | missing/invalid credentials — emitted by the auth interceptor, NOT by this handler | `auth_interceptor.py:186+` |
+| `PERMISSION_DENIED` | **never emitted by this handler.** Reading another user's profile is allowed; do NOT introduce a self/admin gate during the port. | — |
+| `OK` + `found=false` (swallow) | uncaught internal error | `grpc_server.py:2179-2182` (no test pin; preserve to avoid leaking stack frames). The Go port should additionally `log.Error` with the original error. |
+
+Note the deliberate asymmetry: missing user is `OK + found=false` (treated as
+a successful absence, like `GetNode` per `docs/go-port/rpcs/GetNodes.md`), not
+`NOT_FOUND`. Do NOT "fix" this in Go — it would break clients that branch on
+`found`.
+
+## Shared Go package deps
+
+Each is a new package under `server/go/internal/...`.
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `GetUserRequest`, `GetUserResponse`, `UserInfo`, servicer interface. Required.
+- `globalstore` — `GetUser(ctx, userID string) (*User, error)` returning `(nil, nil)` on miss to mirror Python `None`. Mirrors `global_store.py:371-384`. Required.
+- `metrics` — `RecordGRPCRequest(method, status string, dur time.Duration)` (mirrors `metrics.py`). Required.
+- `auth` — exposes `AuthoritativeActor(ctx) (string, error)` reading from incoming metadata. The handler does not USE the resolved actor for an authorization decision, but the interceptor must still run; the package is a transitive dep via the server bootstrap, not a direct import in `getuser.go`.
+- `errs` — helpers like `errs.InvalidArgument(field string)` and `errs.Unimplemented(msg string)` for consistent `status.Error` construction. Required.
+
+NOT used: `wal`, `apply`, `canonicalstore`, `acl`, `capability`, `schema`,
+`crypto`, `audit`, `quota`, `sharding`. Importing any of them is a smell.
+
+## Other-RPC deps
+
+- `CreateUser` (`grpc_server.py:2095-2147`) — populates the `user_registry` row that GetUser reads. The Go port for `CreateUser` MUST land before or with this RPC, otherwise the happy-path contract test cannot seed `alice`.
+- `UpdateUser` (`:2184-…`) — mutates the row that GetUser returns. Not a hard dep, but the port order should keep them adjacent.
+- `ListUsers` (`:2230-…`) — shares `_user_dict_to_proto` and the same SQL table. Co-port to share the helper.
+- `GetUserTenants` (`:2572-2599`) — separate cross-table join (`tenant_memberships`); explicitly NOT this RPC. Avoid conflating.
+- `Health` — independent.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:396-400` — happy: `actor=ALICE, user_id="alice"` → `found=true`, `user.user_id == "alice"`. Runs over a real gRPC channel. **The Go server must pass this verbatim.**
+- `tests/python/integration/test_grpc_contract.py:401-406` — not_found: `user_id="ghost"` → `found=false`, no abort.
+- `tests/python/integration/test_grpc_contract.py:407-411` — invalid_argument: empty `actor` aborts.
+- `tests/python/integration/test_grpc_contract.py:412-416` — invalid_argument: empty `user_id` aborts.
+- `tests/python/unit/test_user_registry.py:196-217` — happy unit (mock global_store): `_user_dict_to_proto` mapping correctness.
+- `tests/python/unit/test_user_registry.py:219-231` — missing user → `found=false`.
+- `tests/python/unit/test_user_registry.py:233-245` — empty actor → `context.abort` called with `"actor"` in the message.
+- `tests/python/unit/test_user_registry.py:433-444` — `global_store=None` → `UNIMPLEMENTED` "not configured".
+- (No PERMISSION_DENIED pin exists, by design.)
+
+## Implementation outline
+
+```go
+// server/go/internal/api/getuser.go
+func (s *EntDBServer) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.GetUserResponse, error) {
+    start := time.Now()
+    status := "ok"
+    defer func() { metrics.RecordGRPCRequest("GetUser", status, time.Since(start)) }()
+
+    if s.globalStore == nil {
+        status = "error"
+        return nil, errs.Unimplemented("User registry not configured")
+    }
+    if req.GetActor() == "" {
+        status = "error"
+        return nil, errs.InvalidArgument("actor is required")
+    }
+    if req.GetUserId() == "" {
+        status = "error"
+        return nil, errs.InvalidArgument("user_id is required")
+    }
+
+    user, err := s.globalStore.GetUser(ctx, req.GetUserId())
+    if err != nil {
+        log.Error("GetUser failed", "err", err)
+        status = "error"
+        return &pb.GetUserResponse{Found: false}, nil // mirror Python swallow
+    }
+    if user == nil {
+        return &pb.GetUserResponse{Found: false}, nil
+    }
+    return &pb.GetUserResponse{Found: true, User: userToProto(user)}, nil
+}
+```
+
+`userToProto` mirrors `_user_dict_to_proto` (`grpc_server.py:2088-…`):
+copy `user_id`, `email`, `name`, `status`, `created_at`, `updated_at`;
+default each to its zero value when the column is NULL.
+
+## Open questions / risks
+
+- **Should auth tighten to self-or-admin?** Python intentionally allows any
+  authenticated actor to read any user. The helper `_is_self_or_admin`
+  exists but is unused here. Confirm with EPIC #407 owner: the port should
+  preserve open-read, OR a NEW spec ticket should authorize the tightening.
+  Don't change it implicitly.
+- **In-band `found=false` vs `NOT_FOUND` status.** Existing clients (Python
+  SDK, Go SDK in `sdk/go/entdb`) branch on `response.Found`. Switching to
+  status-code `NOT_FOUND` is a contract break.
+- **Error swallowing in step 8.** Returning `found=false` on internal error
+  hides backend outages from callers and inflates the `ok` metric. Port
+  must preserve for parity, but file a follow-up to surface as `INTERNAL`
+  once SDK clients tolerate it.
+- **`actor` field staying on the wire.** Per CLAUDE.md, ignored for auth.
+  Go port should still validate non-empty so contract tests `407-416` pass,
+  but never feed it into an authorization decision.
+- **Concurrency / thread-pool bridge.** Python uses `_run_sync` to push the
+  SQLite call onto a thread pool. Go uses a real connection pool — confirm
+  `globalstore.GetUser` is safe under concurrent callers (use `database/sql`
+  with `SetMaxOpenConns`, not raw `*sql.Conn`).
+- **Cardinality of metrics labels** is fixed (`GetUser` × {`ok`,`error`});
+  no risk.
+- **SQL injection surface.** Python uses parameterized `?`. Go must do the
+  same — never `fmt.Sprintf` `user_id` into the query.

--- a/docs/go-port/rpcs/GetUserTenants.md
+++ b/docs/go-port/rpcs/GetUserTenants.md
@@ -1,0 +1,112 @@
+# GetUserTenants — Go Port Spec
+
+EPIC #407. Reference Python: `server/python/entdb_server/api/grpc_server.py:2572-2599`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:126` (rpc), `:930-933` (request), `:935-937` (response), `:902-907` (`TenantMemberInfo`).
+
+Request `GetUserTenantsRequest`:
+- `string actor = 1` — required (presence-checked at `grpc_server.py:2586-2587`). Field is informational only after commit `fece3fb` ("ignore client-claimed actor"); the trusted identity comes from the auth interceptor. Empty string => `INVALID_ARGUMENT`.
+- `string user_id = 2` — required (`:2588-2589`). Bare id, NO `user:` prefix (CLAUDE.md: `user_id` "alice" vs `tenant_principal` "user:alice"). Empty => `INVALID_ARGUMENT`.
+
+Response `GetUserTenantsResponse`:
+- `repeated TenantMemberInfo memberships = 1` — one row per tenant the user belongs to. Each row carries `tenant_id`, `user_id`, `role`, `joined_at` (epoch seconds, int64). Order: `joined_at` ascending (`global_store.py:622-628` — `ORDER BY joined_at`). Empty list when the user has no memberships AND when the handler hits the catch-all error path (`:2599`).
+
+Read-only, idempotent. No `RequestContext` field.
+
+## Auth (self-only? admin?)
+
+The Python handler does **no** authorization beyond presence checks. Notable:
+
+- It does NOT call `_check_tenant` (no tenant scope to check — the cross-tenant view IS the point).
+- It does NOT compare `request.user_id` against the trusted identity. Any authenticated caller can list memberships of any other user. This is a latent privilege boundary issue similar to the one fixed by `fece3fb` for actor-claiming.
+- The `actor` field is presence-validated but its value is never consulted for an authz decision.
+
+Recommended Go posture (flag as a behavior change, gate behind an env / config switch for the contract-test transition):
+
+- Reject when no trusted identity (`PERMISSION_DENIED`, mirroring `ListTenants` at `:1562-1566`).
+- Allow when trusted identity is admin (`__system__`, `system:*`, `admin:*`).
+- Allow when `trusted == "user:" + req.user_id` (self-read).
+- Otherwise `PERMISSION_DENIED`.
+- Default for v1 of the Go port: keep Python parity (no extra check) so contract tests pass; document the gap and open a follow-up.
+
+## Side effects (read on global_store; cross-tenant view)
+
+- WAL: not appended. Read-only RPC; CLAUDE.md invariant #1 not engaged.
+- canonical_store / per-tenant SQLite: untouched. CLAUDE.md invariant #4 (per-tenant isolation) is structurally satisfied — this RPC reads from the **global** store, which is the sanctioned cross-tenant surface.
+- global_store: single read of `tenant_members` table — `SELECT * FROM tenant_members WHERE user_id = ? ORDER BY joined_at` (`global_store.py:622-628`), wrapped via `_run_sync` (`:620`). This produces the cross-tenant view by design.
+- Sharding: handler does NOT filter by `_sharding.is_mine(tenant_id)`. In multi-node deployments the global_store is logically global, so memberships across shards are visible from any node. Go port matches.
+- Quotas / rate limits: not enforced; rely on interceptor.
+- Metrics: `record_grpc_request("GetUserTenants", "ok"|"error", elapsed)` (`:2594`, `:2597`).
+
+## Error contract
+
+| grpc.Code | Trigger |
+|---|---|
+| `OK` | Happy path; also returned with `memberships=[]` from the catch-all (`:2596-2599`). |
+| `INVALID_ARGUMENT` | `actor == ""` (`:2586-2587`); `user_id == ""` (`:2588-2589`). |
+| `UNIMPLEMENTED` | `self.global_store is None` (`:2580-2584`, message: "Tenant registry not configured"). |
+| `UNAUTHENTICATED` | Auth interceptor only (no/invalid creds). Not from handler today. |
+| `PERMISSION_DENIED` | Auth interceptor only today; Go port should add self-vs-admin gate (see Auth). |
+| `INTERNAL` | NOT returned. Any exception from `global_store.get_user_tenants` is caught (`:2596-2599`), logged at error, and a `memberships=[]` `OK` response is sent. Go MUST preserve to keep the contract test green. |
+
+The catch-all behavior is unusual but pinned: the contract test only checks for tenant presence on the happy path; on failure the empty-OK response is the documented degradation. Match it.
+
+## Shared Go package deps
+
+- `internal/globalstore` — Go port of `GlobalStore`; expose `GetUserTenants(ctx, userID string) ([]Membership, error)` returning rows ordered by `joined_at` (`global_store.py:614-628`). Underlying schema: `tenant_members(tenant_id, user_id, role, joined_at)`.
+- `internal/pb` — generated bindings; reuse `*pb.TenantMemberInfo` from `GetTenantMembers` port.
+- `internal/grpcutil` — shared helper `MemberDictToProto` / `MembershipToProto` mirroring `_member_dict_to_proto` (`grpc_server.py:2281-2288`); used by `GetTenantMembers`, `AddTenantMember`, `ChangeMemberRole`, `GetUserTenants`.
+- `internal/auth` — `GetCurrentIdentity(ctx)` (analogue of `auth_interceptor.get_current_identity`) for the recommended authz gate.
+- `internal/metrics` — `RecordGRPCRequest("GetUserTenants", status, dur)`.
+- `internal/logging` — error-level on catch-all (`:2598`).
+
+## Other-RPC deps (overlaps with ListTenants)
+
+- **`ListTenants` overlap**: `ListTenants` also calls `global_store.get_user_tenants(user_id)` (`grpc_server.py:1585`) to filter visible tenants for a regular `user:*` caller. Both RPCs MUST resolve identically in the Go port — share one implementation in `internal/globalstore.GetUserTenants` and one mapping helper. Drift between them would make `ListTenants` show tenants that `GetUserTenants` doesn't return (or vice-versa) and break SDK assumptions in `sdk/go/entdb/admin.go:91-92`.
+- **`GetTenantMembers`**: dual view (rows-for-one-tenant vs rows-for-one-user). Same `TenantMemberInfo` shape, same `_member_dict_to_proto` helper. Port together.
+- **`gdpr_worker`**: `gdpr_worker.py:136` consumes `get_user_tenants` to compute the deletion fan-out. The Go port of GDPR depends on this method having identical semantics (joined_at ordering doesn't matter for set-based fan-out, but presence/absence does).
+- **`DeleteUser` / `RevokeAllUserAccess`**: `grpc_server.py:3034` reads memberships during user-wide revocations; same dependency.
+- SDK consumer: `sdk/go/entdb/client.go:841-847` (`grpcTransport.GetUserTenants`), `sdk/go/entdb/admin.go:89-92` (`Admin.GetUserTenants`). No semantic change — the Go server must produce bytes the existing Go SDK already accepts.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:500-505` — happy path: `actor=ALICE, user_id="alice"`, expect membership for `TENANT`. Go port must satisfy `any(m.tenant_id == TENANT for m in r.memberships)`.
+- `tests/python/integration/test_grpc_contract.py:506-510` — `actor=""`, `user_id="alice"` => mode `invalid_argument`.
+- `tests/python/unit/test_tenant_registry.py:557-582` — `TestGetUserTenantsHandler.test_get_user_tenants`: alice in two tenants `t1`, `t2`, both must come back. Pins multi-tenant return.
+- `sdk/go/entdb/admin_test.go:233`, `:262-276` — `TestAdmin_GetUserTenants_HappyPath`: SDK consumer pins the `[]TenantMember` shape and round-trip through the transport.
+- `sdk/go/entdb/grpc_transport_test.go:111-112`, `:376-379` — fake server signature and request/response wiring; pins the proto contract end-to-end.
+- `sdk/go/entdb/client_test.go:174` — mock transport ensures the interface remains stable.
+
+No test currently exercises the "user_id missing" branch from gRPC level (only `actor=""` is pinned). Add one in the Go port to lock invariant.
+
+## Implementation outline
+
+```go
+func (s *Server) GetUserTenants(ctx context.Context, req *pb.GetUserTenantsRequest) (*pb.GetUserTenantsResponse, error)
+```
+
+1. `start := time.Now()`. Defer `metrics.RecordGRPCRequest("GetUserTenants", status, time.Since(start))` with `status` defaulting to `"ok"` and switched to `"error"` on the catch-all path.
+2. Guard: `if s.globalStore == nil { return nil, status.Error(codes.Unimplemented, "Tenant registry not configured") }` (`:2580-2584`).
+3. Validate: `req.GetActor() == ""` => `codes.InvalidArgument, "actor is required"`. `req.GetUserId() == ""` => `codes.InvalidArgument, "user_id is required"`. Order matters: `actor` first to match Python (`:2586-2589`).
+4. (Recommended, default-off behind config) Authz gate via `auth.GetCurrentIdentity(ctx)`:
+   - `nil` => `PermissionDenied`.
+   - admin (`__system__`, `system:*`, `admin:*`) => allow.
+   - `"user:"+req.UserId` (case-sensitive) => allow.
+   - otherwise => `PermissionDenied`.
+5. Wrap remainder in a closure with `defer recover()`. On panic OR any error from steps 6-7: log at error, set status `"error"`, return `&pb.GetUserTenantsResponse{Memberships: nil}, nil` — preserve Python's empty-OK degradation (`:2596-2599`). Never propagate `Internal`.
+6. `rows, err := s.globalStore.GetUserTenants(ctx, req.UserId)`. Rows are pre-sorted by `joined_at ASC` inside the store (mirror `ORDER BY joined_at`).
+7. Translate: `memberships := make([]*pb.TenantMemberInfo, 0, len(rows))` then `MembershipToProto(row)` for each — fields `TenantId`, `UserId`, `Role`, `JoinedAt`, missing values default to zero (matches `dict.get(..., "")` / `0` at `:2283-2287`).
+8. Return `&pb.GetUserTenantsResponse{Memberships: memberships}, nil`.
+9. Status accounting: `INVALID_ARGUMENT` and `UNIMPLEMENTED` paths emit `record_grpc_request(..., "error", ...)` in Python? — actually they short-circuit before the metric line (`:2594`), so no metric is emitted on those. Match Python: only emit metric on the success-or-degraded paths. (Optional: deviate and emit `"error"` on the validation path; document, but be aware existing dashboards count only post-validation traffic.)
+
+## Open questions / risks
+
+- **Privilege boundary**: today any authenticated caller can read any user's tenant set. This leaks tenant membership graphs. Confirm with EPIC owner whether the Go port should land the self-or-admin gate immediately (recommendation: yes, behind `ENTDB_STRICT_TENANT_REGISTRY_AUTHZ=1`, default-off in v1 to preserve contract tests, default-on in v2). Track in a follow-up issue.
+- **Empty-OK degradation**: contract pins it, but SREs may misread `OK + memberships=[]` as "user has no tenants" when global_store is broken. Recommendation: keep the response shape, but emit a distinct metric label (e.g. `status="degraded"`) so dashboards can alarm. This is additive, doesn't break contract.
+- **Sharding semantics**: `global_store` is logically singleton. In a multi-node deployment, every node must see the same membership view. If global_store is implemented per-node-with-replication, a stale read could return a tenant that this node can't actually serve. Out of scope for this RPC, but document as a precondition for `internal/globalstore`.
+- **`actor` field is dead weight**: presence-checked but unused. Should the Go port deprecate it (proto reserved tag)? Not in this port — keeping it preserves wire compat with Python clients that fill it. Flag for a future proto cleanup.
+- **`joined_at` units**: Python stores epoch seconds (int) in SQLite. Proto field is `int64`. Confirm the Go global_store port uses the same unit; mismatched ms/s would break `ListSharedWithMe`-style time filters elsewhere.
+- **Test gap**: no test pins `user_id=""` rejection through the gRPC contract harness — only `actor=""` is covered. Add one when porting to lock the validation order.
+- **Cross-language helper**: `MembershipToProto` will be reused by 4+ RPCs; place it in `internal/grpcutil` (or co-locate with the global_store package) and unit-test it once with table-driven cases — including the missing-field defaults.

--- a/docs/go-port/rpcs/Health.md
+++ b/docs/go-port/rpcs/Health.md
@@ -1,0 +1,143 @@
+# RPC Port Spec — `entdb.v1.EntDBService/Health`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:1500-1535`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:76` (rpc), `:582-588` (messages).
+
+`HealthRequest` — empty message. No fields. No `RequestContext`, no actor,
+no tenant_id. The probe is server-global, not per-tenant.
+
+`HealthResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `healthy` | 1 | `bool` | True iff `wal == "healthy"` AND `storage == "healthy"` (other component keys are informational, do NOT gate `healthy`). |
+| `version` | 2 | `string` | Server semver. Python returns hard-coded `"1.0.0"` (see `grpc_server.py:1530`). Go port should read from build-stamped var (`-ldflags -X main.version=...`); contract test only requires non-empty (`test_grpc_contract.py:201`). |
+| `components` | 3 | `map<string,string>` | Always contains `wal` and `storage`. Adds `node_id` and `assigned_tenants` only when sharding is multi-node. |
+
+## Auth
+
+- **No authentication required.** `/entdb.EntDBService/Health` is in
+  `AuthInterceptor.UNAUTHENTICATED_METHODS` (`auth/auth_interceptor.py:157-162`).
+  Pinned by `tests/python/unit/test_enhanced_auth.py:648-661`.
+- **No rate-limit.** Bypassed by `RateLimitInterceptor`
+  (`tests/python/unit/test_rate_limiter.py:127-144`).
+- **No `Permission` check.** Handler does not consult `acl` or
+  `capability_registry`.
+- **Trusted-actor invariant: N/A.** Request carries no actor field, so the
+  CLAUDE.md "wire `request.actor` is UNTRUSTED" rule has nothing to ignore here.
+  Go port must NOT add any `request.context` parsing — there is no `context`.
+
+## Side effects
+
+**None.** Strictly read-only, in-memory introspection. In-order narration:
+
+1. `start := time.Now()` for metrics timing.
+2. Probe `wal.IsConnected()` (or treat as healthy if backend lacks the method —
+   matches Python `hasattr(self.wal, "is_connected")` shim at
+   `grpc_server.py:1512`). Catch any error → `components["wal"] = "unknown"`.
+3. Set `components["storage"] = "healthy"` unconditionally. (Python does not
+   actually probe SQLite; Go port should preserve this — adding a real probe
+   would be a behavior change; track as future work.)
+4. If `sharding != nil && sharding.IsMultiNode()`:
+   - `components["node_id"] = sharding.NodeID`
+   - `components["assigned_tenants"] = strings.Join(sortedSlice(sharding.AssignedTenants), ",")`
+5. Compute `healthy = components["wal"]=="healthy" && components["storage"]=="healthy"`
+   (the `node_id`/`assigned_tenants` keys MUST NOT count against health — this
+   is the regression pinned by `test_cron_fixes.py:116-147`).
+6. Record metric `record_grpc_request("Health", "ok"|"error", elapsed)`.
+7. Return `HealthResponse{healthy, version, components}`.
+
+No WAL append, no `canonical_store` write, no `global_store` read, no quota
+charge, no schema lookup.
+
+## Error contract
+
+| gRPC code | Trigger |
+|-----------|---------|
+| `OK` | Always, in practice. Even when `wal.IsConnected()` panics, Python catches and returns `OK` with `components["wal"]="unknown"` (`grpc_server.py:1514-1515`). |
+| `INTERNAL` | Only if a non-recoverable panic escapes the inner `try` (Python re-raises at `grpc_server.py:1535`). Go port: `defer recover() → status.Errorf(codes.Internal, ...)` and increment `record_grpc_request("Health","error",…)`. |
+| `UNAVAILABLE` | Server not started — surfaced by transport, never by the handler. |
+
+The handler MUST NOT abort with `UNAUTHENTICATED`, `PERMISSION_DENIED`, or
+`INVALID_ARGUMENT`. `HealthRequest` is empty so there is nothing to validate.
+
+## Shared Go package deps
+
+Each is a new package under `server/go/internal/...` unless noted.
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `HealthRequest`, `HealthResponse`, servicer interface. Required.
+- `wal` — `IsConnected() bool` interface (mirrors `wal/base.py:337`). Optional method; absence means "assume healthy". Used in step 2.
+- `sharding` — `Config{NodeID string; AssignedTenants []string; IsMultiNode() bool}` (mirrors `sharding.py`). Optional; nil-safe.
+- `metrics` — `RecordGRPCRequest(method, status string, dur time.Duration)` (mirrors `metrics.py:103`). Required.
+- `version` — package-level `Version string` set via `-ldflags`. Required.
+
+NOT used by this RPC and MUST NOT be imported: `auth`, `acl`, `apply`,
+`canonicalstore`, `globalstore`, `schema`, `errs`, `quota`, `crypto`, `audit`.
+Importing any of them is a code-smell signal that the handler is doing too much.
+
+## Other-RPC deps
+
+None. Health is a leaf RPC. Independent of every other RPC; can be ported in
+isolation as the first ticket of the Go port.
+
+Note: this is a **separate** RPC from `grpc.health.v1.Health/Check`, the
+standard probe protocol used by Docker `HEALTHCHECK` and k8s. The Go port
+must register both:
+- `entdb.v1.EntDBService/Health` (this spec)
+- `grpc.health.v1.Health` (use `google.golang.org/grpc/health` package + `health.NewServer()`, set status `SERVING` for `""` — mirrors `grpc_server.py:3283-3296`, pinned by `tests/python/unit/test_health_check.py:34-72`).
+
+## Contract tests pinning behavior
+
+- `tests/python/integration/test_grpc_contract.py:195-202` — happy-path: empty request, `healthy=true`, non-empty `version`. Runs over a real gRPC channel. **The Go server must pass this test verbatim once the Python stubs are swapped for the Go binary.**
+- `tests/python/unit/test_cron_fixes.py:116-147` — multi-node Health stays healthy: `node_id` / `assigned_tenants` info-keys don't drag `healthy` to false. Regression guard.
+- `tests/python/unit/test_enhanced_auth.py:648-661` — auth interceptor lets `/entdb.EntDBService/Health` through with no metadata.
+- `tests/python/unit/test_rate_limiter.py:127-144` — rate limiter bypasses Health even when tenant bucket is empty.
+- `tests/python/unit/test_health_check.py:34-72` — standard `grpc.health.v1.Health/Check` is wired and returns `SERVING`.
+- `tests/python/unit/test_auth.py:47`, `test_jwt_auth.py:360` — additional bypass pins for the JWT auth path.
+- `tests/python/e2e/test_full_flow.py:404-411` — HTTP `/health` returns `{"status":"healthy"}` (separate gateway, out-of-scope for this RPC).
+
+## Implementation outline (Go handler)
+
+```go
+// server/go/internal/api/health.go
+func (s *EntDBServer) Health(ctx context.Context, _ *pb.HealthRequest) (*pb.HealthResponse, error) {
+    start := time.Now()
+    defer func() {
+        status := "ok"
+        if r := recover(); r != nil { status = "error"; panic(r) }
+        metrics.RecordGRPCRequest("Health", status, time.Since(start))
+    }()
+```
+
+1. Initialize `components := map[string]string{}`.
+2. Probe WAL: if `s.wal` implements `interface{ IsConnected() bool }`, call it inside a `func() { defer recover() ... }()` and set `components["wal"]` to `"healthy"`, `"unhealthy"`, or `"unknown"`. Otherwise `"healthy"`.
+3. `components["storage"] = "healthy"` (unconditional; matches Python).
+4. If `s.sharding != nil && s.sharding.IsMultiNode()`:
+   - `components["node_id"] = s.sharding.NodeID`
+   - sort `s.sharding.AssignedTenants` ascending, join with `","`, assign to `components["assigned_tenants"]`.
+5. `healthy := components["wal"] == "healthy" && components["storage"] == "healthy"`.
+6. Return `&pb.HealthResponse{Healthy: healthy, Version: version.Version, Components: components}, nil`.
+7. Wire `/entdb.EntDBService/Health` into the unauth-bypass set in the Go auth interceptor and rate-limit interceptor (separate ticket — track in `docs/go-port/shared/auth.md` once written).
+
+## Open questions / risks
+
+- **Hard-coded `version="1.0.0"`** in Python is a known wart. Go port should
+  fix by reading from `runtime/debug.ReadBuildInfo()` or `-ldflags -X`. Confirm
+  with EPIC #407 owner that this is desired, not a contract break.
+- **`storage="healthy"` is a lie** — Python never opens an SQLite cursor.
+  Decide whether the Go port should add a real probe (`PRAGMA quick_check`)
+  per assigned tenant. Risk: a real probe on N tenants could time out
+  health checks under load. Recommended: keep Python behavior, file a
+  follow-up ticket for a real probe behind a flag.
+- **WAL `IsConnected()` semantics differ across backends** (`memory`, `kafka`,
+  `kinesis`, `sqs`, `pubsub`, `eventhubs`, `servicebus`). Some are pure
+  in-memory flags, some return cached state without a live ping. Go port must
+  preserve the cheap, non-blocking contract — never round-trip to the broker
+  inside Health. Otherwise the Docker HEALTHCHECK can starve.
+- **Concurrency**: Python builds a fresh `dict` each call, no shared state.
+  Go port must do the same — do not memoize `components` across calls,
+  because `assigned_tenants` can change at runtime via SIGHUP.
+- **Metrics label cardinality** is fixed (`Health` × {`ok`,`error`}); no risk.

--- a/docs/go-port/rpcs/ListMailboxUsers.md
+++ b/docs/go-port/rpcs/ListMailboxUsers.md
@@ -1,0 +1,198 @@
+# RPC Port Spec — `entdb.v1.EntDBService/ListMailboxUsers`
+
+EPIC #407 — Python -> Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:1605-1617`.
+
+**Status: deprecated stub.** The legacy per-user mailbox SQLite store has been
+removed. The handler is retained for proto compatibility and unconditionally
+returns an empty `user_ids` list. The Go port MUST replicate this stub
+verbatim — adding a real implementation is a contract change and out of scope
+for #407.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:85` (rpc), `:621-629` (messages).
+
+`ListMailboxUsersRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `tenant_id` | 1 | `string` | Required for tenant routing. No `RequestContext`, no `actor` field on this message. |
+
+`ListMailboxUsersResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `user_ids` | 1 | `repeated string` | Always empty in current contract. Must be returned as `[]`, NOT a nil/null repeated. Pinned by `test_grpc_contract.py:286`. |
+
+Full method name on the wire: `/entdb.v1.EntDBService/ListMailboxUsers`
+(see `server/python/entdb_server/api/generated/entdb_pb2_grpc.py:99`,
+`sdk/go/entdb/internal/pb/entdb_grpc.pb.go:70`).
+
+## Auth (trusted-actor; admin scope?)
+
+- **Authenticated.** NOT in
+  `AuthInterceptor.UNAUTHENTICATED_METHODS`
+  (`server/python/entdb_server/auth/auth_interceptor.py:157-162` — that frozenset
+  contains only `Health` and `grpc.health.v1.Health/Check`). The auth
+  interceptor runs and a missing/invalid identity aborts before the handler
+  is reached.
+- **No admin scope required.** The handler does not call
+  `_is_admin_or_system`, `_check_tenant_access`, or any ACL helper. Any
+  authenticated identity that the tenant-routing check accepts may invoke it.
+- **Trusted-actor invariant: N/A.** `ListMailboxUsersRequest` carries no
+  `actor` and no `RequestContext`. There is nothing on the wire to forge,
+  so the CLAUDE.md rule "wire `request.actor` is UNTRUSTED" has no surface
+  here — but the Go handler MUST NOT introduce any actor parameter or trust
+  any metadata-derived identity for authorization (the empty-list contract
+  is identity-independent today).
+- **Tenant routing.** The handler does call `_check_tenant(request.tenant_id, context)`
+  (`grpc_server.py:1616`), which performs the standard sharding-owner /
+  region-pinning checks (`grpc_server.py:362-410`). This is the only
+  pre-condition gate.
+- **Rate limiting.** Goes through the standard `RateLimitInterceptor`
+  (no bypass). Go port must keep this RPC inside the tenant bucket like
+  every other tenant-scoped RPC.
+
+## Side effects (read-only)
+
+**None.** The handler:
+1. Awaits `_check_tenant(request.tenant_id, context)` — may abort with
+   `UNAVAILABLE` or `FAILED_PRECONDITION` (see error contract). This call
+   may read from `global_store.get_tenant()` for region pinning
+   (`grpc_server.py:401`), but is a side-effect-free read.
+2. Returns `ListMailboxUsersResponse(user_ids=[])`.
+
+No WAL append, no SQLite read, no `canonical_store` access, no `global_store`
+write, no quota charge, no schema lookup, no audit log entry. This RPC MUST
+NOT touch the WAL — even reads of tenant existence go through `global_store`,
+not `wal.append`.
+
+Note: the current Python handler does NOT call `record_grpc_request` (unlike
+most other handlers). The Go port SHOULD record metrics for observability,
+but this is an additive divergence, not a contract break.
+
+## Error contract
+
+| gRPC code | Trigger | Source |
+|-----------|---------|--------|
+| `OK` | Always, for any authenticated caller whose tenant routes to this node. Response is `{user_ids: []}`. | Pinned by `test_grpc_contract.py:281-287` (mode `happy`). |
+| `UNAUTHENTICATED` | Auth interceptor rejects bad/missing credentials before handler runs. | `auth_interceptor.py` — generic, not handler-specific. |
+| `UNAVAILABLE` | Tenant is owned by another node (sharding). Trailer `entdb-redirect-node` carries the owner. | `grpc_server.py:392-394`. |
+| `FAILED_PRECONDITION` | Tenant pinned to a different region than the node serves. | `grpc_server.py:405-409`. |
+| `RESOURCE_EXHAUSTED` | Per-tenant rate limit exceeded. | `RateLimitInterceptor` — generic. |
+| `INTERNAL` | Unhandled panic. The current Python stub has no `try/except` and would let exceptions propagate; in practice none can fire after `_check_tenant`. Go port: `defer recover()` -> `status.Errorf(codes.Internal, ...)`. | n/a |
+
+The handler MUST NOT abort with `INVALID_ARGUMENT`, `PERMISSION_DENIED`, or
+`NOT_FOUND`. An empty `tenant_id` is currently NOT validated at this RPC
+(it falls through `_check_tenant` and returns an empty list); the Go port
+MUST preserve this behavior to keep contract-test parity unless EPIC #407
+explicitly tightens it.
+
+## Shared Go package deps
+
+Each is a package under `server/go/internal/...` unless noted.
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `ListMailboxUsersRequest`,
+  `ListMailboxUsersResponse`, servicer interface. Required.
+- `tenantroute` — `CheckTenant(ctx, tenantID) error` mirroring
+  `_check_tenant` (`grpc_server.py:362-410`). Must surface `UNAVAILABLE`
+  with `entdb-redirect-node` trailer and `FAILED_PRECONDITION` for
+  region-pin mismatch. Shared with every tenant-scoped RPC. Spec it in
+  `docs/go-port/shared/tenant-route.md` (separate ticket).
+- `metrics` — `RecordGRPCRequest(method, status, dur)` (mirrors
+  `metrics.py:103`). Optional for parity, recommended.
+
+NOT used and MUST NOT be imported by this handler: `auth`, `acl`, `apply`,
+`canonicalstore`, `globalstore` (direct), `schema`, `wal`, `errs`, `quota`,
+`crypto`, `audit`. Importing any signals scope creep (e.g. someone trying
+to "implement" the deprecated mailbox-user enumeration — don't).
+
+## Other-RPC deps
+
+- `GetMailbox` (`grpc_server.py:1700+`) — companion deprecated stub, also
+  returns empty (`test_grpc_contract.py:274-279`). Same lifecycle: ported as
+  a stub, not a real implementation. This RPC's spec parallels `GetMailbox`'s
+  spec; keep both consistent.
+- `SearchMailbox` (`grpc_server.py`, `test_grpc_contract.py:265-273`) — third
+  member of the deprecated mailbox triad; same stub treatment.
+
+`ListMailboxUsers` itself is a leaf RPC (no fan-out, no internal RPC calls).
+Can be ported in isolation once `tenantroute` and the auth interceptor are
+landed.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:281-287` — happy path:
+  `ListMailboxUsersRequest(tenant_id="acme")` returns
+  `ListMailboxUsersResponse` with `user_ids == []`. This test runs over a
+  real gRPC channel without an auth interceptor wired (see harness setup
+  at `test_grpc_contract.py:1-80`), so the Go server passes it once
+  `_check_tenant` is satisfied. **The Go server must pass this test
+  verbatim.**
+- No dedicated unit tests for this RPC exist (deliberate — it's a stub).
+  If the Go port adds metrics, add a unit test asserting the metric label
+  but do not add behavioural tests beyond the contract test above.
+- `sdk/go/entdb/cmd/entdb-console/frontend/src/gen/entdb_connect.ts:189-194`
+  — generated client; non-behavioural, do not edit.
+- `sdk/go/entdb/internal/pb/entdb_grpc.pb.go:70` — generated full-method
+  constant; non-behavioural.
+
+## Implementation outline
+
+```go
+// server/go/internal/api/list_mailbox_users.go
+func (s *EntDBServer) ListMailboxUsers(
+    ctx context.Context,
+    req *pb.ListMailboxUsersRequest,
+) (*pb.ListMailboxUsersResponse, error) {
+    start := time.Now()
+    status := "ok"
+    defer func() {
+        if r := recover(); r != nil {
+            status = "error"
+            metrics.RecordGRPCRequest("ListMailboxUsers", status, time.Since(start))
+            panic(r)
+        }
+        metrics.RecordGRPCRequest("ListMailboxUsers", status, time.Since(start))
+    }()
+
+    if err := s.tenantRoute.CheckTenant(ctx, req.GetTenantId()); err != nil {
+        status = "error"
+        return nil, err // already a status.Error from tenantRoute
+    }
+
+    // Deprecated stub — legacy per-user mailbox SQLite store has been removed.
+    // See docs/go-port/rpcs/ListMailboxUsers.md and
+    // server/python/entdb_server/api/grpc_server.py:1610-1614.
+    return &pb.ListMailboxUsersResponse{UserIds: []string{}}, nil
+}
+```
+
+Wire `/entdb.v1.EntDBService/ListMailboxUsers` into the standard
+authenticated + rate-limited interceptor chain (no bypass set). Do NOT
+add to any unauth-bypass list.
+
+## Open questions / risks
+
+- **Should the Go port resurrect a real implementation?** The CLAUDE.md
+  invariants would require: (a) a `mailbox_users` view materialized by the
+  `Applier` from WAL events, NOT a side-table; (b) per-tenant SQLite
+  isolation; (c) field-id storage. This is not in EPIC #407 scope — flag
+  for a follow-up ticket if product still wants the listing.
+- **Empty `tenant_id` handling.** The Python stub does not reject it. If
+  EPIC #407 introduces a global "validate tenant_id" middleware, this RPC
+  will start returning `INVALID_ARGUMENT` for empty input — confirm
+  desired behavior before tightening.
+- **Metrics divergence.** Adding `record_grpc_request` calls in the Go port
+  is a net-positive but technically a behavioural divergence (the Python
+  handler is missing them; see `grpc_server.py:1605-1617`). Recommend
+  adding them in Go AND backfilling Python in a separate cleanup PR so the
+  two implementations stay aligned.
+- **Authentication strictness.** The contract test runs without an auth
+  interceptor and expects `OK`. Production deployments DO have the auth
+  interceptor — confirm with EPIC #407 owner whether the Go contract suite
+  should additionally test the auth-required path.
+- **Trailer behavior on redirect.** The Python `_check_tenant` sets
+  `entdb-redirect-node` synchronously on `grpc.aio` contexts; the Go port
+  must mirror this via `grpc.SetTrailer(ctx, metadata.Pairs(...))` BEFORE
+  returning the `UNAVAILABLE` error — or SDK redirect caches will miss.
+  Cross-link to `docs/go-port/shared/tenant-route.md`.

--- a/docs/go-port/rpcs/ListSharedWithMe.md
+++ b/docs/go-port/rpcs/ListSharedWithMe.md
@@ -1,0 +1,256 @@
+# ListSharedWithMe — Go Port Spec
+
+EPIC #407. Reference Python handler:
+`server/python/entdb_server/api/grpc_server.py:1877-1944`. Proto:
+`proto/entdb/v1/entdb.proto:100, 757-766`.
+
+The RPC answers "what has been shared TO me?" — the inverse of `ShareNode`'s
+direction. It aggregates two indexes:
+1. **per-tenant `node_access`** — same-tenant grants where caller is the grantee.
+2. **global `shared_index`** — cross-tenant grants written by `ShareNode`
+   into `global_store` (one row per recipient × source-tenant × node).
+
+## Wire contract
+
+Request `entdb.v1.ListSharedWithMeRequest` (proto:757):
+- `RequestContext context` (tenant_id, actor — actor is UNTRUSTED on wire).
+- `int32 limit` — page size; `0` means "use server default 100"
+  (grpc_server.py:1896).
+- `int32 offset` — pagination offset; `0` means start.
+
+Response `ListSharedWithMeResponse` (proto:763):
+- `repeated Node nodes` — union of (a) same-tenant nodes the caller (or
+  any of caller's resolved groups) has a non-`deny` grant on, plus (b)
+  nodes from OTHER tenants where `shared_index.user_id == trusted_actor`.
+  Cross-tenant entries are de-duplicated against per-tenant results by
+  `(tenant_id, node_id)` (grpc_server.py:1916, 1919-1928).
+- `bool has_more` — `len(nodes) >= limit` (grpc_server.py:1939). NB: this
+  is a Python bug-compatible signal — it does NOT account for the
+  cross-tenant append step which can push `len(nodes)` past `limit`. Go
+  port must preserve.
+
+Pagination semantics:
+- `limit`/`offset` are applied **independently** to each index and then
+  merged. So at offset=100 you may see up to `2*limit` nodes, and pages
+  can overlap. Documented as a known limitation.
+- Order: per-tenant rows ordered by `na.granted_at DESC`
+  (canonical_store.py:3462), cross-tenant entries ordered by
+  `shared_at DESC` (global_store.py:731), and the merge is
+  per-tenant-first then cross-tenant — NOT a global sort.
+
+## Auth (caller is implicit recipient; trusted-actor)
+
+- Tenant existence: `_check_tenant` (grpc_server.py:1889, 362).
+- Trusted actor: `actor = self._trusted_actor(request.context.actor)`
+  (grpc_server.py:1891, 418-437). The recipient identity is **never**
+  taken from the request payload; it is read from the
+  `AuthInterceptor`'s `ContextVar` via `get_authoritative_actor`. This
+  is the key invariant — the caller is the implicit recipient, and
+  letting the request claim a different recipient would let `user:eve`
+  enumerate `user:alice`'s shares.
+- No capability check (read-of-own-shares is implicitly authorised by
+  identity). Verify against `tests/python/unit/test_capability_registry.py`
+  during port — likely no row, parity is "any authenticated tenant
+  member may call".
+- Group expansion: `canonical_store.resolve_actor_groups(tenant_id,
+  actor)` returns `[actor, group:a, group:b, ...]` — the per-tenant
+  query then matches any of those (grpc_server.py:1892-1895,
+  canonical_store.py:2855).
+- Cross-tenant lookup uses **only the bare actor string** (no group
+  expansion) — `global_store.get_shared_with_me(user_id=actor, ...)`
+  (grpc_server.py:1910-1914). Cross-tenant group-share fan-out happens
+  at write time (`ShareNode` expands group → members and writes one
+  `shared_index` row per member). See
+  `tests/python/unit/test_cross_tenant_read.py:378-400`.
+
+## Side effects (read; cross-tenant — items shared from other tenants)
+
+- Read-only on disk. No WAL append, no SQLite write, no audit row.
+- **Reads cross-tenant SQLite databases.** For each `shared_index`
+  entry from a foreign `source_tenant`, the handler calls
+  `canonical_store.get_node(source_tenant, node_id)`
+  (grpc_server.py:1923-1925). This is the ONE allowed cross-tenant
+  read in EntDB and only legal because the `shared_index` row IS the
+  authorisation token — its existence means `ShareNode` already wrote
+  a `node_access` row in the source tenant. Per CLAUDE.md invariant 4,
+  no SQLite transaction crosses tenants; each `get_node` opens its own
+  per-tenant connection.
+- Stale `shared_index` entries (source tenant unloaded, node deleted,
+  permission revoked but global index lagging) are silently skipped via
+  bare `except` (grpc_server.py:1929-1931). Go port must match — these
+  are eventual-consistency artefacts, not errors.
+- `global_store` failure logs a warning and falls through to per-tenant
+  results only (grpc_server.py:1932-1933) — degrades gracefully.
+- Metric: `record_grpc_request("ListSharedWithMe", "ok"|"error", elapsed)`
+  (grpc_server.py:1936, 1942).
+
+## Error contract
+
+| Condition | Python behaviour | Go port |
+|---|---|---|
+| Tenant missing/disabled | `_check_tenant` aborts `NOT_FOUND` / `FAILED_PRECONDITION` (with `entdb-redirect-node` trailer if owned elsewhere) | match |
+| Forged actor in payload | overwritten by trusted actor; payload value is ignored (no error) | match |
+| Caller has no shares | OK, `nodes=[]`, `has_more=false` | match |
+| `global_store` unavailable | logged warning; return per-tenant results only | match |
+| Stale `shared_index` row (source tenant unloaded, node deleted) | silently skipped | match |
+| Per-tenant SQLite error | bare `except`: log + return `nodes=[]` with status OK (grpc_server.py:1941-1944) — error mode swallowed | preserve for v1 parity; flag for review |
+| `limit < 0` / `offset < 0` | passed straight to SQLite (negative LIMIT = unlimited in SQLite) — undefined behaviour | Go port: clamp to `[0, maxLimit]`, `maxLimit=1000` |
+
+There is no per-RPC `PERMISSION_DENIED`: identity authorises the read,
+and "no shares" is a valid empty success.
+
+## Shared Go package deps (acl, mailbox, global_store)
+
+- `internal/auth` — `GetAuthoritativeActor(ctx)`. The caller IS the
+  implicit recipient; no group/capability check needed.
+- `internal/tenant` — `CheckTenant(ctx, tenantID)` (with redirect-trailer
+  semantics from `_check_tenant`).
+- `internal/canonical` (the per-tenant SQLite store) —
+  `ResolveActorGroups(ctx, tenantID, actor) []string`,
+  `ListSharedWithMe(ctx, tenantID, actorIDs, limit, offset) []*Node`,
+  `GetNode(ctx, tenantID, nodeID) *Node` (used cross-tenant).
+- `internal/globalstore` — `GetSharedWithMe(ctx, userID, limit, offset)
+  []SharedEntry` where `SharedEntry{UserID, SourceTenant, NodeID,
+  Permission, SharedAt}`. Backed by the global SQLite (`shared_index`
+  table, schema in `global_store.py:670-734`).
+- `internal/wire` — `NodeToProto` (id-keyed payload per CLAUDE.md
+  invariant 6).
+- `internal/metrics` — `RecordGRPCRequest`.
+- (Mailbox is NOT a dep here — the listing is over `shared_index`,
+  not the mailbox. See "Other-RPC deps" for the historical confusion.)
+
+## Other-RPC deps (overlap with GetMailbox)
+
+- **`ShareNode` writes both indexes**: same-tenant grants write
+  `node_access` (used by per-tenant query); cross-tenant grants ALSO
+  write `shared_index` rows via `global_store.add_shared`. Group shares
+  are fanned out: one `shared_index` row per (member, source_tenant,
+  node).
+- **`RevokeAccess` removes both**: deletes `node_access` AND
+  `global_store.remove_shared` (grpc_server.py:1862-1867). If the
+  global delete fails, this RPC will keep returning the revoked node
+  until the next ShareNode → applier loop. Same eventual-consistency
+  caveat applies.
+- **Overlap with `GetMailbox`**: `GetMailbox` lists mailbox **messages**
+  (the per-tenant message-passing primitive); `ListSharedWithMe` lists
+  **nodes shared via ACL grants**. They are independent surfaces but
+  often confused because both answer "things addressed to me". The Go
+  port should NOT share an internal helper between the two — different
+  storage (`mailbox_messages` table vs `shared_index` + `node_access`),
+  different write paths.
+- **Capability mapping**: see `test_capability_registry.py` — confirm at
+  port time. No capability is required by the handler; identity alone
+  authorises.
+- All read RPCs share the same auth/tenant helpers; spec lives in
+  `docs/go-port/shared/auth.md` and `shared/tenant.md`.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_acl_v2.py:455-481` — same-tenant index:
+  shared-nodes union, deny exclusion, group-share inclusion via
+  `resolve_actor_groups`.
+- `tests/python/unit/test_cross_tenant_read.py:309-356` — cross-tenant
+  aggregation: `global_store.get_shared_with_me` returns rows from
+  multiple `source_tenant`s; per-tenant + cross-tenant union must
+  surface all of them.
+- `tests/python/unit/test_cross_tenant_read.py:362-400` — group share
+  cross-tenant: a `ShareNode` to `group:eng` writes one
+  `shared_index` row per group member, so each member sees the node
+  on their own `ListSharedWithMe`.
+- `tests/python/unit/test_payload_wire_format.py:15` (file header
+  reference) and the id-keyed payload assertions — `nodes[*].payload`
+  on the wire is field-id-keyed, NOT name-keyed.
+- `tests/python/integration/test_grpc_contract.py:339-350` — happy-path
+  smoke: well-formed response after a `ShareNode`; check is permissive
+  because the in-memory test fixture may or may not have wired
+  `global_store`.
+
+Go port adds (`tests/contract/`):
+- offset>0 with both indexes populated does NOT skip cross-tenant rows
+  (current bug-compat: each index is paginated independently).
+- `has_more=true` when per-tenant alone fills the page.
+- forged actor in payload returns the trusted actor's shares only.
+
+## Implementation outline
+
+```go
+func (s *Server) ListSharedWithMe(ctx context.Context, req *pb.ListSharedWithMeRequest) (*pb.ListSharedWithMeResponse, error) {
+    start := time.Now()
+    statusLabel := "ok"
+    defer func() { metrics.RecordGRPCRequest("ListSharedWithMe", statusLabel, time.Since(start)) }()
+
+    if err := s.checkTenant(ctx, req.Context.TenantId); err != nil { statusLabel = "error"; return nil, err }
+    actor := auth.GetAuthoritativeActor(ctx)              // ignore req.Context.Actor
+
+    limit := req.Limit
+    if limit <= 0 { limit = 100 }
+    if limit > 1000 { limit = 1000 }                       // hardening delta vs Python
+    offset := req.Offset
+    if offset < 0 { offset = 0 }
+
+    actorIDs, err := s.store.ResolveActorGroups(ctx, req.Context.TenantId, actor)
+    if err != nil { statusLabel = "error"; return &pb.ListSharedWithMeResponse{}, nil } // parity: swallow
+
+    // 1. Per-tenant
+    nodes, _ := s.store.ListSharedWithMe(ctx, req.Context.TenantId, actorIDs, limit, offset)
+
+    // 2. Cross-tenant from global shared_index
+    seen := make(map[string]struct{}, len(nodes))
+    for _, n := range nodes { seen[n.TenantID+"\x00"+n.NodeID] = struct{}{} }
+    if s.globalStore != nil {
+        entries, gerr := s.globalStore.GetSharedWithMe(ctx, actor, limit, offset)
+        if gerr != nil {
+            log.Warn().Err(gerr).Msg("shared_index read failed in ListSharedWithMe")
+        } else {
+            for _, e := range entries {
+                key := e.SourceTenant + "\x00" + e.NodeID
+                if _, dup := seen[key]; dup { continue }
+                n, err := s.store.GetNode(ctx, e.SourceTenant, e.NodeID)
+                if err != nil || n == nil { continue }   // stale entry; skip silently
+                nodes = append(nodes, n)
+                seen[key] = struct{}{}
+            }
+        }
+    }
+
+    out := make([]*pb.Node, 0, len(nodes))
+    for _, n := range nodes { out = append(out, wire.NodeToProto(n)) }
+    return &pb.ListSharedWithMeResponse{Nodes: out, HasMore: int32(len(nodes)) >= limit}, nil
+}
+```
+
+Notes:
+- `grpc.aio` parity: Go's grpc-go is request-per-goroutine; no async
+  bridging needed. SQLite calls go through the canonical-store pool.
+- Cross-tenant `GetNode` calls fan out serially in Python; consider
+  bounded parallelism (sem=8) only if benchmarks demand it. Behaviour
+  is independent of order, so safe to parallelise.
+- Per CLAUDE.md invariant 4, never open a single SQLite transaction
+  spanning two tenants. Each `GetNode` opens its own connection.
+
+## Open questions / risks (pagination; expired/revoked filter)
+
+1. **Pagination is broken-by-design**: `limit`/`offset` apply
+   independently to per-tenant and cross-tenant indexes, then merge.
+   Page boundaries do not line up. Two options: (a) parity for v1,
+   document; (b) implement a unified sort key (e.g. opaque cursor over
+   `(shared_at, source_tenant, node_id)`). Recommend (a) + follow-up
+   issue. EPIC #407 owner to confirm.
+2. **`has_more` is misleading**: `len(nodes) >= limit` after the
+   cross-tenant append over-reports `true`. Match Python bug for v1.
+3. **Expired/revoked filter**: per-tenant query already filters
+   `expires_at` and `permission != 'deny'`
+   (canonical_store.py:3460-3461). Cross-tenant `shared_index` has NO
+   `expires_at` column — an expired share lingers in the global index
+   until `RevokeAccess` runs. Go port should match (parity), but file
+   issue: add `expires_at` to `shared_index` and filter at
+   `get_shared_with_me`.
+4. **Stale-entry storm**: if a source tenant is offline,
+   `get_node` returns nil and we skip. A user with hundreds of stale
+   entries pays N round-trips per call. Consider a periodic GC of
+   `shared_index` rows whose `source_tenant` no longer resolves.
+5. **No capability gate**: any authenticated tenant member can list
+   their own shares. Confirm with EPIC #407 — should there be a
+   `READ` capability requirement for symmetry with other read RPCs?
+6. **`type_id` filter**: callers may want "show me shared Documents
+   only". Not in proto today; track as a v2 feature.

--- a/docs/go-port/rpcs/ListTenants.md
+++ b/docs/go-port/rpcs/ListTenants.md
@@ -1,0 +1,213 @@
+# RPC Port Spec — `entdb.v1.EntDBService/ListTenants`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:1537-1603`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:82` (rpc), `:611-619` (messages).
+
+`ListTenantsRequest` — **empty message**. No fields.
+- No `RequestContext`, **no `actor`**, no `tenant_id`.
+- No `filter`, no `page_token`, no `page_size`, no `sort`, no `status` selector.
+- The handler is **identity-driven**, not request-driven. Pinned by
+  `tests/python/integration/test_privilege_escalation.py:397-401` ("The actor
+  field on ListTenantsRequest doesn't even exist in the proto").
+
+`ListTenantsResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `tenants` | 1 | `repeated TenantInfo` | Visible tenants for the trusted caller. Order matches `canonical_store.list_tenants()` which returns `sorted(data_dir.glob("tenant_*.db"))` — i.e. **ascending tenant_id**. Go port MUST preserve sort order; no test pins it explicitly but admin tests use `sorted(...)` everywhere. |
+
+`TenantInfo` (proto `:617-619`) — single field `string tenant_id = 1`. No
+display name, no created_at, no member count. Adding fields is non-breaking
+on the wire but is a contract change for the Go port — **do not add fields**.
+
+**Pagination: none.** All visible tenants returned in a single response.
+A node hosts O(tenants_on_node); 1k–10k is the realistic ceiling. If/when
+pagination is added it must be a new RPC or a new `ListTenantsV2` request
+type — not a silent extension here.
+
+## Auth
+
+Method **is NOT** in `AuthInterceptor.UNAUTHENTICATED_METHODS`
+(`auth/auth_interceptor.py:157-184`). The interceptor MUST run first and
+populate the trusted-identity ContextVar via `set_current_identity()`.
+
+Handler reads the identity via `get_current_identity()` (`grpc_server.py:1557,
+1561`). Visibility classes:
+
+| Trusted identity | Visibility |
+|---|---|
+| `None` (interceptor missing or auth disabled) | **`PERMISSION_DENIED`**, message `"ListTenants requires an authenticated caller"` (`grpc_server.py:1563-1566`). Do NOT fall open. |
+| `"__system__"`, `"system:*"`, `"admin:*"` | All tenants on this node (sharding still applied). `grpc_server.py:1568-1572`. |
+| `"user:<id>"` | Intersection of node-local tenants ∩ `global_store.get_user_tenants(<id>)`. Strip `"user:"` prefix before membership lookup (`grpc_server.py:1584`). |
+| Any other string (no recognised prefix) | Treated as the bare user_id (no strip). Same membership-filter path. |
+
+**Trusted-actor invariant (CLAUDE.md §"Proto is the type system"):** the
+request carries no actor field, so the wire-actor-is-untrusted rule has
+nothing to validate. The Go port MUST NOT add a `request.context.actor`
+read here — pinned by `test_privilege_escalation.py:386-417` (claimed admin
+actors via the metadata-spoofing helper still see only Eve's tenants).
+
+No `Permission` / capability check, no per-tenant ACL — visibility comes
+purely from `tenant_members` rows.
+
+## Side effects
+
+**Strictly read-only.** No WAL append, no `canonical_store` write, no
+`global_store` write, no quota charge.
+
+In-order narration:
+1. `start := time.Now()` for metrics timing.
+2. `trusted := getCurrentIdentity(ctx)`. If nil → abort `PERMISSION_DENIED`.
+3. `isAdmin := trusted=="__system__" || strings.HasPrefix(trusted,"system:") || strings.HasPrefix(trusted,"admin:")`.
+4. `allIDs := canonicalStore.ListTenants()` — directory scan of `data_dir/tenant_*.db` (`canonical_store.py:4047-4061`). Synchronous; cheap; do **not** wrap in goroutine.
+5. If `sharding != nil && sharding.IsMultiNode()` → keep only `sharding.IsMine(tid)` (`grpc_server.py:1575-1576`). Pinned by `test_listtenants_auth.py:200-230`.
+6. If `isAdmin` → `visible = allIDs`.
+7. Else if `globalStore != nil` → strip `"user:"` prefix; `memberships, _ := globalStore.GetUserTenants(userID)`; `memberSet := {m.TenantID}`; `visible = filter(allIDs, in memberSet)`.
+8. Else (`globalStore == nil`, embedded harness) → `visible = []`. Pinned by `test_listtenants_auth.py:238-258`.
+9. `record_grpc_request("ListTenants","ok",elapsed)`.
+10. Build `[]*pb.TenantInfo` and return.
+
+No goroutine fan-out. No cache. No memoization (memberships can change
+between calls; correctness > 1µs of latency).
+
+## Error contract
+
+| gRPC code | Trigger | Wire path |
+|---|---|---|
+| `OK` | Happy path (incl. zero results). | Always returns a response, never an error, on success. |
+| `PERMISSION_DENIED` | Trusted identity is `nil` (interceptor missing/misconfigured). | `context.abort(...)` re-raised as `grpc.aio.AbortError`. Go: `return nil, status.Errorf(codes.PermissionDenied, ...)`. Pinned by `test_listtenants_auth.py:179-192`, `test_grpc_contract.py:288-295`. |
+| `OK` + empty `tenants=[]` | Any **other** unhandled exception inside the handler. | Python `except Exception` swallows and returns empty list (`grpc_server.py:1600-1603`). The Go port MUST replicate this — convert internal errors into `&pb.ListTenantsResponse{}` with `record_grpc_request(...,"error",...)` and `logger.Error(...)`. Returning `codes.Internal` is a **contract break**. |
+| `UNAUTHENTICATED` | Surfaced by the auth interceptor BEFORE the handler when metadata is missing/bad. Not raised by the handler itself. | N/A inside this RPC. |
+
+`INVALID_ARGUMENT` is impossible — request is empty. `NOT_FOUND` is not
+used; missing tenants → empty list.
+
+## Shared Go package deps
+
+Each is a package under `server/go/internal/...` unless noted.
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `ListTenantsRequest`, `ListTenantsResponse`, `TenantInfo`, servicer interface. **Required.**
+- `auth` — must export `GetCurrentIdentity(ctx) (string, bool)` populated by the auth interceptor (mirror of `auth_interceptor.py:66-75`). **Required.**
+- `canonicalstore` — `ListTenants() []string` (mirror of `canonical_store.py:4047`). Directory scan, no SQLite open. **Required.**
+- `globalstore` — `GetUserTenants(ctx, userID string) ([]Membership, error)` returning rows with at least `TenantID` (mirror of `global_store.py:614-628`). **Required**, but nil-safe call site (step 8).
+- `sharding` — `Config{ IsMultiNode() bool; IsMine(tenantID string) bool }` (mirror of `sharding.py`). Optional; nil-safe.
+- `metrics` — `RecordGRPCRequest(method, status string, dur time.Duration)`. **Required.**
+
+NOT used and MUST NOT be imported here: `acl`, `wal`, `apply`, `schema`,
+`errs` (no domain errors raised), `quota`, `crypto`, `audit`. Importing
+`wal` is the smoke signal that someone added a write path — block at code review.
+
+## Other-RPC deps
+
+- **`GetUserTenants` overlap** (`grpc_server.py:2572-2599`, proto `:126`/`:930-940`):
+  same `global_store.get_user_tenants(user_id)` call. The Go port should
+  share the underlying `globalstore.GetUserTenants` method — do not duplicate
+  the SQL. The two RPCs differ in:
+  - `GetUserTenants` takes `user_id` from the request (admin lookup of
+    arbitrary user). `ListTenants` derives it from the trusted identity.
+  - `GetUserTenants` returns full `MembershipInfo` (role, joined_at).
+    `ListTenants` discards everything but `tenant_id`.
+- **`Health`** is a sibling read-only RPC but shares no code path.
+- **`ListMailboxUsers`** (proto `:621-629`) is unrelated despite the name —
+  returns empty stub.
+
+No write-side RPC depends on `ListTenants`. It is a leaf reader; safe to
+port in isolation once `auth`, `canonicalstore`, `globalstore`, `sharding`
+and `metrics` packages exist.
+
+## Contract tests pinning behavior
+
+- `tests/python/unit/test_listtenants_auth.py:99-111` — admin identities (`__system__`, `system:admin`, `system:gdpr-worker`, `admin:root`) see all tenants on the node.
+- `tests/python/unit/test_listtenants_auth.py:119-137` — `user:alice` sees only her membership tenants; non-member tenants invisible.
+- `tests/python/unit/test_listtenants_auth.py:140-154` — user with zero memberships → empty list (no enumeration leak).
+- `tests/python/unit/test_listtenants_auth.py:157-171` — `"user:"` prefix MUST be stripped before `get_user_tenants` lookup.
+- `tests/python/unit/test_listtenants_auth.py:179-192` — no trusted identity → `PERMISSION_DENIED`, never falls open.
+- `tests/python/unit/test_listtenants_auth.py:200-230` — sharding filter still applied to admin (`is_mine` excludes non-local tenants).
+- `tests/python/unit/test_listtenants_auth.py:238-258` — `global_store == nil` → empty list for regular user (embedded-harness safety).
+- `tests/python/integration/test_privilege_escalation.py:386-417` — claimed admin actor in metadata MUST NOT bypass membership filtering for `user:eve`.
+- `tests/python/integration/test_grpc_contract.py:288-295` — over-the-wire: empty request without auth interceptor → `PERMISSION_DENIED`. **The Go server must pass this test verbatim once stubs swap to the Go binary.**
+
+## Implementation outline (Go handler)
+
+```go
+// server/go/internal/api/listtenants.go
+func (s *EntDBServer) ListTenants(ctx context.Context, _ *pb.ListTenantsRequest) (*pb.ListTenantsResponse, error) {
+    start := time.Now()
+    status := "ok"
+    defer func() { metrics.RecordGRPCRequest("ListTenants", status, time.Since(start)) }()
+
+    trusted, ok := auth.GetCurrentIdentity(ctx)
+    if !ok || trusted == "" {
+        status = "error"
+        return nil, grpcstatus.Errorf(codes.PermissionDenied,
+            "ListTenants requires an authenticated caller")
+    }
+
+    isAdmin := trusted == "__system__" ||
+        strings.HasPrefix(trusted, "system:") ||
+        strings.HasPrefix(trusted, "admin:")
+
+    all := s.canonicalStore.ListTenants() // directory scan
+    if s.sharding != nil && s.sharding.IsMultiNode() {
+        all = filter(all, s.sharding.IsMine)
+    }
+
+    var visible []string
+    switch {
+    case isAdmin:
+        visible = all
+    case s.globalStore != nil:
+        userID := strings.TrimPrefix(trusted, "user:")
+        members, err := s.globalStore.GetUserTenants(ctx, userID)
+        if err != nil {
+            status = "error"
+            log.Error("ListTenants membership lookup failed", "err", err)
+            return &pb.ListTenantsResponse{}, nil // swallow → empty, matches Python
+        }
+        set := make(map[string]struct{}, len(members))
+        for _, m := range members { set[m.TenantID] = struct{}{} }
+        visible = filterIn(all, set)
+    default:
+        visible = nil // no global_store wired → empty, NOT all
+    }
+
+    out := make([]*pb.TenantInfo, 0, len(visible))
+    for _, tid := range visible { out = append(out, &pb.TenantInfo{TenantId: tid}) }
+    return &pb.ListTenantsResponse{Tenants: out}, nil
+}
+```
+
+Wrap the entire handler body in a `defer recover()` that converts unexpected
+panics into `&pb.ListTenantsResponse{}, nil` with `status="error"` — matches
+Python's `except Exception` swallow. PERMISSION_DENIED must escape the
+recover (it's the *intended* error path, returned via the explicit
+`return` above, not via panic).
+
+## Open questions / risks
+
+- **Empty-list-on-error is a footgun.** Python silently masks bugs (DB
+  corruption, `global_store` raises) as "you have no tenants". The Go port
+  MUST replicate to keep the contract test green, but file a follow-up to
+  surface internal errors as `codes.Internal` behind a feature flag once
+  callers can handle it. Today's behavior is pinned at `grpc_server.py:1600-1603`.
+- **Identity prefix matching is string-based and fragile.** A future
+  identity provider that issues `"sa:..."` (service account) tokens will
+  silently fall through to the user-membership branch. Recommend adding
+  a typed `Identity{Kind: User|System|Admin|Service; ID string}` in the
+  `auth` package and routing on `Kind` rather than `strings.HasPrefix`.
+- **`canonicalStore.ListTenants()` is a directory scan on every call.**
+  Fine at 1k tenants, allocates at 100k. Not a port-blocker; track as
+  perf follow-up. Memoization is unsafe (tenants can be created/deleted
+  between calls); use `fsnotify` if it ever matters.
+- **Sort order is not contract-tested.** Python returns ascending (sorted
+  glob). Go port should explicitly `sort.Strings(visible)` before building
+  the proto slice — defends against future map-iteration code drift.
+- **No pagination** ships in the wire today. If a customer hits 50k+
+  tenants per node, this RPC degrades into a multi-MB response. Not a
+  port concern; flag for product.
+- **`UNAUTHENTICATED_METHODS` parity:** confirm `/entdb.v1.EntDBService/ListTenants`
+  is **absent** from the Go auth interceptor's bypass set. A copy-paste
+  regression there silently re-introduces the SEC-3 enumeration bug.

--- a/docs/go-port/rpcs/ListUsers.md
+++ b/docs/go-port/rpcs/ListUsers.md
@@ -1,0 +1,209 @@
+# RPC Port Spec — `entdb.v1.EntDBService/ListUsers`
+
+EPIC #407 — Python -> Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2231-2265`.
+
+## Wire contract (filter, pagination)
+
+Proto: `proto/entdb/v1/entdb.proto:115` (rpc), `:840-849` (messages).
+
+`ListUsersRequest`:
+| Field | Tag | Type | Default | Notes |
+|------|-----|------|---------|------|
+| `actor` | 1 | `string` | — | UNTRUSTED wire claim. Required; empty -> `INVALID_ARGUMENT`. NOT used to filter results — only gates the call. See "Auth". |
+| `status` | 2 | `string` | `"active"` | Free-form filter; SQL `WHERE status = ?` exact match against `user_registry.status`. Empty string coerces to `"active"` (`grpc_server.py:2248`). No allow-list — values like `"suspended"`, `"deleted"`, `"frozen"` flow through verbatim. |
+| `limit` | 3 | `int32` | `100` | `0` (unset) coerces to `100` (`grpc_server.py:2249`). NO upper cap is enforced today; Go port should mirror exactly (file follow-up to cap at e.g. 1000). Negative values flow into SQLite `LIMIT ?` and behave as "no limit" — preserve, do not "fix". |
+| `offset` | 4 | `int32` | `0` | `0`-coerce only on falsy. Pagination is offset-based, not cursor-based; no stable ordering guarantee beyond `ORDER BY created_at` (`global_store.py:429`). |
+
+`ListUsersResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `users` | 1 | `repeated UserInfo` | Each row mapped via `_user_dict_to_proto` (`grpc_server.py:2088-2097`): `{user_id, email, name, status, created_at, updated_at}` — missing keys -> empty string / `0`. |
+
+No `has_more`, no `total_count`, no `next_page_token`. Caller infers end-of-list
+when `len(users) < limit`. Go port MUST NOT add a `has_more` field — that is
+a wire change.
+
+## Auth (admin scope; trusted-actor)
+
+- **Authentication required.** `ListUsers` is NOT in
+  `AuthInterceptor.UNAUTHENTICATED_METHODS` (`auth/auth_interceptor.py:157-162`).
+  The auth interceptor runs and stamps the trusted actor into a `ContextVar`.
+- **Admin scope: NO.** Despite the wire field name suggesting otherwise, the
+  handler today only checks `request.actor` is non-empty — any authenticated
+  caller (including `user:alice`) can list users. The contract test at
+  `test_user_registry.py:395` exercises this with `actor="user:u1"` and expects
+  success. The handler docstring says "Available to any authenticated actor"
+  (`grpc_server.py:2236`).
+- **Trusted-actor invariant: ENFORCE BUT BENIGN.** Per CLAUDE.md and the
+  privilege-escalation fix in commit `fece3fb`, every handler MUST rebind
+  `actor` to `_trusted_actor(request.actor)` before any privilege-bearing use.
+  `ListUsers` does no privilege check today (the wire `actor` is only tested
+  for emptiness), so the bug surface is small — but the Go port MUST still:
+  1. Read the trusted identity from the auth context (Go equivalent of
+     `get_authoritative_actor`).
+  2. Use that identity for any audit/log line — never the wire claim.
+  3. Validate `request.actor != ""` exactly as Python does, to keep contract
+     test `test_grpc_contract.py:423-427` passing.
+- **No `Permission` / capability check.** Handler does not consult `acl` or
+  `capability_registry`. (Future: should gate on `users.list` admin
+  capability — see "Open questions".)
+- **Rate limit.** Subject to default per-tenant `RateLimitInterceptor` since
+  not in any bypass list. Go port: same.
+
+## Side effects (read on global_store)
+
+**Pure read.** No WAL append, no SQLite write, no `canonical_store` touch
+(per-tenant SQLite untouched — this is a global-plane RPC).
+
+In-order narration of the handler (`grpc_server.py:2237-2265`):
+
+1. `start = time.perf_counter()` for metrics.
+2. Guard: `self.global_store is None` -> abort `UNIMPLEMENTED`
+   `"User registry not configured"` (`:2239-2243`).
+3. Guard: `request.actor == ""` -> abort `INVALID_ARGUMENT` `"actor is required"`
+   (`:2245-2246`).
+4. Coerce defaults: `status = request.status or "active"`,
+   `limit = request.limit or 100`, `offset = request.offset or 0`
+   (`:2248-2250`).
+5. `await self.global_store.list_users(status=, limit=, offset=)` —
+   reads global-plane SQLite via `_run_sync` thread pool
+   (`global_store.py:411-432`). SQL: `SELECT * FROM user_registry WHERE
+   status = ? ORDER BY created_at LIMIT ? OFFSET ?`.
+6. Map each row through `_user_dict_to_proto` (`:2088-2097`).
+7. `record_grpc_request("ListUsers", "ok", elapsed)` (`:2260`).
+8. Return `ListUsersResponse(users=proto_users)`.
+
+This RPC reads ONLY from `global_store` (the cross-tenant store). Per
+CLAUDE.md invariant #4 it must NOT open any per-tenant SQLite handle.
+
+## Error contract
+
+| gRPC code | Trigger | Site |
+|-----------|---------|------|
+| `OK` | Happy path, including empty result. | `:2261` |
+| `OK` (with `users=[]`) | Any unexpected exception in the inner `try`. Python's outer `except Exception` swallows the error, logs it, and returns an empty response with `users=[]` (`:2262-2265`). Go port MUST mirror this swallow-behavior so contract tests pass; track as a wart for follow-up — silently masking DB errors is bad. |
+| `INVALID_ARGUMENT` | `actor == ""` (`:2245-2246`). Pinned by `test_grpc_contract.py:423-427`. |
+| `UNIMPLEMENTED` | `global_store` is `nil` (server started without user-registry config) (`:2239-2243`). Message verbatim: `"User registry not configured"`. |
+| `UNAUTHENTICATED` | Surfaced by `AuthInterceptor`, not the handler — missing/invalid token. |
+| `RESOURCE_EXHAUSTED` | Surfaced by `RateLimitInterceptor`. |
+
+The handler MUST NOT abort with `PERMISSION_DENIED` (no scope check today)
+nor `NOT_FOUND` (empty list is not an error).
+
+## Shared Go package deps
+
+Each package under `server/go/internal/...` unless noted.
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `ListUsersRequest`,
+  `ListUsersResponse`, `UserInfo`, servicer interface. Required.
+- `globalstore` — `ListUsers(ctx, status string, limit, offset int) ([]User, error)`
+  mirroring `global_store.list_users` (`global_store.py:411`). Required.
+  Must use the global-plane SQLite handle, NOT a tenant handle.
+- `metrics` — `RecordGRPCRequest(method, status string, dur time.Duration)`
+  (mirrors `metrics.py`). Required.
+- `auth` — read trusted actor from `context.Context` (`get_authoritative_actor`
+  Go equivalent). Required for the trusted-actor invariant even though the
+  result is not currently used for filtering.
+- `convert` (or method on servicer) — `userDictToProto` mirroring `:2088-2097`.
+
+NOT used and MUST NOT be imported by this handler: `wal`, `apply`,
+`canonicalstore`, `acl`, `capability`, `schema`, `crypto`, `audit`, `quota`.
+Importing any of them is a smell.
+
+## Other-RPC deps
+
+- `CreateUser`, `UpdateUser`, `DeleteUser`, `FreezeUser` — write paths that
+  populate `user_registry`. `ListUsers` reads what they wrote. The Go port of
+  `ListUsers` can be landed BEFORE these write RPCs are ported, provided the
+  test fixture seeds rows directly via `globalstore.CreateUser` (mirrors what
+  `test_grpc_contract.py` does at module setup).
+- `Health` — independent; no ordering constraint.
+- No fan-out to other RPCs; this is a leaf read.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_user_registry.py:354-386` —
+  `test_list_users_default`: `actor="system:admin"`, no other fields ->
+  `global_store.list_users` called with `status="active", limit=100, offset=0`;
+  proto users preserve `user_id` order from store.
+- `tests/python/unit/test_user_registry.py:388-406` —
+  `test_list_users_with_pagination`: `actor="user:u1"`, `status="suspended"`,
+  `limit=10`, `offset=5` -> store called with those exact kwargs; non-admin
+  actor is allowed.
+- `tests/python/integration/test_grpc_contract.py:417-422` — happy-path:
+  `ListUsersRequest(actor=ADMIN, limit=10)` returns `users` containing the
+  `user_id="alice"` row over a real gRPC channel.
+- `tests/python/integration/test_grpc_contract.py:423-427` — invalid-argument:
+  `actor=""` -> `INVALID_ARGUMENT`.
+- (No regression test today for `global_store=None` -> `UNIMPLEMENTED`. Go
+  port should add one when it ports the handler.)
+
+## Implementation outline
+
+```go
+// server/go/internal/api/list_users.go
+func (s *EntDBServer) ListUsers(
+    ctx context.Context, req *pb.ListUsersRequest,
+) (*pb.ListUsersResponse, error) {
+    start := time.Now()
+    statusLabel := "ok"
+    defer func() { metrics.RecordGRPCRequest("ListUsers", statusLabel, time.Since(start)) }()
+
+    if s.globalStore == nil {
+        statusLabel = "error"
+        return nil, status.Error(codes.Unimplemented, "User registry not configured")
+    }
+    if req.GetActor() == "" {
+        statusLabel = "error"
+        return nil, status.Error(codes.InvalidArgument, "actor is required")
+    }
+    _ = auth.TrustedActor(ctx, req.GetActor()) // invariant: rebind even if unused.
+
+    statusFilter := req.GetStatus()
+    if statusFilter == "" { statusFilter = "active" }
+    limit := int(req.GetLimit()); if limit == 0 { limit = 100 }
+    offset := int(req.GetOffset())
+
+    rows, err := s.globalStore.ListUsers(ctx, statusFilter, limit, offset)
+    if err != nil {
+        // Mirror Python swallow-behavior: log, return empty list, code OK.
+        log.Errorw("ListUsers failed", "err", err)
+        statusLabel = "error"
+        return &pb.ListUsersResponse{}, nil
+    }
+    out := make([]*pb.UserInfo, 0, len(rows))
+    for _, r := range rows { out = append(out, userToProto(r)) }
+    return &pb.ListUsersResponse{Users: out}, nil
+}
+```
+
+Notes:
+1. Bind `_ = auth.TrustedActor(...)` (or drop into a named var used in audit
+   logging) so the invariant cannot regress when a future scope check is added.
+2. `userToProto` must preserve the empty-string / zero defaults from
+   `_user_dict_to_proto` — never panic on missing fields.
+3. `globalStore.ListUsers` should use a `context.Context`-aware DB call
+   (`db.QueryContext`) so client cancellation cuts the SQL.
+
+## Open questions / risks
+
+- **Missing admin-scope check.** Today any authenticated user can list every
+  user in the system — likely a leak. The Go port should preserve this for
+  contract parity, then a follow-up ticket should gate on a `users.list`
+  capability and update `test_list_users_with_pagination` accordingly. Confirm
+  with EPIC #407 owner before adding the scope check in the same PR.
+- **Silent error swallow.** Returning `OK` with `users=[]` on DB error
+  (`:2262-2265`) hides outages and breaks pagination clients. Mirror today;
+  open a follow-up to surface `INTERNAL` once a deprecation window is agreed.
+- **No cap on `limit`.** A malicious caller can pass `limit=2_000_000_000`
+  and OOM the server. Mirror Python's lack-of-cap for parity, but file a
+  ticket to enforce `limit <= 1000` server-side.
+- **No stable secondary sort.** `ORDER BY created_at` alone allows ties
+  to reorder between pages. Go port: keep as-is for parity; follow-up to add
+  `, user_id ASC` as tiebreaker.
+- **Status filter is free-form.** No allow-list means typos like
+  `status="actve"` silently return zero rows. Document in the SDK; do not
+  change server behavior.
+- **PII exposure.** `UserInfo` includes `email` and `name`. A scope check
+  (above) is the real fix; until then, log-redaction must NOT log responses.

--- a/docs/go-port/rpcs/QueryNodes.md
+++ b/docs/go-port/rpcs/QueryNodes.md
@@ -1,0 +1,251 @@
+# QueryNodes — Go-port spec
+
+EPIC #407. RPC `entdb.v1.EntDBService/QueryNodes` (re-exported via
+`console.v1.ConsoleService/QueryNodes`). Python ref:
+`server/python/entdb_server/api/grpc_server.py:1293`.
+
+Read-only: list nodes of `type_id` for a tenant, with typed payload
+filters, sort, offset-pagination, read-after-write WAL-offset gate.
+Cross-tenant actors get an ACL post-filter.
+
+## Wire contract (filter/predicate shape; pagination cursor; sort)
+
+`QueryNodesRequest` (`proto/entdb/v1/entdb.proto:424`): `context`,
+`type_id` (req'd), `limit` (default 100), `offset`, `order_by`,
+`descending`, `filters`, `after_offset`, `wait_timeout_ms` (default
+30s). Field 3 is `reserved` (legacy `filter_json` — Go MUST reject).
+
+`FieldFilter` (`proto/entdb/v1/entdb.proto:675`): `{field, op,
+value}`. `FilterOp`: `EQ, NEQ, GT, GTE, LT, LTE, CONTAINS, IN`
+(line 681).
+
+Python servicer translates `repeated FieldFilter` into a MongoDB-
+style operator dict via `_field_filters_to_filter_dict`
+(`grpc_server.py:190`). Two wire shapes MUST round-trip identically:
+
+1. Typed (Go SDK): `Op=GTE, Value=100` → `{"$gte": 100}`.
+2. Inlined (Python SDK legacy): `Op=EQ, Value=Struct{"$gte":100}` →
+   same `{"$gte": 100}`.
+
+Multiple filters on one field merge into one operator dict (range
+splits `GTE`+`LTE`); equality collapses to `$eq` on merge
+(`grpc_server.py:218-227`). Op map: `grpc_server.py:178-187`.
+
+`order_by` allow-list `{created_at, updated_at, node_id, type_id}`;
+unknown silently falls back to `created_at` (`canonical_store.py:2415`).
+
+`QueryNodesResponse` (`proto/entdb/v1/entdb.proto:448`): `nodes,
+total_count, has_more`. `total_count` is unset (0 on wire); `has_more
+= len(nodes) == requested_limit` — cheap heuristic, NOT a strict
+cursor (`grpc_server.py:1377`). No opaque cursor; pagination is
+`(limit, offset)` only.
+
+## Auth (ACL filter on rows; trusted-actor)
+
+1. `_check_tenant(tenant_id)` — confirms tenant exists (`grpc_server.py:1305`).
+2. `_trusted_actor(request.context.actor)` — derives the actor from
+   the gRPC AuthContext / interceptor metadata, NOT from the
+   client-claimed `actor` field. The claimed value is ignored — see
+   the privilege-escalation fix in commit `fece3fb`
+   (`grpc_server.py:418`, also applied to `GetConnectedNodes`).
+3. `_check_cross_tenant_read(tenant_id, trusted_actor)` returns one
+   of `"member" | "cross_tenant" | "denied"`
+   (`grpc_server.py:561`). `denied` raises `PERMISSION_DENIED`.
+4. When role is `cross_tenant`, the result set is post-filtered: each
+   node is checked via `canonical_store.can_access(tenant, node_id,
+   actor_groups)` and excluded if not accessible
+   (`grpc_server.py:1344-1358`). Group membership is resolved via
+   `resolve_actor_groups`.
+
+The ACL filter is applied AFTER the SQL query — this means
+`limit`/`has_more` reflect the pre-ACL row count, so a cross-tenant
+caller can see fewer than `limit` rows on a page that is not the
+last page. Document this gotcha in the Go SDK; do NOT change it
+without an ADR (changes pagination semantics).
+
+## Side effects (read-only; index hits)
+
+Read-only. No WAL append, no state change, applier not invoked.
+Opens a per-tenant SQLite read connection
+(`canonical_store.py:2413`). Lazy expression indexes
+(`idx_query_t<type>_f<field>`) declared via
+`(entdb.field).indexed = true` are created by the WRITE path
+(`_ensure_query_indexes` on `CreateNode`/`UpdateNode`); QueryNodes
+benefits when the compiled WHERE
+(`json_extract(payload_json, '$."<field_id>"') <op> ?`) matches the
+indexed expression byte-for-byte
+(`docs/decisions/query_indexes.md:25-47`).
+
+`after_offset` triggers `_wait_for_offset` (`grpc_server.py:937`) —
+blocks up to `wait_timeout_ms` (default 30s). Go: context-aware wait
+on the applier's offset condvar; do NOT busy-poll.
+
+## Error contract
+
+| Condition                                  | Status               | Source |
+|--------------------------------------------|----------------------|--------|
+| Unknown tenant                             | `NOT_FOUND`          | `_check_tenant` |
+| Actor lacks read access to tenant          | `PERMISSION_DENIED`  | `_check_cross_tenant_read` |
+| `wait_timeout_ms` elapsed before offset    | `DEADLINE_EXCEEDED`  | `_wait_for_offset` |
+| Unknown field name in filter               | `INVALID_ARGUMENT`   | `QueryFilterError` (`query_filter.py:120`) |
+| Unknown operator / wrong arg shape         | `INVALID_ARGUMENT`   | `query_filter.py:181-202` |
+| Unsupported `FilterOp` enum value          | `INVALID_ARGUMENT`   | `grpc_server.py:216` |
+| Unknown `type_id`                          | `INVALID_ARGUMENT`   | `query_filter.py:113` |
+
+NOTE the Python handler currently swallows ALL exceptions and returns
+an empty `QueryNodesResponse{nodes: []}` (`grpc_server.py:1379-1382`).
+This is a bug — the Go port MUST surface the gRPC status above. Pin
+this as a behaviour CHANGE in EPIC #407 and update the contract test
+listed below.
+
+## Shared Go package deps
+
+- `internal/auth` — `TrustedActor(ctx)`, `CheckTenant`,
+  `CheckCrossTenantRead` (port of `grpc_server.py:362-628`).
+- `internal/canonical` — `QueryNodes(tenantID, typeID, filter,
+  limit, offset, orderBy, desc) ([]Node, error)`; `CanAccess`,
+  `ResolveActorGroups` for the cross-tenant post-filter.
+- `internal/queryfilter` — port of
+  `server/python/entdb_server/apply/query_filter.py`. Pure SQL
+  builder: `Compile(filterDict, typeID, registry) (sqlFrag string,
+  params []any, err error)`. Allow-listed operators only; field
+  names resolved to `field_id` via the schema registry; values
+  always parameter-bound.
+- `internal/schema` — `Registry.GetNodeType(typeID)` /
+  `GetField(typeID, name) -> FieldID`.
+- `internal/applier` — `WaitForOffset(ctx, tenantID, pos)` for
+  read-after-write.
+- `internal/proto/structpb` — for inlined-operator legacy shape;
+  `google.golang.org/protobuf/types/known/structpb`.
+- `internal/metrics` — `RecordGRPCRequest("QueryNodes", status, dur)`.
+
+## Other-RPC deps
+
+- Reads state produced by the applier driven by `Begin` /
+  `CreateNode` / `UpdateNode` — same per-tenant SQLite as `GetNode` /
+  `GetNodes`.
+- Shares the cross-tenant gate with `GetConnectedNodes`,
+  `GetEdgesFrom`/`To`, `GetNodes`. Port the gate ONCE in
+  `internal/auth` and reuse — do not duplicate per RPC.
+- `WaitForOffset` is shared infrastructure with `GetNode`,
+  `WaitForOffset` RPC, `SearchNodes`.
+
+## Contract tests pinning behaviour
+
+- `tests/python/integration/test_grpc_contract.py:234` — basic
+  list-everything wire shape.
+- `tests/python/integration/test_privilege_escalation.py:232` —
+  client-claimed admin actor MUST be rejected (commit fece3fb).
+- `tests/python/unit/test_payload_wire_format.py:219` — response
+  payload MUST be id-keyed (`field_id` strings), not name-keyed.
+- `tests/python/unit/test_cross_tenant_read.py:255` — cross-tenant
+  reader sees only ACL-permitted nodes.
+- `tests/python/unit/test_cross_tenant_read.py:288` — no access ⇒
+  empty result.
+- `tests/python/unit/test_query_operators.py:361` — full
+  `TestQueryNodesE2E` battery (`$eq, $ne, $gte, $between, $in,
+  $like, $or, $and, $contains, unknown-field`).
+- `tests/python/unit/test_query_operators.py:474` — unknown field
+  raises (must surface as `INVALID_ARGUMENT` in Go).
+- `tests/python/unit/test_canonical_store_perf.py:75` —
+  `TestQueryNodesSQLPushdown` confirms filter is pushed to SQL, not
+  applied in Python.
+- `tests/python/unit/test_cron_fixes.py:153` —
+  `TestQueryNodesFilterPagination` (filter + pagination interaction).
+- `tests/python/unit/test_capability_registry.py:63` — RPC mapped to
+  `CoreCapability.READ`.
+
+A new contract test in `tests/contract/` MUST exercise BOTH wire
+shapes (typed `Op=GTE`, inlined `Struct{"$gte": ...}`) against the
+Go server to lock in `_field_filters_to_filter_dict` parity.
+
+## Implementation outline
+
+```
+QueryNodes(ctx, req):
+  start := time.Now()
+  defer recordMetric("QueryNodes", status, time.Since(start))
+
+  if err := auth.CheckTenant(ctx, req.Context.TenantId); err != nil { return nil, err }
+  actor, err := auth.TrustedActor(ctx)              // ignore req.Context.Actor
+  if err != nil { return nil, err }
+  role, err := auth.CheckCrossTenantRead(ctx, req.Context.TenantId, actor)
+  if err != nil { return nil, err }                  // PERMISSION_DENIED
+
+  if req.AfterOffset != "" {
+    timeout := durationOr(req.WaitTimeoutMs, 30*time.Second)
+    if err := applier.WaitForOffset(ctx, req.Context.TenantId, req.AfterOffset, timeout); err != nil {
+      return nil, err                                // DEADLINE_EXCEEDED
+    }
+  }
+
+  filterDict, err := fieldFiltersToDict(req.Filters) // mirror grpc_server.py:190
+  if err != nil { return nil, status.Error(codes.InvalidArgument, err.Error()) }
+
+  nodes, err := canonical.QueryNodes(ctx, canonical.QueryArgs{
+    TenantID: req.Context.TenantId, TypeID: req.TypeId,
+    Filter: filterDict, Limit: limitOr(req.Limit, 100), Offset: int(req.Offset),
+    OrderBy: orderByOr(req.OrderBy, "created_at"), Descending: req.Descending,
+    Registry: s.registry,
+  })
+  if err != nil { return nil, mapFilterError(err) } // QueryFilterError -> InvalidArgument
+
+  if role == auth.RoleCrossTenant {
+    groups, _ := canonical.ResolveActorGroups(ctx, req.Context.TenantId, actor)
+    nodes = filterAccessible(ctx, nodes, groups)     // post-filter
+  }
+
+  return &pb.QueryNodesResponse{
+    Nodes: toProtoNodes(nodes),
+    HasMore: len(nodes) == limitOr(req.Limit, 100),
+  }, nil
+```
+
+SQL builder (`internal/queryfilter`):
+
+- Compile to `(fragment, params)` with ONLY parameter binding for
+  values; operator tokens come from a closed map; field-id JSON path
+  literals come from the registry — never from user input.
+- Mirror `compile_query_filter` recursion for `$and` / `$or`
+  (`query_filter.py:266-282`).
+- `$contains` MUST escape `%` / `_` / `\` in user input before LIKE
+  with `ESCAPE '\\'` (`query_filter.py:215-224`).
+- Reject unknown operators and unknown fields with
+  `QueryFilterError` (mapped to `INVALID_ARGUMENT`).
+- For the legacy inlined-operator shape, the builder accepts a
+  `map[string]any` whose values may themselves be operator dicts —
+  same recursion handles both shapes.
+
+ACL post-filter:
+
+- Iterate `nodes`; call `canonical.CanAccess` for each. Keep this
+  serial (per-tenant SQLite is single-writer; concurrent reads are
+  fine but goroutine-per-row is overkill). Stop early if the caller's
+  context is cancelled.
+
+## Open questions / risks
+
+1. Full-scan vs index strategy: SQLite's planner picks the lazy
+   expression index when the WHERE expression matches
+   `json_extract(payload_json, '$."<field_id>"') <op> ?` exactly.
+   Any rewrite (CAST, COALESCE) silently disables the index. Add an
+   `EXPLAIN QUERY PLAN` regression test in
+   `tests/contract/queryfilter/` per declared
+   `(entdb.field).indexed = true` field.
+2. How the Python applies the index decision: it does NOT — the
+   WRITE path creates the index lazily (`_ensure_query_indexes`,
+   `docs/decisions/query_indexes.md:42`) and the READ path is
+   oblivious. Go must keep this split (index DDL in
+   `internal/applier`, NOT in `QueryNodes`). Freshly-created types
+   pay one full-scan QueryNodes before the first write — per ADR.
+3. Pagination is offset-based; deep pages are O(offset). EPIC #407
+   should decide whether to add keyset pagination now or defer.
+4. `has_more = (len == limit)` lies on exact-multiple boundaries
+   (next page can be empty). ACL post-filter makes it leakier.
+5. Python swallows all exceptions to an empty response
+   (`grpc_server.py:1379-1382`). Go MUST surface gRPC errors —
+   behaviour change; flag in EPIC #407 release notes.
+6. `total_count` is unused. Decide: populate via `COUNT(*)` (extra
+   query) or remove proto field. Defer; Go leaves it 0 for parity.
+7. `order_by` silently downgrades unknown values. Consider
+   `INVALID_ARGUMENT` instead — behaviour change; pin current.

--- a/docs/go-port/rpcs/RemoveGroupMember.md
+++ b/docs/go-port/rpcs/RemoveGroupMember.md
@@ -1,0 +1,247 @@
+# RemoveGroupMember — Go port spec
+
+EPIC #407. Mirror of Python `EntDBServicer.RemoveGroupMember`
+(`server/python/entdb_server/api/grpc_server.py:1986-2028`). Inverse
+of `AddGroupMember` (`grpc_server.py:1946-1984`): removes an actor
+from an ACL group on per-tenant SQLite, then cascades into the
+cross-tenant `shared_index` so `ListSharedWithMe(member)` stops
+surfacing nodes whose only path was the group.
+
+## Wire contract
+
+- Service: `entdb.v1.EntDBService`. Full name
+  `/entdb.v1.EntDBService/RemoveGroupMember`
+  (`sdk/go/entdb/internal/pb/entdb_grpc.pb.go:77`).
+- Proto: `proto/entdb/v1/entdb.proto:106` —
+  `rpc RemoveGroupMember(GroupMemberRequest) returns (GroupMemberResponse);`
+- `GroupMemberRequest` (`proto/entdb/v1/entdb.proto:768-773`):
+  - `RequestContext context = 1` — `tenant_id` (required),
+    `actor` (advisory; see Auth), `trace_id`.
+  - `string group_id = 2` — free-form (e.g. `"group:eng"`).
+  - `string member_actor_id = 3` — actor being removed.
+  - `string role = 4` — proto-only; **ignored on Remove** (Add
+    reads it, `grpc_server.py:1962`). Accept + discard.
+- `GroupMemberResponse` (`proto/entdb/v1/entdb.proto:775-778`):
+  - `bool success` — mirrors `found` from
+    `canonical_store.remove_group_member`: `true` iff a row was
+    deleted (`grpc_server.py:2024`,
+    `apply/canonical_store.py:3539-3544`). **Add/Remove asymmetry**:
+    Add returns `success=true` on no exception; Remove returns
+    `success=false` with empty `error` when the pair did not exist.
+  - `string error` — populated only on exception
+    (`grpc_server.py:2028`).
+
+## Auth
+
+- **Tenant / region.** First call is
+  `await self._check_tenant(request.context.tenant_id, context)`
+  (`grpc_server.py:1994`, helper `:362-410`). Standard redirect
+  semantics: `UNAVAILABLE` + `entdb-redirect-node` trailer on shard
+  miss, `FAILED_PRECONDITION` on region mismatch. Reproduce trailer
+  key exactly — Go SDK redirect cache reads it.
+- **Capability.** `auth/capability_registry.py` does NOT map
+  `RemoveGroupMember` to a `CoreCapability`; handler accepts any
+  caller passing `_check_tenant`. Known parity gap (Open question 6).
+- **Trusted actor.** `request.context.actor` is advisory only.
+  Python’s `_trusted_actor()` (`grpc_server.py:418-437`) is NOT
+  invoked here. Go port: rebind to trusted actor (auth interceptor
+  metadata) for observability; never use `context.actor` for any
+  authz (privilege-escalation invariant, commit `fece3fb`).
+
+## Side effects (WAL append; ACL recompute; cascade)
+
+- **WAL append: NONE today.** Violates CLAUDE.md invariant 1.
+  Handler writes directly to per-tenant SQLite via
+  `canonical_store.remove_group_member`
+  (`apply/canonical_store.py:3546-3558`; `_sync` does
+  `DELETE FROM group_users WHERE group_id=? AND member_actor_id=?`,
+  `:3539-3544`). On rebuild the removal is silently lost. Same
+  defect on Add. Go port matches for v1 byte-parity; file blocker
+  (Open question 1).
+- **SQLite write.** One row deleted from `group_users`. Returns
+  `found: bool` (rowcount > 0).
+- **ACL recompute.** No explicit recompute. `_sync_can_access` /
+  `_sync_resolve_actor_groups` read `group_users` live; removal
+  takes effect at the next read
+  (`tests/python/unit/test_acl_v2_extended.py:172-181`).
+- **Cascade — does removed member’s grants get revoked?**
+  1. **Direct grants** (`acl_grants` rows where
+     `grantee == member_actor_id`) — NOT touched. Use
+     `RevokeAccess` / `RevokeAllUserAccess`.
+  2. **Group-derived access** (`acl_grants` rows where
+     `grantee == group_id`) — NOT removed from the per-tenant ACL;
+     the group still has the grant. Instead the handler cleans up
+     the cross-tenant `shared_index` projection so
+     `ListSharedWithMe(member)` no longer surfaces those nodes:
+     - Read group access via
+       `canonical_store.list_node_access_for_group(tenant_id,
+       group_id)` BEFORE the delete (`grpc_server.py:1998-2008`) —
+       ordering is load-bearing; reading after observes the already
+       removed membership edge.
+     - On `found=True`, iterate and call
+       `global_store.remove_shared(member_actor_id, tenant_id,
+       node_id)` (`grpc_server.py:2014-2020`).
+     - Best-effort: cascade failures logged at WARNING and
+       swallowed; RPC returns `success=found`
+       (`grpc_server.py:2021-2022`). Skipped entirely when
+       `found=False` or `global_store is None` or pre-read failed.
+  3. Effect: if the removed member ALSO has a direct grant on the
+     same node, the cascade wrongly deletes their `shared_index`
+     row (Open question 4).
+
+## Error contract
+
+Python swallows everything below `_check_tenant`: logs and returns
+`GroupMemberResponse(success=False, error=str(e))`
+(`grpc_server.py:2025-2028`). `_check_tenant` aborts propagate as
+gRPC status. Go port:
+
+- Tenant not on this node → `codes.Unavailable` + trailer
+  `entdb-redirect-node: <owner>` when known.
+- Wrong region → `codes.FailedPrecondition`, standard region-pin
+  message.
+- Member not in group → NOT an error;
+  `GroupMemberResponse{Success: false, Error: ""}`
+  (`tests/python/unit/test_acl_v2.py:590-591`,
+  `apply/canonical_store.py:3544`).
+- Empty `group_id` / `member_actor_id` → not validated; deletes
+  nothing, returns `success=false`. Do NOT add `InvalidArgument`.
+- Cascade failure → log + swallow + return `success=found`.
+- Internal failure → `success=false, error=<msg>` with `codes.OK`
+  (parity wins until SDK tests are upgraded).
+
+## Shared Go package deps
+
+- `internal/pb` — generated `entdb.v1` types
+  (`sdk/go/entdb/internal/pb/entdb_grpc.pb.go`); server stubs in
+  `server/go/internal/pb/...`.
+- `shared/canonicalstore` (see
+  `docs/go-port/shared/canonicalstore.md`):
+  - `RemoveGroupMember(ctx, tenantID, groupID, memberActorID
+    string) (found bool, err error)` — mirror
+    `_sync_remove_group_member` (`canonical_store.py:3533-3544`).
+  - `ListNodeAccessForGroup(ctx, tenantID, groupID string)
+    ([]GroupAccessEntry, error)` — `{node_id, permission}` rows;
+    REQUIRED BEFORE the delete (ordering invariant).
+- `shared/globalstore.RemoveShared(ctx, userID, sourceTenant,
+  nodeID string) error` — mirror `global_store.remove_shared`.
+  Idempotent.
+- `shared/auth.CheckTenant`, `TrustedActorFromCtx`.
+- `shared/sharding.IsMine`, `Owner` (redirect trailer).
+- `shared/observability.RecordGRPCRequest("RemoveGroupMember",
+  "ok"|"error", elapsed)` (`grpc_server.py:2023,2026`).
+
+## Other-RPC deps
+
+- `AddGroupMember` (`grpc_server.py:1946-1984`) — symmetric
+  inverse; share helpers. Different cascade direction
+  (`global_store.add_shared` vs `remove_shared`). Land in same PR.
+- `RevokeAccess` / `RevokeAllUserAccess` — remove direct grants;
+  RemoveGroupMember does not. Keep boundary in contract tests.
+- `ListSharedWithMe` (`grpc_server.py:1860-1944`) — consumer of
+  the `shared_index` projection cleaned up here; use in the
+  cascade contract test.
+- `_check_tenant` helper (`grpc_server.py:362-410`) — reuse the
+  Go port from `GetEdgesFrom.md`.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:374-384` — gRPC
+  happy path after Add. Contract intentionally NOT pinning
+  `success=true` (`check: lambda _r: True`) due to shared tenant
+  fixture; Go port may tighten.
+- `tests/python/unit/test_acl_v2.py:584-588` — remove existing
+  member: `_sync_resolve_actor_groups` no longer contains group.
+- `tests/python/unit/test_acl_v2.py:590-591` — remove
+  non-existent returns `False` → wire `success=false`.
+- `tests/python/unit/test_acl_v2_extended.py:172-181` —
+  `test_group_removal_cascades_access`: removing user from a
+  group immediately removes their effective ACL access (read-path
+  recompute, not write-time).
+- `tests/python/unit/test_shared_index.py:311-338` —
+  `test_remove_group_member_cascades_shared_index`: pins cascade
+  ordering and per-member isolation (Bob empties, Carol keeps).
+- `sdk/go/entdb/transport_extras_test.go:319-345` — pins request
+  shape (`group_id`, `member_actor_id`).
+- `sdk/go/entdb/grpc_transport_test.go:311` —
+  `fakeServer.RemoveGroupMember` signature.
+- `sdk/go/entdb/scope.go:100-103`, `client.go:674-680` — SDK arg
+  order `(tenantID, actor, groupID, memberActor)`.
+
+## Implementation outline
+
+```go
+func (s *Server) RemoveGroupMember(
+    ctx context.Context, req *pb.GroupMemberRequest,
+) (*pb.GroupMemberResponse, error) {
+    start := time.Now(); outcome := "ok"
+    defer func() { obs.RecordGRPCRequest("RemoveGroupMember", outcome, time.Since(start)) }()
+
+    tenantID := req.GetContext().GetTenantId()
+    if err := s.checkTenant(ctx, tenantID); err != nil {
+        outcome = "error"; return nil, err // Unavailable / FailedPrecondition
+    }
+    groupID, memberID := req.GetGroupId(), req.GetMemberActorId()
+
+    // 1. Snapshot group access BEFORE delete (cascade source-of-truth).
+    var groupAccess []canonicalstore.GroupAccessEntry
+    if s.globalStore != nil {
+        if e, err := s.cstore.ListNodeAccessForGroup(ctx, tenantID, groupID); err != nil {
+            log.Warn(ctx, "shared_index pre-read failed", "err", err)
+        } else { groupAccess = e }
+    }
+
+    found, err := s.cstore.RemoveGroupMember(ctx, tenantID, groupID, memberID)
+    if err != nil {
+        outcome = "error"
+        log.Error(ctx, "RemoveGroupMember failed", "err", err)
+        return &pb.GroupMemberResponse{Success: false, Error: err.Error()}, nil
+    }
+    // 2. Best-effort cascade; only when found.
+    if found && s.globalStore != nil {
+        for _, e := range groupAccess {
+            if rerr := s.globalStore.RemoveShared(ctx, memberID, tenantID, e.NodeID); rerr != nil {
+                log.Warn(ctx, "shared_index cascade failed", "node", e.NodeID, "err", rerr)
+            }
+        }
+    }
+    return &pb.GroupMemberResponse{Success: found}, nil
+}
+```
+
+Pre-read → delete → cascade ordering is load-bearing; reordering
+breaks `test_remove_group_member_cascades_shared_index`.
+
+## Open questions / risks (idempotency)
+
+1. **Not in the WAL (invariant 1).** Bypasses `wal.append`;
+   rebuild loses it. Blocker for GA: add `RemoveGroupMemberOp` in
+   `TransactionEvent.ops` and apply via `Applier.apply_event`.
+   Same for AddGroupMember.
+2. **Idempotency.** Removing a non-existent (group, member)
+   returns `success=false, error=""`. Repeat is safe (no
+   exception, no SQL violation). Cascade is idempotent —
+   `global_store.remove_shared` is delete-if-exists. Net: this RPC
+   is idempotent and safe to retry.
+3. **No `idempotency_key`.** Unlike `ExecuteAtomic`, no receipt /
+   dedup. Concurrent Add+Remove on the same pair can interleave;
+   final state depends on commit order. Revisit when item 1 lands.
+4. **Cascade over-deletion.** If the member ALSO has a direct
+   grant on a node the group grants, the cascade still deletes
+   their `shared_index` row. `ListSharedWithMe` will mis-report.
+   Fix requires consulting `acl_grants` first; do NOT add the
+   check without a contract test or behaviour diverges.
+5. **`role` on Remove.** Proto carries `role` for both, Remove
+   ignores it. v1: accept + discard. Future: deprecate via comment
+   or split into two messages.
+6. **Capability missing.** Any caller passing `_check_tenant` can
+   remove anyone from any group in that tenant. Add admin /
+   group-admin capability before GA; pin with a
+   privilege-escalation test analogous to
+   `test_get_edges_from_does_not_use_claimed_actor_for_authz`.
+7. **Cascade pre-read race.** Pre-read and membership delete are
+   not in one SQLite transaction. Concurrent `ShareNode(group_id)`
+   between the two steps: a `ShareNode` that already fired
+   `add_shared` for the removed member won’t be caught by the
+   cascade. Consider snapshotting under one transaction in the Go
+   port if affordable.

--- a/docs/go-port/rpcs/RemoveTenantMember.md
+++ b/docs/go-port/rpcs/RemoveTenantMember.md
@@ -1,0 +1,248 @@
+# RPC Port Spec — `entdb.v1.EntDBService/RemoveTenantMember`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2492-2541`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:124` (rpc), `:909-919` (messages).
+
+Request — `TenantMemberRequest` (shared with `AddTenantMember`):
+| Field | Tag | Type | Required | Notes |
+|------|-----|------|----------|------|
+| `actor` | 1 | `string` | yes | Caller, UNTRUSTED. Format `"user:<id>"` or `"system:<name>"`. Rebound via `_trusted_actor` before any decision. |
+| `tenant_id` | 2 | `string` | yes | Tenant whose member is being removed. |
+| `user_id` | 3 | `string` | yes | User to drop. NOT a `tenant_principal` ("user:alice") — bare id ("alice"). |
+| `role` | 4 | `string` | no | IGNORED by this RPC (request type is reused from `AddTenantMember`). Go port MUST NOT read it. |
+
+Response — `TenantMemberResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `success` | 1 | `bool` | True iff a row was deleted. False on "not found" / "last owner". |
+| `error` | 2 | `string` | Human-readable, lowercase-substring-stable: `"Member not found"`, `"Cannot remove the last owner of a tenant"`. Tests match `"not found"` / `"last owner"` (`test_tenant_registry.py:495,526`). DO NOT rephrase. |
+
+## Auth (admin only; trusted-actor)
+
+KNOWN GAP IN PYTHON: the Python handler does NOT enforce admin/owner role.
+`AddTenantMember` (`grpc_server.py:2466-2474`) and `ChangeMemberRole`
+(`grpc_server.py:2627-2634`) both call `_trusted_actor` + `_is_admin_or_system`
++ `_get_member_role` and abort `PERMISSION_DENIED` for non-admins.
+`RemoveTenantMember` skips this check entirely. The contract test at
+`tests/python/integration/test_grpc_contract.py:547-551` only asserts the
+happy path with `actor=ALICE` (a regular user). This is a latent privilege
+escalation (any authenticated caller can remove any member, including the
+last non-owner admin) and tracks against commit `fece3fb` ("ignore
+client-claimed actor in gRPC handlers").
+
+**Go port MUST close the gap**, mirroring `AddTenantMember`:
+
+```
+trusted := s.trustedActor(req.GetActor())          // grpc_server.py:418-437
+if !s.isAdminOrSystem(trusted) {                   // grpc_server.py:2053
+    role, _ := s.getMemberRole(req.TenantId,
+        s.actorUserID(trusted))                    // grpc_server.py:2290
+    if role != "owner" && role != "admin" {
+        return abort(codes.PermissionDenied,
+            "Only owner or admin can remove members")
+    }
+}
+```
+
+`actor` from the wire is UNTRUSTED — Go handler MUST rebind to the trusted
+actor returned by the auth interceptor (`auth.GetAuthoritativeActor`) before
+ANY downstream decision. Pin this with a new contract test
+`TestRemoveTenantMember_NonAdminDenied` so the Go port does not regress on
+parity with `AddTenantMember`.
+
+This RPC is NOT in `AuthInterceptor.UNAUTHENTICATED_METHODS` — auth runs.
+Rate limiter applies normally (per-tenant bucket).
+
+## Side effects (WAL append; ACL cascade revocation; mailbox?)
+
+In-order narration of the Python handler (`grpc_server.py:2498-2537`):
+
+1. `start = perf_counter()` for metrics.
+2. Guard: `self.global_store == nil` → abort `UNIMPLEMENTED "Tenant registry not configured"` (`:2500-2504`).
+3. Validate `actor`, `tenant_id`, `user_id` non-empty → abort `INVALID_ARGUMENT` (`:2506-2511`).
+4. Read all members via `global_store.get_members(tenant_id)` (`:2514`, `global_store.py:598`).
+5. Single pass: count owners; locate target by `user_id` (`:2515-2521`).
+6. If target missing → return `success=false, error="Member not found"`, metric `ok` (`:2523-2525`). NOT an error code — handler treats it as a normal "no-op".
+7. If target is owner AND `owner_count <= 1` → return `success=false, error="Cannot remove the last owner of a tenant"`, metric `error` (`:2527-2532`).
+8. `removed = await global_store.remove_member(tenant_id, user_id)` → `DELETE FROM tenant_members` returning `rowcount > 0` (`global_store.py:582-596`).
+9. Return `success=removed`, metric `ok` (`:2536-2537`).
+10. Outer `except`: log + return `success=false, error=str(e)`, metric `error` (`:2538-2541`).
+
+**WAL append: Python does NOT append.** This is an Architecture Invariant #1
+violation (CLAUDE.md: "Every mutation … MUST be appended to the WAL"). The
+`global_store` write is direct SQLite. Go port has two choices:
+- (A) Match Python bug-for-bug (lowest risk; ports the parity tests). File a
+  follow-up to add a `tenant_member_removed` op to `TransactionEvent.ops`.
+- (B) Fix-during-port: emit a `TenantMemberRemoved` event onto the tenant
+  registry WAL stream and let `Applier` apply it. Requires extending
+  `Applier.apply_event` in lockstep across Python + Go (contract test risk).
+
+Recommended: **(A) for the initial Go port**, with a tracked invariant-debt
+ticket. Do NOT silently diverge from Python.
+
+**ACL cascade: Python does NOT cascade.** The Go SDK doc string says so
+explicitly (`sdk/go/entdb/admin.go:68-71`): "drops a membership row. It does
+NOT reassign nodes the user owns or revoke their direct ACL grants — for
+that see `TransferUserContent` and `RevokeAllUserAccess`. Combine all three
+for a complete off-board." Go port MUST preserve this — direct grants,
+group memberships, `shared_index` rows, and owned nodes survive. The caller
+is responsible for chaining the three RPCs.
+
+**Mailbox: no.** This RPC does not touch the mailbox. No `publish_event`,
+no notify, no fan-out.
+
+## Error contract (last-admin protection)
+
+| gRPC code | Trigger |
+|-----------|---------|
+| `OK` (`success=true`) | Member existed and was deleted. |
+| `OK` (`success=false, error="Member not found")` | `user_id` not a member of `tenant_id`. NOT an `RpcError`. |
+| `OK` (`success=false, error="Cannot remove the last owner …")` | Target is the only owner. **Last-owner protection.** "admin" is NOT protected — only "owner". |
+| `INVALID_ARGUMENT` | Empty `actor`, `tenant_id`, or `user_id`. |
+| `PERMISSION_DENIED` | (Go port only) caller is not owner/admin/system. |
+| `UNIMPLEMENTED` | `global_store` not configured (registry-less deployment). |
+| `INTERNAL` | Unexpected exception. Python returns `success=false, error=str(e)` with `OK`; Go port should match for parity but log at `ERROR`. |
+
+Last-admin nuance: only "owner" is protected. A tenant with one "admin" and
+no owners has no last-owner guard — the admin can be removed and the tenant
+is left with zero privileged members. Python pins this by omission; do NOT
+add an "admin" guard in Go without an ADR.
+
+## Shared Go package deps
+
+- `pb` (`server/go/internal/pb/entdbv1`) — `TenantMemberRequest`, `TenantMemberResponse`. Required.
+- `globalstore` — `GetMembers(ctx, tenantID) ([]Member, error)`, `RemoveMember(ctx, tenantID, userID) (bool, error)`. Mirrors `global_store.py:558-596`. Required.
+- `auth` — `GetAuthoritativeActor(ctx, requestActor) string`, `IsAdminOrSystem(actor) bool`, `ActorUserID(actor) string`. Mirrors `grpc_server.py:412-437,2053`. Required.
+- `metrics` — `RecordGRPCRequest("RemoveTenantMember", status, dur)`. Required.
+- `errs` — wraps `status.Error(codes.X, msg)` with the exact strings above. Required.
+
+NOT used and MUST NOT be imported: `wal`, `apply`, `canonicalstore`, `acl`,
+`schema`, `quota`, `crypto`, `audit`, `mailbox`. Importing any signals
+scope creep — file an ADR first.
+
+## Other-RPC deps (overlaps with RevokeAllUserAccess)
+
+This RPC is **paired** with two siblings — Go port should land them in the
+same PR if practical because callers compose them:
+
+- `AddTenantMember` (`grpc_server.py:2442-2490`) — inverse op; shares request type and auth shape.
+- `ChangeMemberRole` (`grpc_server.py:2620-2680`) — alternative to remove+add; shares the owner/admin enforcement pattern.
+- `GetTenantMembers` (`grpc_server.py:2543-2570`) — Go port can reuse the same `globalstore.GetMembers` call.
+- `RevokeAllUserAccess` (`grpc_server.py:2864-2921`) — **complementary**, NOT a substitute. Strips ACL grants, group memberships, and `shared_index` entries; does NOT delete the membership row. Off-boarding flow = `TransferUserContent` → `RevokeAllUserAccess` → `RemoveTenantMember`. Document this ordering in the Go SDK package doc.
+- `TransferUserContent` (`grpc_server.py:2692-2780`) — reassigns nodes owned by the leaving user.
+
+The four-RPC off-board ordering is encoded only in the Go SDK doc comment
+today (`sdk/go/entdb/admin.go:68-71`). Mention it in the Go server's package
+doc as well.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:546-551` — happy path: `RemoveTenantMember{actor=ALICE, tenant_id=TENANT, user_id="bob"}` over a real gRPC channel. The Go server must pass this verbatim.
+- `tests/python/integration/test_grpc_contract.py:552-556` — empty `actor` → `INVALID_ARGUMENT`.
+- `tests/python/unit/test_tenant_registry.py:462-479` — happy path; one owner + one member; remove member; member list shrinks to owner only.
+- `tests/python/unit/test_tenant_registry.py:481-495` — last-owner protection; `success=false`, `"last owner" in error`.
+- `tests/python/unit/test_tenant_registry.py:497-511` — owner removable when ≥2 owners exist.
+- `tests/python/unit/test_tenant_registry.py:513-526` — non-existent member → `success=false`, `"not found" in error.lower()`.
+- `sdk/go/entdb/admin_test.go:203-216` — Go SDK transport happy path; the fake server returns `Success=true` and the SDK swallows it. Pins the wire shape.
+- `sdk/go/entdb/grpc_transport_test.go:349` — fake-server hook used by SDK tests; ensures the Go SDK transport still calls the right RPC.
+
+New tests Go port should add (close the auth gap):
+- `TestRemoveTenantMember_NonAdminDenied` — `actor=user:eve` who is a `member` of `t1` tries to remove `user:bob` → expect `PERMISSION_DENIED`.
+- `TestRemoveTenantMember_OwnerCanRemoveAdmin` — owner removes an admin → `success=true`.
+- `TestRemoveTenantMember_AdminCanRemoveMember` — admin removes a member → `success=true`.
+- `TestRemoveTenantMember_TrustedActorWins` — interceptor sets `user:eve` (member); request claims `actor="system:admin"` → `PERMISSION_DENIED` (forged actor must lose).
+
+## Implementation outline
+
+```go
+// server/go/internal/api/tenant_member.go
+func (s *EntDBServer) RemoveTenantMember(
+    ctx context.Context, req *pb.TenantMemberRequest,
+) (*pb.TenantMemberResponse, error) {
+    start := time.Now()
+    status := "ok"
+    defer func() { metrics.RecordGRPCRequest("RemoveTenantMember", status, time.Since(start)) }()
+
+    if s.globalStore == nil {
+        status = "error"
+        return nil, errs.Abort(codes.Unimplemented, "Tenant registry not configured")
+    }
+    if req.GetActor() == "" {
+        status = "error"; return nil, errs.Abort(codes.InvalidArgument, "actor is required")
+    }
+    if req.GetTenantId() == "" {
+        status = "error"; return nil, errs.Abort(codes.InvalidArgument, "tenant_id is required")
+    }
+    if req.GetUserId() == "" {
+        status = "error"; return nil, errs.Abort(codes.InvalidArgument, "user_id is required")
+    }
+
+    trusted := s.auth.TrustedActor(ctx, req.GetActor())
+    if !s.auth.IsAdminOrSystem(trusted) {
+        role, _ := s.globalStore.GetMemberRole(ctx, req.GetTenantId(), s.auth.ActorUserID(trusted))
+        if role != "owner" && role != "admin" {
+            status = "error"
+            return nil, errs.Abort(codes.PermissionDenied, "Only owner or admin can remove members")
+        }
+    }
+
+    members, err := s.globalStore.GetMembers(ctx, req.GetTenantId())
+    if err != nil { status = "error"; return errResp(err) }
+    var target *globalstore.Member; ownerCount := 0
+    for i := range members {
+        if members[i].Role == "owner" { ownerCount++ }
+        if members[i].UserID == req.GetUserId() { target = &members[i] }
+    }
+    if target == nil {
+        return &pb.TenantMemberResponse{Success: false, Error: "Member not found"}, nil
+    }
+    if target.Role == "owner" && ownerCount <= 1 {
+        status = "error"
+        return &pb.TenantMemberResponse{Success: false, Error: "Cannot remove the last owner of a tenant"}, nil
+    }
+    removed, err := s.globalStore.RemoveMember(ctx, req.GetTenantId(), req.GetUserId())
+    if err != nil { status = "error"; return errResp(err) }
+    return &pb.TenantMemberResponse{Success: removed}, nil
+}
+```
+
+Notes: keep the get-then-delete in two calls (matches Python; no transaction
+needed — last-owner is advisory, race window is acceptable per current
+contract). Do NOT wrap in a SQL transaction across `GetMembers` and
+`RemoveMember`; SQLite isolation is per-connection and the cost of a busy-
+wait on `tenant_members` is not worth it.
+
+## Open questions / risks
+
+- **WAL invariant violation.** Python skips the WAL for membership writes
+  (CLAUDE.md Architecture Invariant #1). Decide before merge: port-as-is and
+  file an invariant-debt ticket, OR add a `TenantMemberRemoved` op now. The
+  former is recommended — diverging from Python during the port multiplies
+  contract-test risk.
+- **Auth gap fix is a behavior change.** Adding `PERMISSION_DENIED` for
+  non-admins WILL break any caller currently relying on the bug. Audit the
+  console + Python SDK for unaudited callers; the contract test at
+  `test_grpc_contract.py:548` uses `actor=ALICE` (a tenant admin per the
+  fixture), so it should still pass.
+- **Last-admin not protected.** Only "owner" is guarded. Tenants with admin-
+  only privilege can be left with zero privileged members. Confirm with EPIC
+  #407 owner whether to extend the guard or ship parity.
+- **Race: TOCTOU on owner_count.** Two concurrent `RemoveTenantMember` calls
+  for the two only owners can each pass the `owner_count > 1` check, then
+  both delete. Result: zero owners. Python has this race; Go port will too
+  unless we add a SQLite `BEGIN IMMEDIATE` around the get+delete. Accept
+  parity for now; track follow-up.
+- **`role` field on the request is silently ignored.** Risk of caller
+  confusion (they may set it expecting the row to be filtered). Document in
+  the Go SDK that this field is `AddTenantMember`-only; consider proto
+  comment update in a separate PR.
+- **Metrics status mapping.** Python records `"ok"` for "Member not found"
+  but `"error"` for "last owner". Preserve exactly — dashboards depend on
+  this label distribution.
+- **Cross-region pinning.** `_check_tenant` (region pin) is NOT called by
+  this handler. Confirm intentional: tenant registry is global, not region-
+  scoped. If multi-region tenants land later, revisit.

--- a/docs/go-port/rpcs/RevokeAccess.md
+++ b/docs/go-port/rpcs/RevokeAccess.md
@@ -1,0 +1,260 @@
+# RevokeAccess — Go Port Spec
+
+EPIC #407. Counterpart to `ShareNode`. Removes a single direct grant
+on a node for one actor (user/group/tenant principal). Reference Python
+handler: `server/python/entdb_server/api/grpc_server.py:1828-1875`.
+Proto: `proto/entdb/v1/entdb.proto:97, 746-755`.
+
+## Wire contract
+
+Request `entdb.v1.RevokeAccessRequest` (proto:746):
+- `RequestContext context` — tenant_id + actor (UNTRUSTED; see Auth).
+- `string node_id` — node whose grant is being removed.
+- `string actor_id` — fully-qualified principal whose grant to drop.
+  Convention: `"user:<id>"`, `"group:<id>"`, or `"tenant:<id>"`. The
+  handler does not parse/validate the prefix; it is matched verbatim
+  against `node_access.actor_id` (canonical_store.py:3247-3250).
+
+Response `RevokeAccessResponse` (proto:752):
+- `bool found` — `true` iff a row was deleted from `node_access`. False
+  for both "no such grant existed" AND on permission/error paths (see
+  Error contract).
+- `string error` — populated on PermissionError and on any caught
+  exception. Empty on the happy path regardless of `found`.
+
+Idempotency: revoking a non-existent grant returns `found=false,
+error=""` and is **not** an error. See pinned test
+`test_revoke_nonexistent_returns_false`
+(`tests/python/unit/test_acl_v2.py:450-452`).
+
+## Auth (caller must own/share-grant the node; trusted-actor)
+
+- Tenant existence: `_check_tenant(request.context.tenant_id, ctx)`
+  (grpc_server.py:1836, 362).
+- Trusted actor: `_trusted_actor(request.context.actor)` — the payload
+  actor is OVERWRITTEN by `AuthInterceptor.get_authoritative_actor`
+  (grpc_server.py:1837, 418). The Go port MUST read identity from the
+  gRPC metadata via the AuthInterceptor equivalent and ignore the
+  request-payload actor for all auth decisions. Privilege-escalation
+  guard pinned by `tests/python/integration/test_privilege_escalation.py`
+  (RevokeAccess included in the matrix).
+- Capability check: `_check_capability(tenant_id, trusted_actor,
+  node_id, type_id=0, "RevokeAccess", ctx)` (grpc_server.py:1841-1848).
+  Required capability is `CoreCapability.ADMIN`
+  (`server/python/entdb_server/auth/capability_registry.py:74`,
+  pinned by `tests/python/unit/test_capability_registry.py:67`).
+- ADMIN is satisfied by node ownership OR by an explicit ADMIN grant
+  on the node (the share path that ShareNode itself can install with
+  `core_caps=[ADMIN]`). Tenant-admin role also passes via the
+  capability registry — match Python behavior, do not tighten.
+- On `PermissionError`: emit `record_grpc_request("RevokeAccess",
+  "denied", ...)` and return `RevokeAccessResponse{found:false,
+  error:str(perm_err)}` — NOT a gRPC status error
+  (grpc_server.py:1849-1851). Preserve this for client compatibility.
+
+## Side effects (WAL append: revocation; mailbox cleanup)
+
+**INVARIANT VIOLATION IN PYTHON (carry-forward risk).** The current
+Python handler writes directly to per-tenant SQLite via
+`canonical_store.revoke_access` → `_sync_revoke_access` (DELETE on
+`node_access`, canonical_store.py:3240-3265). It does **not** append
+a `TransactionEvent` to the WAL. This means revocations are silently
+**lost on rebuild from the WAL** — a documented violation of the
+"all writes go through the WAL" invariant in `CLAUDE.md`.
+
+Go-port decision (recommended for EPIC #407): **fix this on port.**
+Append a WAL event with op type `revoke_access` (mirroring
+`admin_revoke_access` at applier.py:1240-1245, but scoped to a single
+node + actor rather than a user-wide sweep). Schema:
+
+```
+TransactionEvent.ops = [{
+    "type": "revoke_access",
+    "node_id": <string>,
+    "actor_id": <string>,
+}]
+```
+
+Apply path (Go applier): `DELETE FROM node_access WHERE node_id=? AND
+actor_id=?`; `rowcount > 0` becomes `found`. The handler must wait
+for the receipt to be APPLIED before returning so `found` reflects
+post-apply state — same fence pattern other writes already use.
+
+Cross-tenant `shared_index` cleanup (currently inline in handler at
+grpc_server.py:1857-1869) MUST move into the applier’s post-apply
+hook, mirroring `_update_shared_index_on_revoke`
+(applier.py:1728-1760). Behavior to preserve:
+- If `actor_id` starts with `"group:"`: enumerate group members via
+  `get_group_members(tenant_id, actor_id)` and remove each member’s
+  `shared_index` row for `(tenant_id, node_id)`.
+- Otherwise: a single `global_store.remove_shared(actor_id,
+  tenant_id, node_id)` call (global_store.py:697-712).
+- Errors from shared_index cleanup are **logged and swallowed**
+  (warning level, not fatal). Handler still returns `found=true`.
+  This is intentional: `shared_index` is a hint cache, not
+  authoritative (global_store.py:752-770).
+
+ACL inheritance: revoking a parent automatically blocks children
+through `acl_inherit` chains — no extra work needed; the cascade is
+implicit in the access-check path. Pinned by
+`test_revoke_parent_blocks_children`
+(`tests/python/unit/test_acl_v2.py:366-375`).
+
+Mailbox cleanup: there is no per-node mailbox row tied to ACL grants,
+so no direct mailbox DELETE is required. The brief mentions "mailbox
+cleanup side effect" — confirmed scope is `shared_index` (the
+"shared with me" mailbox view), not `mailbox_items`. Matches
+ListSharedWithMe semantics.
+
+## Error contract
+
+All errors are returned as `RevokeAccessResponse{found:false,
+error:<string>}` — never as a gRPC status error (grpc_server.py:1872-
+1875). Three observable paths:
+1. `PermissionError` → `error=str(perm_err)`, metric label `denied`.
+2. Any other exception → `error=str(e)`, metric label `error`,
+   `logger.error(..., exc_info=True)`.
+3. Happy path → `error=""`, metric label `ok`. `found` is `true` iff
+   at least one row was deleted.
+
+`_check_tenant` may raise; it propagates into the generic `except
+Exception` and surfaces as `error=...`. Match this; do not convert to
+`NOT_FOUND`.
+
+## Shared Go package deps
+
+- `internal/auth` — `AuthInterceptor.AuthoritativeActor(ctx)`,
+  `CheckTenant`, `CheckCapability(tenant, actor, nodeID, typeID,
+  rpcName)`, `CapabilityRegistry` seeded with
+  `RevokeAccess → CoreCapability.ADMIN`.
+- `internal/wal` — `Wal.Append(event)` + receipt wait (re-uses the
+  ExecuteAtomic write fence).
+- `internal/apply` — applier op handler `revoke_access` writing to
+  per-tenant SQLite; post-apply hook calling shared-index cleanup.
+- `internal/canonical` — typed access to `node_access`,
+  `get_group_members`, `acl_inherit` (read-only here; revoke is just
+  a DELETE on `node_access`).
+- `internal/global` — `GlobalStore.RemoveShared(userID, tenant,
+  nodeID)` + `CleanupStaleShared`.
+- `internal/metrics` — `RecordGrpcRequest("RevokeAccess", label,
+  duration)` with labels `ok|denied|error`.
+- `internal/proto` (generated) — `entdb.v1.RevokeAccessRequest`,
+  `RevokeAccessResponse`.
+
+## Other-RPC deps (ShareNode counterpart)
+
+- **ShareNode** (`grpc_server.py:1746-1826`, proto:96) is the inverse.
+  Both write to the same `node_access` row keyed by
+  `(node_id, actor_id)`. ShareNode upserts; RevokeAccess deletes by
+  exact `actor_id`. They MUST round-trip cleanly: any
+  `(node_id, actor_id)` ShareNode can install, RevokeAccess must
+  remove. `permission` / `core_caps` / `ext_cap_ids` / `expires_at`
+  on the share row are not needed by RevokeAccess (whole row is
+  dropped) — but the Go port should reuse the same canonical
+  `actor_id` normalization (whatever ShareNode writes verbatim into
+  `node_access.actor_id` must match here byte-for-byte).
+- **AddGroupMember / RemoveGroupMember** affect membership snapshots
+  used during shared_index fan-out. Eventual-consistency window is
+  acceptable; matches Python.
+- **RevokeAllUserAccess** (proto:1000-1006) is the user-wide sweep
+  (admin op, WAL-backed via `admin_revoke_access`). Distinct surface;
+  do NOT collapse into RevokeAccess.
+- **TransferOwnership** can change who is the owner-by-default ADMIN;
+  RevokeAccess auth re-checks per call so no special coordination.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/integration/test_grpc_contract.py:351-361` — happy
+  path: idempotent on seed node (`found` may be true or false).
+- `tests/python/unit/test_acl_v2.py:443-448`
+  (`test_revoke_removes_access`) — share then revoke removes access.
+- `tests/python/unit/test_acl_v2.py:450-452`
+  (`test_revoke_nonexistent_returns_false`) — revoke without prior
+  grant returns false, no error.
+- `tests/python/unit/test_acl_v2.py:366-375`
+  (`test_revoke_parent_blocks_children`) — ACL inheritance cascade.
+- `tests/python/unit/test_capability_registry.py:67` — RevokeAccess
+  requires `CoreCapability.ADMIN`.
+- `tests/python/unit/test_sdk_hierarchical.py:249-255` — SDK
+  `scope.revoke()` routes through gRPC with the expected kwargs.
+- Go SDK tests already pin transport behavior:
+  `sdk/go/entdb/transport_extras_test.go:239-275` (RemovesGrant +
+  IsIdempotent) and `:358-362` (Scope routing).
+- Privilege-escalation matrix in
+  `tests/python/integration/test_privilege_escalation.py` covers
+  RevokeAccess (trusted-actor enforcement).
+
+## Implementation outline
+
+```go
+func (s *Server) RevokeAccess(ctx context.Context,
+    req *pb.RevokeAccessRequest) (*pb.RevokeAccessResponse, error) {
+    start := time.Now()
+    defer func() { /* metrics elsewhere */ }()
+
+    if err := s.auth.CheckTenant(ctx, req.Context.TenantId); err != nil {
+        return errResp(err, "error", start)
+    }
+    actor := s.auth.AuthoritativeActor(ctx) // ignore req.Context.Actor
+    if err := s.auth.CheckCapability(ctx, req.Context.TenantId, actor,
+        req.NodeId, 0, "RevokeAccess"); err != nil {
+        if errors.Is(err, auth.ErrPermission) {
+            metrics.Record("RevokeAccess", "denied", start)
+            return &pb.RevokeAccessResponse{Found: false,
+                Error: err.Error()}, nil
+        }
+        return errResp(err, "error", start)
+    }
+
+    evt := wal.NewEvent(req.Context.TenantId, []wal.Op{{
+        Type: "revoke_access",
+        NodeID: req.NodeId, ActorID: req.ActorId,
+    }})
+    receipt, err := s.wal.AppendAndWait(ctx, evt)
+    if err != nil { return errResp(err, "error", start) }
+
+    found := receipt.RowsAffected > 0
+    metrics.Record("RevokeAccess", "ok", start)
+    return &pb.RevokeAccessResponse{Found: found}, nil
+}
+```
+
+Applier op handler (sketch):
+```go
+case "revoke_access":
+    res, _ := tx.Exec(`DELETE FROM node_access
+        WHERE node_id=? AND actor_id=?`, op.NodeID, op.ActorID)
+    n, _ := res.RowsAffected()
+    receipt.RowsAffected = n
+    if n > 0 { go s.cleanupSharedIndexOnRevoke(tenant, op) }
+```
+
+## Open questions / risks (idempotency: revoke-not-granted)
+
+1. **WAL parity vs. Python bug-for-bug.** Python skips the WAL today.
+   Decision needed: port the bug (fast, identical behavior) or fix on
+   port (correct, slight contract drift — `found` will require
+   waiting for apply). Recommendation: **fix.** Tests pin only
+   eventual `found` semantics, not the path.
+2. **Idempotency on revoke-not-granted.** Python returns
+   `found=false, error=""`. After WAL-ification, replays of the same
+   `idempotency_key` must collapse to one DELETE; second call returns
+   `found=false`. Confirm the Go applier treats a 0-row DELETE as a
+   normal apply (not an error) so `error` stays empty.
+3. **Group membership timing.** `shared_index` cleanup enumerates
+   group members at apply time. If a member is added between
+   ShareNode and RevokeAccess for a group grant, their shared_index
+   row may have been seeded by ShareNode but not removed here.
+   Acceptable per current design (`shared_index` is a hint), but
+   document it.
+4. **Error string stability.** Tests don’t pin the exact error
+   string, but SDK-side error wrapping does string-contains in some
+   places. Match Python `str(perm_err)` style ("permission denied: …").
+5. **Concurrent ShareNode + RevokeAccess on same `(node, actor)`.**
+   WAL serialization removes the race. Last-writer-wins by
+   stream_pos; verify both ops share the same partition key
+   (likely `tenant_id`) so ordering is deterministic.
+6. **`actor_id` normalization.** Python does no normalization. If
+   ShareNode wrote `"User:Bob"` and RevokeAccess sends `"user:bob"`,
+   no rows match. Preserve this strictness on port; do NOT
+   case-fold.

--- a/docs/go-port/rpcs/RevokeAllUserAccess.md
+++ b/docs/go-port/rpcs/RevokeAllUserAccess.md
@@ -1,0 +1,184 @@
+# RPC Port Spec — `entdb.v1.EntDBService/RevokeAllUserAccess`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2864-2921`.
+
+Use case: **emergency offboarding**. An admin (or compliance officer) yanks
+every form of access a user has inside one tenant in a single shot — direct
+ACL grants, group memberships, visibility rows, and the cross-tenant
+`shared_index` rows that point back at this tenant.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:133` (rpc), `:994-1006` (messages).
+
+`RevokeAllUserAccessRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | Caller-claimed actor. **UNTRUSTED** — overridden by `AuthInterceptor`. See Auth. |
+| `tenant_id` | 2 | `string` | Required. Empty → `INVALID_ARGUMENT`. |
+| `user_id` | 3 | `string` | Required. Empty → `INVALID_ARGUMENT`. Format is the canonical actor string (e.g. `user:alice`), matching `node_access.actor_id`. |
+
+Note: this RPC does **not** use `RequestContext` — it carries `actor` and
+`tenant_id` as flat fields like the rest of the admin/GDPR family
+(`TransferUserContent`, `DelegateAccess`, `SetLegalHold`, `DeleteUser`).
+
+`RevokeAllUserAccessResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `success` | 1 | `bool` | True iff every step succeeded. False with `error` set on caught exception (auth/`_check_tenant` aborts re-raise). |
+| `revoked_grants` | 2 | `int32` | `DELETE FROM node_access WHERE actor_id = ?` rowcount. |
+| `revoked_groups` | 3 | `int32` | `DELETE FROM group_users WHERE member_actor_id = ?` rowcount. |
+| `revoked_shared` | 4 | `int32` | Count of `global_store.shared_index` rows where `source_tenant == tenant_id` removed for this user. |
+| `error` | 5 | `string` | Human-readable; only populated on the swallow path (non-abort exceptions). |
+
+## Auth (admin / compliance; trusted-actor)
+
+1. `_check_tenant(tenant_id)` — sharding owner check (`grpc_server.py:362`); aborts `FAILED_PRECONDITION` with `entdb-redirect-node` trailer if this node does not own the tenant.
+2. Required-field validation BEFORE the auth check, in this order: `tenant_id`, `user_id` (`grpc_server.py:2873-2876`).
+3. `_require_admin_or_owner(tenant_id, request.actor, ctx, "RevokeAllUserAccess")` — `grpc_server.py:2656-2690`:
+   - Trusted actor comes from `auth_interceptor.get_authoritative_actor(...)` (the metadata-derived identity), **not** `request.actor`. The wire `actor` is decorative; clients claiming `system:admin` while authenticated as `user:eve` are downgraded to `user:eve`. Pinned by CLAUDE.md "All writes go through the WAL" + the trusted-actor invariant fix (commit `fece3fb`).
+   - System actors (`system:*`) bypass; otherwise the actor's `tenant_member.role` must be `owner` or `admin`. Anything else → `PERMISSION_DENIED`.
+4. No per-node ACL check — this is a tenant-wide bulk op, gated only by tenant-admin role.
+
+The Go port MUST keep validation order identical so the contract
+`INVALID_ARGUMENT` cases at `test_grpc_contract.py:593-595` and `test_admin_operations.py:781-797` keep passing.
+
+## Side effects (many WAL events; mailbox cleanup; cross-tenant)
+
+Python today (current behavior, pinned by tests):
+
+1. `canonical_store.revoke_user_access(tenant_id, user_id, actor)` — `canonical_store.py:3871-3952`. Single `BEGIN IMMEDIATE` txn on the tenant SQLite:
+   - `DELETE FROM node_access WHERE actor_id = ?` → `revoked_grants`.
+   - `DELETE FROM group_users WHERE member_actor_id = ?` → `revoked_groups`.
+   - `DELETE FROM node_visibility WHERE tenant_id = ? AND principal = ?` (visibility cleanup; not counted).
+   - `append_audit(action="revoke_user_access", target=user_id, metadata={revoked_grants, revoked_groups})`.
+2. Cross-tenant `shared_index` cleanup against `global_store` (`grpc_server.py:2891-2907`):
+   - `get_shared_with_me(user_id, limit=10000)` then `remove_shared(user_id, source_tenant, node_id)` for each row whose `source_tenant == request.tenant_id`. Other-tenant rows are preserved (pinned: `test_admin_operations.py:776-779`).
+   - Wrapped in `try/except` — global_store errors are logged at `WARN` and **do not** fail the RPC. `revoked_shared` is whatever was successfully removed before the exception.
+3. Metric `record_grpc_request("RevokeAllUserAccess", "ok"|"error", elapsed)`.
+
+**WAL invariant gap (Go port MUST fix).** Per CLAUDE.md §1, every mutation
+must go through the WAL. Python today writes directly to SQLite via
+`canonical_store.revoke_user_access` and only uses the WAL for the audit
+trail. On a full WAL rebuild the revocation is **lost** — the deleted
+`node_access` rows would be reapplied. The applier already has an
+`admin_revoke_access` op (`apply/applier.py:1240-1245`) but it only handles
+`node_visibility`, not `node_access` / `group_users`. The Go port should:
+
+- Append a `TransactionEvent` containing one `admin_revoke_access` op with `{user_id, tenant_id}` and let the applier (extended) do the deletes.
+- Mirror the `TransferUserContent` pattern at `grpc_server.py:2711-2715` ("WAL-first: append an admin_transfer_content event so the ownership change survives a full WAL rebuild").
+- The applier extension is in scope for this ticket — broaden `admin_revoke_access` to also delete from `node_access` and `group_users` and return rowcounts so the handler can surface tallies.
+
+The cross-tenant `shared_index` cleanup is on `global_store` (a different
+SQLite); it has its own append-only journal and is best handled by emitting
+a per-row `global_admin_remove_shared` event into the global WAL (or
+keeping the current direct call until the global WAL is in scope —
+document the gap).
+
+## Error contract
+
+| gRPC code | Trigger | Source |
+|-----------|---------|--------|
+| `OK` | Happy path. `success=true`. | `grpc_server.py:2909-2915` |
+| `INVALID_ARGUMENT` | `tenant_id` empty / `user_id` empty / `actor` empty (resolves through `_require_admin_or_owner`). | `:2873-2876`, `:2675` |
+| `PERMISSION_DENIED` | Caller is not tenant `owner`/`admin` and not a `system:*` actor. | `:2685-2689` |
+| `FAILED_PRECONDITION` | Tenant not owned by this node — trailer `entdb-redirect-node` set. | `:362-411` |
+| `OK` (with `success=false`, `error=…`) | Any other Python exception (e.g. SQLite `OperationalError`). The handler swallows and returns `RevokeAllUserAccessResponse(success=False, error=str(e))`. | `:2916-2921` |
+
+The Go port should preserve the swallow behavior on non-RPC errors so
+existing SDK callers (which check `resp.success` rather than the gRPC
+status) keep working — see `sdk/go/entdb/admin.go:117-126` and
+`sdk/python/entdb_sdk/_grpc_client.py:2500-2535`.
+
+## Shared Go package deps
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated request/response types.
+- `auth` — `GetAuthoritativeActor(ctx) string` and the `system:*` predicate (mirrors `auth/auth_interceptor.py`).
+- `tenantroles` — `GetMemberRole(ctx, tenantID, userID) (string, error)` (mirrors `_get_member_role`).
+- `wal` — `Append(ctx, TransactionEvent) (Receipt, error)`. **Required** to fix the WAL invariant gap.
+- `apply` — extended `admin_revoke_access` op handler; returns `(grants, groups int)` rowcounts via the applied-events table or a side-channel.
+- `canonicalstore` — only via the applier; the handler MUST NOT write SQLite directly.
+- `globalstore` — `GetSharedWithMe`, `RemoveShared` (mirrors `global_store.py:670-726`).
+- `audit` — `Append(action="revoke_user_access", target_type="user", target_id, metadata)` (separate from the WAL; backed by S3 Object Lock per CLAUDE.md §2).
+- `sharding` — for `_check_tenant`.
+- `metrics` — `RecordGRPCRequest`.
+- `errs` — common abort helpers.
+
+NOT used: `acl`, `capability_registry`, `crypto`, `quota`, `schema`. ACL is
+not consulted (admin override). Quota is not charged (admin op).
+
+## Other-RPC deps
+
+- **`RevokeAccess`** (`grpc_server.py:1828`, spec TBD): per-node revoke. `RevokeAllUserAccess` is the bulk-form generalization; it does NOT call `RevokeAccess` internally — it issues raw `DELETE` against `node_access`. The two diverge in audit metadata and in the per-node visibility recompute. Port `RevokeAccess` first; reuse only the SQL fragment, not the handler.
+- **`RemoveTenantMember`** (`grpc_server.py:2492`): admins frequently call `RevokeAllUserAccess` *then* `RemoveTenantMember` to fully evict a user. The two are independent; share no state. Order matters because `_require_admin_or_owner` checks membership — call `RevokeAllUserAccess` first while the offender is still a member if you also want their member role.
+- **`FreezeUser`** (`grpc_server.py` — `FreezeUserRequest` at proto `:1029`): GDPR-flavored "stop accepting writes from this user" without deleting access. Frequently chained with `RevokeAllUserAccess` for hard offboarding. Independent code path; port separately.
+- **`DeleteUser`** (`grpc_server.py:2925`): GDPR right-to-erasure. `RevokeAllUserAccess` is **not** a substitute — `DeleteUser` queues data deletion after a grace period, while this RPC is access-only and immediate.
+
+## Contract tests pinning behavior
+
+- `tests/python/integration/test_grpc_contract.py:584-596` — happy path (`actor=ADMIN, tenant_id=TENANT, user_id="bob"` → `success=true`) and `INVALID_ARGUMENT` for empty `user_id`. Runs over a real gRPC channel. Go server must pass verbatim.
+- `tests/python/unit/test_admin_operations.py:711-734` — `test_admin_can_revoke`: shares a node with BOB, adds BOB to a group, expects `revoked_grants=1, revoked_groups=1` after RPC. Pins the rowcount semantics.
+- `tests/python/unit/test_admin_operations.py:735-751` — `test_non_admin_cannot_revoke`: non-member caller → `PERMISSION_DENIED`. Pins auth gate.
+- `tests/python/unit/test_admin_operations.py:753-779` — `test_cleans_up_shared_index`: seeds 3 `shared_index` rows (2 in TENANT, 1 in `other-tenant`), expects `revoked_shared=2` and the `other-tenant` row preserved. Pins cross-tenant scoping.
+- `tests/python/unit/test_admin_operations.py:781-797` — empty `user_id` → `INVALID_ARGUMENT` with `_AbortError`. Pins validation order.
+- `tests/python/unit/test_admin_ops.py:223-264` — store-level: idempotent (second call returns 0), tenant-scoped, non-existent user returns 0 grants/groups. Pin for the applier extension.
+- `tests/python/unit/test_admin_operations.py:347-415` — `revoke_user_access` audit-trail tests: `append_audit(action="revoke_user_access", ...)` is called; metadata contains tallies. Go port must emit the same audit row.
+- `sdk/go/entdb/admin_test.go:367-388` — Go SDK contract: response fields `RevokedGrants/RevokedGroups/RevokedShared` round-trip via `RevokeAllResult`. The server's wire format is what this test fakes; do not change tags.
+
+## Implementation outline (atomicity, partial failure)
+
+```go
+// server/go/internal/api/admin_revoke_all.go
+func (s *EntDBServer) RevokeAllUserAccess(
+    ctx context.Context, req *pb.RevokeAllUserAccessRequest,
+) (*pb.RevokeAllUserAccessResponse, error) {
+    start := time.Now()
+    defer func() { metrics.RecordGRPCRequest("RevokeAllUserAccess", outcome, time.Since(start)) }()
+```
+
+1. `s.checkTenant(ctx, req.TenantId)` — sharding redirect; abort `FAILED_PRECONDITION` with trailer.
+2. Validate: `req.TenantId != ""`, `req.UserId != ""`. `INVALID_ARGUMENT` on empty.
+3. `trustedActor, err := s.requireAdminOrOwner(ctx, req.TenantId, req.Actor, "RevokeAllUserAccess")`. **Ignore `req.Actor` for authorization** — only the metadata-derived identity counts.
+4. **WAL append (single event, atomic on SQLite side):**
+   ```go
+   ev := wal.TransactionEvent{
+       TenantID: req.TenantId,
+       Actor:    trustedActor,
+       IdempotencyKey: deriveKey(req),  // see open-question below
+       Ops: []wal.Op{{Type: "admin_revoke_access", UserID: req.UserId}},
+   }
+   receipt, err := s.wal.Append(ctx, ev)
+   ```
+   On WAL failure → return `INTERNAL`, no partial state. The applier handles the deletes inside one `BEGIN IMMEDIATE` (already the pattern; extend it from `apply/applier.py:1240-1245` to also delete from `node_access` and `group_users` and return tallies).
+5. `s.wal.WaitForApplied(ctx, receipt, timeout=5s)` so the response can quote rowcounts. If timeout, return `success=true, revoked_grants=0, revoked_groups=0, error="applied wait timed out"` — preserves Python's "best-effort tally" feel.
+6. Read tallies from the applier's per-event result channel (or, if absent, query `node_access`/`group_users` row-deltas via the audit row).
+7. **Cross-tenant cleanup** (best-effort, do NOT fail the RPC):
+   - `entries := s.globalStore.GetSharedWithMe(ctx, req.UserId, 10000, 0)`.
+   - For each `e` where `e.SourceTenant == req.TenantId`: `s.globalStore.RemoveShared(ctx, req.UserId, req.TenantId, e.NodeID)`. Increment `revokedShared` only on success.
+   - Catch all errors → `log.Warn("shared_index cleanup failed on RevokeAllUserAccess", "err", err)`. Do not propagate.
+8. `s.audit.Append(...)` — S3 Object Lock entry. (Python does this inside `revoke_user_access`; in Go put it after the WAL applies so the audit row reflects realized state.)
+9. `outcome = "ok"`; return `&pb.RevokeAllUserAccessResponse{Success: true, RevokedGrants: g, RevokedGroups: gr, RevokedShared: rs}`.
+
+**Atomicity boundaries:**
+- Tenant-SQLite deletes: atomic (single applier txn).
+- Cross-tenant `shared_index` deletes: NOT atomic with the tenant deletes — they live in a different SQLite (`global_store`). Partial failure leaves `shared_index` rows behind; an admin can re-run the RPC, which is idempotent.
+- Idempotency: re-running the same WAL event (same `idempotency_key`) is a no-op via the `applied_events` dedupe in the applier. `revoked_grants/groups` will be `0` on retry — matches Python.
+
+**Partial-failure modes:**
+- WAL append succeeds, applier slow → `success=true` with zero tallies (caveat above).
+- WAL append fails → no SQLite change, `INTERNAL` returned, retry-safe.
+- `global_store` unavailable → tenant deletes still applied, `revoked_shared=0`, RPC succeeds with a `WARN` log.
+
+## Open questions / risks
+
+- **Legal hold blocks?** `SetLegalHold` (proto `:980-991`) flags a tenant as on-hold. Today `RevokeAllUserAccess` does NOT check the hold flag — an admin can revoke access even while the tenant is preserving evidence. Decide:
+  - Option A (status quo): access revocation is independent of legal hold — only **deletion** is blocked. Document this clearly. Recommended.
+  - Option B: block when held, return `FAILED_PRECONDITION`. Risk: blocks emergency offboarding during litigation, which is when you most need it. Reject.
+  - Option C: still revoke, but emit an enhanced audit row with `legal_hold_active=true`. Cheap and forensics-friendly. Recommended add-on.
+- **Idempotency key derivation.** Request has no `idempotency_key` field. Server must synthesize (`sha256(tenant_id|user_id|trusted_actor|day_bucket)`?) so retries dedupe but a same-day rerun by a different admin still produces a fresh event. Confirm with EPIC #407.
+- **Tally fidelity vs. Python.** Python returns rowcounts from the synchronous `revoke_user_access` call. Go's WAL-first path makes this asynchronous. If an SDK consumer treats `revoked_grants > 0` as "definitely happened," fine; but `==0` is now ambiguous (zero matches vs. apply pending). Surface a `pending=true` boolean? Or always `WaitForApplied` with a generous timeout? Decide per #407.
+- **Group fan-out.** Today the handler removes the user from `group_users` but does NOT iterate groups they were in to revoke node-level grants held *via group membership*. The visibility cleanup (`node_visibility WHERE principal=user`) catches this in materialized form, but if visibility was never recomputed for a stale node, the user could retain phantom access until the next ACL recompute. Confirm whether the Go port should explicitly recompute or trust the lazy path. Leaning toward an explicit recompute job triggered by the `admin_revoke_access` event.
+- **Cross-tenant cleanup at scale.** Hard cap of `limit=10000` shared rows (`grpc_server.py:2895`). Users who were shared > 10k nodes won't be fully cleaned in one call. Page through, or raise the cap with a streaming variant. Track as follow-up.
+- **No actor metadata in `revoked_shared` audit.** The current code does not append a `global_store` audit row for the per-row removals. Add one in the Go port — important for compliance reconstruction.
+- **Race with concurrent `ShareNode`.** Between WAL append and applier execution a fresh share could land. Applier's `BEGIN IMMEDIATE` serializes within tenant scope, so the new share will either land before the revoke (and be deleted) or after (and survive). Document the "after" case so admins know to FreezeUser the user before RevokeAll if they need a hard barrier.

--- a/docs/go-port/rpcs/SearchMailbox.md
+++ b/docs/go-port/rpcs/SearchMailbox.md
@@ -1,0 +1,178 @@
+# SearchMailbox — Go port spec
+
+EPIC: #407 (Python -> Go server port)
+RPC: `entdb.v1.EntDBService/SearchMailbox`
+Python handler: `server/python/entdb_server/api/grpc_server.py:1456-1476`
+Proto: `proto/entdb/v1/entdb.proto:70` (service entry), `:511-537` (messages)
+
+## Wire contract
+
+Unary RPC. Request `SearchMailboxRequest` (proto field IDs preserved):
+
+| field | id | type | meaning |
+|------|----|------|---------|
+| context | 1 | RequestContext | tenant_id, actor, trace_id |
+| user_id | 2 | string | mailbox owner (cross-tenant scope) |
+| query | 3 | string | FTS5 match expression |
+| source_type_ids | 4 | repeated int32 | optional type filter |
+| limit | 5 | int32 | page size |
+| offset | 6 | int32 | pagination offset |
+
+Response `SearchMailboxResponse`:
+
+| field | id | type |
+|------|----|------|
+| results | 1 | repeated MailboxSearchResult |
+| has_more | 2 | bool |
+
+`MailboxSearchResult`: `item` (MailboxItem), `rank` (float32, FTS5 bm25), `highlights` (string).
+
+Status today: handler is a deprecated stub. It validates tenant ownership and returns
+`SearchMailboxResponse{results=[], has_more=false}` regardless of input
+(`grpc_server.py:1461-1476`). The legacy per-user mailbox SQLite store was removed; fanout now
+writes to a per-tenant `notifications` table (`canonical_store.py:1140-1150`,
+`canonical_store.py:4531`). The Go port MUST preserve this stub semantics for v1 parity, then
+the FTS5-backed implementation lands behind the same RPC in a follow-up.
+
+## Auth (whose mailbox? trusted-actor)
+
+- Wire `request.context.actor` is UNTRUSTED. Always rebind via `_trusted_actor` equivalent,
+  which prefers the `AuthInterceptor` `ContextVar` and only falls back to the wire field for
+  no-auth deployments and unit tests (`grpc_server.py:418-437`).
+- `request.user_id` selects WHICH mailbox to read; it is NOT identity. Authorization rule
+  (when implementation lands): `trusted_actor` MUST be either (a) the same user as
+  `user_id`, or (b) hold tenant-admin / system role on `context.tenant_id`. Anything else =>
+  `PERMISSION_DENIED`.
+- Tenant gate runs first via `_check_tenant` (`grpc_server.py:362-410`): rejects with
+  `UNAVAILABLE` + `entdb-redirect-node` trailer if this node is not the shard owner;
+  rejects with `FAILED_PRECONDITION` if the tenant is region-pinned elsewhere.
+- "Mailbox is cross-tenant for a user" applies at the data layer (notifications can come
+  from any tenant a user belongs to), but the RPC itself is scoped to a single
+  `context.tenant_id` — the caller must drive the cross-tenant fanout client-side. The Go
+  port keeps that contract: one tenant per call.
+
+## Side effects
+
+None today (stub returns empty). Future FTS5-backed impl is read-only:
+
+- Reads from per-tenant SQLite only — no cross-tenant SQLite transaction
+  (per CLAUDE.md invariant 4). Cross-user-tenant aggregation is the caller's job.
+- Uses FTS5 virtual tables `fts_t{type_id}`, lazily created on first read/write
+  (`canonical_store.py:1993-2037`, `docs/decisions/fts.md:37-70`).
+- Joins FTS rows against `notifications` (per-tenant) keyed by `node_id`.
+- NOT a write path — never appends to the WAL. (Mailbox writes happen via the fanout
+  applier, which IS WAL-driven; see invariant 1.)
+
+## Error contract (exhaustive)
+
+Today (stub):
+
+- Tenant not owned by this node => `UNAVAILABLE` + trailer `entdb-redirect-node=<owner>`
+  (`grpc_server.py:392-395`).
+- Tenant region-pinned elsewhere => `FAILED_PRECONDITION` (`grpc_server.py:405-410`).
+- Any other exception inside the handler is swallowed: returns `SearchMailboxResponse{results=[]}`
+  with `has_more` defaulted to false, logged at ERROR (`grpc_server.py:1473-1476`).
+  The Go port MUST replicate the swallow-and-return-empty behavior — a contract test pins it.
+
+For the future FTS5-backed impl:
+
+- Authorization fail => `PERMISSION_DENIED`.
+- Malformed FTS5 query => `INVALID_ARGUMENT` with "fts5: syntax error" detail.
+- `limit < 0` or `offset < 0` => `INVALID_ARGUMENT`.
+- Unknown `source_type_ids` => silently filtered out (no error), matches `SearchNodes`.
+- SQLite I/O error => `INTERNAL`.
+
+## Shared Go package deps
+
+- `internal/auth` — `TrustedActor(ctx, wireActor) string`, mirrors `_trusted_actor`.
+- `internal/sharding` — `IsMine(tenantID)`, `Owner(tenantID)`, redirect-trailer helper.
+- `internal/region` — `ServedRegion()`, tenant-region pin check.
+- `internal/store/canonical` — per-tenant SQLite handle pool.
+- `internal/fts` (NEW subsystem) — wraps SQLite FTS5 access:
+  - `EnsureTable(conn, tenantID, typeID int32, fieldIDs []int32) error`
+  - `Search(conn, tenantID, typeID int32, query string, limit, offset int) ([]Hit, error)`
+  - Hit: `{NodeID string, Rank float32, Highlights string}`
+  - Lazy DDL with process-local cache (mirrors `_fts_table_cache`,
+    `canonical_store.py:451`, `:2025-2037`).
+- `internal/proto/structpb` — for response payload Struct conversion (when impl lands).
+- `internal/metrics` — `RecordGRPCRequest("SearchMailbox", outcome, latency)`.
+
+## Other-RPC deps (overlap)
+
+- **GetMailbox** (`grpc_server.py:1478-1498`) — same stub pattern, same auth gate, same
+  swallow-and-return-empty error policy. Implement together; share the auth helper.
+- **SearchNodes** (`canonical_store.py:2101-2168`, proto `:SearchNodesRequest`) — the
+  "real" FTS5 RPC. Future SearchMailbox is structurally `SearchNodes` with a fixed
+  type-set (notification source types) and an extra `user_id` predicate. Reuse the
+  `internal/fts` package; do NOT fork.
+- **ListMailboxUsers** — also a deprecated stub returning empty; same family.
+- **AuthInterceptor** — populates the trusted-actor `ContextVar`; required for the
+  authz check.
+
+## Contract tests pinning behavior
+
+- `tests/python/integration/test_grpc_contract.py:267-273` — happy path, asserts
+  `results == [] and has_more == False`. Go port MUST satisfy this byte-for-byte.
+- `tests/python/integration/test_grpc_contract.py:282-287` — `ListMailboxUsers` empty
+  stub (sister assertion).
+- `tests/python/integration/test_grpc_contract.py:288-295` — `ListTenants` returns
+  `PERMISSION_DENIED` when no auth interceptor; documents the trusted-actor contract
+  the Go port must reproduce.
+- No test currently exercises tenant-redirect / region-pin paths for SearchMailbox
+  specifically — copy the patterns from `_check_tenant` tests in
+  `tests/python/integration/test_sharding_*` and add equivalents.
+
+## Implementation outline
+
+```go
+func (s *EntDBServer) SearchMailbox(
+    ctx context.Context, req *entdbv1.SearchMailboxRequest,
+) (*entdbv1.SearchMailboxResponse, error) {
+    start := time.Now()
+    defer func() { metrics.RecordGRPC("SearchMailbox", outcome, time.Since(start)) }()
+
+    if err := s.checkTenant(ctx, req.GetContext().GetTenantId()); err != nil {
+        return nil, err  // UNAVAILABLE / FAILED_PRECONDITION already typed
+    }
+
+    // v1 stub parity with Python handler.
+    return &entdbv1.SearchMailboxResponse{Results: nil, HasMore: false}, nil
+}
+```
+
+When FTS5 impl lands (follow-up issue):
+
+1. `actor := auth.TrustedActor(ctx, req.Context.Actor)`.
+2. Authz: `actor == "user:"+req.UserId` OR `s.isTenantAdmin(actor, tenantID)` else
+   `PERMISSION_DENIED`.
+3. Validate `limit >= 0`, `offset >= 0` else `INVALID_ARGUMENT`.
+4. Acquire per-tenant SQLite handle.
+5. For each source type id (or default notification type set), call
+   `fts.Search(conn, tenantID, typeID, req.Query, limit+1, offset)`. If
+   `source_type_ids` empty, query the union of registered notification types.
+6. Join hit `node_id`s against `notifications` to build `MailboxItem`s; keep
+   FTS `rank` and `highlights` (use `snippet()`/`highlight()` FTS5 aux funcs).
+7. ACL filter server-side (mirrors `SearchNodes` ACL trim).
+8. Trim to `limit`; set `has_more = len(hits) > limit`.
+9. Wrap unexpected errors: log at ERROR, return empty response (Python swallow
+   parity is REQUIRED until contract tests are updated to expect typed errors).
+
+## Open questions / risks
+
+- **Stub vs real**: Issue #407 should clarify whether the Go port lands the
+  v1 stub only, or also implements the FTS5-backed version. Default: stub now,
+  FTS5 in a follow-up — matches "behavioral parity first" rule.
+- **Cross-tenant fanout**: a user belongs to many tenants; today the RPC is
+  single-tenant. Confirm there is no hidden caller relying on cross-tenant
+  results (grep for SDK callers in `sdk/python/entdb_sdk` and
+  `sdk/go/entdb`).
+- **Highlights/rank shape**: `MailboxSearchResult.highlights` is a single
+  string — Python never populated it. Define the format (FTS5 `snippet(...)`
+  output, `<mark>...</mark>` tags?) before any client depends on it.
+- **Rank type**: proto says `float`; FTS5 bm25 in SQLite returns float64.
+  Cast at the boundary; document loss of precision is acceptable.
+- **Error swallow**: returning `OK` with empty results for an internal failure
+  is a misleading metric. Once the FTS5 impl ships, flip to `INTERNAL` and
+  update the contract test in the same PR.
+- **Empty `query`**: Python stub accepts it; future impl should treat empty
+  query as `INVALID_ARGUMENT` (FTS5 MATCH on empty string is an error anyway).

--- a/docs/go-port/rpcs/SearchNodes.md
+++ b/docs/go-port/rpcs/SearchNodes.md
@@ -1,0 +1,186 @@
+# SearchNodes — Go port spec
+
+EPIC: #407 (Python -> Go server port)
+RPC: `entdb.v1.EntDBService/SearchNodes`
+Python handler: `/Users/arun/projects/opensource/tenant-shard-db/server/python/entdb_server/api/grpc_server.py:1130-1213`
+Proto: `/Users/arun/projects/opensource/tenant-shard-db/proto/entdb/v1/entdb.proto:148` (service entry), `:1124-1136` (messages)
+Decision: `/Users/arun/projects/opensource/tenant-shard-db/docs/decisions/fts.md`
+
+## Wire contract (query string, filter, ranking, pagination)
+
+Unary RPC. `SearchNodesRequest` is a flat message (NOT wrapped in `RequestContext` — `tenant_id` and `actor` live at the top level, unlike most RPCs):
+
+| field   | id | type   | meaning                                                                        |
+|---------|----|--------|--------------------------------------------------------------------------------|
+| tenant_id | 1 | string | tenant scope; mandatory                                                       |
+| actor    | 2 | string | wire-claimed actor — UNTRUSTED, rebound via `_trusted_actor`                   |
+| type_id  | 3 | int32  | node type whose FTS5 virtual table to query                                    |
+| query    | 4 | string | FTS5 MATCH expression (AND/OR/NOT, phrase `"..."`, prefix `wid*`, `f3:term`)   |
+| limit    | 5 | int32  | page size, defaults to 50 when zero (`grpc_server.py:1168`)                    |
+| offset   | 6 | int32  | pagination offset, defaults to 0 (`grpc_server.py:1169`)                       |
+
+`SearchNodesResponse`:
+
+| field | id | type            |
+|-------|----|-----------------|
+| nodes | 1  | repeated Node   |
+
+No `has_more`, no `total_count`, no per-row `rank`/`highlights` in this RPC — those are explicitly out of scope per `docs/decisions/fts.md:117-122`. Ordering is FTS5 `bm25` ascending (best match first) via `ORDER BY fts.rank` (`canonical_store.py:2139`). The Go port MUST preserve the response shape exactly: a single repeated `Node` field, same proto field numbers.
+
+Pagination: stateless `LIMIT/OFFSET` against the joined query — no cursor token. Callers wanting "next page" must re-issue with `offset += len(nodes)`. `Node.payload` is emitted as `google.protobuf.Struct` keyed by **field-id strings** (not field names) per CLAUDE.md invariant 6 — translation to names is the SDK's job.
+
+## Auth (per-tenant; ACL post-filter; trusted-actor)
+
+1. `_check_tenant(tenant_id, ctx)` (`grpc_server.py:362-410`, called at `:1146`) is the first gate:
+   - Returns `UNAVAILABLE` + trailer `entdb-redirect-node=<owner>` if shard not owned by this node.
+   - Returns `FAILED_PRECONDITION` if the tenant is region-pinned elsewhere.
+2. `actor = self._trusted_actor(request.actor)` (`:1173`, helper at `:418-437`) prefers the AuthInterceptor `ContextVar` over the wire-claimed string. The Go port MUST NOT trust `request.actor` directly — it is purely a fallback for no-auth dev/test. Per commit fece3fb the wire actor is treated as untrusted for all gRPC handlers.
+3. **No pre-FTS authz**: `SearchNodes` does NOT require admin or membership before running the FTS5 query. Anyone whose tenant gate passes can MATCH against the FTS index. The privacy boundary is the per-row ACL post-filter, not a coarse RPC-level check.
+4. `_check_cross_tenant_read(tenant_id, trusted_actor, ctx)` (`:561` / called at `:1174`) classifies the actor as `"member"` or `"cross_tenant"`. **Only when role is `cross_tenant`** does the handler ACL-trim the result set (`:1179-1192`):
+   - `actor_ids = canonical_store.resolve_actor_groups(tenant_id, trusted_actor)` expands the trusted actor into its group memberships.
+   - For each candidate node, `canonical_store.can_access(tenant_id, node_id, actor_ids)` is checked; non-accessible rows are dropped silently.
+5. Implication for parity: an in-tenant member sees the unfiltered FTS result set (including nodes they have no ACL grant on). This matches `QueryNodes` semantics — both treat ACL as a cross-tenant-only filter today. The Go port MUST replicate this exactly; do NOT tighten it without a separate decision doc.
+6. Per-tenant SQLite isolation (CLAUDE.md invariant 4): the FTS5 virtual table `fts_t{type_id}` lives in the SAME per-tenant SQLite file as the `nodes` table. Cross-tenant search is impossible by construction.
+
+## Side effects (read on FTS5 + canonical_store)
+
+- Read-only RPC — does NOT append to the WAL. (FTS5 mutations are applied inside `Applier._apply_event_with_conn`, see `applier.py:1001,1108,1130` and `docs/decisions/fts.md:73-83`.)
+- **Lazy DDL**: `_ensure_fts_table` (`canonical_store.py:1993-2037`) issues `CREATE VIRTUAL TABLE IF NOT EXISTS fts_t{type_id} USING fts5(node_id UNINDEXED, f{fid1}, f{fid2}, ..., tokenize='porter unicode61')` on first read or write. Cached in `self._fts_table_cache: set[(tenant_id, type_id)]` (`canonical_store.py:451`). The Go port MUST replicate this lazy + cached DDL behavior — first-call latency includes the CREATE.
+- **Single SQL JOIN**: `SELECT n.* FROM fts_t{type_id} AS fts JOIN nodes AS n ON n.node_id = fts.node_id AND n.tenant_id = ? WHERE fts_t{type_id} MATCH ? ORDER BY fts.rank LIMIT ? OFFSET ?` (`canonical_store.py:2135-2142`).
+- Empty `searchable_field_ids` => returns `[]` immediately, no SQL issued (`canonical_store.py:2128-2129`). This is the path covered by the contract test "type 1 has no searchable fields".
+- Metrics: `record_grpc_request("SearchNodes", "ok"|"error", elapsed)` at `:1208,1211`. Go port wires same labels.
+- ACL post-filter (cross-tenant only) issues additional reads against `acl` / group-membership tables via `resolve_actor_groups` + `can_access` — N+1 in row count. Acceptable per Python parity; optimize later if needed.
+
+## Error contract (INVALID_ARGUMENT for bad query)
+
+| condition                                              | gRPC status              | source                          |
+|--------------------------------------------------------|--------------------------|---------------------------------|
+| `query.strip() == ""`                                  | `INVALID_ARGUMENT` "query must not be empty" | `grpc_server.py:1149-1152` |
+| `len(query) > 1000`                                    | `INVALID_ARGUMENT` "query must be under 1000 characters" | `:1153-1158` |
+| Tenant not owned by this node                          | `UNAVAILABLE` + redirect trailer | `:362-395`              |
+| Tenant region-pinned elsewhere                         | `FAILED_PRECONDITION`    | `:405-410`                      |
+| Type with no searchable fields                         | `OK` with `nodes: []`     | `:1161` + `canonical_store.py:2128` |
+| Malformed FTS5 syntax (e.g. unbalanced quotes)         | swallowed -> `OK` with `nodes: []` (logged ERROR) | `:1210-1213` |
+| SQLite I/O error                                       | swallowed -> `OK` with `nodes: []` (logged ERROR) | `:1210-1213` |
+
+The blanket `except Exception` at `:1210` is a known Python wart: ANY error after the validation gates becomes an empty-result `OK`. Contract tests (below) pin this behavior. The Go port MUST preserve swallow-to-empty for parity in v1; `INTERNAL`-status errors can be introduced only with a contract-test update in the same PR.
+
+`limit < 0` / `offset < 0`: Python does NOT validate these; SQLite errors and the swallow path returns empty. Go port should match — do NOT add a stricter check.
+
+## Shared Go package deps (fts subsystem)
+
+- `internal/auth` — `TrustedActor(ctx, wireActor) string` (mirrors `_trusted_actor`, `grpc_server.py:418`).
+- `internal/sharding` — `IsMine(tenantID)`, `Owner(tenantID)`, redirect-trailer helper for `_check_tenant`.
+- `internal/region` — `ServedRegion()` + tenant-region pin lookup.
+- `internal/store/canonical` — per-tenant SQLite handle pool; surfaces `Conn(tenantID)`.
+- `internal/store/canonical/acl` — `ResolveActorGroups(conn, tenantID, actor) []string`, `CanAccess(conn, tenantID, nodeID, actorIDs) bool` mirroring `canonical_store.py`.
+- `internal/schema` — `Registry.SearchableFieldIDs(typeID int32) []int32` mirroring `get_searchable_field_ids` (`schema/registry.py:311`).
+- `internal/fts` (NEW subsystem, shared with future `SearchMailbox`):
+  - `EnsureTable(conn *sql.Conn, tenantID string, typeID int32, fieldIDs []int32) error` — idempotent `CREATE VIRTUAL TABLE IF NOT EXISTS`, process-local cache keyed by `(tenantID, typeID)`.
+  - `Search(conn, tenantID, typeID, query string, limit, offset int) ([]NodeRow, error)` — runs the JOIN, returns `nodes`-table rows in rank order.
+  - Cache type: `sync.Map[ftsKey]struct{}` to mirror Python `_fts_table_cache` (`canonical_store.py:451`, `:2025-2037`).
+- `internal/proto/structpb` — `MapToStruct(map[string]any) *structpb.Struct` for `Node.payload`.
+- `internal/metrics` — `RecordGRPC("SearchNodes", outcome, latency)`.
+
+**SQLite driver**: must be the same one used by `GetNode`/`QueryNodes` (one driver across the canonical store). FTS5 is a compile-time SQLite feature — the chosen driver build MUST include it (see Open questions).
+
+## Other-RPC deps (SearchMailbox sibling)
+
+- `SearchMailbox` (`docs/go-port/rpcs/SearchMailbox.md`) — same FTS5 family. Its future real impl is structurally `SearchNodes` with a fixed type-set (notification source types) plus a `user_id` predicate. Both MUST share `internal/fts`; do not fork.
+- `QueryNodes` (`docs/go-port/rpcs/QueryNodes.md`) — sibling read RPC. Identical ACL-post-filter pattern; reuse the same `acl.CanAccess` helper. Verify both go-port specs land the same shared helpers.
+- `GetNode`/`GetNodes` — same per-tenant SQLite handle pool; same `Node` row shape.
+- `ExecuteAtomic` — produces the FTS index rows (writer side via `Applier`); behavioral parity test for `SearchNodes` requires `ExecuteAtomic` writes to be visible (`tests/python/unit/test_fts_search.py:558-589` writes via the applier, then reads via `SearchNodes`).
+- `AuthInterceptor` — populates the trusted-actor `ContextVar`; mandatory dependency for the trusted-actor rebind (commit fece3fb).
+
+## Contract tests pinning behavior (file:line)
+
+- `/Users/arun/projects/opensource/tenant-shard-db/tests/python/integration/test_grpc_contract.py:627-632` — empty query => `INVALID_ARGUMENT`. Go port MUST satisfy byte-for-byte.
+- `/Users/arun/projects/opensource/tenant-shard-db/tests/python/integration/test_grpc_contract.py:633-641` — `type_id=1` has no searchable fields => `OK` with `nodes == []`. The "no searchable fields short-circuit" is a load-bearing contract.
+- `/Users/arun/projects/opensource/tenant-shard-db/tests/python/unit/test_fts_search.py:537-554` — empty-query `INVALID_ARGUMENT` (unit-level coverage).
+- `/Users/arun/projects/opensource/tenant-shard-db/tests/python/unit/test_fts_search.py:557-589` — happy path: write `Product` via the applier with `desc="findme"`, search `query="widget"`, expect exactly one node with `node_id == "p1"` (FTS Porter stemming + multi-field index).
+- `/Users/arun/projects/opensource/tenant-shard-db/tests/python/unit/test_fts_search.py` (full file) — additional assertions on phrase / prefix / column-filter syntax and update/delete propagation through the applier.
+- `/Users/arun/projects/opensource/tenant-shard-db/tests/python/unit/test_payload_wire_format.py:14` — `SearchNodes` payload Struct format is field-id-keyed (CLAUDE.md invariant 6); regression target.
+
+Cross-implementation contract tests under `tests/contract/` are a placeholder per CLAUDE.md ("Project Structure"); when the Go server lands, port the four cases above into the polyglot suite first.
+
+## Implementation outline
+
+```go
+func (s *EntDBServer) SearchNodes(
+    ctx context.Context, req *entdbv1.SearchNodesRequest,
+) (resp *entdbv1.SearchNodesResponse, err error) {
+    start := time.Now()
+    outcome := "ok"
+    defer func() { metrics.RecordGRPC("SearchNodes", outcome, time.Since(start)) }()
+
+    // 1. Tenant gate (UNAVAILABLE / FAILED_PRECONDITION).
+    if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
+        outcome = "error"; return nil, err
+    }
+
+    // 2. Validate query (INVALID_ARGUMENT before anything else touches storage).
+    q := strings.TrimSpace(req.GetQuery())
+    if q == "" {
+        outcome = "error"
+        return nil, status.Error(codes.InvalidArgument, "query must not be empty")
+    }
+    if len(q) > 1000 {
+        outcome = "error"
+        return nil, status.Error(codes.InvalidArgument, "query must be under 1000 characters")
+    }
+
+    // 3. Schema lookup: empty searchable set => empty response, no SQL.
+    typeID := req.GetTypeId()
+    fids := s.schema.SearchableFieldIDs(typeID)
+    if len(fids) == 0 {
+        return &entdbv1.SearchNodesResponse{}, nil
+    }
+
+    // 4. Open per-tenant conn and run the FTS5 JOIN. Lazy DDL inside.
+    limit := int(req.GetLimit()); if limit == 0 { limit = 50 }
+    offset := int(req.GetOffset())
+    rows, ferr := s.fts.Search(ctx, req.GetTenantId(), typeID, q, limit, offset)
+    if ferr != nil {
+        // PARITY: swallow + return empty + log ERROR (do NOT surface INTERNAL yet).
+        s.log.Error("SearchNodes failed", "err", ferr)
+        return &entdbv1.SearchNodesResponse{}, nil
+    }
+
+    // 5. ACL post-filter only when the actor is cross-tenant.
+    actor := auth.TrustedActor(ctx, req.GetActor())
+    role, err := s.checkCrossTenantRead(ctx, req.GetTenantId(), actor)
+    if err != nil { outcome = "error"; return nil, err }
+    if role == auth.RoleCrossTenant {
+        actorIDs, _ := s.acl.ResolveActorGroups(ctx, req.GetTenantId(), actor)
+        kept := rows[:0]
+        for _, n := range rows {
+            ok, _ := s.acl.CanAccess(ctx, req.GetTenantId(), n.NodeID, actorIDs)
+            if ok { kept = append(kept, n) }
+        }
+        rows = kept
+    }
+
+    // 6. Convert to proto.
+    out := make([]*entdbv1.Node, 0, len(rows))
+    for _, n := range rows { out = append(out, n.ToProto()) }
+    return &entdbv1.SearchNodesResponse{Nodes: out}, nil
+}
+```
+
+Notes on parity:
+- Order of operations matches Python exactly: tenant -> validate query -> searchable lookup -> SQL -> ACL trim -> proto convert. Swapping any two breaks at least one contract test.
+- Convert payload via field-id-keyed Struct; do NOT translate to field names server-side.
+- Default `limit = 50` only when caller passes 0; negative limits flow into SQLite (which errors), then the swallow path returns empty.
+
+## Open questions / risks (Go FTS5 driver choice, parity with Python)
+
+- **SQLite driver / FTS5 build**: `mattn/go-sqlite3` requires the `sqlite_fts5` build tag; pure-Go `modernc.org/sqlite` ships FTS5 in default builds and avoids cgo (preferred for cross-compile + supply-chain). Decision needed before `internal/fts` lands; document in a follow-up `docs/decisions/go-sqlite-driver.md`. Whichever driver is picked MUST also be used by `GetNode`/`QueryNodes`/`Applier` — one driver across the canonical store.
+- **Tokenizer parity**: Python uses `tokenize='porter unicode61'`. Both candidate Go drivers expose the same FTS5 tokenizers, but verify behavior on accented input + Porter stemming with a tokenizer-level test (compare Go output against `pytest tests/python/unit/test_fts_search.py` corpus).
+- **Lazy DDL race**: two concurrent first-time searches on the same `(tenant, type)` could both run `CREATE VIRTUAL TABLE IF NOT EXISTS` — idempotent in SQLite but the cache update needs `sync.Map.LoadOrStore`. Python is single-process per tenant SQLite + GIL-serialized; Go can have true concurrency.
+- **Error swallow semantics**: returning `OK` with `nodes: []` for malformed FTS syntax is a misleading metric — operators can't distinguish "no matches" from "user typo". Log volume is the only signal today. Flip to `INVALID_ARGUMENT` (with detail "fts5: syntax error") only in a follow-up that updates the contract test in the same PR.
+- **ACL trim cost**: cross-tenant searches do an N-row N+1 query loop. Acceptable for parity; revisit with a JOIN-based ACL filter once `QueryNodes` does the same (keep both RPCs in lockstep).
+- **`limit`/`offset` validation**: Python lets negative values reach SQLite. Go drivers may differ in error shape; `internal/fts` should normalize to "swallow-and-empty" so the contract is preserved.
+- **bm25 stability**: `ORDER BY fts.rank` is `bm25(fts_t{type_id})` ascending. SQLite's bm25 weights default to 1.0 per column; if a follow-up tunes per-column weights, both Python and Go must change together (contract: "best match first" only — no exact-rank assertions exist today).
+- **Concurrency with writers**: FTS index is updated inside the applier's per-event SQLite transaction. Search reads see consistent snapshots only if WAL-mode SQLite is used (it is, in Python). Confirm Go canonical_store opens with `_journal_mode=WAL`.
+- **Empty-but-whitespace query**: Python `query.strip()` rejects `"   "` as empty. Go must call `strings.TrimSpace` before the empty-check, not just compare to `""`.
+- **Wire-actor exposure**: `SearchNodesRequest` carries `actor` at the top level (not inside `RequestContext`). The trusted-actor rebind is identical, but logging must avoid leaking `request.actor` as identity (use the rebound `actor` only).

--- a/docs/go-port/rpcs/SetLegalHold.md
+++ b/docs/go-port/rpcs/SetLegalHold.md
@@ -1,0 +1,248 @@
+# RPC Port Spec — `entdb.v1.EntDBService/SetLegalHold`
+
+EPIC #407 — Python → Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2808-2862`.
+
+## Wire contract (set vs clear; scope)
+
+Proto: `proto/entdb/v1/entdb.proto:132` (rpc), `:982-992` (messages).
+
+`LegalHoldRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | Caller actor string. **Untrusted** — overwritten by `AuthInterceptor` trusted identity (see Auth). |
+| `tenant_id` | 2 | `string` | Required. Empty → `INVALID_ARGUMENT` (`grpc_server.py:2821-2822`). |
+| `enabled` | 3 | `bool` | `true` = set hold, `false` = clear hold. There is no separate "Clear" RPC — the same RPC toggles. |
+
+`LegalHoldResponse`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `success` | 1 | `bool` | True iff the tenant row was updated. False if tenant not found. |
+| `status` | 2 | `string` | New `tenant_registry.status` literal: `"legal_hold"` or `"active"` (`grpc_server.py:2834`, pinned by `tests/python/unit/test_admin_operations.py:607,624`). |
+| `error` | 3 | `string` | Human-readable error on `success=false` (e.g. `"Tenant not found"`). |
+
+**Scope.** The RPC mutates exactly one column: `tenant_registry.status` for one
+`tenant_id`. Toggling between `"active"` ⇄ `"legal_hold"` only. It does NOT
+touch the parallel `legal_holds` table (that table — `global_store.py:247-253`
+with `(tenant_id, held_by, reason, created_at)` — is currently a separate
+ledger consumed by `audit/compliance.py` and is **not** populated by this
+handler today). The Go port MUST preserve this minimal scope (issue #408
+tracks merging the two).
+
+## Auth (compliance officer; trusted-actor)
+
+Method **is not** in `AuthInterceptor.UNAUTHENTICATED_METHODS`. The interceptor
+populates the trusted identity ContextVar before the handler runs.
+
+Authorization is delegated to `_require_admin_or_owner(tenant_id, actor, ctx,
+"SetLegalHold")` (`grpc_server.py:2823-2825`, helper at `:2656-2690`). It:
+
+1. Calls `get_authoritative_actor(actor)` — payload `actor` is *replaced* by
+   the interceptor's trusted identity. A client claiming
+   `actor: "system:admin"` while authenticated as `user:eve` is downgraded to
+   `user:eve` (`grpc_server.py:2671-2673`). Pinned by
+   `tests/python/integration/test_privilege_escalation.py` (whole file pattern).
+2. Empty trusted actor → `INVALID_ARGUMENT "actor is required"` (`:2674-2675`).
+3. `_is_admin_or_system(trusted_actor)` (system:* / __system__ / admin:*) → ok.
+4. Otherwise looks up `tenant_members.role`; only `owner` or `admin` may
+   proceed. Anything else (member / viewer / guest / non-member) →
+   `PERMISSION_DENIED "SetLegalHold requires admin or owner role"`.
+   Pinned by `test_admin_operations.py:626-638` (member rejected with
+   `PERMISSION_DENIED`).
+
+There is no dedicated "compliance officer" role today. If/when one lands
+(EPIC #407 punt-list), it must be allowed alongside `admin`/`owner` here.
+`global_store == None` short-circuits to `UNIMPLEMENTED "Tenant registry not
+configured"` (`grpc_server.py:2816-2820`) **before** the auth check — Go port
+should preserve that ordering.
+
+## Side effects (WAL; flag in canonical_store/global_store; downstream RPCs check hold)
+
+Sequence (`grpc_server.py:2815-2856`):
+
+1. `global_store.set_legal_hold(tenant_id, enabled, trusted_actor)` →
+   `_sync_set_tenant_status` UPDATEs `tenant_registry.status` to
+   `"legal_hold"` or `"active"` (`global_store.py:528-554`). Returns False if
+   tenant row missing — handler returns `success=false, error="Tenant not
+   found"` (`:2830-2832`). Note: no separate `legal_holds`-table insert here.
+2. `canonical_store.append_audit(...)` (`:2839-2851`) writes one tenant-scoped
+   audit row with `action="set_legal_hold"`, `target_type="tenant"`,
+   `target_id=tenant_id`, `metadata={"enabled": bool, "status": new_status}`.
+   **Best effort** — failure is logged at WARN and *does not* roll back the
+   status flip (`:2852-2853`). The `tenant_registry` row is the authoritative
+   record. Pinned by `test_admin_operations.py:640-656`.
+
+**WAL invariant deviation (must address in Go port).** CLAUDE.md §1 says
+"every mutation MUST be appended to the WAL". The Python handler does NOT
+call `wal.append()` — the status mutation lives only in the global-store
+SQLite. This means a global-store rebuild from WAL replay would lose the
+hold. Tracked as a known gap; the Go port SHOULD add a
+`TransactionEvent.ops` entry (e.g. `admin_set_legal_hold`) and apply via
+`Applier.apply_event()`. See Open questions.
+
+**Tamper-evidence.** The CLAUDE.md §2 audit trail belongs to the WAL +
+S3 Object Lock (COMPLIANCE), not a separate hash-chained table. Once the
+WAL gap above is closed, S3 Object Lock provides the immutable record of
+the hold being set/cleared — do NOT add a parallel hash-chain audit table.
+
+**Downstream enforcement.** The flag is consulted by
+`_check_tenant_access(..., op_kind="delete")` at `grpc_server.py:524-528`,
+which aborts with `FAILED_PRECONDITION "Tenant '<id>' is on legal hold;
+deletes are not allowed"`. `ExecuteAtomic` calls this with op-kind derived
+per-operation (`grpc_server.py:755-758`); a `delete_node` / `delete_edge`
+under hold raises FAILED_PRECONDITION while `create_node` / read RPCs
+succeed. Pinned by `test_admin_operations.py:664-703` and
+`test_tenant_roles.py:380-432, 610-635`.
+
+## Error contract
+
+| Condition | Code | Body |
+|---|---|---|
+| `global_store` not configured | `UNIMPLEMENTED` | `"Tenant registry not configured"` |
+| `tenant_id == ""` | `INVALID_ARGUMENT` | `"tenant_id is required"` (pinned `test_admin_operations.py:860-868`, `test_grpc_contract.py:579-583`) |
+| Trusted actor empty | `INVALID_ARGUMENT` | `"actor is required"` |
+| Caller is non-owner / non-admin tenant member | `PERMISSION_DENIED` | `"SetLegalHold requires admin or owner role"` |
+| Tenant row missing | **OK** | `LegalHoldResponse{success=false, error="Tenant not found"}` (NOT a gRPC error — pinned by `_check_tenant_access` not being called here) |
+| Unexpected exception | **OK** | `LegalHoldResponse{success=false, error=str(e)}` (`:2862`); existing `RpcError` is re-raised (`:2859`) |
+
+`record_grpc_request("SetLegalHold", "ok"/"error", elapsed)` is called on
+every exit (`:2831, 2855, 2858`). Go port must wire equivalent metric.
+
+## Shared Go package deps
+
+| Python | Go package (port) | Used by |
+|---|---|---|
+| `global_store.set_legal_hold`, `get_tenant`, `get_member_role` | `internal/store/global` | handler core |
+| `canonical_store.append_audit` | `internal/store/canonical` | best-effort audit row |
+| `auth.auth_interceptor.get_authoritative_actor`, `get_current_identity` | `internal/auth` | trusted-actor binding |
+| `record_grpc_request` | `internal/metrics` | latency/status histogram |
+| (future) `wal.Append` for `admin_set_legal_hold` op | `internal/wal` | close CLAUDE.md §1 gap |
+| (future) `audit/compliance.export_audit_trail` | `internal/audit/compliance` | only on export, not in-handler |
+
+`legal_holds` table (`global_store.py:247-253`) and the
+`set_legal_hold_record` / `is_under_legal_hold` / `get_legal_holds` /
+`remove_legal_hold` family (`global_store.py:967-1050`,
+`tests/python/unit/test_admin_ops.py:152-218`) are NOT touched by this
+handler today. They live in the same package but the Go port should keep
+them as a separate concern (court-order ledger) until #408 unifies them.
+
+## Other-RPC deps (DeleteUser, ArchiveTenant must check)
+
+Status is checked **only** inside `_check_tenant_access`. RPCs that route
+through it pick up legal-hold semantics for free:
+
+- `ExecuteAtomic` — per-op `op_kind` is "delete" for `delete_node`/`delete_edge`
+  (`grpc_server.py:755-758`). Hold blocks. Pinned by
+  `test_admin_operations.py:664-703`.
+- `DeleteNode` / `DeleteEdge` standalone RPCs — same path.
+- `ArchiveTenant` (`grpc_server.py:2397-2440`) — does NOT call
+  `_check_tenant_access`; it calls `set_tenant_status("archived")` directly.
+  **Gap:** archiving over a legal_hold silently overwrites the status to
+  `"archived"` and removes hold protection. Go port MUST add an explicit
+  `if status == "legal_hold": FAILED_PRECONDITION` guard in `ArchiveTenant`
+  before the status flip. (Issue: open.)
+- `DeleteUser` (`grpc_server.py:2925-2981`) — does NOT call
+  `_check_tenant_access` (no tenant_id on the request — it's user-global,
+  GDPR scope). The user can be queued for erasure even if every tenant
+  they belong to is on legal_hold. **Gap.** Go port should iterate
+  `global_store.get_user_tenants(user_id)` and refuse the queue if any
+  tenant is `legal_hold` (or any has a row in `legal_holds` once #408 is
+  done). See Open questions.
+- `CancelUserDeletion`, `ProcessDeletions` — read-only / cleanup; no hold
+  check today.
+
+## Contract tests pinning behavior
+
+| Test | File:line | Pins |
+|---|---|---|
+| owner enables hold, status=`legal_hold` | `tests/python/unit/test_admin_operations.py:594-609` | happy-path response shape and side effect |
+| disable returns to `active` | `:611-624` | toggle semantics |
+| member → `PERMISSION_DENIED` | `:626-638` | auth |
+| audit row written with `action="set_legal_hold"` | `:640-656` | side-effect (audit) |
+| empty `tenant_id` → `INVALID_ARGUMENT` | `:860-868` | validation |
+| `legal_hold` blocks `delete_node` via `ExecuteAtomic` | `:664-684` | downstream enforcement |
+| `legal_hold` allows `create_node` | `:686-703` | downstream non-blocking |
+| reads + creates allowed, deletes rejected | `tests/python/unit/test_tenant_roles.py:380-432, 610-635` | role-matrix interaction |
+| GlobalStore.set_legal_hold idempotency, status flip | `tests/python/unit/test_admin_operations.py:322-340` | store-level |
+| gRPC contract sweep happy + invalid_argument | `tests/python/integration/test_grpc_contract.py:573-583` | wire-level |
+| `legal_holds` ledger family (separate from this RPC) | `tests/python/unit/test_admin_ops.py:152-218` | NOT this RPC, but proves the ledger exists |
+
+## Implementation outline
+
+```go
+func (s *Server) SetLegalHold(ctx context.Context, req *pb.LegalHoldRequest) (*pb.LegalHoldResponse, error) {
+    start := time.Now()
+    defer func() { metrics.RecordGRPC("SetLegalHold", status, time.Since(start)) }()
+
+    if s.globalStore == nil {
+        return nil, status.Error(codes.Unimplemented, "Tenant registry not configured")
+    }
+    if req.TenantId == "" {
+        return nil, status.Error(codes.InvalidArgument, "tenant_id is required")
+    }
+    trusted, err := s.requireAdminOrOwner(ctx, req.TenantId, req.Actor, "SetLegalHold")
+    if err != nil { return nil, err }
+
+    newStatus := "active"
+    if req.Enabled { newStatus = "legal_hold" }
+
+    updated, err := s.globalStore.SetTenantStatus(ctx, req.TenantId, newStatus)
+    if err != nil { return nil, status.Errorf(codes.Internal, "%v", err) }
+    if !updated {
+        return &pb.LegalHoldResponse{Success: false, Error: "Tenant not found"}, nil
+    }
+
+    // TODO(#407): WAL-first — append admin_set_legal_hold op so a global-store
+    // rebuild reproduces the flag. Until then, parity with Python.
+    meta, _ := json.Marshal(map[string]any{"enabled": req.Enabled, "status": newStatus})
+    if err := s.canonicalStore.AppendAudit(ctx, audit.Entry{
+        TenantID: req.TenantId, ActorID: trusted, Action: "set_legal_hold",
+        TargetType: "tenant", TargetID: req.TenantId, Metadata: string(meta),
+    }); err != nil {
+        log.Warn().Err(err).Msg("audit append failed on SetLegalHold")
+    }
+    return &pb.LegalHoldResponse{Success: true, Status: newStatus}, nil
+}
+```
+
+Match Python's exact error strings — they are observed by SDK callers and
+by `test_grpc_contract.py`. Keep the audit-failure-is-warning semantics
+identical.
+
+## Open questions / risks
+
+1. **WAL gap (CLAUDE.md §1).** Python writes the status flip directly to
+   global-store SQLite. A WAL rebuild loses the hold. The Go port should
+   close this with a new `TransactionEvent.ops` op
+   (`admin_set_legal_hold`). Behavioral test: stop server, drop global
+   SQLite, replay WAL, assert tenant is still on hold. Coordinate with #408.
+2. **Two ledgers, one concept.** `tenant_registry.status="legal_hold"`
+   (toggle, no reason) vs `legal_holds` table (multi-row, `held_by`,
+   `reason`, used by `audit/compliance.export_audit_trail`). The RPC
+   only touches the first. Decision needed: extend `LegalHoldRequest`
+   with `held_by`/`reason` (proto change, breaking) or keep the ledger
+   write in a follow-up RPC (`AddLegalHoldRecord`). Recommend: punt to
+   a new RPC; keep this one wire-stable.
+3. **GDPR DeleteUser interaction (HIGH).** `DeleteUser`
+   (`grpc_server.py:2925-2981`) queues an erasure with no tenant-status
+   check. If `user:alice` belongs to a tenant on legal_hold and Alice
+   invokes `DeleteUser`, the grace timer starts and (after grace)
+   `ProcessDeletions` will run — destroying data the hold is supposed
+   to preserve. **Resolution required before Go port ships:** in
+   `DeleteUser`, look up the user's tenants and abort
+   `FAILED_PRECONDITION "user belongs to tenant <id> on legal hold"`
+   if any are held. Belt-and-suspenders: `ProcessDeletions` should
+   re-check at execute time. No Python test pins this today — add one
+   in the Go port (`tests/contract/`). This is the GDPR-vs-legal-hold
+   precedence question; legal hold wins per
+   `audit/compliance.py` semantics.
+4. **ArchiveTenant over a hold (MEDIUM).** Same gap as above for
+   `ArchiveTenant` — currently silently overrides the status. Add
+   explicit `legal_hold` guard.
+5. **Compliance-officer role.** Today only owner/admin/system can set
+   the hold. If a `compliance` role is added to `tenant_members.role`,
+   include it in `_require_admin_or_owner` allowlist.
+6. **Idempotency.** Setting hold twice is a no-op at the SQL layer
+   (`UPDATE ... SET status = 'legal_hold'` rowcount > 0 either way).
+   The audit log will record both. Go port should preserve this — do
+   not dedupe — auditors want to see repeated set actions.

--- a/docs/go-port/rpcs/ShareNode.md
+++ b/docs/go-port/rpcs/ShareNode.md
@@ -1,0 +1,235 @@
+# RPC Port Spec — `entdb.v1.EntDBService/ShareNode`
+
+EPIC #407 — Python -> Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:1746-1826`. Storage method:
+`server/python/entdb_server/apply/canonical_store.py:2962-3051` (sync +
+async wrappers). Cross-tenant index: `apply/applier.py:1689-1726`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:94` (rpc), `:720-744` (messages).
+
+`ShareNodeRequest`:
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `context` | 1 | `RequestContext` | `tenant_id` + `actor`. Server overrides `actor` with the trusted identity (`grpc_server.py:1763`). |
+| `node_id` | 2 | `string` | Target node. Treated as opaque; existence is **not** pre-validated, the auth check carries the existence signal (`PERMISSION_DENIED` if missing-or-no-grant). |
+| `actor_id` | 3 | `string` | Recipient principal. Format `user:<id>` / `group:<id>` / `service:<id>` / `tenant:<id>`. Bare `<id>` MUST be normalised to `user:<id>` server-side (`entdb.proto:723-725`). |
+| `permission` | 4 | `string` | DEPRECATED string ("read"/"write"/"admin"/"deny"). Persisted verbatim for legacy readers. Default `"read"` when empty (`grpc_server.py:1772`). |
+| `actor_type` | 5 | `string` | "user" / "group" / "service". Defaults to `"user"` (`grpc_server.py:1800`). |
+| `expires_at` | 6 | `int64` | Epoch-ms. `0` means "never" (treated as `nil`/`NULL`). Past values are persisted but filtered at read time (pinned by `tests/python/unit/test_acl_capabilities.py:151-162`). |
+| `type_id` | 7 | `int32` | Node-type-id of target; `0` means "any". Pinned by `test_acl_capabilities.py:60-82`. |
+| `core_caps` | 8 | `repeated CoreCapability` | Typed grant — authoritative when set. **This is the `Permission` enum referenced by CLAUDE.md invariant #5.** Use `pb.CoreCapability` enum values, not raw ints. |
+| `ext_cap_ids` | 9 | `repeated int32` | Extension capability IDs (per-schema). |
+
+`ShareNodeResponse`: `{ bool success = 1; string error = 2; }` — deliberately
+**not** `google.rpc.Status`; the handler returns `success=false, error=<msg>`
+on `PermissionError` instead of aborting (`grpc_server.py:1791-1793`). Go
+port MUST preserve this — flipping to `status.Errorf` is a contract break.
+
+Back-fill rule (in `canonical_store._sync_share_node` at `:2978-2985`): when
+`core_caps` is empty, derive via `CapabilityRegistry.legacy_permission_to_core_caps(permission)`.
+Pinned by `test_acl_capabilities.py:101-117` (`"write"` -> READ+COMMENT+EDIT).
+
+## Auth
+
+1. `_check_tenant(tenant_id)` (`grpc_server.py:362-410`) — sharding ownership +
+   region pinning. On wrong owner: `UNAVAILABLE` + `entdb-redirect-node`
+   trailer. On region mismatch: `FAILED_PRECONDITION`.
+2. `_trusted_actor(request.context.actor)` (`grpc_server.py:418-437`) — replaces
+   the wire actor with `AuthInterceptor`'s authoritative identity. **The
+   request-supplied actor is UNTRUSTED** (CLAUDE.md invariant). Privilege
+   escalation regression pinned by commit `fece3fb`.
+3. `_check_tenant_access(..., require_write=True)` — must be tenant
+   owner/admin/member; viewer/guest -> `PERMISSION_DENIED`; archived tenant
+   -> `FAILED_PRECONDITION`; deleted -> `NOT_FOUND`.
+4. `_check_capability(tenant, actor, node_id, type_id, "ShareNode")`
+   (`grpc_server.py:299-360`) — sharing requires `CoreCapability.ADMIN` on
+   the target node. System actors (`system:*`, `__system__`) and tenant
+   owners short-circuit. Mapping pinned by
+   `tests/python/unit/test_capability_registry.py:66`.
+
+A grant whose `permission == "deny"` with empty caps blocks the grantor too
+(`grpc_server.py:341-347`); preserve this.
+
+## Side effects
+
+**CLAUDE.md invariant #1 violation in Python — FIX in Go port.** The current
+handler writes directly to SQLite via `canonical_store.share_node()`
+(`grpc_server.py:1794-1805`) with **no `wal.append()` call**. This means a
+materialized-view rebuild from the WAL silently loses every share grant.
+
+Go port MUST:
+
+1. Build a `TransactionEvent` with a single op `{op: "share_node", node_id,
+   actor_id, actor_type, permission, expires_at, type_id, core_caps,
+   ext_cap_ids, granted_by: trusted_actor}`. Use the same envelope as
+   `ExecuteAtomic` (`grpc_server.py:790`).
+2. `wal.Append(ctx, event)` — get back `stream_pos`.
+3. Wait for the applier (or apply inline in tests) to materialise into
+   `node_access`. Add a new `op_type == "share_node"` branch in
+   `apply/applier.go` mirroring `_sync_share_node` (`canonical_store.py:2962`).
+4. After commit, the applier calls `_update_shared_index_on_share`
+   (`applier.py:1689-1726`): writes `GlobalStore.shared_index` so the
+   recipient's `ListSharedWithMe` returns the share. Group `actor_id`s are
+   expanded to per-member rows. Cross-tenant: when `actor_id == "tenant:<X>"`
+   or recipient lives in another tenant, the row goes into the **global**
+   shared_index DB (one DB per cluster, not per tenant).
+5. Mailbox fanout: ShareNode does NOT currently fan a notification into the
+   recipient's mailbox SQLite. The `MailboxFanoutConfig` path
+   (`applier.py:295-1367`) only triggers on `create_node`. **Open question
+   below** — confirm whether the Go port should add a mailbox row on share.
+
+There is no idempotency-key dedupe today (the handler doesn't even read
+`request.idempotency_key` — none on the proto). Re-issuing the same
+ShareNode produces an `INSERT OR REPLACE` that updates `granted_at`
+(`canonical_store.py:2989`). Preserve this.
+
+## Error contract
+
+| gRPC code | Trigger |
+|-----------|---------|
+| `OK` + `success=true` | Grant persisted. |
+| `OK` + `success=false, error=...` | `PermissionError` from `_check_capability` (`grpc_server.py:1791-1793`) **or** any unexpected exception (`:1823-1826`). Go port: same — wrap the catch-all and return `success=false`. |
+| `UNAVAILABLE` (abort) | Tenant not served by this node. Trailer `entdb-redirect-node` carries owner. |
+| `FAILED_PRECONDITION` (abort) | Tenant region pinning mismatch, or tenant `archived`. |
+| `PERMISSION_DENIED` (abort) | Caller is not a tenant member, or is a viewer/guest (write op). |
+| `NOT_FOUND` (abort) | Tenant marked `deleted`. |
+| `INVALID_ARGUMENT` | Reserved. Python doesn't validate `node_id`/`actor_id` shape today; Go port SHOULD reject empty strings and malformed actor prefixes here, but file as a behaviour-tightening ticket — current contract tests don't pin this. |
+| `UNAUTHENTICATED` | Auth interceptor; never raised by the handler. |
+
+`INTERNAL` is intentionally avoided; failures route through `success=false`.
+
+## Shared Go package deps
+
+Each lives under `server/go/internal/...` unless noted.
+
+- `pb` (`server/go/internal/pb/entdbv1`) — generated `ShareNodeRequest`,
+  `ShareNodeResponse`, `CoreCapability`, `RequestContext`. Required.
+- `auth` — `AuthInterceptor` + `GetAuthoritativeActor(ctx, fallback string) string`
+  (mirrors `auth/auth_interceptor.py`). Required.
+- `acl` — typed-capability registry (`CapabilityRegistry`,
+  `LegacyPermissionToCoreCaps`, `RequiredForOp`, `CheckGrant`). Mirrors
+  `auth/capability_registry.py`. Required — this is the home of the
+  `Permission`/`CoreCapability` typed enum that CLAUDE.md invariant #5
+  mandates over raw strings.
+- `wal` — `Append(ctx, *TransactionEvent) (StreamPos, error)`. Required to
+  fix the invariant violation.
+- `apply` — applier with new `share_node` op handler. Required.
+- `store` (canonical) — `ShareNode(...)` writing `node_access` row. Required.
+  The current Python signature is the target shape (`canonical_store.py:3008-3021`).
+- `globalstore` — `AddShared(userID, srcTenant, nodeID, permission)` (mirrors
+  `applier.py:1709-1721`). Required for `ListSharedWithMe` to see the share.
+- `groups` (or part of `store`) — `GetGroupMembers(tenantID, groupID)` for
+  group-actor expansion.
+- `metrics` — `RecordGRPCRequest("ShareNode", "ok"|"denied"|"error", dur)`.
+- `sharding` — for `_check_tenant`.
+- `errs` — typed `PermissionError` so the catch returns `success=false` cleanly.
+
+NOT used and MUST NOT be imported: `crypto`, `audit`, `quota`, `mailbox`
+(unless we adopt the open-question fanout below).
+
+## Other-RPC deps
+
+- **`RevokeAccess`** (`grpc_server.py:1828-...`) — inverse op; shares the
+  `node_access` table and `_update_shared_index_on_revoke` helper. Port as a
+  pair to keep `acl` package internally consistent.
+- **`ListSharedWithMe`** — reader of `GlobalStore.shared_index`. Cannot
+  observe a share until ShareNode's applier-side index update runs. The
+  contract test at `tests/python/integration/test_grpc_contract.py:339-350`
+  is deliberately permissive (`check: lambda _r: True`) because of this
+  race — Go port should keep both behaviours consistent.
+- `AddGroupMember` / `RemoveGroupMember` — feed group expansion in `_update_shared_index_on_share`.
+- `ExecuteAtomic` — the WAL envelope shape this RPC must adopt comes from
+  here (`grpc_server.py:790`).
+- `GetReceiptStatus` — once ShareNode goes through the WAL it gets an
+  `idempotency_key`; receipt-status queries become meaningful. Add an
+  `idempotency_key` field to a v2 `ShareNodeRequest` (out of scope; track).
+
+## Contract tests pinning behavior
+
+- `tests/python/integration/test_grpc_contract.py:327-338` — happy path: admin
+  shares with `user:bob` using legacy `permission="read"`, expects
+  `success=true`. **Go port must pass this verbatim.**
+- `tests/python/unit/test_capability_registry.py:66` — `("ShareNode", CoreCapability.ADMIN)`.
+- `tests/python/unit/test_acl_capabilities.py:60-82` — typed `core_caps` persist verbatim.
+- `tests/python/unit/test_acl_capabilities.py:84-98` — typed `ext_cap_ids` persist verbatim.
+- `tests/python/unit/test_acl_capabilities.py:101-117` — legacy `"write"` derives `[READ, COMMENT, EDIT]`.
+- `tests/python/unit/test_acl_capabilities.py:120-148` — back-fill via `migrate_permissions_to_capabilities`.
+- `tests/python/unit/test_acl_capabilities.py:151-162` — past `expires_at` filtered at read.
+- `tests/python/unit/test_acl_capabilities.py:165-174` — round-trip with revoke.
+- `tests/python/unit/test_shared_index.py:193-208` — `share_node` writes one `shared_index` row per recipient (group expansion covered separately).
+- `tests/python/unit/test_acl_v2.py:116`, `:315` — sync-path coverage of typed grants.
+- `tests/python/unit/test_admin_operations.py:355-392`, `:718` — share + admin-op interaction.
+- `tests/python/unit/test_cross_tenant_read.py:75-105` — share with a `tenant:<X>` recipient lands in cross-tenant index.
+- `tests/python/unit/test_sdk_hierarchical.py:241-242` — SDK -> RPC kwargs shape.
+
+## Implementation outline
+
+```go
+// server/go/internal/api/share_node.go
+func (s *EntDBServer) ShareNode(ctx context.Context, req *pb.ShareNodeRequest) (*pb.ShareNodeResponse, error) {
+    start := time.Now()
+    if err := s.checkTenant(ctx, req.Context.TenantId); err != nil { return nil, err }
+    actor := auth.GetAuthoritativeActor(ctx, req.Context.Actor)
+    if err := s.checkTenantAccess(ctx, req.Context.TenantId, actor, true); err != nil { return nil, err }
+
+    if err := s.acl.CheckCapability(ctx, req.Context.TenantId, actor, req.NodeId, int(req.TypeId), "ShareNode"); err != nil {
+        metrics.RecordGRPCRequest("ShareNode", "denied", time.Since(start))
+        return &pb.ShareNodeResponse{Success: false, Error: err.Error()}, nil
+    }
+
+    ev := wal.NewEvent(req.Context.TenantId, []wal.Op{{
+        "op": "share_node", "node_id": req.NodeId,
+        "actor_id": normalizeActor(req.ActorId), "actor_type": defStr(req.ActorType, "user"),
+        "permission": defStr(req.Permission, "read"),
+        "expires_at": nilZero(req.ExpiresAt), "type_id": req.TypeId,
+        "core_caps": req.CoreCaps, "ext_cap_ids": req.ExtCapIds,
+        "granted_by": actor,
+    }})
+    if _, err := s.wal.Append(ctx, ev); err != nil {
+        metrics.RecordGRPCRequest("ShareNode", "error", time.Since(start))
+        return &pb.ShareNodeResponse{Success: false, Error: err.Error()}, nil
+    }
+    metrics.RecordGRPCRequest("ShareNode", "ok", time.Since(start))
+    return &pb.ShareNodeResponse{Success: true}, nil
+}
+```
+
+Applier branch (in `apply/applier.go`, alongside `create_node`):
+`case "share_node": store.SyncShareNode(...); applier.UpdateSharedIndexOnShare(...)`.
+
+`ShareNodeResponse` carries no receipt today. When the proto is bumped (#407
+follow-up), add `string idempotency_key` to the request and return the
+applier `stream_pos` so callers can `WaitForOffset`/`GetReceiptStatus`.
+
+## Open questions / risks
+
+- **WAL invariant fix is a behaviour change.** Today, ShareNode is synchronous-
+  to-SQLite; clients that read their own grant immediately get it. After the
+  WAL fix, there is an applier lag. Mitigation: inline-apply when
+  `wal.Backend == "memory"` (test config), or expose a `WaitForApply`
+  knob. Confirm with #407 owner.
+- **Mailbox fanout on share.** Prompt assumes a "mailbox-of-recipient side
+  effect". Code search shows no current fanout for ShareNode — only
+  `create_node` triggers `_fanout_node` (`applier.py:1361-1367`). Decide:
+  (a) port as-is (no mailbox row), or (b) add a `share_received` notification
+  op as part of the Go port. Recommended: file follow-up; do not silently
+  expand scope.
+- **Cross-tenant grants**: when `actor_id` is `tenant:<X>` or
+  `user:<id>@tenant:<Y>`, today the share lands in the source tenant's
+  `node_access` plus `GlobalStore.shared_index`. There is **no** write into
+  the recipient tenant's DB (CLAUDE.md invariant #4). Pinned by
+  `test_cross_tenant_read.py:75-105`. Preserve.
+- **Group expansion races**: a member added to the recipient group AFTER the
+  share will not have a `shared_index` row (no back-fill). Known limitation;
+  tracked in `test_shared_index.py`. Don't regress.
+- **`success=false` vs `status.Errorf`**: keep the soft-fail shape. Do not
+  "fix" by switching to gRPC status codes — SDK clients (Python + Go) parse
+  the response field.
+- **Untyped `permission` string**: the deprecated field is still authoritative
+  for storage when `core_caps` is empty. Removing it is a major-version
+  break; out of scope for the port.
+- **Idempotency**: until the proto carries `idempotency_key`, retries write
+  duplicate WAL records that collapse at the applier via `INSERT OR REPLACE`.
+  Acceptable but noisy; flag for the receipt-tracking follow-up.

--- a/docs/go-port/rpcs/TransferOwnership.md
+++ b/docs/go-port/rpcs/TransferOwnership.md
@@ -1,0 +1,248 @@
+# TransferOwnership — Go Port Spec
+
+EPIC #407. Reference Python handler:
+`server/python/entdb_server/api/grpc_server.py:2030-2049`. Proto:
+`proto/entdb/v1/entdb.proto:108-109, 780-789`. Capability declaration:
+`server/python/entdb_server/auth/capability_registry.py:75`.
+
+> NOTE: the Python handler is thin and intentionally under-enforced.
+> Go port MUST close the gaps in "Open questions / risks" before
+> ship. Behaviour pinned by contract tests is preserved verbatim;
+> the rest is hardened.
+
+## Wire contract
+
+Request `entdb.v1.TransferOwnershipRequest` (proto:780):
+- `RequestContext context` — tenant_id, actor (UNTRUSTED, see Auth),
+  trace_id.
+- `string node_id` — node whose `owner_actor` is being reassigned.
+- `string new_owner` — fully-qualified principal string
+  (`"user:alice"`, `"group:admins"`, or `"system"`). The Python store
+  writes whatever string it receives; there is no validation today
+  (canonical_store.py:3631-3650). Go port MUST validate the prefix
+  matches `Actor.user(...)` / `Actor.group(...)` (CLAUDE.md §"Actors")
+  and reject empty strings with `INVALID_ARGUMENT`.
+
+Response `TransferOwnershipResponse` (proto:786):
+- `bool found` — `true` iff the row existed and was updated
+  (`cursor.rowcount > 0`, canonical_store.py:3650). For a missing
+  node, returns `found=false` (no error string). Pinned by
+  `test_acl_v2.py:534-536`.
+- `string error` — set ONLY on exception path
+  (grpc_server.py:2049). Successful "node not found" returns
+  `(found=false, error="")`.
+
+## Auth (current owner only; trusted-actor)
+
+Today the handler ONLY calls `_check_tenant` (grpc_server.py:2038)
+and trusts whatever caller asks. This is a known gap.
+
+Go port MUST enforce, before any mutation:
+1. `_check_tenant(tenant_id)` — tenant exists and is not archived
+   (grpc_server.py:362).
+2. `trustedActor := AuthInterceptor.GetAuthoritativeActor(ctx)` —
+   IGNORE `request.context.actor`. Same fix as commit fece3fb
+   ("ignore client-claimed actor in gRPC handlers"). Pinned by
+   `tests/python/integration/test_privilege_escalation.py`.
+3. `_check_tenant_access(tenant_id, trustedActor, require_write=true)`
+   — caller must be a writing tenant member.
+4. Capability check: `TransferOwnership` requires `CORE_CAP_ADMIN`
+   on the node (capability_registry.py:75). Use
+   `_check_capability(tenant_id, trustedActor, node_id, type_id,
+   "TransferOwnership")`, mirroring `ShareNode`
+   (grpc_server.py:1782-1793). On `PermissionError` return
+   `(found=false, error="permission denied: …")` — no gRPC abort,
+   string-error in the response is the existing convention for ACL
+   ops (`ShareNode`/`RevokeAccess`).
+5. Effective rule: ADMIN includes the current owner (owner is
+   implicitly ADMIN per `_sync_can_access`). Non-owner admins (system
+   actor, ACL-granted ADMIN) can also transfer; this matches existing
+   `ShareNode` semantics and is intentional.
+
+`new_owner` does NOT need to be an existing tenant member today —
+the field is a free-form principal string. Go port should warn-log
+when `new_owner` resolves to a user that is not a member of the
+tenant; do not reject (would break test_grpc_contract.py:387-393
+which uses `BOB` without membership setup).
+
+## Side effects
+
+### WAL append (REQUIRED — gap vs CLAUDE.md §1)
+
+Python today writes SQLite directly (canonical_store.py:3637-3650),
+violating the invariant "every mutation goes through the WAL". Go
+port MUST:
+- Append a new `OwnershipTransferOp` (or reuse a generic
+  `AdminOp.transfer_ownership`) inside a `TransactionEvent` to the
+  WAL via the shared `wal.Append` package.
+- Have the `Applier` apply it: `UPDATE nodes SET owner_actor=?` and
+  refresh `node_visibility` (mirrors `_update_visibility` call at
+  canonical_store.py:3643-3649).
+- Block the handler on `WaitForOffset` if `wait_applied=true` is
+  signalled via context — TransferOwnership has no such field today,
+  but the Go port should default to **synchronous-apply** (the
+  current Python store call is synchronous-equivalent because it
+  bypasses the WAL).
+
+Add a new op variant under `TransactionEvent.ops` in the proto and a
+matching handler in `Applier.apply_event()`. Do NOT shoehorn this
+into `UpdateNodeOp` — `owner_actor` is not a payload field and is
+not in `field_mask`.
+
+### ACL changes
+
+On apply:
+- `nodes.owner_actor` row mutated (canonical_store.py:3639-3641).
+- `node_visibility` rebuilt for that node with the NEW owner as a
+  principal (canonical_store.py:3643-3649). The OLD owner is dropped
+  unless they retain access via an ACL grant — verified by
+  `test_acl_v2.py:528-532` (ALICE can access pre-transfer; BOB can
+  access post-transfer; no assertion that ALICE loses access — but
+  the visibility rebuild makes that the de-facto outcome).
+- The node's existing `acl_blob` is NOT modified. Explicit grants
+  to the previous owner survive (this is by design — if an admin
+  shared the node back to the old owner, they keep that grant).
+
+### Mailbox
+
+No mailbox effects. TransferOwnership touches `nodes` only.
+`MailboxItem`s keyed by `user_id` are untouched. New owner does NOT
+receive a notification (out of scope).
+
+### Cross-tenant `global_store.shared_index`
+
+Python TransferOwnership does NOT touch `shared_index`. Pre-existing
+share rows pointing at this node remain valid (the new owner having
+a redundant share row is harmless; old owner's inbox-of-shares is
+independent of ownership). Go port: no `global_store` writes.
+
+Cross-tenant transfer is NOT supported — `new_owner` is resolved in
+the requesting tenant's namespace. Use `TransferUserContent` for
+bulk reassignment. Reject `new_owner` strings with tenant qualifiers.
+
+## Error contract
+
+| Condition                                  | Response                                                                  |
+|--------------------------------------------|---------------------------------------------------------------------------|
+| Tenant unknown / archived                  | gRPC `NOT_FOUND` from `_check_tenant` (matches existing pattern)          |
+| Empty `node_id` or empty `new_owner`       | `INVALID_ARGUMENT` (Go port hardens; Python passes through)               |
+| Caller lacks ADMIN on node                 | `(found=false, error="permission denied: …")` (mirrors ShareNode)         |
+| Node does not exist                        | `(found=false, error="")` — pinned by `test_acl_v2.py:534-536`            |
+| Internal failure (SQLite, WAL append)      | `(found=false, error=str(exc))` — matches Python catch-all (line 2049)    |
+
+The handler MUST NOT raise gRPC status codes for the "not found"
+case — the contract test asserts `r.found is True` for the happy
+path (`test_grpc_contract.py:392`) and `False` for missing rows;
+both via the message body, not status.
+
+## Shared Go package deps
+
+- `internal/auth` — `AuthInterceptor.GetAuthoritativeActor`,
+  `_trusted_actor` equivalent.
+- `internal/auth/capability` — `CapabilityRegistry`, op→cap map
+  (mirrors `capability_registry.py`).
+- `internal/store/canonical` — per-tenant SQLite handle pool, the
+  `transfer_ownership` sync impl, `update_visibility` helper.
+- `internal/wal` — `Append(event)`. Backend-agnostic
+  (Kafka/Kinesis/SQS/memory).
+- `internal/apply` — `Applier.Apply(event)`. New case for the
+  ownership-transfer op.
+- `internal/observability/metrics` — `record_grpc_request` →
+  `metrics.RecordGRPC("TransferOwnership", outcome, dur)`.
+- `internal/actor` — `Actor.User(...)` / `Actor.Group(...)` parser
+  for `new_owner` validation.
+
+## Other-RPC deps
+
+- `ExecuteAtomic` — shares the WAL append + apply path; the Go port
+  should reuse the same `wal.Append` and `Applier` machinery.
+- `WaitForOffset` — if a future revision adds `wait_applied`, this
+  is the synchronisation primitive.
+- `ShareNode` / `RevokeAccess` — share the capability-check pattern
+  (`grpc_server.py:1782-1793`). Copy the same scaffolding.
+- `TransferUserContent` (proto:`TransferUserContentRequest`) — the
+  bulk, cross-user variant. Distinct semantics: bulk reassign by
+  old-owner identity, not per-node.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_acl_v2.py:525-536` — happy path returns
+  `True`, ALICE→BOB owner change makes the node visible to BOB; a
+  missing `node_id` returns `False`.
+- `tests/python/integration/test_grpc_contract.py:385-393` — gRPC
+  wire happy path: `TransferOwnershipRequest(context, SEED_NODE_ID,
+  BOB)` ⇒ `r.found is True`.
+- `tests/python/unit/test_admin_ops.py:127-144` — adjacent
+  `transfer_user_content` tests; useful as a sanity reference for
+  what BULK ownership transfer looks like (do NOT confuse with this
+  RPC).
+- `server/python/entdb_server/auth/capability_registry.py:75` —
+  fixes `TransferOwnership: CoreCapability.ADMIN` for the
+  capability table.
+
+No existing test asserts: WAL append occurred, old owner loses
+visibility, or non-admin caller is rejected. The Go port adds those
+tests under `tests/contract/` as part of EPIC #407.
+
+## Implementation outline
+
+```go
+func (s *Server) TransferOwnership(
+    ctx context.Context, req *pb.TransferOwnershipRequest,
+) (*pb.TransferOwnershipResponse, error) {
+    start := time.Now()
+    defer metrics.RecordGRPC("TransferOwnership", &outcome, start)
+
+    // 1. Validate.
+    if req.NodeId == "" || req.NewOwner == "" {
+        return nil, status.Error(codes.InvalidArgument, "node_id/new_owner required")
+    }
+    if _, err := actor.Parse(req.NewOwner); err != nil {
+        return nil, status.Error(codes.InvalidArgument, err.Error())
+    }
+    // 2. Auth.
+    if err := s.checkTenant(ctx, req.Context.TenantId); err != nil { return nil, err }
+    trusted := auth.TrustedActor(ctx)
+    if err := s.checkTenantAccess(ctx, req.Context.TenantId, trusted, true); err != nil {
+        return nil, err
+    }
+    if err := s.checkCapability(ctx, req.Context.TenantId, trusted,
+        req.NodeId, /*typeId*/0, "TransferOwnership"); err != nil {
+        return &pb.TransferOwnershipResponse{Found: false, Error: err.Error()}, nil
+    }
+    // 3. WAL append.
+    evt := wal.NewTransactionEvent(req.Context.TenantId, trusted,
+        wal.TransferOwnershipOp{NodeId: req.NodeId, NewOwner: req.NewOwner})
+    if err := s.wal.Append(ctx, evt); err != nil {
+        return &pb.TransferOwnershipResponse{Found: false, Error: err.Error()}, nil
+    }
+    // 4. Synchronous apply (or wait-for-offset).
+    found, err := s.applier.WaitTransferOwnership(ctx, evt.Offset)
+    if err != nil { return &pb.TransferOwnershipResponse{Found: false, Error: err.Error()}, nil }
+    return &pb.TransferOwnershipResponse{Found: found}, nil
+}
+```
+
+`Applier.applyTransferOwnership`: `UPDATE nodes SET owner_actor=?
+WHERE tenant_id=? AND node_id=?`; if rowcount > 0, refresh
+`node_visibility`. Return `rowcount > 0` to the caller via the
+`WaitTransferOwnership` channel.
+
+## Open questions / risks
+
+1. **Atomicity across tenants?** N/A — single-tenant by construction.
+   Cross-tenant ownership transfer would need 2PC/saga between
+   tenant shards; out of scope. Reject tenant-qualified `new_owner`.
+2. **WAL gap.** Python bypasses the WAL — replay would silently
+   lose ownership transfers (CLAUDE.md §1 violation). Go port MUST
+   close this. Add a replay-rebuild test that asserts owner state.
+3. **Old owner self-access.** Owner is implicitly ADMIN, so ALICE
+   loses access on transfer (no explicit ACL row to retain). Confirm
+   product intent; alternative is auto-grant old-owner READ.
+4. **Old owner's outgoing shares.** If ALICE shared with CHARLIE,
+   CHARLIE retains access post-transfer until BOB calls RevokeAccess.
+5. **Mailbox notification?** Decide if BOB gets a "you now own X"
+   item. Out of scope for parity.
+6. **Owner-only vs ADMIN-only.** Spec title says "current owner";
+   capability_registry.py:75 says ADMIN. Go port follows the
+   capability table (ADMIN) — that is the pinned source of truth.

--- a/docs/go-port/rpcs/TransferUserContent.md
+++ b/docs/go-port/rpcs/TransferUserContent.md
@@ -1,0 +1,268 @@
+# RPC Port Spec — `entdb.v1.EntDBService/TransferUserContent`
+
+EPIC #407 — Python -> Go server port. Source of truth: Python handler at
+`server/python/entdb_server/api/grpc_server.py:2692-2745`.
+
+> Offboarding flow. Reassigns ownership of every node a user owns inside a
+> single tenant to a new owner, and ensures the new owner is a tenant member.
+> WAL-first: the per-tenant ownership change MUST be appended as an
+> `admin_transfer_content` event so it survives WAL rebuild
+> (CLAUDE.md invariant 1). Direct canonical-store writes from this handler
+> are forbidden and pinned against by `tests/python/unit/test_admin_ops.py:373-407`.
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:130` (rpc), `:953-958` (request),
+`:960-964` (response).
+
+`TransferUserContentRequest` (note: this RPC does NOT use the standard
+`RequestContext` envelope — `actor`/`tenant_id` are top-level scalars):
+
+| Field | Tag | Type | Notes |
+|------|-----|------|------|
+| `actor` | 1 | `string` | Wire-untrusted. MUST be replaced by `_trusted_actor()` (gRPC peer identity) before any auth check. See "Auth". |
+| `tenant_id` | 2 | `string` | Required. Validated by `_check_tenant` (`grpc_server.py:362`). |
+| `from_user` | 3 | `string` | Required. Owner being offboarded. Bare id form (e.g. `"alice"`) — translation rules per CLAUDE.md. |
+| `to_user` | 4 | `string` | Required. New owner. May or may not already be a tenant member (idempotent membership upsert). |
+
+`TransferUserContentResponse`:
+
+| Field | Tag | Type | Semantics |
+|------|-----|------|------|
+| `success` | 1 | `bool` | `true` on append + bookkeeping success; `false` for non-abort errors (handler returns the response with `error` populated). |
+| `transferred` | 2 | `int32` | **Pre-apply count.** SELECT `COUNT(*) FROM nodes WHERE owner_actor = from_user` performed AFTER the WAL append (`grpc_server.py:2727-2736`). Reflects nodes still owned at the time of the call; the Applier materializes the rename asynchronously. Pinned by `test_admin_ops.py:404`. |
+| `error` | 3 | `string` | Non-empty only on caught (non-abort) exceptions; abort cases use gRPC status, not this field. |
+
+## Auth (admin; trusted-actor)
+
+1. `_check_tenant(request.tenant_id)` — rejects unknown/archived tenants and
+   wrong-region requests (`grpc_server.py:362`).
+2. INVALID_ARGUMENT validation: `tenant_id`, `from_user`, `to_user`
+   non-empty (`:2701-2706`).
+3. `_require_admin_or_owner(tenant_id, request.actor, ctx, "TransferUserContent")`
+   (`:2707-2709`, defined `:2680-2690`):
+   - **MUST ignore** `request.actor` for trust — calls `_trusted_actor()`
+     to derive the identity from the gRPC peer, then resolves the role via
+     `_get_member_role(tenant_id, actor_uid)`.
+   - Allowed roles: `owner`, `admin`. Anything else (`member`, `viewer`,
+     non-members) -> `PERMISSION_DENIED`.
+   - System actors (`system:*`) bypass membership and pass — pinned by
+     `test_admin_operations.py:489-505`.
+   - Privilege-escalation regression pinned by
+     `tests/python/integration/test_privilege_escalation.py:344-365`:
+     a client claiming `actor="user:admin"` while the trusted identity is
+     `user:eve` MUST `PERMISSION_DENIED` AND MUST NOT append to the WAL.
+
+The Go port MUST keep the trusted-actor lookup inside the same code path as
+the WAL append so a refactor cannot accidentally drop the auth check while
+keeping the side effect.
+
+## Side effects (potentially many WAL events; bulk ACL changes; mailbox cascades)
+
+Order in the Python handler (`grpc_server.py:2715-2725` ->
+`api/admin_handlers.py:27-67`):
+
+1. **Global-store membership upsert (direct write).**
+   `global_store.transfer_user_content` (`global_store.py:921-963`) inserts a
+   `tenant_members` row for `to_user` with role `'member'` if absent. Returns
+   `{membership_created: bool}`. This is global metadata, not per-tenant
+   WAL-sourced data — invariant 1 explicitly carves this out
+   (`admin_handlers.py:7-11`).
+
+2. **WAL append.** Single event with one op:
+   ```json
+   {"tenant_id": T, "actor": <trusted>,
+    "idempotency_key": "admin-transfer-<uuid4>",
+    "ts_ms": <now>,
+    "ops": [{"op": "admin_transfer_content",
+             "from_user": F, "to_user": T2}]}
+   ```
+   Topic: `self.topic` (default `"entdb-wal"`), key: `tenant_id`.
+
+3. **Applier materialization** (`apply/applier.py:1231-1238`): single
+   `UPDATE nodes SET owner_actor=?, updated_at=? WHERE tenant_id=? AND
+   owner_actor=?`. Bulk-rewrites ownership in one SQL statement — O(rows) but
+   one round-trip per event.
+
+   The Python Applier currently does NOT refresh `node_visibility` on this
+   op (the eager `transfer_user_content` path does, via
+   `_update_visibility`, `canonical_store.py:3707-3715`). The Go port must
+   match the Applier path: add visibility-index refresh inside the applier
+   handler so behavior survives rebuild. See "Open questions".
+
+4. **Audit log.** Eager `canonical_store.transfer_user_content` writes
+   `action="transfer_content"` (`canonical_store.py:3753-3766`). Under the
+   WAL-first handler this path is NOT called (handler does not invoke
+   `canonical_store`). Audit trail comes from the WAL itself + S3 Object
+   Lock per CLAUDE.md invariant 2 — do NOT add a parallel audit table.
+
+5. **Mailbox / notifications cascade.** Out of scope for this RPC. Nodes
+   keep their notification rows (keyed by node, not owner). No fanout is
+   triggered; downstream subscribers observing the WAL see the
+   `admin_transfer_content` event and can react.
+
+6. **ACL blobs.** Not modified. Existing per-node ACL grants survive — only
+   `owner_actor` changes.
+
+## Error contract
+
+| Condition | Status | Where |
+|-----------|--------|-------|
+| Empty `tenant_id` / `from_user` / `to_user` | `INVALID_ARGUMENT` | `grpc_server.py:2701-2706` |
+| Unknown / archived tenant, wrong region | per `_check_tenant` | `:2700` |
+| Caller not admin/owner (and not `system:*`) | `PERMISSION_DENIED` | `:2685-2689` |
+| Claimed-admin actor with non-admin trusted identity | `PERMISSION_DENIED`, no WAL append | `test_privilege_escalation.py:344-365` |
+| Other internal failure (WAL append, count query) | `success=false`, `error=str(e)` (NOT abort) | `:2740-2745` |
+
+Note: the count-query failure path is swallowed (`:2735-2736`) — `transferred=0`
+is returned even if SELECT fails post-append. The Go port should preserve
+this exact behavior for contract parity, though it is arguably a bug worth
+calling out (see "Open questions").
+
+`grpc.RpcError` / abort exceptions re-raise; everything else is mapped to
+the response with `success=false`.
+
+## Shared Go package deps
+
+- `internal/auth` — `TrustedActor(ctx)`, `RequireAdminOrOwner(ctx, tenantID, rpcName)`
+  (consolidated form of `_trusted_actor` + `_require_admin_or_owner`).
+- `internal/tenant` — `CheckTenant(ctx, tenantID)`.
+- `internal/wal` — `WALStream.Append(ctx, topic, key, value)`.
+- `internal/store/global` — `TransferUserContent(ctx, tenantID, fromUser, toUser) (membershipCreated bool, err error)`.
+- `internal/store/canonical` — read-only `CountOwnedNodes(ctx, tenantID, owner) (int32, error)` for the post-append count. **Must NOT expose a writer call from the handler path.**
+- `internal/event` — `BuildAdminTransferContentEvent(tenantID, actor, from, to) []byte` (JSON encoder; idempotency key generator).
+- `internal/metrics` — `RecordGRPCRequest("TransferUserContent", outcome, dur)`.
+- `internal/applier` — handler for `admin_transfer_content` op (parity with `applier.py:1231-1238`).
+
+## Other-RPC deps (TransferOwnership, RevokeAllUserAccess)
+
+- **`TransferOwnership`** (`proto:109`, `:780-789`): single-node owner change.
+  Different code path; uses `RequestContext` envelope and per-node update.
+  Shares no implementation with `TransferUserContent` but ports should land
+  together since both rewrite `nodes.owner_actor`.
+- **`RevokeAllUserAccess`** (`proto:133`, `:994-1006`): the natural follow-up
+  call after `TransferUserContent` in the offboarding flow. Emits an
+  `admin_revoke_access` WAL event (`admin_handlers.py:143-180`,
+  `applier.py:1240-1245`). Together they form the offboarding pair: transfer
+  first (so the user owns nothing), then revoke (so the user has no ACL or
+  group access). Operators may script this; no server-side coupling.
+- **`DelegateAccess`** (`proto:131`): adjacent admin op, same WAL-first
+  pattern (`admin_handlers.py:70-115`). Use as a structural template.
+
+## Contract tests pinning behavior (file:line)
+
+- `tests/python/unit/test_admin_operations.py:153-213` — canonical-store
+  level: count returned, untouched-owners preserved, audit row, visibility
+  index refreshed.
+- `tests/python/unit/test_admin_operations.py:426-505` — gRPC handler:
+  owner allowed, member denied, viewer denied, `system:*` allowed.
+- `tests/python/unit/test_admin_operations.py:806-839` — INVALID_ARGUMENT
+  on missing `actor` / `from_user`.
+- `tests/python/unit/test_admin_ops.py:88-119` — global-store: membership
+  upsert idempotency, returned fields.
+- `tests/python/unit/test_admin_ops.py:127-144` — canonical-store ownership
+  rewrite + zero-when-empty.
+- `tests/python/unit/test_admin_ops.py:373-407` — **WAL-first contract**:
+  exactly one append with `op="admin_transfer_content"`, NO direct
+  `canonical_store.transfer_user_content` call, response carries pre-apply
+  count.
+- `tests/python/integration/test_privilege_escalation.py:344-365` —
+  trusted-actor: claimed-admin string ignored; PERMISSION_DENIED + no WAL.
+- `tests/python/integration/test_grpc_contract.py:558-572` — happy path
+  (`success=True`) and INVALID_ARGUMENT on empty `tenant_id`.
+
+## Implementation outline (atomicity? streaming?)
+
+Not streaming — single unary request/response. Suggested Go shape:
+
+```
+func (s *Server) TransferUserContent(ctx, req) (*resp, error) {
+    if err := s.checkTenant(ctx, req.TenantId); err != nil { return nil, err }
+    if req.TenantId == "" || req.FromUser == "" || req.ToUser == "" {
+        return nil, status.Error(InvalidArgument, "<field> is required")
+    }
+    trusted, err := s.auth.RequireAdminOrOwner(ctx, req.TenantId, "TransferUserContent")
+    if err != nil { return nil, err }   // PERMISSION_DENIED on non-admin
+
+    // 1. Global membership upsert (direct write — global metadata).
+    if _, err := s.gstore.TransferUserContent(ctx, req.TenantId, req.FromUser, req.ToUser); err != nil {
+        return &resp{Success: false, Error: err.Error()}, nil
+    }
+    // 2. WAL append (source of truth for the rename).
+    payload := event.BuildAdminTransferContent(req.TenantId, trusted, req.FromUser, req.ToUser)
+    if _, err := s.wal.Append(ctx, s.topic, req.TenantId, payload); err != nil {
+        return &resp{Success: false, Error: err.Error()}, nil
+    }
+    // 3. Best-effort pre-apply count (errors swallowed, count -> 0).
+    n, _ := s.cstore.CountOwnedNodes(ctx, req.TenantId, req.FromUser)
+    return &resp{Success: true, Transferred: n}, nil
+}
+```
+
+**Atomicity.** There is NO cross-store transaction. Steps 1 (global SQLite)
+and 2 (WAL) are independent — failure ordering matters:
+- If step 1 succeeds and step 2 fails: stale `tenant_members` row for
+  `to_user` exists but no ownership rewrite. Acceptable (membership is
+  idempotent and benign).
+- If step 1 fails: handler returns early; nothing else runs. Safe.
+The Applier's UPDATE (step 3 / on consume) is itself atomic per tenant
+SQLite (single statement in `BEGIN IMMEDIATE`-equivalent via SQLite
+auto-commit). Applier visibility-index refresh, if added, must run inside
+the same transaction as the UPDATE.
+
+**Streaming.** Not needed. Even tenants with millions of nodes -> one bulk
+`UPDATE` in the Applier. Memory cost is bounded.
+
+**Idempotency.** Event idempotency key is `admin-transfer-<uuid4>` — every
+call produces a NEW key, so retries cause repeat applies. The bulk UPDATE
+is naturally idempotent (a second apply finds zero matching rows). Watch
+out: visibility-index refresh must also be idempotent.
+
+## Open questions / risks
+
+1. **Cross-tenant.** Hard scoped — `tenant_id` partitions both the WAL key
+   and the SQLite database file. No cross-tenant transfer is expressible.
+   `from_user`/`to_user` strings collide across tenants but are
+   tenant-scoped semantically. Confirm Go port keeps `tenant_id` as the
+   WAL partition key.
+
+2. **Large user (10M+ owned nodes).** Applier issues a single
+   `UPDATE nodes ... WHERE owner_actor=?`. SQLite will hold a write lock
+   for the duration; gRPC clients on the same tenant block on writes (not
+   reads). Risks: WAL consumer lag spike; potential statement timeout if
+   applier sets one. Mitigation options for the Go port: chunked update by
+   `node_id` rowid range; or accept the lock and document. **Decision
+   needed.**
+
+3. **Partial failure between global membership upsert and WAL append.**
+   See atomicity note. Current behavior leaves a benign membership row.
+   Alternative: append WAL first, then upsert membership. But then a
+   replay-from-WAL on a fresh global store would miss the membership row
+   (global store is not WAL-sourced). Current order is correct; just risky
+   on the failure surface. Document it.
+
+4. **Visibility-index drift after rebuild.** The eager
+   `canonical_store.transfer_user_content` path refreshes
+   `node_visibility` per node (`canonical_store.py:3707-3715`). The
+   Applier path (the only one used by the handler) does NOT
+   (`applier.py:1231-1238`). On full WAL rebuild, the visibility index for
+   transferred nodes will be stale until the next ACL touch. **The Go
+   Applier port MUST refresh visibility for affected nodes inside the
+   same op handler** to close this gap, and a contract test should pin
+   it.
+
+5. **Pre-apply count is a lie under concurrent writes.** The count is
+   taken AFTER the WAL append but BEFORE the Applier consumes — between
+   those moments, other handlers can mutate ownership. Returning a
+   post-apply count would require waiting on the receipt (see
+   `WaitForOffset.md`). For parity, keep current semantics; document.
+
+6. **`actor` field is wire-untrusted but required to be non-empty.** The
+   non-empty check (`:2701`) runs before `_require_admin_or_owner`
+   substitutes the trusted actor. A client sending `actor=""` aborts
+   `INVALID_ARGUMENT` even if the trusted identity is a legitimate admin.
+   Pinned by `test_admin_operations.py:806-820`. Preserve this quirk.
+
+7. **No legal-hold check.** Legal hold blocks GDPR deletion but does NOT
+   block ownership transfer. Confirm with compliance whether this should
+   change before the Go cutover.

--- a/docs/go-port/rpcs/UpdateUser.md
+++ b/docs/go-port/rpcs/UpdateUser.md
@@ -1,0 +1,223 @@
+# UpdateUser — Go Port Spec
+
+EPIC #407. Mutates a row in the global user registry. Reference Python
+handler: `server/python/entdb_server/api/grpc_server.py:2184-2229`.
+Proto: `proto/entdb/v1/entdb.proto:114, 826-838`. Backing store:
+`server/python/entdb_server/global_store.py:386-409`.
+
+## Wire contract
+
+Request `entdb.v1.UpdateUserRequest` (proto:826):
+- `string actor` — UNTRUSTED payload. See Auth.
+- `string user_id` — required. Identifies the row in
+  `global_store.user_registry`. Not a `tenant_principal` (no `user:`
+  prefix).
+- `string email`, `string name`, `string status` — partial-update
+  fields. **Truthiness gates each one** (grpc_server.py:2209-2214):
+  empty string == "do not update". There is **no `FieldMask`** and no
+  way to clear a field to empty. Go port MUST replicate truthy-only
+  semantics; do not switch to proto3 presence/`optional` without a
+  proto change. Status is a free-form string (`active`, `suspended`,
+  …) — no enum is enforced server-side, but only `email`/`name`/
+  `status` are whitelisted in `_sync_update_user`
+  (global_store.py:397). Unknown fields silently no-op (filtered by
+  the whitelist).
+
+Partial vs full: **partial only**. Any subset of the three mutable
+fields may be sent. If all three are empty, the handler short-circuits
+and returns `success=false, error="No fields to update"`
+(grpc_server.py:2216-2218) — this is **not an INVALID_ARGUMENT abort**;
+it is an in-band `UpdateUserResponse`.
+
+Immutable on this RPC: `user_id`, `created_at`. `updated_at` is set
+server-side by `_sync_update_user` (global_store.py:401).
+
+Response `UpdateUserResponse` (proto:835):
+- `bool success` — true iff one row was updated.
+- `string error` — populated for the in-band failures
+  ("No fields to update", "User not found", and the catch-all
+  `str(e)`).
+
+## Auth
+
+- `request.actor` REQUIRED (`INVALID_ARGUMENT` if empty,
+  grpc_server.py:2198-2199). `request.user_id` REQUIRED
+  (`INVALID_ARGUMENT`, grpc_server.py:2200-2201).
+- Trusted-actor pattern: `_is_self_or_admin` calls
+  `get_authoritative_actor(actor)` (grpc_server.py:2071-2086,
+  auth/auth_interceptor.py:92) and ignores the request payload for
+  the privilege decision. This is the post-#168 invariant — Go port
+  MUST resolve the trusted identity via the AuthInterceptor
+  equivalent (gRPC metadata / context value) and NEVER trust the
+  payload `actor` for the auth check.
+- Authorization rule (grpc_server.py:2202-2206):
+  - admin / system → allowed (`trusted` starts with `system:`,
+    `admin:`, or equals `__system__`).
+  - self → allowed when `trusted == "user:" + user_id` or
+    `trusted == user_id`.
+  - else → `PERMISSION_DENIED` with message
+    `"UpdateUser requires the user themselves or admin actor"`.
+- Tenant scoping: **none**. UpdateUser writes to the global registry,
+  not a per-tenant SQLite. No `_check_tenant` is called.
+- Configuration gate: if `self.global_store` is unset, abort
+  `UNIMPLEMENTED "User registry not configured"`
+  (grpc_server.py:2192-2196).
+
+## Side effects
+
+- Writes a single `UPDATE user_registry SET … WHERE user_id = ?` to the
+  global SQLite via `_sync_update_user` (global_store.py:404-409),
+  off-loaded from the asyncio loop by `_run_sync` (thread pool).
+- **NOT WAL-routed today.** The user registry lives in `global_store`
+  and is not event-sourced through `TransactionEvent` /
+  `Applier.apply_event`. This is a deliberate carve-out for cross-
+  tenant identity rows; per CLAUDE.md the per-tenant data plane is
+  WAL-sourced, but the global registry tables are direct SQLite. Go
+  port MUST preserve this — do **not** route `UpdateUser` through
+  `wal.append`. If event-sourcing the global registry is desired, it
+  is a separate epic and a proto change.
+- Metrics: `record_grpc_request("UpdateUser", "ok"|"error", elapsed)`
+  (grpc_server.py:2217, 2222, 2227). Note "ok" is recorded even for
+  in-band failures (no-fields, not-found) because no abort fires.
+- No audit-log write. Compliance trail for global-registry mutations
+  is not in scope of this RPC; `audit/compliance.py` exports the WAL,
+  which does not contain user-registry edits.
+
+## Error contract
+
+| Condition                     | Channel                  | Status / value                                        |
+|-------------------------------|--------------------------|-------------------------------------------------------|
+| `global_store` unset          | `context.abort`          | `UNIMPLEMENTED "User registry not configured"`        |
+| empty `actor`                 | `context.abort`          | `INVALID_ARGUMENT "actor is required"`                |
+| empty `user_id`               | `context.abort`          | `INVALID_ARGUMENT "user_id is required"`              |
+| not self, not admin           | `context.abort`          | `PERMISSION_DENIED "UpdateUser requires the user themselves or admin actor"` |
+| no mutable fields set         | in-band response         | `success=false, error="No fields to update"`          |
+| user not found                | in-band response         | `success=false, error="User not found"`               |
+| unhandled exception           | in-band response         | `success=false, error=str(e)`; metric label `error`   |
+
+Go port note: in Go we'd normally promote the catch-all to
+`codes.Internal` — **do not**, until contract tests are loosened. The
+Python handler returns `error=str(e)` in-band on the same response
+type, and contract tests assert success/failure on the response body
+not on status codes for these arms.
+
+## Shared Go package deps
+
+- `entdbserver/auth` — `GetAuthoritativeActor(ctx, payloadActor) string`
+  (port of `auth/auth_interceptor.py:92`) and `AuthInterceptor`
+  unary interceptor that stuffs the trusted actor into `context.Context`.
+- `entdbserver/globalstore` — `UpdateUser(ctx, userID string, fields UserUpdate) (bool, error)` returning `(updated, err)`.
+  `UserUpdate` is a struct of `*string` (or three booleans + values)
+  to mirror truthy-only gating. Backed by per-process `*sql.DB` over
+  the global SQLite file.
+- `entdbserver/metrics` — `RecordGRPCRequest(method, outcome string, elapsed time.Duration)` (port of `record_grpc_request`).
+- `entdbpb` — generated `entdb.v1` Go bindings (UpdateUserRequest,
+  UpdateUserResponse, UserInfo).
+- `google.golang.org/grpc/status` and `codes` for aborts.
+
+## Other-RPC deps
+
+- `CreateUser` (grpc_server.py near line 2100) — must run first to
+  populate the row that `UpdateUser` mutates. Contract test fixture
+  preseeds `alice` and `bob`.
+- `GetUser` (grpc_server.py:2120-ish) — used by tests to verify the
+  post-update state. Not called by the handler.
+- `_is_self_or_admin` shared with TransferUser / RevokeUser /
+  DeleteUser style RPCs (grpc_server.py:2944, 2997, 3028, 3086) — Go
+  port should expose `auth.IsSelfOrAdmin(ctx, userID)` once and reuse.
+
+## Contract tests pinning behavior
+
+- `tests/python/unit/test_user_registry.py:255-271` — happy self update
+  passes only `name=` kwarg (proves truthy-only gating: empty `email`
+  and `status` are not forwarded to `update_user`).
+- `tests/python/unit/test_user_registry.py:273-290` — admin actor
+  (`admin:root`) can update another user; only `status=` is forwarded.
+- `tests/python/unit/test_user_registry.py:292-309` — non-admin
+  updating another user → `context.abort` with the
+  "user themselves or admin" message; store NOT called.
+- `tests/python/unit/test_user_registry.py:311-328` — store returns
+  False → response `success=false, error contains "not found"`.
+- `tests/python/unit/test_user_registry.py:330-345` — no mutable fields
+  → `success=false, error contains "no fields"`. **No abort.**
+- `tests/python/integration/test_grpc_contract.py:448-453` — happy:
+  Alice updating her own row returns `success=true`.
+- `tests/python/integration/test_grpc_contract.py:454-458` — Alice
+  attempting to update Bob → `PERMISSION_DENIED`.
+
+These seven cases form the Go-port acceptance bar. Wire them into
+`tests/contract/` once the Go server speaks `entdb.v1.EntDBService`.
+
+## Implementation outline
+
+```go
+func (s *Server) UpdateUser(ctx context.Context, req *pb.UpdateUserRequest) (*pb.UpdateUserResponse, error) {
+    start := time.Now()
+    defer func() { metrics.RecordGRPCRequest("UpdateUser", outcome, time.Since(start)) }()
+
+    if s.globalStore == nil {
+        return nil, status.Error(codes.Unimplemented, "User registry not configured")
+    }
+    if req.GetActor() == "" {
+        return nil, status.Error(codes.InvalidArgument, "actor is required")
+    }
+    if req.GetUserId() == "" {
+        return nil, status.Error(codes.InvalidArgument, "user_id is required")
+    }
+    if !auth.IsSelfOrAdmin(ctx, req.GetUserId()) {
+        return nil, status.Error(codes.PermissionDenied,
+            "UpdateUser requires the user themselves or admin actor")
+    }
+
+    var u globalstore.UserUpdate
+    if req.GetEmail()  != "" { u.Email  = ptr(req.GetEmail())  }
+    if req.GetName()   != "" { u.Name   = ptr(req.GetName())   }
+    if req.GetStatus() != "" { u.Status = ptr(req.GetStatus()) }
+    if u.IsEmpty() {
+        return &pb.UpdateUserResponse{Success: false, Error: "No fields to update"}, nil
+    }
+
+    updated, err := s.globalStore.UpdateUser(ctx, req.GetUserId(), u)
+    if err != nil {
+        return &pb.UpdateUserResponse{Success: false, Error: err.Error()}, nil
+    }
+    if !updated {
+        return &pb.UpdateUserResponse{Success: false, Error: "User not found"}, nil
+    }
+    return &pb.UpdateUserResponse{Success: true}, nil
+}
+```
+
+`globalstore.UpdateUser` builds the `UPDATE … SET …` dynamically from
+the non-nil `*string` fields, sets `updated_at = now()`, and returns
+`rowsAffected > 0` (mirror global_store.py:396-409). Use a single
+transaction; the table is in the global DB so no per-tenant routing.
+
+## Open questions / risks
+
+- **Concurrent updates / lost writes.** No `version` / `etag` / OCC
+  column on `user_registry`. Two concurrent `UpdateUser`s racing on
+  the same `user_id` last-writer-wins on a per-column basis. SQLite
+  serializes writes, so there is no torn row, but a `name` update
+  from caller A and a `status` update from caller B issued
+  concurrently both succeed and produce a merged row — which is
+  probably the desired behavior, but it is undocumented. Go port
+  should preserve last-write-wins (do not silently add OCC).
+- **No way to clear a field.** Truthy-only gating means `email=""`
+  cannot blank an email. Tracked separately if/when proto adds
+  `optional` presence.
+- **`status` is unconstrained.** Free-form string; clients can write
+  anything. `ListUsers` filters by `status="active"` by default
+  (global_store.py:411-424), so a typo silently hides the user from
+  default listings. Consider a server-side enum check (proto change,
+  separate epic).
+- **No audit trail.** Global-registry mutations are not WAL-sourced
+  and not S3-Object-Lock-tamper-evident. If GDPR/SOC2 demand an
+  immutable record of identity changes, that is a follow-up epic
+  (event-source the global registry through a `GlobalEvent` topic).
+- **`success=false` vs gRPC status.** Mixing in-band failure flags
+  with `context.abort` makes client error handling awkward. Go port
+  must keep the split for parity but flag this for a v2 cleanup.
+- **Idempotency.** Re-issuing the same `UpdateUser` is naturally
+  idempotent (same `SET` produces the same row, `updated_at` ticks).
+  No request-ID dedup; acceptable given last-write-wins semantics.

--- a/docs/go-port/rpcs/WaitForOffset.md
+++ b/docs/go-port/rpcs/WaitForOffset.md
@@ -1,0 +1,244 @@
+# WaitForOffset — Go Port Spec (EPIC #407)
+
+`entdb.v1.EntDBService/WaitForOffset` provides read-after-write consistency: a
+client passes a WAL stream position from a prior `Receipt` and blocks until the
+applier on this node has materialized at least that position into per-tenant
+SQLite (or until timeout).
+
+## Wire contract
+
+Proto: `proto/entdb/v1/entdb.proto:88` (RPC), `:694-703` (messages).
+
+```
+rpc WaitForOffset(WaitForOffsetRequest) returns (WaitForOffsetResponse);
+
+message WaitForOffsetRequest {
+    RequestContext context = 1;     // tenant_id, actor (untrusted), trace_id
+    string stream_position = 2;     // "topic:partition:offset", e.g. "entdb-wal:0:42"
+    int32 timeout_ms = 3;           // 0 ⇒ server default 30s (Python: grpc_server.py:982)
+}
+message WaitForOffsetResponse {
+    bool reached = 1;               // true iff applied_offset >= stream_position
+    string current_position = 2;    // applier's latest applied offset (may be "")
+}
+```
+
+Unary, idempotent, no side effects. Stream position format is opaque to the
+wire but parsed by `_parse_stream_offset` (`canonical_store.py:90`): split on
+last `:` and parse trailing int; non-numeric ⇒ 0. Therefore an empty
+`stream_position` parses to 0 and is "already reached" once anything has been
+applied — but if nothing has been applied for the tenant yet,
+`get_applied_offset` returns `None` and the call blocks until timeout (see
+contract test note at `tests/python/integration/test_grpc_contract.py:296`).
+
+## Auth
+
+- `request.context.tenant_id` is checked via `_check_tenant`
+  (`grpc_server.py:362-407`): sharding ownership (UNAVAILABLE +
+  `entdb-redirect-node` trailer) and region pinning (FAILED_PRECONDITION).
+- `request.context.actor` is **UNTRUSTED on the wire** (per CLAUDE.md
+  invariant). Note: the current Python handler does not consult the actor at
+  all — there is no per-actor authorization for waiting on an offset. Do not
+  add one in Go without an explicit decision; just match Python.
+- No `_trusted_actor()` translation needed (the handler doesn't read actor).
+- No additional ACL checks. This is a side-effect-free synchronization
+  primitive scoped by tenant.
+
+## Side effects
+
+None on storage. Read-only with respect to WAL and SQLite. **Blocks the
+calling RPC** on `CanonicalStore.wait_for_offset`
+(`canonical_store.py:478-512`), which is event-driven (no polling):
+
+1. Per-tenant `asyncio.Condition` lazily created in `_offset_conditions`
+   (`:455-461`).
+2. Predicate reads `_applied_offsets[tenant_id]` and returns
+   `_compare_stream_pos(current, target) >= 0` (`:499-503`).
+3. The applier (`apply/applier.py:447`, `:599`) calls
+   `update_applied_offset` after each committed batch, which `notify_all()`s
+   the Condition (`canonical_store.py:463-476`).
+4. Waiter sleeps inside `cond.wait_for(...)` wrapped in `asyncio.wait_for`.
+
+`current_position` is read AFTER the wait via `get_applied_offset`
+(`grpc_server.py:986`); `""` if applier has never updated this tenant.
+
+## Error contract
+
+Python handler swallows all exceptions and returns
+`WaitForOffsetResponse(reached=False, current_position="")` with `OK` status
+(`grpc_server.py:989-992`). Go MUST mirror this swallow-and-return-false
+behavior **except** for aborts raised by `_check_tenant`, which emit gRPC
+status codes via `context.abort()` and bypass the try/except:
+
+| Condition | Status | Notes |
+|-----------|--------|-------|
+| Tenant not owned by node + known owner | `UNAVAILABLE` | trailer `entdb-redirect-node: <owner>`; SDK retry hint (see `sdk/go/entdb/redirect_cache.go`). |
+| Tenant not owned by node + unknown owner | `UNAVAILABLE` | no trailer. |
+| Tenant region-pinned to other region | `FAILED_PRECONDITION` | permanent; do not retry. |
+| Target offset reached within timeout | `OK`, `reached=true` | |
+| Timeout elapsed before reached | `OK`, `reached=false`, `current_position=<latest or "">` | **Not** `DEADLINE_EXCEEDED`. The deadline is server-internal (driven by `timeout_ms`). |
+| Internal error during wait | `OK`, `reached=false`, `current_position=""` | logged; metric `WaitForOffset/error`. |
+| Client-side gRPC deadline expires before timeout | `DEADLINE_EXCEEDED` | grpc-go cancels the stream itself; Go handler should respect `ctx.Done()` and unblock the waiter. |
+
+Note: client-side cancellation via `ctx.Done()` is NOT modeled by the Python
+handler explicitly, but `asyncio.wait_for` will unwind on RPC cancellation.
+Go must wire `ctx` into the wait so cancellation is honored without leaking
+goroutines.
+
+## Shared Go package deps
+
+Suggested layout under `server/go/`:
+
+- `internal/applystate` — owns `AppliedOffsets`: per-tenant
+  `map[tenantID]string` + per-tenant condition variable. Mirror Python's
+  `_applied_offsets` + `_offset_conditions` (`canonical_store.py:429-461`).
+- `internal/streampos` — `Parse(s string) int64` and `Compare(a, b string)
+  int` mirroring `_parse_stream_offset` / `_compare_stream_pos`
+  (`canonical_store.py:90-109`). Pin to identical edge cases (split on last
+  `:`, non-numeric → 0).
+- `internal/sharding` — `IsMine(tenantID)` / `GetOwner(tenantID)` for the
+  redirect logic in `_check_tenant`.
+- `internal/region` — region pinning lookup against `global_store`.
+- `internal/metrics` — `recordGRPCRequest("WaitForOffset", "ok"|"error",
+  duration)` mirroring `record_grpc_request` calls at
+  `grpc_server.py:987,990`.
+
+## Other-RPC deps
+
+- `ExecuteAtomic` returns `Receipt.stream_position`
+  (`proto/entdb/v1/entdb.proto`, message `Receipt`, field 3) — clients feed
+  that exact string back here. Go port of `ExecuteAtomic` MUST preserve the
+  `topic:partition:offset` format produced by the WAL backend.
+- The Go `Applier` (port of `apply/applier.py`) MUST call
+  `applystate.UpdateAppliedOffset(tenantID, pos)` after every committed batch
+  (mirror `applier.py:447,599`). Without this, all `WaitForOffset` calls
+  time out.
+- Read RPCs that accept `after_offset` (`GetNode`, `GetNodes`, `QueryNodes`,
+  `GetNodeByKey`) call the same `wait_for_offset` helper internally
+  (`grpc_server.py:806,1018,1238,1316`). Share the implementation.
+
+## Contract tests pinning behavior
+
+Behavior pinned by tests (Go port MUST keep these green via cross-language
+contract harness once it exists, and the Go SDK transport tests already
+exist):
+
+- `tests/python/unit/test_wait_for_offset.py:25-52` — `_parse_stream_offset`
+  and `_compare_stream_pos` semantics (full format, plain int,
+  `partition:offset`, non-numeric → 0).
+- `tests/python/unit/test_wait_for_offset.py:65-84` — per-tenant offset
+  isolation; `get_applied_offset` returns `None` initially.
+- `tests/python/unit/test_wait_for_offset.py:97-114` — already-reached and
+  exactly-reached return immediately True; never-set returns False on
+  timeout.
+- `tests/python/unit/test_wait_for_offset.py:117-127` — waiter wakes on
+  applier `update_applied_offset` (event-driven, no polling).
+- `tests/python/unit/test_wait_for_offset.py:130-146` — multiple concurrent
+  waiters at different positions all resolve from a single applier update.
+- `tests/python/unit/test_wait_for_offset.py:149-163` — incremental progress
+  wakes waiter exactly when target is crossed.
+- `tests/python/unit/test_wait_for_offset.py:166-176` — applier sets a
+  position below target → False on timeout, response carries the
+  below-target current position.
+- `tests/python/integration/test_grpc_contract.py:296-311` — gRPC-level
+  contract: `stream_position="entdb-wal:0:0"` with `timeout_ms=500` returns
+  a well-formed response (no abort) regardless of `reached`.
+- `sdk/go/entdb/transport_extras_test.go:80-125` — Go SDK already exercises
+  the wire contract; server port must satisfy these client expectations.
+
+## Implementation outline (Go handler)
+
+grpc-go handlers run on a goroutine per RPC. Blocking is acceptable, but
+avoid busy loops and goroutine leaks on cancel. `sync.Cond` does not
+compose with `ctx.Done()`; use a per-tenant broadcast channel instead.
+
+```go
+// internal/applystate/state.go
+type State struct {
+    mu     sync.Mutex
+    pos    map[string]string         // tenantID -> applied stream position
+    bcast  map[string]chan struct{}  // tenantID -> closed-on-update channel
+}
+
+func (s *State) Update(tenant, pos string) {
+    s.mu.Lock()
+    s.pos[tenant] = pos
+    ch := s.bcast[tenant]
+    s.bcast[tenant] = make(chan struct{})
+    s.mu.Unlock()
+    if ch != nil { close(ch) }
+}
+
+func (s *State) WaitFor(ctx context.Context, tenant, target string, timeout time.Duration) (reached bool, current string) {
+    deadline := time.NewTimer(timeout)
+    defer deadline.Stop()
+    for {
+        s.mu.Lock()
+        cur := s.pos[tenant]
+        if _, ok := s.pos[tenant]; ok && streampos.Compare(cur, target) >= 0 {
+            s.mu.Unlock()
+            return true, cur
+        }
+        ch := s.bcast[tenant]
+        if ch == nil { ch = make(chan struct{}); s.bcast[tenant] = ch }
+        s.mu.Unlock()
+        select {
+        case <-ch:           // applier updated; loop and re-check
+        case <-deadline.C:   // server-side timeout_ms
+            return false, s.snapshot(tenant)
+        case <-ctx.Done():   // client cancel / grpc deadline
+            return false, s.snapshot(tenant)
+        }
+    }
+}
+```
+
+Handler skeleton:
+
+```go
+func (s *Server) WaitForOffset(ctx context.Context, req *pb.WaitForOffsetRequest) (*pb.WaitForOffsetResponse, error) {
+    start := time.Now()
+    if err := s.checkTenant(ctx, req.GetContext().GetTenantId()); err != nil {
+        // Aborts (UNAVAILABLE / FAILED_PRECONDITION) returned as status errors,
+        // matching context.abort() in Python. Trailer set via grpc.SetTrailer.
+        return nil, err
+    }
+    timeout := 30 * time.Second
+    if req.GetTimeoutMs() > 0 { timeout = time.Duration(req.GetTimeoutMs()) * time.Millisecond }
+    reached, current := s.applyState.WaitFor(ctx, req.GetContext().GetTenantId(), req.GetStreamPosition(), timeout)
+    metrics.RecordGRPC("WaitForOffset", "ok", time.Since(start))
+    return &pb.WaitForOffsetResponse{Reached: reached, CurrentPosition: current}, nil
+}
+```
+
+Notes:
+- One waiter goroutine per call; parks on `select` (no CPU burn).
+- `Update` is O(1) and broadcasts via `close(ch)` — identical wakeup
+  semantics to Python's `cond.notify_all()`.
+- No `time.Sleep` polling. No worker pools.
+- `current_position` is read after timeout, matching Python at
+  `grpc_server.py:986`.
+- Client cancel: Python swallows and returns OK+reached=false. Go should
+  return `ctx.Err()` (Canceled/DeadlineExceeded) — see open question 4.
+
+## Open questions / risks
+
+1. **Empty `stream_position`**: parses to 0. If applier has applied
+   anything, returns immediately; otherwise blocks until timeout (footgun
+   noted at `test_grpc_contract.py:296`). Match Python; do not validate.
+2. **Topic/partition ignored**: `_compare_stream_pos` only compares the
+   trailing int. `"other-topic:9:5"` ≡ `"entdb-wal:0:5"`. Preserve quirk
+   for parity; flag as follow-up.
+3. **Unbounded per-tenant condition map** (`canonical_store.py:457-461`).
+   Same trade-off in Go; consider LRU eviction later.
+4. **Client cancel semantics**: Python returns OK+reached=false on cancel
+   (broad `except`). Go idiom is `ctx.Err()`. Pick and document — SDK
+   tests only cover the timeout path
+   (`sdk/go/entdb/transport_extras_test.go:106`).
+5. **Server-side timeout never yields `DEADLINE_EXCEEDED`** — it is
+   encoded in `reached=false`. Only client-side gRPC deadline does.
+6. **Actor is unused** by the handler. Confirm via EPIC #407 whether to
+   add a tenant-membership check; today any caller past `_check_tenant`
+   can wait on any tenant.
+7. **Region/sharding lookups** in `_check_tenant` hit `global_store` and
+   `_sharding`. Cache hot path in Go (sync.Map / TTL).

--- a/docs/go-port/shared/acl.md
+++ b/docs/go-port/shared/acl.md
@@ -1,0 +1,275 @@
+# ACL / Permission Model — Go Port Spec
+
+EPIC: #407 (Python -> Go server port).
+Frozen decision: `docs/decisions/acl.md` — 2026-04-13 typed capability-based permissions (CoreCapability + per-type ExtensionCapability) and 2026-04-13 cross-tenant ACL via `tenant:<id>` grantee.
+Source of truth (Python): `server/python/entdb_server/apply/acl.py`, `server/python/entdb_server/auth/capability_registry.py`, `server/python/entdb_server/apply/canonical_store.py`.
+
+## Model
+
+### Permission enum (legacy, still on the wire)
+
+`Permission` is the legacy coarse enum. New writes carry typed capabilities; the legacy string is retained for backwards compatibility and is mechanically derived for old grants.
+
+Defined at `server/python/entdb_server/apply/acl.py:32-42`:
+
+| Value     | Notes                                                       |
+|-----------|-------------------------------------------------------------|
+| `READ`    | implied by every higher tier                                |
+| `COMMENT` | implies `READ`                                              |
+| `WRITE`   | implies `READ`, `COMMENT`                                   |
+| `SHARE`   | implies `READ`, `COMMENT`, `WRITE`                          |
+| `DELETE`  | implies `READ`, `COMMENT`, `WRITE`, `DELETE` (no `SHARE`)   |
+| `ADMIN`   | implies all positive permissions                            |
+| `DENY`    | grants nothing — explicit negative override                 |
+
+Hierarchy table at `server/python/entdb_server/apply/acl.py:190-210`.
+
+### CoreCapability + ExtensionCapability (typed, current model)
+
+CoreCapability values (universal, stable, wire-frozen — see `docs/decisions/acl.md:24-31`):
+`CORE_CAP_UNSPECIFIED=0`, `CORE_CAP_READ=1`, `CORE_CAP_COMMENT=2`, `CORE_CAP_EDIT=3`, `CORE_CAP_DELETE=4`, `CORE_CAP_ADMIN=5`.
+
+ExtensionCapability is a per-type proto enum declared by the user via `option (entdb.node).extension_capability_enum` (decision doc `docs/decisions/acl.md:36-54`). Stored on the wire as `repeated int32 ext_cap_ids` keyed by `type_id`.
+
+### Actor / Principal variants
+
+Two parallel representations (today):
+
+- `Actor` — SDK-facing typed identifier in `sdk/python/entdb_sdk/typed.py:22-75`. Factories: `Actor.user(id)`, `Actor.group(id)`, `Actor.service(id)`. Internal storage is the canonical `kind:id` string.
+- `Principal` — server-internal parsed form in `server/python/entdb_server/apply/acl.py:61-137`. Valid kinds: `user`, `role`, `group`, `tenant`, `system`. Cross-tenant decision adds `tenant:<id>` (`docs/decisions/acl.md:177-185`).
+
+Wildcards:
+- `tenant:*` — every authenticated user in the current tenant (`acl.py:127-129`, `canonical_store.py:2887`).
+- `tenant:<id>` — every authenticated user in tenant `<id>` (cross-tenant grantee).
+
+### Storage schema (per-tenant SQLite)
+
+All in `server/python/entdb_server/apply/canonical_store.py`:
+
+- `nodes.acl_blob` (`canonical_store.py:1055`) — JSON list of `{principal, permission}` snapshot kept on the row for round-trip.
+- `node_access` (`canonical_store.py:1103-1115`) — direct grants. Columns: `node_id`, `actor_id`, `actor_type`, `permission`, `granted_by`, `granted_at`, `expires_at` (nullable). Extended at `canonical_store.py:1211-1222` with `type_id INTEGER`, `core_caps_json TEXT`, `ext_cap_ids_json TEXT`. PK `(node_id, actor_id)`.
+- `node_visibility` (`canonical_store.py:1080-1088`) — denormalized projection of all principals (owner + grantees + `tenant:*`) keyed by `(tenant_id, principal, node_id)`. Used as the index for `ListSharedWithMe` and ACL post-filter joins.
+- `group_users` (`canonical_store.py:1118-1127`) — group membership; PK `(group_id, member_actor_id)`. Drives group expansion.
+- `acl_inherit` (`canonical_store.py:1130-1137`) — node->parent pointers used to walk the inheritance chain. Edges with `propagates_acl=1` (`canonical_store.py:1070`) write into this table.
+
+Cross-tenant grants are recorded in the global `shared_index` (in `global_store.py`, populated from `ShareNode` and `RemoveGroupMember` cascades — `grpc_server.py:1807-1820`, `1958-1978`, `2015-2022`).
+
+## Capability semantics
+
+### What each Permission allows
+
+- `READ` — `GetNode`, `GetNodes`, `QueryNodes`, edge traversal in `GetConnectedNodes` post-filter, visibility in `ListSharedWithMe`.
+- `COMMENT` — create `Comment` child nodes via the `op:"CreateChild" child_type:"Comment"` mapping (`docs/decisions/acl.md:99-107`). Implies `READ`.
+- `WRITE` / `EDIT` (CoreCapability) — `UpdateNode` on the target. Field-level gating via `capability_mappings` with `field`/`field_value` selectors (`docs/decisions/acl.md:87-96`).
+- `SHARE` — legacy permission allowing further sharing without full ADMIN. Not represented in CoreCapability; collapses to ADMIN in the typed model.
+- `DELETE` — `DeleteNode`. Implies `EDIT` chain.
+- `ADMIN` — `ShareNode`, `RevokeAccess`, `TransferOwnership`. Implies every positive cap.
+- `DENY` — explicit deny row blocks every check on this node for the matching actor (handled before allow-scan in `_sync_can_access` at `canonical_store.py:2893-2904` and in the `AclManager.check_permission` two-pass at `acl.py:243-264`).
+
+### Owner short-circuit
+
+`canonical_store._sync_can_access` and `AclManager.check_permission` both treat the row's `owner_actor` as having every permission (`acl.py:240-241`). System actors (`system:*`, `admin:*`, `__system__`) bypass capability checks at the handler boundary in `_check_capability` (`grpc_server.py:322-323`) and at `_sync_can_access` (`canonical_store.py:2883-2884`).
+
+### Group expansion
+
+Resolved at **check time**, not at grant time. Grants reference the group principal (`group:<id>`); membership is looked up on every check via `resolve_actor_groups` (`canonical_store.py:2828-2862`) which walks `group_users` recursively. The handler calls it once per request, hands the resolved `actor_ids` list to canonical-store reads, and the SQL filter uses `IN (?, ?, ...)` against `node_access.actor_id` and `node_visibility.principal`.
+
+`shared_index` is the **eager** mirror: when a group is granted access to a node, every member is fanned out to `shared_index` rows (`grpc_server.py:1809-1814`, `1967-1976`). When a member is added/removed, the rows are recomputed (`grpc_server.py:1964-1976`, `2015-2022`). This is the only place where membership is materialized; same-tenant ACL checks resolve groups dynamically.
+
+### Extension implications
+
+User-declared per type, computed once at startup as the transitive closure of the implication DAG (`docs/decisions/acl.md:141`). Held in the `CapabilityRegistry` in `server/python/entdb_server/auth/capability_registry.py`; `_check_capability` consults `required_for_op(type_id, op_name, field, field_value, child_type)` (`grpc_server.py:325-331`) and `check_grant(core_cap_ids, ext_cap_ids, required_core, required_ext, type_id)` (`grpc_server.py:348-355`).
+
+### Legacy migration
+
+Old `permission` strings are mapped on read: `READ -> [CORE_CAP_READ]`, `WRITE -> [READ, COMMENT, EDIT]`, `ADMIN -> [CORE_CAP_ADMIN]` (`docs/decisions/acl.md:138`). Back-fill happens lazily at `canonical_store.py:3054-3081`.
+
+## Check sites
+
+### Pre-write authorization (handler ingress)
+
+Every mutating handler calls `_check_capability(tenant_id, trusted_actor, node_id, type_id, op_name, ctx)` (`grpc_server.py:299-360`). On failure raises `PermissionError`; the handler turns it into a denied response and emits `record_grpc_request("<op>", "denied", ...)`.
+
+Trusted actor comes from `auth_interceptor.get_authoritative_actor` (`grpc_server.py:1721`, `1763`) — the client-supplied `request.context.actor` is **never** used as the authorization principal (recent fix, commit `fece3fb`).
+
+### Post-read filtering
+
+Two paths:
+
+1. **SQL JOIN at canonical-store.** Read RPCs that scan many nodes (`QueryNodes`, `ListSharedWithMe`, `GetConnectedNodes`) use a SQL `LEFT JOIN node_visibility` (e.g. `canonical_store.py:2728`) plus an `IN (actor_ids, "tenant:*")` filter. Cheaper than per-row Python callbacks.
+2. **Per-row check via `can_access`.** `_sync_can_access` (`canonical_store.py:2868-2946`) walks the `acl_inherit` chain with a recursive CTE (depth-bounded by `_ACL_MAX_DEPTH`) to support inherited grants. Used by single-node reads and edge expansion when the join would explode.
+
+### Cascade behaviors
+
+- `TransferOwnership` (`grpc_server.py:2030-2049`, `canonical_store.py:3631-3674`) — rewrites `nodes.owner_actor` and updates `node_visibility`. Existing ACL grants are kept.
+- `RevokeAccess` (`grpc_server.py:1828-1875`) — deletes the `node_access` row, deletes the principal from `node_visibility`, and on `group:` revokes recomputes `shared_index` for every member.
+- `AddGroupMember` / `RemoveGroupMember` (`grpc_server.py:1946-2028`) — fan out `shared_index` add/remove for every node the group has access to (`canonical_store.list_node_access_for_group`).
+- `RevokeAllUserAccess` (GDPR path) — deletes every `node_access` row for the actor across the tenant; visibility is reprojected.
+
+## Go design
+
+Module: `server/go/internal/acl/`. Stays internal (no exported package) until the wire types stabilize; SDK types live in `sdk/go/entdb` and are independent.
+
+### Types
+
+```go
+// permission.go
+type Permission uint8
+const (
+    PermissionUnspecified Permission = iota
+    PermissionRead
+    PermissionComment
+    PermissionWrite
+    PermissionShare
+    PermissionDelete
+    PermissionAdmin
+    PermissionDeny
+)
+
+// capability.go — wire-stable, must match proto enum values exactly
+type CoreCapability uint8
+const (
+    CoreCapUnspecified CoreCapability = 0
+    CoreCapRead        CoreCapability = 1
+    CoreCapComment     CoreCapability = 2
+    CoreCapEdit        CoreCapability = 3
+    CoreCapDelete      CoreCapability = 4
+    CoreCapAdmin       CoreCapability = 5
+)
+
+type ExtCapID int32  // opaque; meaning is type-scoped
+
+// actor.go
+type ActorKind uint8
+const (
+    ActorKindUser ActorKind = iota
+    ActorKindGroup
+    ActorKindService
+    ActorKindRole
+    ActorKindTenant
+    ActorKindSystem
+)
+
+type Actor struct {
+    Kind ActorKind
+    ID   string  // bare id, no "kind:" prefix
+}
+
+func (a Actor) String() string  // "user:bob"
+func ParseActor(s string) (Actor, error)
+func UserActor(id string) Actor
+func GroupActor(id string) Actor
+
+// grant.go
+type Grant struct {
+    SubjectActor Actor
+    NodeID       string
+    TypeID       int32
+    Permission   Permission         // legacy
+    CoreCaps     []CoreCapability
+    ExtCapIDs    []ExtCapID
+    GrantedBy    Actor
+    GrantedAt    int64              // unix millis
+    ExpiresAt    *int64             // nullable
+}
+```
+
+### Interfaces
+
+```go
+// Resolver expands group principals to a flat actor_ids list.
+type Resolver interface {
+    Resolve(ctx context.Context, tenantID string, a Actor) ([]Actor, error)
+}
+
+// Checker answers single-node authorization questions.
+type Checker interface {
+    Check(ctx context.Context, req CheckRequest) error  // returns errs.PermissionDenied
+}
+
+type CheckRequest struct {
+    TenantID   string
+    Actor      Actor
+    NodeID     string
+    TypeID     int32
+    OpName     string
+    Field      string  // optional, for field-level gating
+    FieldValue string
+    ChildType  string  // optional, for CreateChild
+}
+
+// Filter is the bulk-read variant — returns the subset of node_ids
+// the actor can read. Implementation should prefer a single SQL join
+// over per-row Check calls.
+type Filter interface {
+    FilterReadable(ctx context.Context, tenantID string, a Actor, nodeIDs []string) ([]string, error)
+}
+
+// Registry holds the proto-derived capability mappings and implication
+// closures. Built once at server startup; immutable thereafter.
+type Registry interface {
+    RequiredForOp(typeID int32, op, field, fieldValue, childType string) (core *CoreCapability, ext *ExtCapID)
+    CheckGrant(grantedCore []CoreCapability, grantedExt []ExtCapID, requiredCore *CoreCapability, requiredExt *ExtCapID, typeID int32) bool
+    LegacyToCoreCaps(p Permission) []CoreCapability
+}
+```
+
+### Enforcer wiring
+
+A single `Enforcer` struct owns `Registry`, `Resolver`, and the `store.ACLReader`. `Enforcer.Check` corresponds 1:1 to `_check_capability` in `grpc_server.py:299-360`. Handlers in `server/go/internal/api/` call `acl.Enforcer.Check` before any state mutation; read paths call `acl.Enforcer.FilterReadable` after a non-filtered fetch, or push the predicate down into the SQL.
+
+## Dependencies
+
+- `server/go/internal/pb` — proto-generated types for `ACLEntry`, `CoreCapability`, `Permission` (legacy string), `ShareNodeRequest` etc. The Go enum constants must be kept synchronized with the generated proto values; consider a `go:generate` check.
+- `server/go/internal/store` — `ACLReader.GetGrants(tenant, node, actor, includeCrossTenant)`, `ACLReader.ResolveGroups(tenant, actor)`, `ACLReader.NodeVisibility(tenant, principals, ...)`, `ACLReader.WalkInheritance(tenant, node)`. The ACL package consumes only; writes go through `wal.append` like every other mutation (CLAUDE.md invariant 1).
+- `server/go/internal/errs` — `errs.PermissionDenied(actor, node, want)` mapping to gRPC `PERMISSION_DENIED`.
+- `server/go/internal/auth` — supplies the trusted actor via the auth interceptor (port of `auth_interceptor.get_authoritative_actor`).
+- No dependency on `server/go/internal/wal` or applier — ACL is a pure read-side concern at check time. Grant *writes* are events authored elsewhere.
+
+## Test surface
+
+Port these Python suites to Go (`server/go/internal/acl/*_test.go`):
+
+- `tests/python/unit/test_acl.py` — `Permission` hierarchy, `Principal.parse`, `AclManager.check_permission`, DENY override, `tenant:*` wildcard.
+- `tests/python/unit/test_acl_v2.py`, `tests/python/unit/test_acl_v2_extended.py` — typed capability columns, legacy string co-existence, migration back-fill.
+- `tests/python/unit/test_acl_capabilities.py` — implication closure, field-level gating, `CreateChild` mapping.
+- `tests/python/unit/test_capability_registry.py` — registry build from schema, `required_for_op`, `check_grant`.
+- `tests/python/unit/test_cross_tenant_read.py` — `tenant:<id>` grantee, cross-tenant capability check.
+- `tests/python/unit/test_shared_index.py` — group fan-out semantics on `ShareNode`, `AddGroupMember`, `RemoveGroupMember`, `RevokeAccess`.
+- `tests/python/integration/test_privilege_escalation.py` — actor-from-context vs trusted actor; must mirror in Go.
+
+Fixture pattern: a per-test in-memory SQLite store seeded with a tiny schema, a stub `Registry` built from a fixed proto descriptor set, and an `Actor` factory matching the Python `Actor.user("bob")` ergonomics. No Kafka/Kinesis dependency — the ACL package is below the WAL layer in the dependency graph.
+
+Contract tests: place cross-language equivalence cases in `tests/contract/acl/` so Go and Python implementations are checked against the same JSON fixtures.
+
+## RPCs that depend on it
+
+All in `server/python/entdb_server/api/grpc_server.py` (line refs are check sites in the Python today; the Go port keeps the same shape).
+
+| RPC                  | Required cap         | How ACL is consulted                                   |
+|----------------------|----------------------|--------------------------------------------------------|
+| `GetNode`            | `CoreCapRead`        | `_check_capability("GetNode", ...)` then fetch         |
+| `GetNodes`           | `CoreCapRead` per id | per-id check or `FilterReadable` bulk path             |
+| `QueryNodes`         | `CoreCapRead`        | SQL `JOIN node_visibility` post-filter                 |
+| `UpdateNode`         | `CoreCapEdit` (+field map) | `_check_capability` with `field`/`field_value`   |
+| `DeleteNode`         | `CoreCapDelete`      | `_check_capability("DeleteNode", ...)`                 |
+| `CreateNode`         | tenant membership    | tenant-access check, no node-level ACL                 |
+| `CreateChild`        | mapped via `child_type` | `_check_capability(..., child_type=)`               |
+| `ShareNode`          | `CoreCapAdmin`       | `grpc_server.py:1783-1790` then write grant            |
+| `RevokeAccess`       | `CoreCapAdmin`       | `grpc_server.py:1841-1848`                             |
+| `ListSharedWithMe`   | (caller scoped)      | `resolve_actor_groups` + `node_visibility` + `shared_index` (`grpc_server.py:1892-1933`) |
+| `AddGroupMember`     | tenant-admin         | fan out to `shared_index`                              |
+| `RemoveGroupMember`  | tenant-admin         | fan out reverse to `shared_index`                      |
+| `TransferOwnership`  | owner or admin       | rewrites `owner_actor` + visibility                    |
+| `GetConnectedNodes`  | `CoreCapRead` on neighbors | `actor_ids` filter passed into traversal SQL     |
+
+## Open questions / risks
+
+- **Group nesting depth.** Python uses recursive expansion in `resolve_actor_groups` without an explicit cap. The Go port must bound depth (mirroring `_ACL_MAX_DEPTH` for inheritance) and add a metric/event when the cap fires; otherwise pathological group cycles freeze the request.
+- **Orphan grants.** When a user or group is hard-deleted (GDPR or tenant teardown) `node_access` rows referencing them remain. Today this is handled by GDPR cascade in the applier; the Go port must keep the cascade and add a sweeper for tenant deletes (decision doc `docs/decisions/acl.md:196`).
+- **Cross-tenant grant lookups.** `_check_capability` uses `include_cross_tenant=True` (`grpc_server.py:338`) which queries the global `shared_index`. The Go port needs a clean abstraction across the per-tenant SQLite and the global store so a single check can hit both — propose a `store.UnifiedGrantReader`.
+- **Performance: read post-filter vs SQL JOIN.** Python sometimes filters in Python after fetch (legacy paths) and sometimes joins in SQL. Pick one in Go: SQL JOIN against `node_visibility` for any RPC that returns >1 node; per-row `Check` only for single-node RPCs. Benchmark before settling.
+- **`shared_index` consistency.** Eager fan-out is best-effort and logs `warning` on failure (`grpc_server.py:1819-1820`). Decide for Go whether to make this transactional (write to `shared_index` inside the same WAL event) or keep best-effort with a reconciliation job. Recommendation: fold into the WAL event, it's the only way to guarantee `ListSharedWithMe` after a group-add is consistent.
+- **DENY semantics under inheritance.** Today `_sync_can_access` checks DENY only on the target node, not on ancestors (`canonical_store.py:2893-2904`). Confirm whether ancestor DENYs should propagate; the decision doc is silent. Track as an ACL semantics bug to fix in the Go port if confirmed intentional.
+- **Field-level grants.** The decision doc rejects a separate field-level ACL primitive but field gating is expressed via `capability_mappings`. Make sure the Go `Registry` can answer `RequiredForOp(..., field, fieldValue, ...)` cheaply — pre-index by `(typeID, op, field)`.
+- **Actor string format on the wire.** Python serializes `Actor` as `kind:id`. The Go `Actor` should render identically and round-trip through proto fields that are still typed as `string` (`ACLEntry.grantee`).

--- a/docs/go-port/shared/applier.md
+++ b/docs/go-port/shared/applier.md
@@ -1,0 +1,431 @@
+# Applier — Go port spec (shared)
+
+EPIC #407 — Python → Go server port. The Applier is the WAL consumer that
+materialises `TransactionEvent`s into per-tenant SQLite. CLAUDE.md flags
+it as the most intricate piece to port. This spec captures the contract
+the Go implementation must satisfy.
+
+Reference Python implementation:
+[`server/python/entdb_server/apply/applier.py`](../../../server/python/entdb_server/apply/applier.py).
+
+Target Go package: `server/go/internal/apply/` (new). Sibling packages
+referenced below: `server/go/internal/wal/`, `server/go/internal/store/`,
+`server/go/internal/pb/`, `server/go/internal/errs/`,
+`server/go/internal/telemetry/`.
+
+---
+
+## Roles & responsibilities
+
+The Applier is a long-running consumer with five jobs, in order:
+
+1. **Consume** records from the WAL via `WalStream.Subscribe` /
+   `PollBatch` (`applier.py:418-468`). One Applier instance consumes one
+   `(topic, group_id)` pair; a node may run several with disjoint
+   `assigned_tenants` filters (`applier.py:483-489`).
+2. **Validate + dispatch by op-type**. Inspect `event.ops`, classify
+   storage mode (`_event_storage_mode`, `applier.py:629-667`), open the
+   correct physical SQLite file (tenant / mailbox / public —
+   `_open_event_connection`, `applier.py:669-691`), then for each op
+   call the matching write helper on `CanonicalStore` (the giant
+   `if/elif` ladder in `_sync_apply_event_body`, `applier.py:929-1248`).
+3. **Write SQLite atomically**. All ops in one event execute inside
+   a single `BEGIN IMMEDIATE` … `COMMIT` block opened via
+   `canonical_store.batch_transaction()` (`canonical_store.py:1264-1289`).
+   The `applied_events` row is inserted in the same transaction
+   (`applier.py:1250-1262`). Idempotency check happens **inside** the
+   transaction before any mutation (`applier.py:921-927`).
+4. **Advance the WAL offset**. Only on success and only per partition
+   that fully succeeded (`applier.py:541-557`). Read the partition-
+   commit logic carefully — it is the load-bearing correctness hook.
+5. **Notify offset waiters / build receipts**. After commit, call
+   `canonical_store.update_applied_offset(tenant_id, stream_pos)`
+   (`applier.py:446-449`, `applier.py:597-602`) which wakes
+   `wait_for_offset` (`canonical_store.py:478-512`). The
+   `(stream_pos, status)` pair is what `ExecuteAtomic` returns to the
+   caller as a receipt.
+
+Side responsibilities, in declining importance:
+
+- **Mailbox fanout** after commit (`applier.py:1361-1368`,
+  `_fanout_node`, `applier.py:1615-1668`). Writes notification rows in
+  the tenant DB; fanout failure is logged but never fails the apply.
+- **Shared-index maintenance** for cross-tenant share/revoke/group-
+  member changes (`applier.py:1687-1845`). All best-effort against
+  `GlobalStore`.
+- **Quota counter increment** (`_increment_usage_safe`,
+  `applier.py:1306-1325`). Strictly fire-and-forget.
+- **Lazy index/FTS bootstrap** — first write of a new type creates the
+  unique/query/composite/FTS expression indexes (`applier.py:946-954`,
+  `1001-1012`).
+
+---
+
+## Determinism contract
+
+`tests/python/integration/test_wal_replay_determinism.py` is the bedrock
+contract. Three properties are asserted:
+
+1. **Round-trip determinism** (`test_wal_replay_determinism.py:179-382`).
+   Drive a fixed sequence of mixed ops (create_node × 3, update_node,
+   create_edge, delete_edge, admin_transfer_content, create_edge after
+   transfer), `_canonical_dump` the state, wipe SQLite, replay from
+   offset 0 with a fresh applier and a new `group_id`, dump again. The
+   two dumps **must compare equal as Python dicts**, including
+   `payload_json` byte-for-byte (`:128-136`).
+2. **Idempotency on replay** (`:385-440`). Two appends of the same
+   `idempotency_key` produce **exactly one** node. Detection is the
+   `SELECT 1 FROM applied_events WHERE tenant_id=? AND
+   idempotency_key=?` probe inside the transaction
+   (`applier.py:766-772`, `:921-927`).
+3. **Halt on poison** (`:443-549`). A `USER_MAILBOX` create_node with no
+   `target_user_id` raises `ValidationError` in
+   `_event_storage_mode`. With `halt_on_error=True` (production
+   default) the applier:
+   - applies the preceding good event,
+   - does NOT advance the WAL past the poisoned record,
+   - does NOT apply any subsequent record.
+
+The Go applier MUST replicate these byte-level outcomes. Specifically:
+
+- `payload_json` is stored as the JSON encoding of the input payload
+  dict. Use a JSON encoder that emits the same key order / spacing as
+  Python's `json.dumps(obj)` with default args. **Open question:** the
+  determinism test compares `payload_json` strings — the Go encoder
+  must produce identical output (no whitespace, sort-by-insertion or
+  sort-by-key matching Python). See **Open questions / risks** below.
+- The `applied_events` row uses `int(time.time() * 1000)` for
+  `applied_at` (`applier.py:891`, `:1260`). This is **not** part of
+  the determinism dump (the dump only reads nodes + edges) but
+  `WaitForOffset` consumers depend on it.
+- Generated node IDs (when an op omits `id`) come from
+  `canonical_store.create_node_raw`. The determinism test pins ids
+  via `op["id"]` so the Go port doesn't need byte-identical UUIDs —
+  but it MUST honour caller-supplied ids verbatim.
+
+Halt semantics, precisely (`applier.py:427-443`, `:519-572`):
+
+- A failed apply MUST NOT call `wal.commit(record)`.
+- A failed apply MUST set `_running = false` when `halt_on_error` is
+  true. The loop returns; the caller (supervisor) decides whether to
+  surface or restart.
+- In the batched path, partition-level commit is gated on every record
+  in that partition succeeding (`applier.py:541-557`). A failure on
+  partition 3 must not block commits on partitions 0–2.
+
+---
+
+## Concurrency model
+
+Python's applier is a single asyncio task per `(topic, group_id)`. The
+synchronous SQLite work is offloaded to a `ThreadPoolExecutor` owned by
+the `CanonicalStore` (`canonical_store.py:417-425`):
+
+- `apply_event` builds the `TransactionEvent`, then calls
+  `loop.run_in_executor(self.canonical_store._executor,
+  self._sync_apply_event_body, event)` (`applier.py:1349-1354`).
+- `_apply_tenant_batch` does the same with
+  `_sync_apply_tenant_batch_body` (`applier.py:586-592`).
+- The executor is shared with all read RPCs. Per-tenant locks
+  (`canonical_store.py:410-412`) and per-tenant async semaphores
+  (`canonical_store.py:413-416`) serialise same-tenant writers and
+  cap fair-share of the pool.
+
+Reader/writer interaction is exercised by
+`tests/python/integration/test_concurrent_applier_reads.py`. The
+contract (`:104-136`, `:139-`):
+
+- Readers running `get_node` / `get_edges_from` / `get_nodes_by_type`
+  in tight loops MUST NEVER observe a half-applied transaction. An
+  edge whose `to_node_id` resolves to a missing node is a violation.
+- Per-event atomicity is delivered by the single SQLite `BEGIN
+  IMMEDIATE` … `COMMIT` block. `BEGIN IMMEDIATE` takes a RESERVED
+  lock; readers in WAL mode keep going against the pre-commit
+  snapshot.
+- No deadlocks under bursts of 100 writes × 10 readers × 2× pool
+  workers.
+
+**Go implications:**
+
+- Python's GIL hides ordering bugs that Go preemption will surface.
+  The test is harder to satisfy in Go; budget for it.
+- The natural Go equivalent of `run_in_executor` is a bounded worker
+  pool of goroutines, each owning an `*sql.DB` with `MaxOpenConns=1`
+  per tenant DB file (SQLite is serialised internally anyway).
+- Per-tenant batching: keep the `_apply_tenant_batch` design — group
+  records by `tenant_id`, apply each tenant's slice in one
+  transaction, commit per-partition only on full success
+  (`applier.py:575-614`). Mixed-storage-mode batches must fall back
+  to single-event dispatch (`applier.py:743-751`).
+
+---
+
+## Recovery tiers
+
+Recovery is **not** part of the steady-state Applier. It runs at boot
+or on tenant rebuild via
+`server/python/entdb_server/tools/recovery_strategy.py` (`RecoveryTier`,
+`:38-43`):
+
+1. **Tier 1 — SNAPSHOT**: Find the latest `s3://…/snapshots/tenant=…/
+   ts=…sqlite.gz` (`snapshot/snapshotter.py:1-50`). Decompress, restore
+   to `data_dir/<tenant>.db`, read manifest's `last_stream_pos` and
+   resume the WAL from that offset.
+2. **Tier 2 — KAFKA_WAL**: Drive the Applier from the snapshot's
+   `last_stream_pos` forward. This is just the steady-state apply
+   loop (`recovery_strategy.py:391-414`).
+3. **Tier 3 — S3_ARCHIVE**: When records have aged out of Kafka, pull
+   them from `archive/archiver.py` (`:300-385`), feed them into the
+   Applier as if they came from the WAL, then transition to Tier 2.
+
+The Go applier needs a `Replay(ctx, tenantID, fromPos)` entry point
+distinct from `Run(ctx)` so the recovery harness can drive batches
+without a live WAL subscription. Snapshot manifests carry the resume
+offset — Tier 1 must hand it to Tier 2 atomically.
+
+The Snapshotter itself uses SQLite's online backup API
+(`snapshotter.py:88-117`) — out of scope for this spec but the Applier
+must not hold a write transaction across snapshot start, otherwise
+backup latency spikes.
+
+---
+
+## Receipt construction
+
+`ExecuteAtomic` (`api/grpc_server.py:620-826`) is the only RPC that
+produces a write receipt. Flow:
+
+1. Handler validates the request, builds a `TransactionEvent`, calls
+   `wal.append(...)` and gets back a `StreamPos`.
+2. Handler waits via `_wait_for_offset(tenant, stream_pos, timeout)`
+   (`grpc_server.py:806`, `:937-944`) which delegates to
+   `canonical_store.wait_for_offset` (`canonical_store.py:478-512`).
+3. The Applier processes the record asynchronously, commits SQLite,
+   then calls `update_applied_offset` (`applier.py:446-449`,
+   `:597-602`) which `notify_all`s the waiter.
+4. Handler returns `ExecuteAtomicResponse{stream_pos, status,
+   error_trail?}` (`grpc_server.py:806-819`).
+
+The receipt's three observable fields:
+
+- `stream_pos` — `topic:partition:offset` string from
+  `StreamPos.__str__` (decoded by `_parse_stream_offset`,
+  `canonical_store.py:90-100`).
+- `status` — APPLIED / SKIPPED / FAILED. SKIPPED is set when the
+  idempotency check inside the transaction hits an existing row
+  (`applier.py:925-927`).
+- `error_trail` — populated from `ApplyResult.error` on failures
+  (`applier.py:289`, `:1387-1392`). Today it's the stringified
+  exception. Go port should categorise (see **Open questions** below).
+
+`GetReceiptStatus` (`grpc_server.py:946-968`) is a separate RPC that
+just looks up the `applied_events` row by `idempotency_key`. The
+Applier does not need to do anything special for it beyond writing the
+row inside the apply transaction.
+
+`WaitForOffset` is documented in
+[`docs/go-port/rpcs/WaitForOffset.md`](../rpcs/WaitForOffset.md).
+
+---
+
+## Field-id payload encoding
+
+Per CLAUDE.md invariant 6: payloads are stored keyed by `field_id`
+(stringified ints) on disk, e.g. `{"1": "alice@example.com", "2":
+"Alice"}`. The Applier sees field-id-keyed payloads in the WAL — no
+translation happens here. Translation between names and ids is the
+gRPC boundary's job (`api/grpc_server.py`).
+
+The Applier touches `data` / `patch` keyed by field-id strings in:
+
+- `create_node_raw` (`applier.py:782-791`, `:956-1012`) — passed
+  through to `CanonicalStore.create_node_raw` and dumped as
+  `payload_json`.
+- `update_node` patch merge (`applier.py:805-813`, `:1029-1073`) —
+  the patch is `dict.update`d onto the existing payload by
+  string key; field-id renames are therefore free.
+- Unique-constraint violation reporting (`applier.py:967-998`,
+  `:1075-1102`) — `dup_value = data.get(str(dup_field_id))` looks up
+  the colliding value by stringified field-id.
+- FTS indexing (`applier.py:1001-1012`, `:1108-1120`) — accepts the
+  field-id-keyed payload directly.
+
+**Go port:** the wire `data` field is a `google.protobuf.Struct` or
+JSON `map<string, Value>`. Decode it as `map[string]any` and pass
+through unchanged. The on-disk form is `json.Marshal` of that map.
+This is the determinism-critical encoding — see open questions.
+
+---
+
+## Go design
+
+Proposed package layout (`server/go/internal/apply/`):
+
+```
+apply/
+  applier.go          // type Applier, Run(ctx), Replay(ctx, ...)
+  event.go            // type TransactionEvent (mirrors applier.py:204-269)
+  result.go           // type ApplyResult (applier.py:272-290)
+  storage_route.go    // _event_storage_mode + _open_event_connection
+  ops_node.go         // create/update/delete_node handlers
+  ops_edge.go         // create/delete_edge + ACL inheritance
+  ops_admin.go        // admin_transfer_content, admin_revoke_access
+  alias.go            // _resolve_ref / _resolve_node_ref
+  errors.go           // ApplierError, ValidationError, UniqueConstraintError
+  fanout.go           // _fanout_node + _generate_snippet
+  shared_index.go     // shared-index hooks (best-effort)
+```
+
+### Single goroutine vs per-tenant worker pool
+
+The Python applier is a **single asyncio task** that offloads SQLite
+work to a shared pool. Two viable Go shapes:
+
+| Option | Pros | Cons |
+|---|---|---|
+| **A. Single consumer goroutine + shared worker pool (Python parity)** | Mirrors Python exactly; simplest mental model; easy to satisfy halt-on-error (one place to stop); per-partition commit logic stays simple. | One slow tenant blocks the consume loop until its batch finishes (already the case in Python). |
+| **B. Per-tenant worker goroutine, fan-out from consume loop** | Hot tenants can't head-of-line block cold ones; matches Kafka's per-partition consumer model. | Doubles the partition-commit complexity (per-tenant offset bookkeeping); poison-event halt becomes per-tenant, harder to reason about. |
+
+**Recommendation: start with A** for parity with the Python reference
+(makes the determinism + halt tests trivially equivalent). Move to B
+only if benchmarks show consume-side starvation.
+
+### Locks needed (option A)
+
+- `*sync.Mutex` per tenant for write serialisation, mirroring
+  `_tenant_locks` (`canonical_store.py:410-412`). The Go store layer
+  owns these, not the Applier.
+- `*sync.Cond` (or `chan struct{}` per tenant) for `wait_for_offset`
+  fan-out, mirroring `_offset_conditions`
+  (`canonical_store.py:413-416`, `:455-512`).
+- `*sync.Map[string]string` for `_applied_offsets`
+  (`canonical_store.py:429`).
+- `_node_alias_map` (`applier.py:375`) is **per-event**; in Go make it
+  a local `map[string]string` inside `applyEvent`, not a field. The
+  Python field is reset at every event entry (`applier.py:776`,
+  `:911`) — bug-prone, don't replicate the global mutable state.
+
+### Context cancellation
+
+Every batch / event apply should respect `ctx.Done()`. SQLite calls
+themselves don't honour context — wrap the goroutine entry so that
+on cancel the in-flight transaction either completes or rolls back.
+Long replays (Tier 2/3 recovery, hours of WAL) MUST be cancellable.
+
+---
+
+## Dependencies
+
+| Go package | Python equivalent | Used for |
+|---|---|---|
+| `internal/pb` | `entdb.v1` proto + `apply.applier.TransactionEvent` | Op message types, payload Struct decoding |
+| `internal/wal` | `wal/base.WalStream` | `Subscribe`, `PollBatch`, `Commit` |
+| `internal/store` | `apply.canonical_store.CanonicalStore` | `BatchTransaction`, `CreateNodeRaw`, `EnsureFieldIndexes`, `UpdateAppliedOffset`, `WaitForOffset`, `BatchCreateNotifications` |
+| `internal/store/global` | `global_store.GlobalStore` | `IncrementUsage`, `AddShared`, `RemoveShared`, `CleanupStaleShared` |
+| `internal/schema` | `schema.registry.SchemaRegistry` | `GetUniqueFieldIDs`, `GetIndexedFieldIDs`, `GetSearchableFieldIDs`, `GetCompositeUniqueConstraints`, `GetDataPolicy` |
+| `internal/errs` | `apply.applier.ApplierError` hierarchy | Typed error returns at the package boundary |
+| `internal/telemetry` | `metrics.record_applier_event` | Prometheus counters: `applier_events_total{result}` |
+| `internal/auth/acl` | `apply.acl.AclManager` | Mostly read-side; applier holds it but doesn't write to it directly |
+
+---
+
+## RPCs that depend on it
+
+- **`ExecuteAtomic`** (`docs/go-port/rpcs/ExecuteAtomic.md`,
+  `grpc_server.py:620-826`). Write path: append to WAL, wait for
+  Applier to commit, return receipt. Direct dependency on the
+  `applied_offsets` notification fan-out.
+- **`GetReceiptStatus`** (`docs/go-port/rpcs/GetReceiptStatus.md`,
+  `grpc_server.py:946-968`). Reads `applied_events` table. Depends on
+  the Applier writing the row inside the apply transaction so a
+  successful response implies the data is durably visible.
+- **`WaitForOffset`** (`docs/go-port/rpcs/WaitForOffset.md`). Thin
+  wrapper around `canonical_store.wait_for_offset`. Depends on the
+  Applier calling `update_applied_offset` after every successful
+  commit.
+
+Indirectly, **every read RPC** that wants read-after-write consistency
+(GetNode, QueryNodes, GetEdgesFrom, …) eventually calls
+`WaitForOffset`, so anything that breaks the offset notification
+breaks the whole read path.
+
+---
+
+## Open questions / risks
+
+1. **JSON encoding determinism.** Python `json.dumps(obj)` with default
+   args emits compact JSON with insertion-order keys. Go's
+   `encoding/json` sorts map keys alphabetically. The replay test
+   compares `payload_json` strings (`test_wal_replay_determinism.py:128-
+   136`). **Decision needed:** either (a) change the Python side to
+   use sorted keys before the Go port lands, or (b) implement a
+   custom encoder on the Go side that preserves wire-order. Option (a)
+   is safer; do it as a pre-port migration with a one-shot rewrite of
+   existing rows.
+
+2. **SQLite driver choice.** Two contenders:
+   - `modernc.org/sqlite` — pure Go, no cgo, easy cross-compile, but
+     ~30% slower on write-heavy benchmarks and lags upstream SQLite
+     by 1–2 minor versions.
+   - `github.com/mattn/go-sqlite3` — cgo binding to upstream SQLite.
+     Faster, full feature parity (FTS5, JSON1), but cgo complicates
+     static builds and Docker image size.
+   Recommendation: **`mattn/go-sqlite3`** for production parity with
+   Python's `sqlite3` (which is also a C binding). Accept the cgo
+   tax. Revisit if static binary becomes a hard requirement.
+
+3. **Thread safety with `mattn/go-sqlite3`.** `*sql.DB` is goroutine-
+   safe but each connection is single-threaded. Must set
+   `db.SetMaxOpenConns(1)` per tenant DB or use the shared pool with
+   careful lock ordering. The per-tenant lock from canonical_store
+   covers this.
+
+4. **Context cancellation through long replays.** Tier-3 archive
+   replays can run for minutes. Pattern: chunk archive batches to
+   ≤1k events, check `ctx.Err()` between batches, store progress in
+   `applied_events` so a cancelled replay resumes idempotently.
+
+5. **Error categorisation.** Today Python lumps everything into
+   `ApplyResult.error = str(e)` (`applier.py:1391`). The Go port
+   should distinguish:
+   - **Poisoned event** (`ValidationError`, `SchemaFingerprintMismatch`,
+     malformed JSON) — halt, surface as `INVALID_ARGUMENT` in the
+     receipt, never retry.
+   - **Constraint violation** (`UniqueConstraintError`,
+     `CompositeUniqueConstraintError`) — return `ALREADY_EXISTS` to
+     the caller (`grpc_server.py` already does this), do **not**
+     halt; this is a normal client-error path, the WAL offset
+     should advance.
+   - **Transient infra** (SQLite I/O, disk full, lock timeout) —
+     halt and let the supervisor restart; do not advance offset.
+   The current `halt_on_error=True` catch-all is too coarse; the Go
+   port has a chance to fix this. Wire it as a typed-error switch in
+   the consume loop.
+
+6. **`acl_inherit` cycle detection** uses a recursive CTE bounded at
+   depth 10 (`applier.py:851-870`, `:1193-1212`). Verify
+   `mattn/go-sqlite3` supports recursive CTEs (it does, but worth
+   checking with an integration test in the port).
+
+7. **`_node_alias_map` global state.** The Python field is reset at
+   every event entry but is still an instance attribute, which means
+   concurrent events on the same Applier instance would race. In
+   Python this is masked by the single-task design. The Go port must
+   make this strictly per-event (local var). Document explicitly.
+
+8. **Mailbox fanout outside the transaction.** `_fanout_node`
+   (`applier.py:1361-1368`) runs after the apply transaction commits.
+   A crash between commit and fanout drops notifications. Today this
+   is accepted (notifications are best-effort). Confirm the Go port
+   makes the same trade-off explicitly rather than silently.
+
+9. **Quota counter (`_increment_usage_safe`)** is fire-and-forget per
+   ADR `docs/decisions/quotas.md`. The Go port should preserve this:
+   billing drift is preferable to a write outage. Use a buffered
+   channel + best-effort drain on shutdown.
+
+10. **Storage-mode mixed batches.** The batched path explicitly
+    rejects mixed-mode events (`applier.py:743-751`) and falls back
+    to per-event apply (`applier.py:510-533`). The Go port must
+    keep this fallback or the test
+    `test_applier_halts_on_poisoned_event` will fail intermittently.

--- a/docs/go-port/shared/auth-interceptor.md
+++ b/docs/go-port/shared/auth-interceptor.md
@@ -1,0 +1,257 @@
+# Shared Port Spec — Auth Interceptor + Trusted-Actor Pattern
+
+EPIC #407 — Python → Go server port. Source of truth:
+`server/python/entdb_server/auth/auth_interceptor.py` (the gRPC interceptor
+and `get_authoritative_actor` helper). Behavioural pin:
+`tests/python/integration/test_privilege_escalation.py` (34 cases).
+
+This doc is referenced by every RPC spec under `docs/go-port/rpcs/` — the
+Go port MUST land this primitive before any privileged RPC is wired up.
+
+## Wire-level mechanics
+
+The interceptor reads gRPC metadata only — no TLS-cert or peer-address
+identity. Three credential carriers are accepted, in this fixed order
+(`auth_interceptor.py:222-276`):
+
+1. **OAuth/OIDC bearer token** — header `authorization: Bearer <jwt>`.
+   The leading `Bearer ` is stripped (`:245`). A value is treated as a JWT
+   only if it has exactly two dots (`_is_jwt`, `:278-281`). Validation
+   delegates to `OAuthValidator.validate_token` (RS256/ES256 against JWKS,
+   `oauth_validator.py:41`); identity is `claims["sub"]`, falling back to
+   `claims["email"]`, falling back to `"unknown"` (`:248`).
+2. **API key** — header `x-api-key: <secret>`. Looked up via
+   `ApiKeyManager.validate_key` (`api_key_manager.py`); identity is the
+   key's `name`. Scopes are surfaced on `AuthContext.scopes` for use by
+   the quota interceptor and any future scope-gated RPC.
+3. **Session token** — header `x-session-token: <token>`. Validated via
+   `SessionManager.validate_session` (`session_manager.py`); identity is
+   the session's `user_id`.
+
+The first method whose header is non-empty AND whose validator is
+configured is used; subsequent methods are not tried. Validation failure
+in any path raises (`AuthenticationError` / `ApiKeyError` / `SessionError`)
+and the interceptor returns gRPC `UNAUTHENTICATED`
+(`auth_interceptor.py:193-198`). If no header is present at all, the
+interceptor returns `UNAUTHENTICATED` with `"No valid authentication
+credentials provided."` (`:200-204`).
+
+A small allow-list bypasses auth entirely (`UNAUTHENTICATED_METHODS`,
+`:157-162`):
+
+- `/entdb.EntDBService/Health`
+- `/grpc.health.v1.Health/Check`
+
+On success the verified identity string is parked in a Python
+`ContextVar` (`_current_identity`, `:61-63`) for the duration of the
+handler invocation, then reset in a `finally` block (`:216-220`). This
+ContextVar is what `get_authoritative_actor` reads. **The Go port must
+replace the ContextVar with `context.Context` value propagation** (see
+"Go interface" below) — there is no equivalent of an async-task-local
+`ContextVar` that survives across goroutine hops, and a
+`grpc.UnaryServerInterceptor` is the natural place to attach a value.
+
+## Trusted-actor contract
+
+`get_authoritative_actor(request_actor: str) -> str`
+(`auth_interceptor.py:92-115`):
+
+- If the interceptor populated a trusted identity for this request, that
+  value is returned — **even if `request_actor` claims a different (or
+  more-privileged) actor**. This is the privilege-escalation fix.
+- The trusted identity is normalised: if it already starts with `user:`,
+  `system:`, `admin:`, or equals the literal `__system__`, it is
+  returned verbatim. Otherwise it is wrapped as `user:<identity>`
+  (`:108-115`). So a JWT `sub: "alice"` becomes `user:alice`; a session
+  for `user_id: "user:alice"` stays `user:alice`.
+- If no trusted identity is set (interceptor disabled, unit tests, or
+  the no-auth deployment mode), `request_actor` is returned unchanged.
+  This is the documented fallback for tests and dev-mode servers; a
+  production server MUST run the interceptor.
+
+`Actor` is just a string in this codebase — there is no struct. The
+prefix encodes the kind:
+
+- `user:<id>` — a real authenticated user.
+- `system:<service>` — internal service identity (e.g.
+  `system:gdpr-worker`); bypasses tenant-membership checks
+  (`grpc_server.py:498-499`).
+- `admin:<id>` — operator/admin identity; same bypass as `system:`.
+- `__system__` — bootstrap/replay actor used by the Applier; never
+  appears on the wire.
+- `group:<id>` — only valid in ACL grant subjects, never as a caller
+  identity.
+
+For Go, model this as `type Actor string` (zero-cost) plus accessors,
+not a sum type — every site already does prefix-string checks.
+
+## Privilege escalation invariants
+
+`tests/python/integration/test_privilege_escalation.py` is the
+behavioural pin. Every RPC that takes a wire-level `actor` (top-level
+field or nested in `RequestContext`) MUST consult the trusted identity
+before any authorization decision and MUST persist the trusted identity
+into the WAL when the operation succeeds.
+
+Authentication setup in every test: `with _trusted_identity("user:eve")`
+(`:97-104`). Privileged claims tried in the payload: `system:admin`,
+`system:gdpr-worker`, `__system__`, `admin:root` (`CLAIMED_ADMIN_ACTORS`,
+`:166-171`).
+
+The 34 cases break down by class:
+
+| Class | Cases | RPCs | Asserted |
+|-------|-------|------|----------|
+| Read-path, `RequestContext.actor` | 12 | `GetNode`, `GetNodes`, `QueryNodes` × 4 claimed strings | `ctx.aborted == True` AND `abort_code == PERMISSION_DENIED` (`:204-209`, `:225-228`, `:244-247`) |
+| Write-path reject (`ExecuteAtomic`, non-member) | 4 | `ExecuteAtomic` × 4 | `PERMISSION_DENIED` regardless of payload claim (`:280-284`) |
+| Write-path persists trusted (`ExecuteAtomic`, member) | 1 | `ExecuteAtomic` with eve as member, claim `system:admin` | WAL event `actor == "user:eve"` (`:308-313`) — proves the persisted log is not poisoned |
+| Admin-only top-level `actor` | 12 | `CreateUser`, `TransferUserContent`, `GetTenantQuota` × 4 claimed | `PERMISSION_DENIED`; for `TransferUserContent` also `wal.append.assert_not_awaited()` (`:362-365`) |
+| `ListTenants` membership filter | 4 | `ListTenants` (one per claimed string) | eve sees only `["globex"]`; sanity check that a *trusted* admin caller DOES see all three tenants (`:402-417`) |
+| Edge read negative | 1 | `GetEdgesFrom` with payload `system:admin` | handler does not crash and does not forward the claimed actor downstream (`:443-447`) |
+
+Total: **34** parameterised cases across 8 RPCs. Any Go handler that
+fails to substitute the trusted actor will trip at least one of these
+when the contract test is ported.
+
+## Go interface
+
+Proposed package layout (mirrors `server/python/entdb_server/auth/`):
+
+```
+server/go/internal/auth/
+  interceptor.go     // UnaryAuthInterceptor + StreamAuthInterceptor
+  identity.go        // contextKey, Authoritative(), WithIdentity()
+  actor.go           // Actor type, prefix predicates
+  oauth.go           // JWKS-backed JWT validator
+  apikey.go          // API key store
+  session.go         // session manager
+  errors.go          // typed errors -> codes.Unauthenticated
+```
+
+Sketch (no implementation in this doc):
+
+```go
+package auth
+
+type contextKey struct{}
+var identityKey = contextKey{}
+
+type Identity struct {
+    Method   string   // "oauth" | "api_key" | "session"
+    Subject  string   // raw verified id (e.g. JWT sub)
+    Scopes   []string // API-key scopes; nil for oauth/session
+    Claims   map[string]any
+}
+
+type Interceptor struct {
+    OAuth    *OAuthValidator
+    APIKeys  *APIKeyManager
+    Sessions *SessionManager
+}
+
+func (i *Interceptor) Unary() grpc.UnaryServerInterceptor
+func (i *Interceptor) Stream() grpc.StreamServerInterceptor
+
+// Identity from ctx, or zero value if anonymous.
+func IdentityFromContext(ctx context.Context) (Identity, bool)
+
+// Authoritative implements get_authoritative_actor semantics:
+// trusted wins over claimed; falls back to claimed when no identity.
+func Authoritative(ctx context.Context, claimed Actor) Actor
+```
+
+The `Health` allow-list is matched on `info.FullMethod` exactly as in
+Python (`auth_interceptor.py:185-187`). For streaming RPCs use
+`grpc.ServerStream` wrapping to keep the augmented context available
+to the handler.
+
+The `Authoritative` helper is the choke point — call it once at the top
+of each handler and rebind the local variable, mirroring
+`grpc_server.py:493`. Subsequent helpers (`_is_admin_or_system`,
+`_check_tenant_access`, `_check_cross_tenant_read`) all re-call it as
+defence-in-depth; the Go port should keep that belt-and-suspenders.
+
+## Dependencies
+
+- `pb` (generated proto): no runtime dependency from the interceptor —
+  it operates on metadata only. `Authoritative()` is consumed by every
+  handler in `pkg/server/grpc/...`.
+- `errs` mapping: `OAuth/APIKey/SessionError` → `codes.Unauthenticated`
+  with the original message; transport-level failures (JWKS fetch,
+  store backend) → `codes.Unavailable`. Mirror the Python catch
+  (`auth_interceptor.py:193-198`).
+- Context plumbing: install via
+  `grpc.ChainUnaryInterceptor(authInterceptor.Unary(), quotaInterceptor.Unary(), ...)`.
+  Order matters — auth must run *before* quota so the quota interceptor
+  can read the identity for per-identity rate limiting.
+- `sync.Map` (or a cache library like `ristretto`) for JWKS and session
+  lookups — Python uses dicts behind a single `asyncio.Lock`; Go needs
+  proper concurrency primitives.
+
+## RPCs that consume this
+
+Every RPC in `entdb.v1.EntDBService` consumes the interceptor for
+authentication. The set that additionally consumes `Authoritative` for
+authorization (i.e. cannot be ported correctly without it) is at least:
+
+- `ExecuteAtomic` (writes WAL; `grpc_server.py:435-437`, `:491-493`)
+- `GetNode`, `GetNodes`, `QueryNodes`, `SearchNodes` (cross-tenant read
+  check; `grpc_server.py:586-588`)
+- `GetEdgesFrom`, `GetEdgesTo`
+- `CreateUser`, `UpdateUser`, `DeleteUser`, `GetUser`, `ListUsers`
+- `CreateTenant`, `ArchiveTenant`, `DeleteTenant`, `RestoreTenant`,
+  `SetTenantLegalHold`
+- `AddGroupMember`, `RemoveGroupMember`, `ChangeMemberRole`
+- `TransferUserContent` (`_require_admin_or_owner`,
+  `grpc_server.py:2671-2673`)
+- `GetTenantQuota`, `SetTenantQuota`
+- `ListTenants` (special: rejects when `get_current_identity()` is
+  None, `grpc_server.py:1561-1566` — does NOT fall back to the payload)
+- All GDPR / audit-export RPCs
+
+Bypass / unauthenticated:
+
+- `Health` and `grpc.health.v1.Health/Check` — explicit allow-list
+  (`auth_interceptor.py:158-162`). The Go port MUST keep the allow-list
+  exact; orchestrators (k8s, ECS) probe the standard health service
+  without credentials (`grpc_server.py:3274-3275`).
+
+Special: `ListTenants` deliberately does **not** fall back to the
+payload when the interceptor is absent — it aborts with
+`PERMISSION_DENIED` instead (`grpc_server.py:1562-1566`). The Go port
+must preserve this; it is the one RPC where the
+"no-interceptor → trust claimed" fallback is unsafe (cross-tenant
+enumeration).
+
+## Open questions / risks
+
+- **Tenant scoping from token vs request.** Today every request carries
+  `RequestContext.tenant_id` and the interceptor has no opinion on it;
+  membership is checked in `_check_tenant_access`. JWTs commonly carry a
+  `tenant_id` (or list) claim — should the Go port reject requests
+  whose `request.context.tenant_id` does not match a token claim?
+  Decision deferred; flagged in EPIC #407. Today: trust the request
+  field, gate via membership.
+- **Session caching strategy.** Python uses an in-memory dict
+  (`session_manager.py:14-23`). For the Go port behind a load balancer
+  this needs to be either (a) sticky sessions, (b) Redis, or (c)
+  signed/stateless session tokens. Picking one is out of scope here but
+  must be settled before the Go server is multi-replica.
+- **Rate-limit-by-identity.** The quota interceptor
+  (`auth/quota_interceptor.py`) currently keys off tenant. Once
+  `Identity` is in `context.Context`, per-identity (per-API-key) rate
+  limits become trivial — but the quota proto needs new fields. Track
+  separately.
+- **JWKS rotation thundering herd.** Python serialises refetch behind a
+  single asyncio lock. Go's natural pattern is `singleflight.Group` —
+  use that, not a plain mutex, so a kid miss does not block all
+  concurrent requests on the same JWKS URL.
+- **`sub` collisions across providers.** When multiple OIDC issuers are
+  configured, two different users at two providers can share a `sub`.
+  Python ignores this. The Go port should namespace identities by
+  issuer (e.g. `user:<iss>#<sub>`) — but doing so changes every
+  persisted WAL `actor` and is a breaking change. Leave Python-compat
+  for now; revisit before multi-IdP support ships.
+- **Constant-time API key compare.** `validate_key` should use
+  `subtle.ConstantTimeCompare` on the SHA-256 hash; flagged in
+  `api_key_manager.py:23` as a TODO and inherited.

--- a/docs/go-port/shared/canonical-store.md
+++ b/docs/go-port/shared/canonical-store.md
@@ -1,0 +1,276 @@
+# CanonicalStore — Go Port Spec
+
+EPIC #407. Per-tenant SQLite materialized view of the WAL. Source of
+truth for every read RPC. Rebuildable from the WAL — no data must
+exist here that is not also in an event.
+
+Python source: `server/python/entdb_server/apply/canonical_store.py`
+(5345 LOC, single class `CanonicalStore`). This spec captures the
+contract a Go port must preserve, not a line-for-line translation.
+
+CLAUDE.md invariant #4: **per-tenant SQLite isolation** — each tenant
+has its own DB file, no cross-tenant queries inside a single SQLite
+transaction. Cross-tenant state (users, tenants, memberships) lives in
+`global_store` (separate spec).
+
+## Schema
+
+One physical SQLite file per tenant: `{data_dir}/tenant_{tenant_id}.db`.
+Strict id validation at `canonical_store.py:138-162` —
+`tenant_id` must match `[A-Za-z0-9_-]{1,128}` or open is rejected
+(prevents path-collision data leak). Same alphabet enforced for any id
+that becomes a filename.
+
+Mailbox + public files share the `nodes`/`edges` schema (storage modes
+TENANT/USER_MAILBOX/PUBLIC, `canonical_store.py:732-892`):
+
+- `tenant_{id}.db` — TENANT mode (default).
+- `{tenant_id}/user_{user_id}.db` — USER_MAILBOX (per-user, lazy create).
+- `public.db` — singleton PUBLIC.
+
+DDL is a single `executescript` at `canonical_store.py:1037-1200` plus
+typed-capability ALTERs at `:1211-1224`. Tables (all keyed by
+`tenant_id` first):
+
+| Table | Primary key | Purpose |
+|---|---|---|
+| `schema_version` | `version` | migration tracking |
+| `nodes` | `(tenant_id, node_id)` | node rows; `payload_json` keyed by **field_id** (invariant #6); `acl_blob` legacy JSON |
+| `edges` | `(tenant_id, edge_type_id, from_node_id, to_node_id)` | typed edges with `props_json`, `propagates_acl` |
+| `node_visibility` | `(tenant_id, node_id, principal)` | denormalized index for principal → visible nodes |
+| `applied_events` | `UNIQUE (tenant_id, idempotency_key)` | applier dedup |
+| `node_access` | `(node_id, actor_id)` | typed-capability ACL grants (`type_id`, `core_caps_json`, `ext_cap_ids_json`) |
+| `group_users` | `(group_id, member_actor_id)` | nested group membership |
+| `acl_inherit` | `(node_id, inherit_from)` | structural ACL inheritance |
+| `notifications` | `id` | per-user mailbox |
+| `read_cursors` | `(user_id, channel_id)` | last-read timestamps |
+| `type_metadata` | `type_id` | data_policy + PII fields cache |
+| `audit_log` | `event_id` | hash-chained audit (now superseded by S3 Object Lock — invariant #2) |
+
+Indexes (DDL `:1059-1186`): `idx_nodes_type`, `idx_nodes_owner`,
+`idx_nodes_updated`, `idx_edges_from/to/type`,
+`idx_visibility_principal`, `idx_applied_events_key`,
+`idx_access_actor`, `idx_group_users_member`, `idx_inherit_from`,
+`idx_notif_user`, `idx_audit_time`, `idx_audit_actor`.
+
+**Lazy expression indexes** (per-type, idempotent `IF NOT EXISTS`,
+process-local cache `:439-451`):
+
+- `idx_unique_t<type>_f<field>` — `CREATE UNIQUE INDEX … ON nodes(tenant_id, json_extract(payload_json, '$."<field>"')) WHERE type_id = <type>` (`_ensure_unique_indexes` `:1721`). Replaces the deleted `node_keys` table — see `docs/decisions/unique_keys.md` (superseded section).
+- `idx_unique_composite_t<type>_…` — multi-field composite unique (`:1809`).
+- `idx_query_t<type>_f<field>` — non-unique twin for `(entdb.field).indexed = true` (`_ensure_query_indexes` `:1876`, `docs/decisions/query_indexes.md`).
+- `fts_t<type>` — FTS5 virtual table, `tokenize='porter unicode61'`, `node_id UNINDEXED`, columns `f<field_id>` (`_ensure_fts_table` `:1993`, `docs/decisions/fts.md`).
+
+## Write surface
+
+Only the Applier writes. Every `_sync_*` write helper takes either
+`tenant_id` (opens its own connection + transaction) or `conn`
+(participates in an outer `batch_transaction`). The Applier path uses
+`batch_transaction` (`:1264-1289`) so an entire `TransactionEvent.ops`
+list is one `BEGIN IMMEDIATE … COMMIT`; partial application is
+impossible by construction.
+
+Methods called by `Applier.apply_event` (see `apply/applier.py`):
+
+- `create_node_raw(conn, …)` `:1291` — inserts `nodes` row, calls `_ensure_field_indexes` `:1942` first, calls `_update_visibility` `:2785`, FTS insert via `_sync_fts_insert` `:2039`.
+- `_sync_update_node` `:1612` — partial payload merge, FTS delete-then-insert if any searchable field changed.
+- `_sync_delete_node` `:1688` — cascades to `edges`, `node_visibility`, `node_access`, `acl_inherit`, FTS.
+- `_sync_create_edge` / `_sync_delete_edge` `:2476` / `:2564` — `INSERT OR REPLACE` on edges; storage-mode hierarchy enforced by `_validate_edge_direction` `:989`.
+- `_sync_share_node` / `_sync_revoke_access` / `_sync_delegate_access` / `_sync_revoke_user_access` / `_sync_transfer_ownership` / `_sync_transfer_user_content` `:2962`–`:3774`.
+- `_sync_add_group_member` / `_sync_remove_group_member` `:3497` / `:3533`.
+- `_sync_create_notification` / `_sync_batch_create_notifications` / `_sync_mark_notification_read` / `_sync_mark_all_read` / `_sync_update_read_cursor` `:4518`–`:4759`.
+- `_sync_anonymize_user_in_tenant` `:4890` (GDPR), `_sync_delete_user_drafts` `:893`.
+- `_sync_record_applied_event` `:1409` + `_sync_check_idempotency` `:1379` (idempotency on every batch).
+- `_sync_append_audit` `:4170` — legacy hash-chained audit; **do not extend** (invariant #2 — S3 Object Lock supersedes).
+
+**Field-id payload contract.** `payload_json` is `{"<field_id_int>": value, …}`. Rename of a proto field is free; rename of a `field_id` is breaking. Translation to/from names happens at the SDK boundary only. JSON columns: `payload_json`, `acl_blob`, `props_json`, `core_caps_json`, `ext_cap_ids_json`, `pii_fields`, audit `metadata`.
+
+**Lazy index hook.** Before `CreateNode`/`UpdateNode` the Applier calls `_ensure_field_indexes` once per `(db_path, type_id)`; the cache `:439-451` is process-local, the `IF NOT EXISTS` clauses keep it correct across restarts.
+
+## Read surface
+
+Called directly from gRPC handlers (`api/grpc_server.py`) — all async,
+all dispatched via `_run_sync`. None of these read paths take an outer
+connection; each opens-or-borrows the pooled tenant connection.
+
+| Async method | Sync impl | Used by RPC |
+|---|---|---|
+| `get_node` `:2326` | `_sync_get_node` `:2305` | `GetNode` |
+| `get_nodes_by_type` `:2372` | `_sync_get_nodes_by_type` `:2340` | `GetNodes` |
+| `query_nodes` `:2450` | `_sync_query_nodes` `:2394` | `QueryNodes` (uses `compile_query_filter` from `apply/query_filter.py` — Mongo-style operator allow-list, parameterised SQL fragment) |
+| `search_nodes` `:2157` | `_sync_search_nodes` `:2101` | `SearchNodes` (FTS5 `MATCH … ORDER BY rank`) |
+| `get_node_by_key` `:2215` | `_sync_get_node_by_key` `:2177` | unique-key lookup; planner picks `idx_unique_t…` automatically |
+| `get_node_by_composite_key` `:2270` | `_sync_get_node_by_composite_key` `:2229` | composite unique |
+| `get_visible_nodes` `:2761` | `_sync_get_visible_nodes` `:2715` | ACL-pre-filtered enumeration via `node_visibility` JOIN |
+| `get_edges_from` `:2642` | `_sync_get_edges_from` `:2609` | `GetEdgesFrom` |
+| `get_edges_to` `:2695` | `_sync_get_edges_to` `:2662` | `GetEdgesTo` |
+| `get_connected_nodes` (via `_sync_get_connected_nodes` `:3267`) | | `GetConnectedNodes` |
+| `_sync_get_edges_and_nodes` `:3387` | | bulk fetch |
+| `list_shared_with_me` `:3481` | `_sync_list_shared_with_me` `:3444` | `ListSharedWithMe` |
+| `_sync_get_acl_grants` `:3099` | | ACL inspection |
+| `list_node_access_for_group` `:3609` | `_sync_list_node_access_for_group` `:3592` | console |
+| `_sync_has_node_access` / `_sync_can_access` `:3956` / `:2867` | | ACL post-filter |
+| `_sync_get_notifications` / `_sync_get_unread_count` / `_sync_get_unread_channels` `:4562` / `:4675` / `:4826` | | mailbox/notifications |
+
+**ACL post-filter pattern.** `node_visibility` is an optimization for
+"enumerate what I can see"; full ACL evaluation (typed capabilities,
+groups, inheritance) runs through `_sync_can_access` `:2867` and the
+group-resolution helper `_sync_resolve_actor_groups` `:2828` (recursive,
+`_ACL_MAX_DEPTH = 10`). Read RPCs that return lists call `_can_access`
+per row before emitting (server-side, never trust the client).
+
+**Pagination.** Every list endpoint takes `limit`, `offset`. Order
+keys are validated against an allow-list (e.g. `_sync_query_nodes`
+`:2415-2417`) — no user string is ever interpolated into SQL.
+
+**Read-after-write consistency.** `wait_for_offset` `:478` (and
+`update_applied_offset` `:463`) — `asyncio.Condition` per tenant; the
+applier signals after each batch. Read RPCs that pass
+`after_offset` + `wait_timeout_ms` block until the materialized view
+catches up (default 30 s).
+
+## Concurrency
+
+- **WAL mode + busy_timeout.** `PRAGMA journal_mode=WAL`, `synchronous=NORMAL`, `busy_timeout=5000ms`, `cache_size=-64000` (~64 MiB) — `_get_connection` `:711-717`. SQLite WAL mode allows one writer + many readers without blocking readers.
+- **One pooled connection per file.** `self._connections` keyed by physical path (`:683`, `:783`). `check_same_thread=False`, `isolation_level=None` (autocommit; explicit `BEGIN IMMEDIATE`/`COMMIT`).
+- **Per-tenant `threading.Lock`** (`_get_tenant_lock` `:642`) serializes same-tenant SQLite calls so the single pooled connection never sees overlapping `execute()`s from different threads. Acquired BEFORE the cache check (`:690`) to avoid orphaned-FD races on first open.
+- **Per-tenant `asyncio.Semaphore(1)`** (`_get_tenant_semaphore` `:605`) — fair-share guard at the asyncio layer so a single noisy tenant cannot occupy all 32 thread-pool workers and starve others. Keyed by `(tenant_id, loop_id)` for test isolation.
+- **Thread pool.** `ThreadPoolExecutor(max_workers=min(32, cpu+4))` `:420-425`, `thread_name_prefix="entdb-sqlite"`. All `_sync_*` calls dispatched via `_run_sync` `:536`.
+- **Single-writer guarantee.** `BEGIN IMMEDIATE` in `batch_transaction` `:1283` — the per-tenant lock + WAL mode mean readers proceed concurrently while the applier holds the writer slot.
+- **Applier replay behavior.** During replay the Applier opens one `batch_transaction` per WAL batch; reads in flight see the pre-batch snapshot, then the post-batch snapshot atomically. Pinned by `tests/python/integration/test_concurrent_applier_reads.py` (no half-applied transaction visible; no deadlock; final reads see every committed write).
+
+## Go design
+
+Proposed location: **`server/go/internal/store/`** (currently only
+`server/go/README.md` exists). Split:
+
+```
+server/go/internal/store/
+  canonical.go        — type CanonicalStore (per-tenant ops)
+  schema.go           — DDL + lazy index/FTS creation
+  pool.go             — connection pool, per-tenant locks, executor
+  txn.go              — BatchTransaction wrapper (BEGIN IMMEDIATE)
+  visibility.go       — _update_visibility helpers
+  acl_engine.go       — typed-capability evaluation (mirrors :2823+)
+  fts.go              — _ensure_fts_table + search
+  indexes.go          — _ensure_unique/query/composite indexes
+  notifications.go    — mailbox + read cursors
+  audit.go            — legacy hash-chain (frozen — see invariant #2)
+  errors.go           — TenantNotFoundError, IdempotencyViolationError
+```
+
+**Driver choice.** Two viable options:
+
+| | `modernc.org/sqlite` | `mattn/go-sqlite3` |
+|---|---|---|
+| CGO | no (pure Go transpile of SQLite) | yes |
+| FTS5 | yes (built in) | yes (with `sqlite_fts5` build tag) |
+| `json_extract` | yes | yes |
+| Cross-compile | trivial — single binary, alpine-friendly | needs CC per target; complicates Docker multi-arch |
+| Performance | ~10–20 % slower than CGO on hot paths | fastest |
+| Encryption (SEE/SQLCipher) | no | via SQLCipher fork |
+| Licence | BSD-3 | MIT |
+| Maturity | production at large scale (cznic/ql lineage) | de-facto Go standard |
+
+Recommendation: **`modernc.org/sqlite`** for the default build —
+matches the "single static binary, no CGO toolchain" Go-server posture
+and removes Docker cross-compile pain. Keep the driver behind an
+interface (`store.Driver`) so a `mattn` build tag can be added if
+encryption-at-rest (SQLCipher) re-enters scope.
+
+**Type sketch:**
+
+```go
+type CanonicalStore struct {
+    dataDir       string
+    walMode       bool
+    busyTimeout   time.Duration
+    cacheSizeKB   int
+    encryption    *EncryptionConfig
+    pool          *connPool       // path -> *sql.DB (pooled at driver level)
+    tenantMu      *keyedMutex     // per-tenant serializer
+    appliedOffset *offsetTracker  // tenant -> stream pos + sync.Cond
+    indexCache    *indexCache     // (path, type_id) -> set
+}
+
+func (s *CanonicalStore) GetNode(ctx context.Context, tenantID, nodeID string) (*Node, error)
+func (s *CanonicalStore) QueryNodes(ctx context.Context, q QueryNodesArgs) ([]*Node, error)
+func (s *CanonicalStore) BatchTxn(ctx context.Context, tenantID string, fn func(*Tx) error) error
+// …
+```
+
+Async-via-thread-pool dance from Python disappears — Go's
+`database/sql` gives us native goroutines and a per-`*sql.DB`
+connection pool. We still need the per-tenant mutex if we keep one
+`*sql.DB` per tenant DB path with `SetMaxOpenConns(1)` (matches the
+Python single-pooled-connection model and serializes writers without
+WAL contention surprises). Alternative: `SetMaxOpenConns(N)` + rely on
+SQLite's WAL — needs benchmarking against the Python baseline before
+choosing.
+
+## Dependencies
+
+- **proto/pb** — `entdb/v1` generated types: `Node`, `Edge`, `Operation`, `TransactionEvent`, `RequestContext`, FieldOpts. Imported as `pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb/entdb/v1"`.
+- **schema** — `NodeTypeDef`, `EdgeTypeDef`, `SchemaRegistry` (Go port of `schema/registry.py` + `schema/types.py`). Provides `GetUniqueFieldIDs`, `GetIndexedFieldIDs`, `GetSearchableFieldIDs`, `GetCompositeUnique` per type.
+- **acl** — `Permission` enum + typed `CoreCap`/`ExtCap` (Go port of `auth/permissions.py`). Used by `node_access` writes and `_sync_can_access` evaluation.
+- **errs** — typed errors: `TenantNotFound`, `IdempotencyViolation`, `UniqueConstraintError`, `ACLDenied`. Mapped to gRPC codes at the handler boundary.
+- **query_filter** — Go port of `apply/query_filter.py` (Mongo-style operator allow-list → SQL fragment). Same operator set, same parameterisation rules.
+- **metrics** — Prometheus counters for `sqlite_op{type=read|write}` (mirrors `_record_sqlite_op` `:83-84`).
+
+## RPCs touching this
+
+**Read RPCs (every one calls a `_sync_*` here):**
+`GetNode`, `GetNodes`, `QueryNodes`, `SearchNodes`, `GetNodeByKey`
+(spec yet to be added — uses `get_node_by_key`), `GetEdgesFrom`,
+`GetEdgesTo`, `GetConnectedNodes`, `ListSharedWithMe`, `GetMailbox`,
+`SearchMailbox`, `ListMailboxUsers`, `GetReceiptStatus`,
+`GetTenantMembers`, `WaitForOffset`.
+
+**Write RPCs (all funnel through `ExecuteAtomic` → WAL → Applier →
+`batch_transaction` here):** `ExecuteAtomic`, `ShareNode`,
+`RevokeAccess`, `TransferOwnership`, `AddTenantMember`,
+`ChangeMemberRole`, `AddGroupMember`, `RemoveGroupMember`,
+`CreateTenant`, `ArchiveTenant`. (`CreateUser`, `UpdateUser`, etc. hit
+`global_store`, not this store — separate spec.)
+
+See per-RPC files in `docs/go-port/rpcs/` for handler-side detail.
+
+## Test surface
+
+**Fixture pattern for Go integration tests:**
+
+```go
+func newTestStore(t *testing.T) *store.CanonicalStore {
+    dir := t.TempDir()
+    s, err := store.Open(dir, store.Options{WAL: true, BusyTimeout: 5 * time.Second})
+    require.NoError(t, err)
+    t.Cleanup(func() { s.Close() })
+    return s
+}
+```
+
+In-memory mode (`:memory:` per tenant) is **not** supported because
+the per-tenant file-path identity is load-bearing for the pool; tests
+use `t.TempDir()` instead — same shape as `tests/python/integration/`
+fixtures.
+
+Behaviours to pin (Go ports of existing Python tests):
+
+- `tests/python/unit/test_canonical_store.py` — schema creation, basic CRUD, idempotency dedup.
+- `tests/python/unit/test_canonical_store_concurrency.py` — per-tenant lock correctness, no FD leaks under racing opens.
+- `tests/python/unit/test_canonical_store_perf.py` — sanity perf budgets (Go SHOULD beat Python on every line).
+- `tests/python/integration/test_concurrent_applier_reads.py` — readers + applier contract: no half-applied transaction observable, no deadlocks, every committed write visible post-test.
+
+Cross-implementation contract tests live in `tests/contract/` (per
+`CLAUDE.md` project layout); the Go store must pass the same fixtures.
+
+## Open questions / risks
+
+1. **Driver licensing + CGO.** `modernc.org/sqlite` removes CGO at the cost of ~15 % perf on hot paths and no SQLCipher. If encryption-at-rest is required (`encryption.py`, `derive_tenant_key`), we must either (a) keep `mattn/go-sqlite3` + SQLCipher, (b) implement application-level field encryption above the driver, or (c) defer encryption to filesystem-level (LUKS/EBS) and drop SQLCipher. Decision needed before GA.
+2. **Per-tenant file lifecycle.** Python lazy-creates files on first write and never closes them until process exit. With many idle tenants this leaks FDs. Go port should add an LRU eviction (`evict_mailbox_connection` `:955` is the only existing eviction hook). Threshold + policy TBD.
+3. **FTS5 availability.** `modernc.org/sqlite` ships FTS5 by default; `mattn/go-sqlite3` requires the `sqlite_fts5` build tag — easy to forget. Add a startup self-test (`SELECT fts5_version()`) that aborts boot on a missing FTS5.
+4. **`busy_timeout` tuning.** 5 s is the Python default; under bursty multi-tenant load with one `*sql.DB` per file we may need higher. Bench against the integration suite before locking in.
+5. **`SetMaxOpenConns(1)` vs N.** Python serializes via threading.Lock; Go could trust WAL and let N readers proceed without an explicit mutex. Risk: `INSERT OR REPLACE` semantics + lazy DDL inside a transaction need verification under concurrent readers. Decide via benchmark, not vibes.
+6. **type_id ignored in `GetNode`.** Already noted in `docs/go-port/rpcs/GetNode.md` — wire field is present but unused. Fix (filter on `type_id`) or formally delete from the proto in v2; tracked separately from this spec.
+7. **Audit log table.** `audit_log` + hash chain still ships in DDL but invariant #2 says S3 Object Lock supersedes. Go port keeps the table for backwards-compat read-only queries; **do not extend**, do not write new audit rows from the Go applier.
+8. **Pool key by physical path.** Path is a string; on macOS case-insensitive FS this is a footgun. Validator alphabet excludes upper/lower collisions in IDs but not in `data_dir`. Document the assumption (`data_dir` must be on a case-sensitive FS) or canonicalize via `filepath.EvalSymlinks` at open.

--- a/docs/go-port/shared/error-mapping.md
+++ b/docs/go-port/shared/error-mapping.md
@@ -1,0 +1,278 @@
+# Error / gRPC Status Code Mapping (Go Port)
+
+EPIC: #407 (Python -> Go server port). The Go server MUST emit byte-for-byte
+identical `(grpc.StatusCode, message-prefix, trailers)` triples for every
+error path observable from `tests/python/integration/test_grpc_contract.py`,
+`tests/python/integration/test_privilege_escalation.py`, and
+`tests/python/unit/test_grpc_wire_format.py`.
+
+This is the canonical source for the mapping. Per-RPC specs in
+`docs/go-port/rpcs/*.md` reference this file for code semantics and only
+list the per-RPC trigger conditions.
+
+## Code catalogue
+
+Every status code emitted by the Python server today, with where it
+fires. RPC names are the proto methods on `entdb.v1.EntDBService`.
+
+| Code | Trigger | Where (file:line) | RPCs |
+|---|---|---|---|
+| `OK` | Success path; also the fallback when broad `except Exception` swallows handler-internal failures and returns an empty/default response | `api/grpc_server.py:1600`, `:1603`, `:826` (ExecuteAtomic outer), and many handler `except Exception` blocks (see Swallow Patterns) | most happy paths; ListTenants, ExecuteAtomic outer, schema/legacy paths |
+| `INVALID_ARGUMENT` | Missing required field on the request (`tenant_id`, `actor`, `user_id`, `email`, `name`, `from_user`, `to_user`, `new_role`, `query`, empty `operations`); also surfaced by `QueryFilterError` at `api/grpc_server.py:1154-1155` | `api/grpc_server.py:633,635,637,1151,2114,2121,2123,2125,2164,2166,2199,2201,2246,2319,2321,2323,2377,2379,2412,2414,2457,2459,2461,2507,2509,2511,2558,2560,2587,2589,2616,2618,2620,2622,2675,2702,2704,2706,2757,2759,2761,2822,2874,2876,2941,2943,2994,2996,3025,3027,3083,3085,3128` | every write/admin RPC with required args |
+| `NOT_FOUND` | Tenant does not exist on this node, OR the request actor is not a member of the tenant (treated as "not found" to avoid existence leak) | `api/grpc_server.py:505-516` (`_check_tenant`) | every RPC that calls `_check_tenant` |
+| `ALREADY_EXISTS` | Idempotency key replay with conflicting payload; unique constraint or composite-unique constraint violation during apply | `api/grpc_server.py:697,746` (raised from `IdempotencyViolationError` / `UniqueConstraintError` / `CompositeUniqueConstraintError`) | `ExecuteAtomic` |
+| `PERMISSION_DENIED` | Caller is not admin/owner; cross-tenant read denied; ACL `AccessDeniedError`; client-claimed actor differs from authenticated identity (privilege escalation guard) | `api/grpc_server.py:535,542,553,615-616,1042-1043,1563-1564,2117,2204,2425,2472,2633,2680,2687,2946,2999,3030,3088` | `GetNode`, `ExecuteAtomic`, admin RPCs (`CreateUser`, `UpdateUser`, `DeleteUser`, `AddTenantMember`, `RemoveTenantMember`, `ChangeMemberRole`, `TransferOwnership`, `TransferUserContent`, `DelegateAccess`, `ExportUserData`, `EraseUser`, `RevokeAccess`, etc.) |
+| `FAILED_PRECONDITION` | Tenant pinned to a region this node does not serve (permanent, must NOT be retried); also some compatibility/state-machine guards | `api/grpc_server.py:520,526,406` | every RPC behind `_check_tenant` when region-pinned |
+| `RESOURCE_EXHAUSTED` | Per-tenant rate-limit bucket empty; quota interceptor (ops/sec, monthly cap); transport-layer cap exceeded (`grpc.max_receive_message_length`, default 4 MiB on a stock gRPC server, 50 MiB on configured server -- see `api/grpc_server.py:3265-3266`) | `api/rate_limiter.py:94`, `auth/quota_interceptor.py:237`, gRPC core (no Python line) | any RPC; default-config server returns it for oversized payloads |
+| `UNAUTHENTICATED` | Missing / malformed / expired bearer token; failed JWT or session validation; API-key validation failure | `auth/auth_interceptor.py:196,202`, `api/auth.py:81,131,139,152,187` | every RPC outside `UNAUTHENTICATED_METHODS` (the bypass set is `Health`, JWT login flows) |
+| `UNAVAILABLE` | Tenant is not owned by this node (sharding mismatch). Trailers carry `entdb-redirect-node` so SDK redirect cache can update | `api/grpc_server.py:392-395` | every RPC that calls `_check_tenant` |
+| `UNIMPLEMENTED` | Optional dependency not configured (no `global_store`, no user registry, no compliance/audit subsystem); also the proto-generated default for any RPC the servicer does not override (`api/generated/entdb_pb2_grpc.py:268-554`) | `api/grpc_server.py:2108,2158,2193,2240,2313,2371,2406,2451,2501,2552,2581,2610,2817,2939,2992,3023,3081,3123` | `CreateTenant`, `ArchiveTenant`, `AddTenantMember`, `RemoveTenantMember`, `ChangeMemberRole`, `GetTenant`, `GetTenantMembers`, `GetUser*`, `*UserContent`, legal-hold, etc., when the corresponding store is `None` |
+| `INTERNAL` | Currently NOT raised as a gRPC code by handlers. Returned as a string field `error_code = "INTERNAL"` inside `ExecuteAtomicResponse` on inner-handler exceptions (the RPC itself stays `OK`) | `api/grpc_server.py:824` | `ExecuteAtomic` only (in-band, not status-coded) |
+| `DEADLINE_EXCEEDED` | Not raised by the server; surfaces only when the client deadline elapses (transport-level) | n/a | any |
+| `UNKNOWN` | Not raised by handlers. Will surface only if a handler `raise`s a non-`AbortError`, non-`RpcError` exception that escapes the broad `except Exception` blocks — currently impossible because each handler has a fallback | n/a | n/a |
+| `OUT_OF_RANGE`, `CANCELLED`, `ABORTED`, `DATA_LOSS` | Not used by the Python server | n/a | n/a |
+
+Notes:
+
+- `ExecuteAtomic` has a *layered* error model: the outer status stays
+  `OK` even on apply failures; failures are reported in
+  `ExecuteAtomicResponse{success=false, error, error_code}`. The Go
+  port MUST preserve this. See `api/grpc_server.py:818-825`.
+- The auth interceptor and quota interceptor produce status from
+  *outside* the handler -- the Go port must keep these as interceptors
+  too, otherwise the codes would not be observable for streaming /
+  unary calls that never enter the handler body.
+
+## Exception -> code mapping
+
+Python exception types and the status code they map to. Many are
+mapped *manually* by handlers (caught and rethrown via `context.abort`)
+rather than via a central handler -- the Go port should centralize.
+
+| Python exception | File | gRPC code | Proposed Go (`server/go/internal/errs`) |
+|---|---|---|---|
+| `grpc.aio.AbortError` | (raised by `context.abort`) | (already encoded) | `errs.From(status.Error(...))` -- pass-through |
+| `AccessDeniedError` | `apply/acl.py:44` | `PERMISSION_DENIED` | `errs.ErrPermission` |
+| `TenantNotFoundError` | `apply/canonical_store.py:165` | `NOT_FOUND` (via `_check_tenant`) | `errs.ErrNotFound` |
+| `IdempotencyViolationError` | `apply/canonical_store.py:171` | `ALREADY_EXISTS` | `errs.ErrAlreadyExists` |
+| `UniqueConstraintError`, `CompositeUniqueConstraintError` | `apply/applier.py:114,146` | `ALREADY_EXISTS` | `errs.ErrAlreadyExists` |
+| `ValidationError`, `SchemaFingerprintMismatch` | `apply/applier.py:53,59` | reported in-band on `ExecuteAtomicResponse` (NOT a status code) | `errs.ErrValidation` (only the in-band path) |
+| `QueryFilterError` | `apply/query_filter.py:60` | `INVALID_ARGUMENT` | `errs.ErrInvalidArgument` |
+| `SchemaValidationError` | `schema/validator.py:18` | in-band on `ExecuteAtomicResponse` | `errs.ErrValidation` |
+| `CompatibilityError` | `schema/compat.py:128` | `FAILED_PRECONDITION` (when surfaced through admin path) | `errs.ErrFailedPrecondition` |
+| `RegistryFrozenError`, `DuplicateRegistrationError` | `schema/registry.py:51,57` | `FAILED_PRECONDITION` | `errs.ErrFailedPrecondition` |
+| `AuthenticationError` | `auth/oauth_validator.py:44` | `UNAUTHENTICATED` (via interceptor) | `errs.ErrUnauthenticated` |
+| `SessionError` | `auth/session_manager.py:36` | `UNAUTHENTICATED` | `errs.ErrUnauthenticated` |
+| `ApiKeyError` | `auth/api_key_manager.py:41` | `UNAUTHENTICATED` | `errs.ErrUnauthenticated` |
+| `AuthError` | `api/jwt_auth.py:40` | `UNAUTHENTICATED` | `errs.ErrUnauthenticated` |
+| `CryptoShreddedError`, `TenantShreddedError` | `crypto/key_manager.py:59`, `crypto/tenant_key_vault.py:55` | `FAILED_PRECONDITION` (tenant has been crypto-shredded; permanent) | `errs.ErrFailedPrecondition` |
+| `TenantKeyAlreadyProvisionedError` | `crypto/tenant_key_vault.py:67` | `ALREADY_EXISTS` | `errs.ErrAlreadyExists` |
+| `WalConnectionError`, `WalTimeoutError` | `wal/base.py:47,53` | currently swallowed -> `OK` with empty/error response (see Swallow Patterns) | `errs.ErrUnavailable` (Go port may upgrade -- behind feature flag if it breaks contract tests) |
+| `WalSerializationError` | `wal/base.py:59` | swallowed | `errs.ErrInternal` (in-band only) |
+| `PermissionError` (Python builtin) | `api/grpc_server.py:1791,1849` | swallowed inside admin paths | `errs.ErrPermission` |
+
+## Detail trailers
+
+The Python server attaches trailing metadata in two places. The Go
+port MUST emit these with identical keys and value formats (header
+matching is byte-for-byte after lower-casing per HTTP/2).
+
+| Trailer key | Status | Value | Set at |
+|---|---|---|---|
+| `entdb-redirect-node` | `UNAVAILABLE` | The owning node id (string) the SDK should retry against | `api/grpc_server.py:387-389` |
+| `retry-after` | `RESOURCE_EXHAUSTED` (quota) | Seconds until next allowed attempt (`str(int)`) | `auth/quota_interceptor.py:233` |
+
+Other RPC paths do NOT attach trailers. No `error_details` /
+`google.rpc.Status` proto encoding is used today -- error context is
+purely the gRPC `message` string. The Go port should NOT introduce
+`google.rpc.ErrorInfo` / `google.rpc.RetryInfo` proto details
+(out-of-scope for parity).
+
+A subtle quirk: Python's `set_trailing_metadata` on the redirect path
+is *synchronous* in `grpc.aio` but the code awaits it conditionally
+(`api/grpc_server.py:390`) so unit-test `AsyncMock`s work. In Go this
+is just `grpc.SetTrailer(ctx, metadata.Pairs(...))` followed by
+returning the `status.Error(...)`.
+
+Order matters: trailer MUST be set BEFORE the abort/return-error,
+otherwise gRPC flushes trailers along with the closing status and the
+late call is a no-op.
+
+## Swallow patterns
+
+The Python server has several broad `except Exception` blocks that
+the Go port must mirror behavior-for-behavior to avoid breaking
+contract tests:
+
+1. **Re-raise gRPC aborts, swallow the rest**
+   (`api/grpc_server.py:2740-2745`, `:2801-2806`, `:2857-2860`,
+   `:2916-2920`, `:2976-2978`, `:3007-3009`, `:3065-3067`,
+   `:3099-3101`, `:3158-3160`):
+   ```
+   except Exception as e:
+       if isinstance(e, grpc.RpcError) or "StatusCode" in type(e).__name__:
+           raise
+       logger.error(...)
+       return ResponseProto(success=False, error=str(e))
+   ```
+   These RPCs return `OK` with `success=false` for any non-gRPC
+   exception. Go equivalent: `if status.Code(err) != codes.Unknown { return err } else { return &Resp{Success: false, Error: err.Error()}, nil }`.
+
+2. **Pure swallow -> empty default** (`api/grpc_server.py:1600-1603`,
+   `:826-828`, `:680`, `:720`, `:1514`, `:1533`, `:1929`, `:2735`,
+   `:2794`, `:2852`):
+   Catches everything and returns the proto's zero value (`ListTenantsResponse(tenants=[])`,
+   `count=0`, etc.). Status stays `OK`. The Go port must emulate this
+   for **read** paths used by the SDK happy-path test set.
+
+3. **In-band error code on ExecuteAtomic**
+   (`api/grpc_server.py:818-825`):
+   Inner handler exception -> `ExecuteAtomicResponse{success=false,
+   error=str(e), error_code="INTERNAL"}`, gRPC status `OK`. The string
+   `"INTERNAL"` is part of the wire contract -- contract tests assert
+   on it. Do NOT change to `codes.Internal`.
+
+4. **Re-raise `AbortError`** (`api/grpc_server.py:1597-1599`):
+   `grpc.aio.AbortError` is caught only to record metrics and is
+   re-raised. Go: same -- record metric in deferred function, then
+   return the status error.
+
+## Go design
+
+```
+server/go/internal/errs/
+    errs.go        -- typed sentinel errors + GRPCStatus()
+    map.go         -- (Python-equivalent-exception) -> code translator
+    trailers.go    -- helpers for redirect-node / retry-after
+```
+
+Sentinels (each implements `GRPCStatus() *status.Status` so
+`status.Code(err)` works directly):
+
+```go
+var (
+    ErrInvalidArgument    = newCode(codes.InvalidArgument)
+    ErrNotFound           = newCode(codes.NotFound)
+    ErrAlreadyExists      = newCode(codes.AlreadyExists)
+    ErrPermission         = newCode(codes.PermissionDenied)
+    ErrFailedPrecondition = newCode(codes.FailedPrecondition)
+    ErrResourceExhausted  = newCode(codes.ResourceExhausted)
+    ErrUnauthenticated    = newCode(codes.Unauthenticated)
+    ErrUnavailable        = newCode(codes.Unavailable)
+    ErrUnimplemented      = newCode(codes.Unimplemented)
+)
+```
+
+Helper:
+
+```go
+// Errorf wraps msg in the canonical status. Use in handlers instead of
+// status.Errorf so the Python -> Go contract stays in one place.
+func Errorf(code codes.Code, format string, a ...any) error
+```
+
+Trailer helpers:
+
+```go
+func SetRedirectTrailer(ctx context.Context, ownerNode string) error
+func SetRetryAfter(ctx context.Context, seconds int) error
+```
+
+Callers MUST invoke these before returning the error -- the request
+spec for each RPC will instruct.
+
+Single chokepoint for swallow-pattern (1):
+
+```go
+// PreserveStatusOrSwallow returns err if it already carries a gRPC
+// status code; otherwise returns nil and writes the message into
+// dst.Success/dst.Error. Mirrors grpc_server.py "isinstance(e, RpcError)"
+// branch.
+func PreserveStatusOrSwallow(err error, dst interface{ SetError(string) }) error
+```
+
+## Dependencies
+
+- `google.golang.org/grpc/codes`
+- `google.golang.org/grpc/status`
+- `google.golang.org/grpc/metadata` (trailers)
+- `google.golang.org/grpc` (`grpc.SetTrailer`)
+- stdlib `errors` (for `errors.Is` against sentinels)
+
+No third-party dependency is required. Do NOT pull
+`google.golang.org/genproto/googleapis/rpc/errdetails` -- the Python
+server does not use proto error details and adding them would
+de-sync the contract.
+
+## Test surface
+
+Go-side mirror of Python contract assertions. Each becomes a row in
+`tests/go/contract/error_codes_test.go` (or equivalent).
+
+| Python assertion | Go assertion |
+|---|---|
+| `tests/python/integration/test_grpc_contract.py:725` -- `INVALID_ARGUMENT` for missing required field, every required-arg RPC | `status.Code(err) == codes.InvalidArgument` |
+| `:731` -- `PERMISSION_DENIED` when caller is not admin/owner | `codes.PermissionDenied` |
+| `:737` -- `UNIMPLEMENTED` when registry / global_store is `nil` | `codes.Unimplemented` |
+| `tests/python/integration/test_privilege_escalation.py:209,228,247,284,341,363,378` -- claimed-actor mismatch -> `PERMISSION_DENIED` on `GetNode`, `ExecuteAtomic`, admin RPCs | `codes.PermissionDenied` for every per-handler privilege guard |
+| `tests/python/unit/test_grpc_wire_format.py:315` -- 5 MiB request on default-cap server -> `RESOURCE_EXHAUSTED` | `codes.ResourceExhausted` (transport-layer) |
+| Sharding redirect (when `_sharding.is_mine == false`) | `codes.Unavailable` AND trailer `entdb-redirect-node` matches owner |
+| Region pin mismatch | `codes.FailedPrecondition`, no retry trailer |
+| Quota exceeded | `codes.ResourceExhausted` AND trailer `retry-after` is a positive integer string |
+
+For each existing per-RPC spec in `docs/go-port/rpcs/`, the "Errors"
+section must list the codes from this catalogue rather than redefining
+them.
+
+## Open questions / risks
+
+1. **`RESOURCE_EXHAUSTED` for oversized messages.** The Python wire-
+   format test (`test_grpc_wire_format.py:293-317`) uses a server with
+   the *default* 4 MiB receive cap; the production server raises the
+   cap to 50 MiB (`api/grpc_server.py:3265-3266`). The Go port should:
+   - Build the production server with `grpc.MaxRecvMsgSize(50<<20)`
+     and `grpc.MaxSendMsgSize(50<<20)` to match Python defaults.
+   - Run the contract test variant against a server built with the
+     gRPC default (4 MiB). The Go gRPC default is also 4 MiB, so the
+     code emitted for an oversized payload is `codes.ResourceExhausted`
+     out-of-the-box -- parity is automatic provided we DO NOT call
+     `grpc.MaxRecvMsgSize` in the test fixture.
+   - Risk: gRPC-Go's exact error message for oversized messages is
+     `"grpc: received message larger than max"`; SDK string-parses
+     would break. The Python SDK only checks `code()`, so the message
+     drift is acceptable -- but future SDK contributors must not
+     depend on the message text.
+
+2. **Retry trailer propagation.** `grpc.SetTrailer` only takes effect
+   if called before the handler returns. If the handler is wrapped by
+   an interceptor that re-classifies errors (we expect one for the
+   swallow-pattern mapping), the interceptor must propagate trailers.
+   Use `grpc.SetTrailer(ctx, ...)` (which writes to the call's trailer
+   set, not a return value) before returning the status error.
+
+3. **`ExecuteAtomic` in-band `error_code = "INTERNAL"`.** This is a
+   string in the proto, NOT a gRPC code. Tempting to delete -- do not.
+   The Python SDK keys retry behavior off the proto field, not the
+   status. Keep the literal `"INTERNAL"`.
+
+4. **`UNKNOWN` should never appear.** If contract tests start seeing
+   `codes.Unknown`, it means an unwrapped Go error escaped a handler.
+   Treat as a P0 bug. Add a final `recover()` / wrapping interceptor
+   that maps any naked error to `errs.ErrInternal` *only* for
+   `ExecuteAtomic` (which has the in-band channel) and re-raises
+   elsewhere as `codes.Internal` -- after confirming no contract test
+   currently exercises a `codes.Internal` path. (Today's Python
+   surface emits zero `codes.Internal` from any handler.)
+
+5. **Auth bypass set drift.** `UNAUTHENTICATED_METHODS` lives in two
+   places (`auth/auth_interceptor.py:157`, `api/auth.py:51,102`) --
+   the Go port should consolidate into a single
+   `errs.AnonymousMethods` set referenced by the interceptor. Audit
+   contract tests for any RPC that currently bypasses auth and
+   document it in the per-RPC spec.
+
+6. **Streaming RPCs.** None of the EntDB RPCs are streaming today; the
+   quota interceptor (`auth/quota_interceptor.py:242-244`) explicitly
+   only wraps unary-unary. If a streaming RPC is added during the
+   port, this mapping must be revisited -- streaming errors arrive on
+   `Send`/`Recv`, not as a single status.

--- a/docs/go-port/shared/global-store.md
+++ b/docs/go-port/shared/global-store.md
@@ -1,0 +1,304 @@
+# Go Port Spec — `globalstore` (cross-tenant SQLite)
+
+EPIC #407 component spec. Source of truth in Python:
+`server/python/entdb_server/global_store.py` (1333 lines, single class
+`GlobalStore`). The Go reimplementation lives at
+`server/go/internal/globalstore/`.
+
+This is the only place cross-tenant state may be read or written
+(CLAUDE.md invariant #4). It owns its own SQLite file at
+`{data_dir}/global.db`, distinct from per-tenant `canonical_store` files.
+
+## Schema
+
+All tables live in one file (`global.db`), all timestamps are integer
+Unix epoch **seconds** unless suffixed `_ms`. Schema is created
+idempotently on startup; column additions use `ALTER TABLE ... ADD
+COLUMN` guarded by `PRAGMA table_info` (see `_migrate_tenant_quotas`,
+`_migrate_tenant_registry_region` at `global_store.py:187,280`).
+
+| Table | Purpose | PK | Notes |
+|---|---|---|---|
+| `user_registry` | identity registry | `user_id` | `email UNIQUE`, `status` ∈ {active, suspended, pending_deletion, deleted}, `created_at`, `updated_at` (`global_store.py:203`) |
+| `tenant_registry` | tenant metadata + region pin | `tenant_id` | `status` ∈ {active, archived, legal_hold, deleted}, `region` defaults `us-east-1` (`global_store.py:212,217`) |
+| `tenant_members` | user→tenant mapping with role | `(tenant_id, user_id)` | `role` is free-text (`owner`, `admin`, `member`); secondary index on `user_id` (`global_store.py:220-228`) |
+| `shared_index` | cross-tenant share hint | `(user_id, source_tenant, node_id)` | `permission` text; **hint-only**, authoritative ACLs live in canonical_store (`global_store.py:230,755`) |
+| `deletion_queue` | GDPR right-to-erasure scheduler | `user_id` | `requested_at`, `execute_at`, `export_path`, `status` ∈ {pending, completed} (`global_store.py:239`) |
+| `legal_holds` | per-tenant legal hold records | `(tenant_id, held_by)` | informational; the `tenant_registry.status='legal_hold'` flag is what gates writes (`global_store.py:247`) |
+| `tenant_quotas` | rate-limit / monthly write config | `tenant_id` | monthly cap + Phase-2/3 token-bucket columns (`global_store.py:255`) |
+| `tenant_usage` | rolling write counters | `tenant_id` | `period_start_ms` is start-of-UTC-month in **milliseconds** (`global_store.py:266`) |
+
+Identifier conventions:
+
+- `user_id` — bare id, e.g. `"alice"`. This is what's stored in
+  `user_registry.user_id`, `tenant_members.user_id`,
+  `shared_index.user_id`, `deletion_queue.user_id`.
+- `tenant_id` — bare id, e.g. `"acme"`.
+- Mailbox routing: there is **no** `mailbox_index` or `region_pinning`
+  table. Region is a column on `tenant_registry`. The legacy mailbox
+  store is gone (see `grpc_server.py:1461,1483,1610` — RPCs
+  deprecated, return empty).
+
+## Operations
+
+Async public methods that thread through a single-thread executor (one
+SQLite connection) via `_run_sync`. Each `async def foo` has a paired
+`_sync_foo` (`global_store.py:312`).
+
+**Reads:**
+
+- `get_user(user_id)` → row or `None` (`global_store.py:371`)
+- `list_users(status='active', limit, offset)` (`global_store.py:411`)
+- `get_tenant(tenant_id)` (`global_store.py:489`)
+- `list_tenants(status='active')` — no pagination (`global_store.py:504`)
+- `get_members(tenant_id)` (`global_store.py:598`)
+- `get_user_tenants(user_id)` (`global_store.py:614`)
+- `is_member(tenant_id, user_id)` (`global_store.py:648`)
+- `get_shared_with_me(user_id, limit, offset)` (`global_store.py:713`)
+- `get_shared_entries_for_node(source_tenant, node_id)` (`global_store.py:774`)
+- `get_pending_deletions()` / `get_executable_deletions(now)` /
+  `get_deletion_entry(user_id)` (`global_store.py:850,865,887`)
+- `get_legal_holds(tenant_id)` / `is_under_legal_hold(tenant_id)` (`global_store.py:1021,1040`)
+- `get_quota_config(tenant_id)` / `get_usage(tenant_id)` (`global_store.py:1193,1227`)
+
+**Writes:**
+
+- `create_user(user_id, email, name)` — UNIQUE on email; raises `IntegrityError` on duplicate (`global_store.py:336`)
+- `update_user(user_id, **{email,name,status})` (`global_store.py:386`)
+- `set_user_status(user_id, status)` (`global_store.py:434`)
+- `create_tenant(tenant_id, name, region='us-east-1')` (`global_store.py:453`)
+- `set_tenant_status(tenant_id, status)` (`global_store.py:520`)
+- `set_legal_hold(tenant_id, enabled, actor)` — flips
+  `tenant_registry.status` between `legal_hold` and `active` (`global_store.py:528`)
+- `add_member` / `remove_member` / `change_role` (`global_store.py:558,582,630`)
+- `add_shared` (`INSERT OR REPLACE`) / `remove_shared` /
+  `cleanup_stale_shared(source_tenant, node_id)` /
+  `remove_all_shared_for_user(user_id)` (`global_store.py:670,697,751,736`)
+- `queue_deletion(user_id, grace_days=30)` /
+  `cancel_deletion(user_id)` /
+  `mark_deletion_completed(user_id)` (`global_store.py:800,834,898`)
+- `remove_all_memberships_for_user(user_id)` (`global_store.py:910`)
+- `transfer_user_content(tenant_id, from_user, to_user)` —
+  ensures `to_user` is a member; **does not** touch canonical_store
+  (`global_store.py:921`)
+- `set_legal_hold_record(tenant_id, held_by, reason)` /
+  `remove_legal_hold(tenant_id, held_by)` — `legal_holds` table only;
+  separate from `set_legal_hold` (`global_store.py:967,1001`)
+- `revoke_user_access(tenant_id, user_id)` — deletes membership +
+  scoped shared_index in one txn (`global_store.py:1061`)
+- `set_quota_config(...)` (UPSERT) (`global_store.py:1102`)
+- `increment_usage(tenant_id, n_writes)` — calendar-month rollover
+  baked in (`global_store.py:1256`)
+- `reset_period(tenant_id)` (`global_store.py:1310`)
+
+## WAL coupling
+
+**`GlobalStore` has no WAL.** All writes are direct SQLite operations
+inside the single connection's autocommit/manual-txn model. This is a
+documented carve-out from CLAUDE.md invariant #1 ("all writes go
+through the WAL"); the Python implementation also reflects this.
+
+Coupling to the per-tenant WAL pipeline:
+
+1. **Applier** consumes `TransactionEvent`s for one tenant and, as a
+   side-effect, writes to `global_store.shared_index` for `share` /
+   `revoke` / `delete_node` events
+   (`apply/applier.py:1709,1716,1745,1751,1772`). It also calls
+   `increment_usage` after each successful commit
+   (`apply/applier.py:1319`). These are **best-effort**: errors are
+   logged, not raised — the WAL has already been durable.
+2. **Handlers** (gRPC) write directly to `global_store` for ops that
+   have no per-tenant analogue: `CreateUser`, `CreateTenant`,
+   `AddTenantMember`, `RemoveTenantMember`, `ChangeMemberRole`,
+   `UpdateUser`, `ArchiveTenant`, GDPR delete-account, legal hold
+   admin ops (see `grpc_server.py:2127,2335,2477,2534,2637,2429,2950`
+   and `admin_handlers.py:42,130,156`).
+3. **Quotas/usage** are read by `quota_interceptor`
+   (`auth/quota_interceptor.py:278,314`).
+
+**Recovery story:** because there's no WAL, `global.db` is itself the
+durable record for cross-tenant state. SQLite `journal_mode=WAL` +
+`synchronous=NORMAL` (`global_store.py:172-174`) is the only crash
+safety. There is no rebuild-from-events path. **This is an open
+question for the Go port** (see "Open questions").
+
+## Identifier translation
+
+CLAUDE.md key pattern: `user_id "alice"` (bare) vs
+`tenant_principal "user:alice"` (prefixed). `GlobalStore` deals
+**exclusively in bare ids** — every column named `user_id` stores
+`alice`, never `user:alice`.
+
+Translation happens at the gRPC boundary in
+`grpc_server.py`: helpers like `_extract_user_id` strip `user:`
+(`grpc_server.py:413,1584,2299`). The Go port must enforce the same
+contract: `globalstore` package types take `UserID string` (bare); any
+prefix-stripping happens in the gRPC layer (server/go/internal/api).
+
+Group actors (`group:admins`) never appear as a `user_id` in
+`shared_index`; the Applier expands groups via
+`canonical_store.get_group_members` and inserts one row per resolved
+member (`apply/applier.py:1707`).
+
+## Concurrency
+
+Single SQLite connection guarded by a single-thread `ThreadPoolExecutor`
+(`global_store.py:132`). All `async` methods funnel through
+`_run_sync` (`global_store.py:312`), serializing writes. WAL mode is
+enabled so concurrent reads from sibling processes (e.g. tests) are
+allowed, but the in-process model is "one writer, no contention".
+
+Go port choice: a `*sql.DB` with `SetMaxOpenConns(1)`, or a
+hand-rolled mutex around a `*sql.Conn`. Either preserves the
+"no two goroutines touch SQLite simultaneously" property and avoids
+`SQLITE_BUSY` retry loops in hot paths. Prefer `MaxOpenConns(1)` —
+matches the Python invariant exactly.
+
+## Go design
+
+```
+server/go/internal/globalstore/
+    globalstore.go        // type GlobalStore + constructor + close
+    schema.go             // CREATE TABLE statements + migrations
+    users.go              // user_registry CRUD
+    tenants.go            // tenant_registry CRUD
+    members.go            // tenant_members CRUD + is_member
+    shared.go             // shared_index ops
+    deletion.go           // deletion_queue ops (GDPR)
+    legalhold.go          // legal_holds + status flag
+    quota.go              // tenant_quotas + tenant_usage
+    encryption.go         // open_encrypted_connection adapter
+    globalstore_test.go   // table-driven parity tests
+```
+
+Sketch:
+
+```go
+type GlobalStore struct {
+    db        *sql.DB           // MaxOpenConns(1)
+    dataDir   string
+    busyMS    int
+    walMode   bool
+    encCfg    *EncryptionConfig // optional
+    nowFn     func() int64      // injectable for tests
+}
+
+func New(opts Options) (*GlobalStore, error)
+func (g *GlobalStore) Close() error
+
+// ctx-first signatures everywhere — Go convention, no _run_sync wrapper needed
+func (g *GlobalStore) CreateUser(ctx context.Context, id, email, name string) (*pb.UserInfo, error)
+func (g *GlobalStore) GetTenant(ctx context.Context, id string) (*pb.TenantInfo, error)
+// ...
+```
+
+Return typed protobuf messages directly (`pb.UserInfo`,
+`pb.TenantInfo`, `pb.Membership`) rather than `map[string]any`; the
+Python `dict` returns are an artifact of dynamic typing.
+
+Errors: domain sentinels in `internal/errs` —
+`ErrUserNotFound`, `ErrTenantNotFound`, `ErrEmailTaken`,
+`ErrMembershipExists`, `ErrAlreadyQueued`. Map SQLite `UNIQUE`
+violations at the boundary, never leak `sqlite3.IntegrityError`
+analogues.
+
+## Dependencies
+
+- `server/go/internal/pb/entdb/v1` — generated proto types
+  (`UserInfo`, `TenantInfo`, `Member`, `Membership`).
+- `server/go/internal/errs` — typed errors.
+- `database/sql` + `modernc.org/sqlite` (pure-Go) or
+  `mattn/go-sqlite3` (cgo). Match whatever `canonical_store` chooses.
+- `server/go/internal/encryption` — encrypted connection helper,
+  parity with Python `encryption.derive_global_key` /
+  `open_encrypted_connection` (`global_store.py:80,156`).
+- `time` for epoch-second helpers; a `nowFn` field for test injection.
+
+No dependency on `wal/`, `applier/`, or `canonical_store`. Other
+components depend on `globalstore`, never the reverse.
+
+## RPCs touching this
+
+From `grpc_server.py` and `admin_handlers.py` (audit complete via
+grep at line refs above):
+
+**Reads:**
+`ListTenants`, `GetTenant`, `ListUsers`, `GetUser`,
+`GetTenantMembers`, `GetUserTenants`, `ListSharedWithMe`,
+`Health` (indirectly via tenant existence check at line 401, 503),
+`ExecuteAtomic` (membership check at 599), `GetUsage` (3133-3134).
+
+**Writes:**
+`CreateUser`, `UpdateUser`, `CreateTenant` (also `add_member` for
+creator), `ArchiveTenant`, `AddTenantMember`, `RemoveTenantMember`,
+`ChangeMemberRole`, `ShareNode` (Applier path),
+`RevokeAccess` (Applier path + `admin_handlers.revoke_user_access`),
+`TransferOwnership` (`admin_handlers.transfer_user_content`),
+`SetLegalHold` / admin legal-hold endpoints,
+`DeleteAccount` / `CancelAccountDeletion` /
+`SuspendUser` / `ReactivateUser` (`grpc_server.py:2950-3093`),
+`SetQuotaConfig` (admin).
+
+GDPR worker (`gdpr_worker.py:113-173`): scans deletion_queue,
+fans out to per-tenant deletion, then clears memberships, shared,
+and marks status=`deleted`.
+
+## Test surface
+
+Existing Python tests that establish parity expectations (port to Go):
+
+- `tests/python/unit/test_user_registry.py` — user CRUD, email uniqueness, status transitions.
+- `tests/python/unit/test_tenant_registry.py` — tenant CRUD, region default.
+- `tests/python/unit/test_tenant_roles.py` — membership + role changes.
+- `tests/python/unit/test_listtenants_auth.py` — `ListTenants` RBAC; reads `get_user_tenants`.
+- `tests/python/unit/test_cross_tenant_read.py` — invariant #4 enforcement.
+- `tests/python/unit/test_tenant_key_vault.py` — encryption parity.
+- `tests/python/integration/test_region_pinning.py` — `region` column round-trip.
+- `tests/python/integration/test_privilege_escalation.py` — actor / `user:` boundary.
+- Cross-implementation contract tests in `tests/contract/` should
+  exercise: GDPR queue, legal hold gating of writes, quota
+  enforcement, share/revoke side-effects.
+
+New Go tests (`globalstore_test.go`):
+
+- Schema migration: open old-shape DB (no `region`, no Phase-2 quota
+  columns), assert ALTER ran.
+- Concurrent caller goroutines vs `MaxOpenConns(1)` — no
+  `SQLITE_BUSY`, FIFO-ish.
+- Calendar-month rollover in `IncrementUsage` (inject `nowFn`).
+- `RevokeUserAccess` atomicity — both deletes succeed or neither.
+
+## Open questions / risks
+
+1. **Recovery / durability.** The Python store relies entirely on
+   `global.db` being durable. Snapshot/Archive (server/python/.../snapshot.py)
+   does **not** capture `global.db`. For the Go port, decide:
+   (a) keep status quo and document it as a non-replayable substrate,
+   (b) emit a parallel global-WAL stream, or
+   (c) snapshot `global.db` to S3 alongside per-tenant snapshots.
+   Recommend (c) — minimal new code, preserves the "S3 Object Lock is
+   the audit trail" invariant.
+2. **`shared_index` is a hint.** Python comments call it
+   "not authoritative" (`global_store.py:755`). Authoritative ACLs
+   live in canonical_store. The Go port must preserve this — never
+   gate access checks on `shared_index` alone.
+3. **`set_legal_hold` vs `legal_holds` table double-write.** Two
+   independent code paths exist (`set_legal_hold` flips
+   `tenant_registry.status`; `set_legal_hold_record` inserts into
+   `legal_holds`). Today they're called from different RPCs and can
+   drift. Consider unifying in Go behind one `SetLegalHold(record)`
+   API.
+4. **No transactional boundary across stores.** A failure between
+   `global_store.create_tenant` and `global_store.add_member` (creator
+   becomes owner, `grpc_server.py:2335,2344`) leaves a tenant with no
+   owner. Wrap related ops in a single SQLite transaction in Go
+   (currently each `_sync_*` opens its own implicit txn).
+5. **Mailbox routing has no table.** Several RPCs (`SearchMailbox`,
+   `GetMailbox`, `ListMailboxUsers`) are deprecated stubs. Confirm
+   the Go port can drop them entirely (proto deprecated?) before
+   building.
+6. **`tenant_usage` rollover races.** Two concurrent
+   `IncrementUsage` at month-boundary may both insert / both update.
+   Python is safe via single-thread executor; Go must keep
+   `MaxOpenConns(1)` or wrap rollover in a transaction with
+   `ON CONFLICT` semantics.

--- a/docs/go-port/shared/payload-translation.md
+++ b/docs/go-port/shared/payload-translation.md
@@ -1,0 +1,233 @@
+# Payload Translation Boundary — Go Port Spec
+
+EPIC #407, Python→Go server port. Pins CLAUDE.md invariant #6: **payloads are
+stored keyed by `field_id`**, not by name. Translation happens **only at the
+gRPC boundary**. Storage, WAL events, and the applier deal exclusively with
+id-keyed maps.
+
+Reference (Python):
+- `server/python/entdb_server/schema/field_id_translation.py:75` — `name_to_id_keys`
+- `server/python/entdb_server/schema/field_id_translation.py:133` — `id_to_name_keys`
+- `server/python/entdb_server/schema/field_id_translation.py:184` — `translate_payload_json_to_names`
+- `server/python/entdb_server/schema/field_id_translation.py:215` — `translate_filter_name_to_id`
+- `server/python/entdb_server/api/grpc_server.py:149` — `_struct_to_dict` / `_dict_to_struct`
+- `server/python/entdb_server/api/grpc_server.py:846` — ingress translation in `_convert_operations`
+- `server/python/entdb_server/api/grpc_server.py:1693` — `_node_to_proto` (egress, no translation)
+- `tests/python/unit/test_grpc_wire_format.py` — pinned wire contract
+
+---
+
+## Encoding
+
+Payloads on the wire are `google.protobuf.Struct`. On disk and in WAL events
+they are `map[uint32]any` — the key is the field's stable numeric `field_id`
+(positive `int`, ≤ 65535; see `server/python/entdb_server/schema/types.py:194`).
+
+- **Key shape on the wire**: `Struct.fields` keyed by **numeric strings**
+  (`"1"`, `"2"`). Per `_node_to_proto` the server returns the on-disk dict
+  verbatim through `_dict_to_struct`; the keys are stringified `field_id`s.
+  See `tests/python/unit/test_grpc_wire_format.py:172` (`assert keys == {"1", "2"}`).
+- **Key shape on disk / in events**: prefer `map[uint32]any` in Go (no
+  string round-trip). Stringify only at the protobuf boundary because
+  `structpb.Struct` requires `map[string]*Value`.
+- **Value types preserved**: string, int (as float64 — `Struct` has no int
+  type; document this loss-of-precision caveat), float, bool, list, nested
+  map, null. `bytes` and `timestamp` are encoded per `FieldKind` rules
+  (`schema/types.py:54`): `bytes` → base64 string in JSON; `timestamp` →
+  Unix milliseconds as integer.
+- **Null / optional**: an absent field is omitted from the map entirely. An
+  explicit JSON `null` is stored as `nil`; the schema validator treats it as
+  "not provided" (see `FieldDef.validate_value`, `schema/types.py:212`).
+- **Empty payload**: `Struct{}` round-trips to an empty `map[uint32]any{}`
+  (and back). `tests/python/unit/test_grpc_wire_format.py:320` pins this.
+- **Unknown field names**: dropped silently on ingress. `field_id_translation.py:122`.
+- **Unknown field ids**: kept verbatim on egress so future-schema rows are
+  not lossy. `field_id_translation.py:175`.
+
+---
+
+## Boundary
+
+Translation happens at **exactly two points** inside the gRPC handler layer.
+Nowhere else.
+
+1. **Ingress** (`_convert_operations`, `grpc_server.py:830`): name-keyed
+   `Struct` → `map[uint32]any` via `name_to_id_keys`. Applies to
+   `create_node.data`, `update_node.patch`, and any filter dict on
+   `QueryNodes` (`translate_filter_name_to_id`).
+2. **Egress** (`_node_to_proto`, `grpc_server.py:1693`): the on-disk
+   id-keyed payload is wrapped in a `Struct` **without translation**. The
+   wire stays id-keyed; SDKs translate to names on the client side using
+   their own registry.
+
+Forbidden:
+- The applier (`apply/applier.py`) MUST NOT translate. It receives id-keyed
+  events and writes id-keyed rows.
+- The canonical store (`apply/canonical_store.py`) MUST NOT translate.
+  Persistence is `field_id` only.
+- WAL serializers MUST NOT translate. Events on the WAL are id-keyed.
+
+Rationale: translation is a function of `(payload, type_id, schema)`. The
+schema lives in the registry, which is a request-time dependency; allowing
+inner layers to translate would make WAL replay schema-version-dependent and
+break invariant #1 (WAL is source of truth).
+
+---
+
+## Test contract
+
+`tests/python/unit/test_grpc_wire_format.py` is the cross-implementation
+contract. The Go server MUST satisfy every test (transcribed to Go test
+infrastructure, same protocol-level assertions).
+
+| Test | Pins |
+|---|---|
+| `test_node_payload_on_wire_is_id_keyed` (line 172) | `Node.payload.fields` keys are numeric strings (`"1"`, `"2"`); values match originally-supplied content. |
+| `test_payload_with_id_keyed_input_round_trips` (line 202) | Partial payloads accepted (no-required-fields type). Absent fields are not synthesized on read. |
+| `test_field_order_on_wire_does_not_matter` (line 228) | proto3 field-order independence — two requests with identical content but reversed `Struct.update` order yield byte-equivalent stored state. |
+| `test_oversized_message_is_rejected` (line 293) | Request larger than the **default 4 MiB** receive cap returns `RESOURCE_EXHAUSTED`. The handler is never invoked. Production server raises this to 50 MiB but the protocol-default rejection MUST surface as `RESOURCE_EXHAUSTED`. |
+| `test_empty_payload_is_tolerated` (line 320) | Empty `Struct` accepted for types with no required fields; round-trips to empty `Struct` on read. |
+| `test_unknown_field_name_is_silently_dropped` (line 354) | Unknown name keys are dropped; only known field ids appear on the wire. |
+
+Order independence is a property of proto3 encoding but the test guards
+against any handler that silently depends on Go map iteration order or
+`structpb` insertion order. The Go implementation must keep this property.
+
+---
+
+## Schema-driven translation
+
+`field_id` is resolved from a name via the **per-tenant schema registry**.
+
+- Python: `SchemaRegistry.get_node_type(type_id)` returns a `NodeTypeDef`
+  whose `.fields` carry `(field_id, name, kind)` — see
+  `schema/types.py:427`.
+- Lookup table built per call: `name → field_id` from `node_type.fields`
+  (`field_id_translation.py:107`).
+- **Schema-less mode**: when the registry has no entry for `type_id`, the
+  payload passes through unchanged (`field_id_translation.py:101`). This
+  keeps tests and legacy schema-less tenants working.
+- **Pre-translated keys**: a digit-only string that matches a known
+  `field_id` is left alone, allowing typed clients (Go SDK) to send
+  pre-translated payloads (`field_id_translation.py:114`).
+
+The Go implementation MUST honor all three behaviors.
+
+---
+
+## Go design
+
+Module: `server/go/internal/payload/`.
+
+```go
+package payload
+
+import (
+    "github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+    structpb "google.golang.org/protobuf/types/known/structpb"
+)
+
+// PayloadToStruct wraps an id-keyed map for the wire. No name lookup;
+// keys are stringified field_ids verbatim. Used by egress.
+func PayloadToStruct(typeID uint32, raw map[uint32]any) (*structpb.Struct, error)
+
+// StructToPayload translates a name-keyed (or pre-id-keyed) Struct to the
+// id-keyed internal representation. Unknown names dropped, schema-less
+// types pass through. Used by ingress.
+func StructToPayload(typeID uint32, s *structpb.Struct, reg schema.Registry) (map[uint32]any, error)
+
+// FilterNamesToIDs translates a name-keyed filter dict for QueryNodes.
+// Mirrors translate_filter_name_to_id.
+func FilterNamesToIDs(typeID uint32, filter map[string]any, reg schema.Registry) (map[uint32]any, error)
+
+// PayloadJSONToNames translates a stored id-keyed JSON blob back to
+// name keys (egress JSON path; mirrors translate_payload_json_to_names).
+func PayloadJSONToNames(typeID uint32, raw []byte, reg schema.Registry) ([]byte, error)
+```
+
+Notes:
+- `PayloadToStruct` does **not** depend on the schema. Egress is a
+  zero-translation wrap (the wire is id-keyed).
+- `StructToPayload` depends on `schema.Registry`. When `reg.GetNodeType(typeID)`
+  is nil → pass through. Digit-only keys matching known field ids are kept.
+- Use `map[uint32]any` internally (not `map[string]any`). Convert at the
+  `structpb` boundary only.
+- `nil` / empty `Struct` → empty map (not `nil`) to keep downstream JSON
+  marshalling deterministic (`{}` not `null`).
+
+---
+
+## Dependencies
+
+- `google.golang.org/protobuf/types/known/structpb` — wire `Struct`.
+- `server/go/internal/schema` — `Registry`, `NodeTypeDef`, `FieldDef`.
+- `server/go/internal/errs` — typed errors (`ErrSchemaLess` is **not** an
+  error; pass-through is the contract). `RESOURCE_EXHAUSTED` for oversized
+  payloads is enforced by the gRPC server option, not by `payload`.
+- No dependency on the applier, canonical store, or WAL packages — those
+  are downstream and consume the id-keyed map directly.
+
+---
+
+## Test surface
+
+`server/go/internal/payload/payload_test.go` (unit) and
+`tests/contract/payload_translation_test.go` (cross-impl contract).
+
+- **Round-trip property**: for any registered type and any name-keyed map
+  whose keys are subsets of the schema, `StructToPayload ∘ PayloadToStruct`
+  preserves the id-keyed map. Use `testing/quick` or `gopter`.
+- **Drop-unknown property**: injecting a synthetic unknown key never
+  changes the id-keyed output.
+- **Order independence**: shuffle `Struct.Fields` insertion order; assert
+  byte-equal id-keyed output.
+- **Schema-less pass-through**: with `nil` `NodeTypeDef`, both functions
+  are identity (modulo string↔uint32 key shape — only when keys are
+  digits).
+- **Unknown id preservation**: egress keeps unknown id keys verbatim.
+- **Type fidelity**: cover string, int (note float64 round-trip), float,
+  bool, list, nested map, null, base64 bytes, timestamp ms.
+- **Wire-format mirror**: replay every assertion from
+  `tests/python/unit/test_grpc_wire_format.py` against the Go server in
+  the contract harness.
+
+---
+
+## Open questions / risks
+
+1. **Unknown field_ids on egress.** Python keeps the raw key (forward
+   compat). Go should match — but `map[uint32]any` cannot represent a
+   "name-keyed legacy" key. Decision: store unknown ids in the same
+   `map[uint32]any` (the id is still numeric); if a legacy *name-keyed*
+   row is encountered (digits only fail), surface it via a separate
+   `extras map[string]any` on the internal Node struct or run the
+   migration helper at read time. Track in a follow-up issue.
+2. **Nested `Struct` handling.** `FieldKind.JSON` (`schema/types.py:60`)
+   accepts arbitrary nested objects. Translation MUST NOT recurse into
+   nested structs — only top-level keys are translated. The Python impl
+   only translates the outer dict; Go must do the same.
+3. **`bytes` encoding.** `structpb.Value` has no bytes type. Python stores
+   bytes as base64 strings inside JSON. Go must follow: encode `[]byte`
+   as base64 `string_value` on the wire and decode on ingress when the
+   schema field kind is `BYTES`. This is a **schema-aware decode** —
+   document that `StructToPayload` uses field kind to coerce string →
+   `[]byte` for `BYTES` fields.
+4. **`timestamp` encoding.** Unix ms as integer (`schema/types.py:58`).
+   `structpb` integer fidelity: values pass as `float64`; safe up to
+   2^53. Document the cutoff; reject values outside it on ingress.
+5. **Missing schema (chicken-and-egg on first write).** A tenant's first
+   `RegisterSchema` op itself carries no payload, but subsequent ops
+   before the schema is durably applied will hit `get_node_type → nil`
+   and pass through as schema-less. Risk: a row written in this window is
+   stored name-keyed and later re-read against a now-present schema gets
+   the legacy fallback path (`field_id_translation.py:166`). Mitigation:
+   the existing `migrate_payloads_to_field_ids` helper. Go port must
+   provide an equivalent and run it on tenant init.
+6. **Pre-translated digit keys colliding with names.** If a future schema
+   names a field literally `"1"`, the digit-key passthrough heuristic
+   (`field_id_translation.py:114`) becomes ambiguous. Document and
+   forbid digit-only field names at registry validation in Go.
+7. **`Struct.NullValue` vs absent key.** Python's `MessageToDict` drops
+   `NullValue` to `None`; Go's `structpb.AsMap` returns `nil`. Confirm
+   the Go path treats both the same: keep the key with `nil` value, do
+   not synthesize, do not drop. Pin with a contract test.

--- a/docs/go-port/shared/schema-registry.md
+++ b/docs/go-port/shared/schema-registry.md
@@ -1,0 +1,272 @@
+# Shared Port Spec — Schema Registry
+
+EPIC #407 — Python → Go server port. Source of truth:
+`server/python/entdb_server/schema/` (the whole package). Behavioural pins:
+`tests/python/unit/test_schema.py`, `test_schema_validator.py`,
+`test_compat.py`, `test_composite_unique_schema.py`,
+`test_schema_cli_e2e.py`. The registry is a *server-wide singleton*,
+populated at boot, frozen before serving — every privileged RPC under
+`docs/go-port/rpcs/` consults it for type IDs, field IDs, validation, and
+data-policy decisions.
+
+CLAUDE.md invariant #5: **proto is the type system.** The Go port MUST
+populate the registry from the same proto descriptors the Python side
+already uses — no parallel codegen, no hand-maintained type tables.
+
+## Concepts
+
+`NodeTypeDef` (`schema/types.py:427-642`) is a stable type definition with:
+
+- `type_id` (1..2^31, `:483-486`) — canonical identifier; never reused
+  even after deprecation.
+- `name` — label only; renames are free because storage is keyed by id.
+- `fields` — tuple of `FieldDef`; duplicate `field_id` or duplicate name
+  rejected at construction (`:491-498`).
+- `data_policy` (`DataPolicy` enum, defaults `None` → `PERSONAL` at
+  runtime, `registry.py:241-250`) — drives encryption tier and GDPR.
+- `subject_field` — name of the field holding the data-subject id.
+- `default_acl` — applied when a node is created without an explicit ACL.
+- `composite_unique` — tuple of `CompositeUniqueDef`
+  (`types.py:373-424`); each entry is `(name, (field_id, ...))` with
+  ≥2 distinct field ids, names unique per type, no two composites
+  sharing the same field set.
+
+`FieldDef` (`types.py:143-309`) carries `field_id` (1..65535,
+`:192-195`), `kind` (`FieldKind`: `str|int|float|bool|timestamp|json|`
+`bytes|enum|ref|list_str|list_int|list_ref`), and four schema bits the
+applier and query planner read directly: `required`, `unique`, `indexed`,
+`searchable`. Plus `pii`, `deprecated`, `enum_values` (append-only,
+`compat.py:573-584`), `ref_type_id`.
+
+`EdgeTypeDef` (`types.py:644-798`) is unidirectional with
+`from_type_id`/`to_type_id` (`:701-713`), `props` (own `FieldDef`s),
+`unique_per_from`, `on_subject_exit` (`from|to|both`, drives GDPR edge
+cleanup, `registry.py:371-389`), and its own `data_policy`.
+
+Registry helpers the rest of the server depends on:
+
+- `get_node_type(int|str)` / `get_edge_type(...)` — id-or-name lookup.
+- `get_unique_field_ids(type_id)` (`registry.py:252-268`) — drives lazy
+  `CREATE UNIQUE INDEX` in the applier (`docs/decisions/sdk_api.md`).
+- `get_composite_unique_constraints(type_id)` (`:270-290`) — same, multi-
+  field.
+- `get_indexed_field_ids(type_id)` (`:292-309`) — non-unique indexes;
+  `unique` is a superset of `indexed`, so unique fields are excluded
+  here.
+- `get_searchable_field_ids(type_id)` (`:311-331`) — only `STRING` kind;
+  feeds FTS5 index creation.
+- `get_pii_fields(type_id)`, `get_data_policy(type_id)`,
+  `get_subject_field(type_id)` — GDPR / compliance.
+
+## Lifecycle
+
+The registry is a **process-wide singleton**, mutable during boot,
+frozen exactly once before serving. There is **no per-tenant variant**;
+all tenants share one schema (`registry.py:46-48,554-585`).
+
+Boot sequence as Python runs it today (`server/python/entdb_server/main.py:278-289`):
+
+1. `registry = get_registry()` — lazily creates the global on first call.
+2. Optional `_load_schema_file(registry, path)` — reads a JSON file
+   (the format produced by `SchemaRegistry.to_json`, `:479-488`) and
+   calls `register_node_type` / `register_edge_type` for each entry.
+   This is how the SDK-emitted schema (via
+   `entdb_sdk.codegen.register_proto_schema`,
+   `sdk/python/entdb_sdk/codegen.py:431-510`) reaches the server in
+   environments where the server doesn't import the proto module
+   directly.
+3. `freeze_registry()` (`registry.py:573-585`) — computes a SHA-256
+   fingerprint over the canonical `to_dict()` (`:448-461`) and flips
+   `_frozen = True`. After freeze, `register_node_type` raises
+   `RegistryFrozenError` (`:122-125`).
+
+Compatibility ratchet: `tools/schema_cli.py` runs
+`check_compatibility(old, new)` (`schema/compat.py:144-188`) against a
+checked-in baseline JSON before deployment. Breaking changes
+(`ChangeKind.is_breaking`, `compat.py:78-97`) — field removal, kind
+change, id reuse, enum value removal/reorder, `from_type` change,
+making an optional field required, `propagate_share` flip — fail CI.
+Allowed: add type, add field, add enum value, deprecate, rename.
+
+Note: a top-level `.schema-snapshot.json` does not currently exist in
+the repo; the CLI accepts an explicit `--baseline` path
+(`schema_cli.py:179-181`). The Go port should adopt the same convention
+and wire the same baseline into CI.
+
+## Ingress consumers
+
+Three consumers read the registry on the hot path; the Go port must
+preserve all three contracts.
+
+**Payload translation at the gRPC boundary.** Storage is keyed by
+stringified `field_id` (CLAUDE.md invariant #6). `name_to_id_keys` /
+`id_to_name_keys` (`schema/field_id_translation.py:1-46`) translate
+ingress and egress payloads using the registry's per-type field map.
+Unknown names on ingress are dropped silently; unknown ids on egress
+are kept as-is (forward compat). See the dedicated payload-translation
+spec for details.
+
+**Validation on write.** `NodeTypeDef.validate_payload`
+(`types.py:557-581`) and per-field `FieldDef.validate_value`
+(`:203-261`) check required, kind, enum membership, and reference
+shape before the WAL append in the gRPC servicer. The applier later
+re-reads the registry to discover unique/composite-unique/indexed/
+searchable field ids and to drive lazy `CREATE INDEX` statements
+(`apply/applier.py:939,1046,1107,1129,1560`).
+
+**Query planning.** `SearchNodes` / `QueryNodes` consult
+`get_indexed_field_ids` / `get_searchable_field_ids` to decide whether
+a filter is index-backed or a full scan. `GetNodeByKey` resolves a
+typed `UniqueKey[T]` token (carrying `type_id`, `field_id`) against the
+registry's unique-index for the type.
+
+## Go design
+
+Layout: `server/go/internal/schema/`. Single source of truth shared
+across the server.
+
+```
+server/go/internal/schema/
+  types.go         — NodeTypeDef, EdgeTypeDef, FieldDef, FieldKind, OnSubjectExit, AclEntry, CompositeUniqueDef
+  registry.go      — Registry struct, Get/Register/Freeze, helper accessors
+  loader.go        — LoadFromJSON, LoadFromDescriptors (proto files)
+  compat.go        — Check(old, new) → []Change; CompatibilityError
+  fingerprint.go   — Fingerprint(reg) string ("sha256:…")
+  translate.go     — NameToID / IDToName payload-key translation
+```
+
+Proposed shape:
+
+```go
+type Registry struct {
+    nodes       map[int32]*NodeTypeDef
+    nodesByName map[string]*NodeTypeDef
+    edges       map[int32]*EdgeTypeDef
+    edgesByName map[string]*EdgeTypeDef
+    frozen      atomic.Bool
+    fingerprint string
+    mu          sync.Mutex // only held during registration
+}
+
+func (r *Registry) RegisterNode(t *NodeTypeDef) error
+func (r *Registry) RegisterEdge(t *EdgeTypeDef) error
+func (r *Registry) Freeze() (string, error)
+func (r *Registry) Node(idOrName any) *NodeTypeDef
+func (r *Registry) Edge(idOrName any) *EdgeTypeDef
+func (r *Registry) UniqueFieldIDs(typeID int32) []int32
+func (r *Registry) CompositeUnique(typeID int32) []CompositeUniqueDef
+func (r *Registry) IndexedFieldIDs(typeID int32) []int32
+func (r *Registry) SearchableFieldIDs(typeID int32) []int32
+func (r *Registry) PIIFields(typeID int32) []string
+func (r *Registry) DataPolicy(typeID int32) DataPolicy
+func (r *Registry) SubjectField(typeID int32) string
+```
+
+After `Freeze()` returns, all read methods are lock-free (mirrors
+`registry.py:69-72`). The frozen guarantee lets the gRPC handlers and
+applier hold a `*Registry` reference without further synchronization.
+
+Population path: at boot, `loader.LoadFromDescriptors` walks
+`protoreflect.FileDescriptor`s and reads the `entdb.node` / `entdb.field`
+options via `protoc-gen-go`-generated extension accessors —
+the same proto annotations Python re-parses in
+`sdk/python/entdb_sdk/codegen.py:475-510`. **Do not** re-implement
+codegen (CLAUDE.md #5). Alternative: `loader.LoadFromJSON` accepts the
+existing `to_dict()` JSON shape verbatim, so a Python-emitted schema
+file boots a Go server unchanged — this is the cross-language contract
+test.
+
+A `DefaultRegistry()` package-level accessor mirrors Python's
+`get_registry()` for ergonomics, but production code paths take
+`*Registry` as a constructor argument (so tests can inject fixtures
+without touching globals).
+
+## Dependencies
+
+- `proto/entdb/v1/entdb.proto` — `Node`, `Edge`, `GetSchemaResponse`,
+  `Struct` (carrying field-id-keyed payloads).
+- `proto/entdb_options.proto` — `(entdb.node)`, `(entdb.edge)`,
+  `(entdb.field)` extensions; the registry reads these to populate
+  `NodeTypeDef`/`FieldDef`.
+- `internal/errs` — `ErrSchemaFrozen`, `ErrDuplicateRegistration`,
+  `ErrUnknownType`, `ErrSchemaIncompatible` (mapped to gRPC
+  `FAILED_PRECONDITION` / `INVALID_ARGUMENT`).
+- `internal/datapolicy` — `DataPolicy` enum, used by encryption and
+  GDPR layers.
+
+The registry has **no** dependency on the WAL, SQLite, or any I/O. It
+is pure data + lookup.
+
+## RPCs
+
+- **GetSchema** (`docs/go-port/rpcs/GetSchema.md`) — serializes the
+  registry to the wire `GetSchemaResponse`. Read-only; returns the
+  fingerprint so clients can detect drift.
+- **ExecuteAtomic** — every op in the plan validates against the
+  registry (kind, required, enum, ref shape) before the WAL append.
+  Reject early with `INVALID_ARGUMENT`; do not let bad payloads reach
+  the applier.
+- **GetNodeByKey** — resolves the `(type_id, field_id, value)` triple
+  via the registry's unique-field bookkeeping; falls back to
+  `NOT_FOUND` if the type has no unique field with that id.
+- **SearchNodes / QueryNodes** — consult `IndexedFieldIDs` and
+  `SearchableFieldIDs` to pick an index-backed plan vs a full scan;
+  also rely on `Node(typeID).GetField(name)` for filter-name → field-id
+  rewriting when a client sends a name-keyed filter.
+- **CreateUser / CreateTenant / admin RPCs** — use `DataPolicy` and
+  `SubjectField` to label new nodes for GDPR tracking.
+
+The interceptor stack itself is registry-independent — auth runs first
+(`docs/go-port/shared/auth-interceptor.md`), then the handler validates
+against the schema.
+
+## Test surface
+
+Go-side parity tests, all reading the same Python-emitted JSON
+(`SchemaRegistry.to_json`) so the two implementations cannot drift:
+
+- `internal/schema/registry_test.go` — register / get / freeze /
+  duplicate-id / frozen-write rejection (mirrors
+  `tests/python/unit/test_schema.py`).
+- `internal/schema/compat_test.go` — every `ChangeKind` enum case from
+  `compat.py:45-97` produces the expected breaking/non-breaking
+  classification (mirrors `test_compat.py`).
+- `internal/schema/composite_test.go` — composite-unique constraint
+  validation, name uniqueness, ≥2 fields rule (mirrors
+  `test_composite_unique_schema.py`).
+- `internal/schema/fingerprint_test.go` — Go fingerprint matches
+  Python fingerprint byte-for-byte for the same registry contents.
+  This is the single most important parity check; CI runs both
+  implementations over a shared fixture set and compares.
+- `tests/contract/schema_parity_test.go` — load the in-tree proto
+  files via `protoreflect`, register via the Go loader, register via
+  Python `register_proto_schema`, diff `to_dict()` outputs.
+
+## Open questions / risks
+
+1. **Runtime schema mutation.** Python freezes once at boot and never
+   re-opens. The Go port should preserve this — no hot reload, no
+   per-RPC override. If a future requirement needs mutable schema, it
+   must come with an `RFC` and a migration story for the WAL replay
+   path (the applier assumes the registry is stable for the lifetime
+   of the process).
+2. **Per-tenant schema variants.** Out of scope. The current model is
+   one schema per cluster; multi-tenant schema isolation would
+   complicate the WAL (events would need a schema fingerprint header)
+   and the applier (per-tenant index sets). Flag this for the post-port
+   roadmap; do not attempt during the rewrite.
+3. **Compatibility ratchet location.** Python's CLI loads an explicit
+   `--baseline` path; there is no committed `.schema-snapshot.json`
+   today. The Go port should standardise the baseline location
+   (probably `proto/.schema-snapshot.json`) and ensure the
+   `release.yml` workflow regenerates it on every tag.
+4. **Descriptor option re-parsing.** Python serialises `MessageOptions`
+   then re-parses through the entdb extension surface
+   (`sdk/python/entdb_sdk/codegen.py:475-485`) to recover the typed
+   `NodeOpts`/`EdgeOpts`. Go's `proto.GetExtension` does this natively
+   — verify the Python-emitted JSON and the Go-emitted JSON match
+   bit-for-bit on the same `.proto` source before declaring parity.
+5. **Field-id translation drop semantics.** Ingress drops unknown
+   names silently (`field_id_translation.py:21-23`). The Go port must
+   match — emitting a warning is fine, raising is not. Document this
+   explicitly because it is surprising.

--- a/docs/go-port/shared/test-harness.md
+++ b/docs/go-port/shared/test-harness.md
@@ -1,0 +1,261 @@
+# Shared Port Spec — Cross-Implementation Test Harness
+
+EPIC #407 — Python -> Go server port. The Go server MUST pass the **same**
+Python contract tests that gate the Python server today. This spec
+defines how the existing pytest suite is reused against a Go binary
+without forking the test code.
+
+## Reading list (sources)
+
+- `tests/python/integration/test_grpc_contract.py` — 41 RPC × ~70 cases
+  (CONTRACT_CASES list around `:195`, fixture `live_server` at `:84`).
+- `tests/python/integration/test_wal_replay_determinism.py` — replay,
+  idempotency, halt-on-poison (3 P0 properties).
+- `tests/python/integration/test_concurrent_applier_reads.py` — reader
+  vs applier safety (`:60-`).
+- `tests/python/unit/test_grpc_wire_format.py` — id-keyed payload,
+  4 MiB cap, op-order independence (`:73-` `server_with_default_limits`).
+- `tests/python/integration/test_privilege_escalation.py` — 34 cases,
+  asserts handlers consult `get_authoritative_actor`, not request body.
+- Python entrypoint: `server/python/entdb_server/main.py:1`.
+- Python config (env vars): `server/python/entdb_server/config.py:125`
+  (gRPC), `:454` (storage), `:708` (WAL backend selection).
+
+## Current Python harness — how the test server is started
+
+Today, **there is no `conftest.py` for `tests/python/integration/`**
+(verified: only `tests/python/benchmarks/conftest.py` and
+`tests/python/e2e/conftest.py` exist). Each test that needs a live gRPC
+server constructs one in-process with its own fixture:
+
+- **Contract suite** — `live_server` fixture
+  (`test_grpc_contract.py:84-171`): builds `SchemaRegistry`,
+  `GlobalStore` on a `TemporaryDirectory`, `InMemoryWalStream`,
+  `CanonicalStore(wal_mode=False)`, an `Applier` task with
+  `MailboxFanoutConfig(enabled=False)` and `batch_size=1`, then a bare
+  `grpc.aio.server()` bound to a free 127.0.0.1 port (`_free_port`,
+  `:56`). Auth interceptor is **not installed** — handlers run with no
+  `_current_identity` set; happy-path RPCs trust whatever
+  `RequestContext.actor` claims.
+- **Wire-format suite** — `server_with_default_limits`
+  (`test_grpc_wire_format.py:73-`): same shape as above but uses the
+  bare `grpc_aio.server()` (no 50 MiB receive override) so the
+  oversized-payload test exercises the protocol-default 4 MiB cap.
+- **WAL replay & concurrent reader suites** — no gRPC at all. They
+  drive `Applier` + `CanonicalStore` directly against
+  `InMemoryWalStream` (`test_wal_replay_determinism.py:39`,
+  `test_concurrent_applier_reads.py:35`). These are **applier-internal**
+  contracts, not wire contracts; the Go port runs them via a separate
+  Go-native test (see "Per-RPC gating" below).
+- **Privilege-escalation suite** — `EntDBServicer` is constructed
+  in-process with mock collaborators (`test_privilege_escalation.py:62`)
+  and called through a `_FakeContext` (`:79`). The trusted identity is
+  injected via `set_current_identity` (`auth_interceptor.py`), so this
+  test never touches a socket.
+
+Tear-down is per-fixture: `server.stop(grace=0)`, `applier.stop()`,
+`applier_task.cancel()`, `wal.close()`, `global_store.close()`,
+`TemporaryDirectory` exits.
+
+## What needs to change
+
+Add `tests/python/integration/conftest.py` with a single
+`grpc_endpoint` fixture (returns `"127.0.0.1:<port>"`). Existing
+fixtures that build their own in-process server are refactored to call
+this fixture instead. Selection is via env var:
+
+```
+ENTDB_SERVER_TARGET=python   # default, in-process Python (today's path)
+ENTDB_SERVER_TARGET=go       # subprocess: $ENTDB_GO_BINARY
+```
+
+Behaviour:
+
+- `python` -> existing in-process spin-up moves into the conftest;
+  fixtures now `yield port` from there.
+- `go` -> `subprocess.Popen([$ENTDB_GO_BINARY, ...flags])` bound to a
+  `_free_port()`-allocated TCP port; conftest waits for `Health` to
+  return `healthy=true` (10 s timeout, 50 ms poll), yields, then
+  `proc.terminate()` + `proc.wait(5)` on teardown. stdout/stderr
+  captured to a per-test file under `pytest`'s `tmp_path` and printed
+  on failure.
+- Seed data (the `seeded-node` row) is created by the conftest after
+  spin-up via the same `ExecuteAtomic` call that lives in
+  `test_grpc_contract.py:131-154` today — moves with the fixture.
+- Suites that don't talk to gRPC (replay, concurrent applier,
+  privilege-escalation) are **not** parameterised by target. They stay
+  Python-only and a Go-native equivalent lives under `tests/go/`
+  (separate file, not in scope here).
+
+## Go binary contract
+
+The harness expects `$ENTDB_GO_BINARY` to honour these flags / env
+vars. Defaults must match the Python in-process fixture so the same
+contract assertions hold.
+
+| Flag / env                    | Required | Notes                                                       |
+| ----------------------------- | -------- | ----------------------------------------------------------- |
+| `--listen 127.0.0.1:<port>`   | yes      | Mirrors `GRPC_BIND` (`config.py:125`).                      |
+| `--wal-backend memory`        | yes      | In-memory WAL — equivalent of `InMemoryWalStream`.          |
+| `--data-dir <path>`           | yes      | Per-tenant SQLite dir; harness passes a `tmp_path`.         |
+| `--auth-disabled`             | yes      | No `AuthInterceptor` installed; matches today's fixture.    |
+| `--mailbox-fanout=false`      | yes      | Mirrors `MailboxFanoutConfig(enabled=False)`.               |
+| `--batch-size 1`              | yes      | Mirrors `Applier(..., batch_size=1)`.                       |
+| `--max-message-bytes`         | no       | Omit -> 4 MiB default (wire-format test depends on this).   |
+| `--seed-tenant acme`          | yes      | Pre-creates tenant + alice (owner) + bob (member).          |
+| `--ready-probe`               | yes      | Process exits non-zero if `Health` not servable in 5 s.     |
+| `ENTDB_LOG_LEVEL`             | no       | Defaults to `info`; harness sets `debug` on `-v`.           |
+
+The binary MUST NOT require any other env var (no Kafka brokers, no
+S3, no KMS). Anything else the test fixture needs (schema registration)
+is done over the wire after start-up — the registry is global to the
+process and the fixture registers `User`, `Task`, `AssignedTo` via
+`GetSchema` + an internal `RegisterSchema` admin RPC (already covered
+by Python in-process today; for Go the binary must pre-register the
+same registry when `--seed-tenant` is set, since that registry is what
+the contract suite assumes — see `_build_registry` at
+`test_grpc_contract.py:64`).
+
+## CI matrix
+
+Add to `.github/workflows/ci.yml` the `integration-tests` job (around
+`ci.yml:113-`):
+
+```
+integration-tests:
+  strategy:
+    fail-fast: false
+    matrix:
+      server: [python, go]
+  env:
+    ENTDB_SERVER_TARGET: ${{ matrix.server }}
+```
+
+For `server: go`:
+
+1. `actions/setup-go@v5` with the version pinned in
+   `sdk/go/entdb/go.mod` (Go SDK already exists).
+2. Build step: `go build -o /tmp/entdb-server ./server/go/cmd/entdb-server`
+   (this path is the **first deliverable** of the Go port — until it
+   exists the matrix leg is `continue-on-error: true`, see Phase 0
+   below).
+3. `ENTDB_GO_BINARY=/tmp/entdb-server` exported into the test step.
+4. Cache: `actions/cache@v4` keyed on
+   `hashFiles('server/go/**/*.go','server/go/go.sum')` -> caches both
+   `~/.cache/go-build` and `~/go/pkg/mod`.
+
+Gating: the `all-checks` aggregator (`ci.yml:225-`) MUST require the
+`server: go` leg only after Phase 2 (parity reached). Phase 0 / 1 leave
+it at `continue-on-error: true` so red Go runs don't block Python PRs.
+
+Tests skipped on the Go side use `pytest.mark.skipif(...)` driven by
+the registry below — they show as `skipped`, not failures, in the
+matrix output.
+
+## Per-RPC gating
+
+Test source MUST stay implementation-agnostic. Gating lives in **one**
+file: `tests/python/integration/_go_parity.py` — a registry of RPC
+names known to be implemented by the Go binary at `HEAD`:
+
+```
+GO_IMPLEMENTED: frozenset[str] = frozenset({
+    "Health",
+    # add as RPCs land
+})
+```
+
+`conftest.py` exposes a single helper:
+
+```
+def requires_target(rpc: str) -> pytest.MarkDecorator:
+    if os.environ.get("ENTDB_SERVER_TARGET") == "go" and rpc not in GO_IMPLEMENTED:
+        return pytest.mark.skip(reason=f"{rpc}: not yet implemented in Go")
+    return pytest.mark.usefixtures()  # no-op
+```
+
+The contract test (`test_grpc_contract.py`) is parametrised over
+`CONTRACT_CASES`; the param-id is the `rpc` field. A
+`pytest_collection_modifyitems` hook in conftest reads the case's `rpc`
+out of the param-id and applies `requires_target(rpc)` automatically.
+**No edits to `CONTRACT_CASES`**, no skip decorators sprinkled across
+71 cases, no fork of the test file. Adding an RPC to the Go side is a
+one-line change to `GO_IMPLEMENTED`.
+
+Wire-format suite (`test_grpc_wire_format.py`): the four invariants
+are RPC-agnostic protocol properties — they run unconditionally on
+both targets once `Health` works (the suite calls `ExecuteAtomic` and
+`GetNode`, so those two RPCs must be in `GO_IMPLEMENTED` before this
+suite runs against Go; until then, mark the whole module
+`pytestmark = requires_target("ExecuteAtomic")`).
+
+## Phase progression
+
+Aligned with the EPIC #407 wave plan:
+
+- **Wave 0 — harness** (this doc): land conftest + `_go_parity.py` +
+  CI matrix (with `continue-on-error` on the Go leg). Python tests must
+  remain green; Go leg is allowed to be all-skipped.
+- **Wave 1 — Health is the proof-of-life**: `Health` RPC in Go,
+  `GO_IMPLEMENTED = {"Health"}`. CI matrix Go leg now runs **one**
+  contract case green; everything else skipped. This is the smallest
+  signal that subprocess spin-up, port allocation, ready-probe, and
+  metadata propagation all work end-to-end.
+- **Wave 2 — read RPCs** (`GetNode`, `GetNodes`, `GetSchema`,
+  `QueryNodes`, ...): added to `GO_IMPLEMENTED` one PR at a time. Each
+  PR ships the Go handler **and** the registry entry in the same diff.
+- **Wave 3 — write RPCs** (`ExecuteAtomic` and friends): unlocks the
+  wire-format suite against Go.
+- **Wave 4 — flip gate**: when `GO_IMPLEMENTED` covers all 41 RPCs,
+  drop `continue-on-error` on the Go matrix leg in `ci.yml` and add
+  it to the `all-checks` `needs:` list. Parity reached.
+
+## Dependencies
+
+- **Python harness**: `pytest>=8.0.0`, `pytest-asyncio>=0.23.0`,
+  `grpcio>=1.60.0` (already in `ci.yml:96-99`). No new pip deps.
+- **Go binary**: `server/go/cmd/entdb-server/main.go` (does not exist
+  yet — Wave 1 deliverable). Must be a single static binary; no `cgo`
+  required for the in-memory WAL + temp SQLite test mode (use
+  `modernc.org/sqlite` to keep `CGO_ENABLED=0`).
+- **CI runner**: stock `ubuntu-latest`. No Docker for the matrix
+  (subprocess only); the existing `e2e-tests` job covers the Docker
+  path and stays Python-only.
+
+## Open questions / risks
+
+1. **Go build cache** — first-run `go build` on a cold cache is ~40 s
+   on `ubuntu-latest`; caching `~/.cache/go-build` brings it to ~5 s.
+   If the Go server grows large deps (e.g. `confluent-kafka-go`), we
+   may need a separate `go-build` job that uploads the binary as an
+   artifact and the test job downloads it.
+2. **Subprocess port allocation** — `_free_port()`'s bind-then-close
+   trick (`test_grpc_contract.py:56`) has a TOCTOU window: another
+   process can grab the port between close and the Go subprocess'
+   `Listen`. Acceptable for serial CI; under `pytest-xdist -n auto`
+   we will see flakes. Mitigation: add a 3-attempt retry around
+   subprocess spin-up in conftest (rebind on `address already in use`).
+3. **Auth-disabled mode** — `--auth-disabled` is a test-only flag.
+   Risk: it ships in production builds. Mitigation: gate behind a
+   build tag (`//go:build testharness`) so a release binary lacks the
+   flag entirely. The CI test build adds `-tags=testharness`; the
+   release workflow does not.
+4. **Diverging behaviour triage** — when one impl passes and the other
+   fails on the same case, the failure is almost certainly Go-side
+   (Python is the reference). Convention: open a Go-port bug tagged
+   `port-divergence`, link the failing case-id, and **do not** weaken
+   the Python assertion. The contract is the contract; the Go binary
+   moves to it, never the reverse.
+5. **In-process vs subprocess perf gap** — Go subprocess adds ~80 ms
+   start-up per test session; multiplied by ~80 cases that's not free.
+   Use a **session-scoped** `grpc_endpoint` fixture for the contract
+   suite (Python's existing fixture is already session-shaped via the
+   single seeded node) and reset state between cases via tenant scope,
+   not by restarting the process.
+6. **Schema registration on the Go side** — the Python fixture mutates
+   a process-global `_global_registry` (`test_grpc_contract.py:87-91`).
+   The Go binary cannot share that process. Open question: do we
+   expose a `RegisterSchema` admin RPC, or hard-code the contract
+   registry into the `--seed-tenant` path? Leaning toward the latter
+   for Wave 1 (less surface), promote to an RPC in Wave 3 once write
+   paths are in.

--- a/docs/go-port/shared/wal-producer.md
+++ b/docs/go-port/shared/wal-producer.md
@@ -1,0 +1,263 @@
+# WAL Producer — Go Port Spec
+
+Tracks EPIC #407 (Python → Go server port). Scope: the **producer** half of
+the WAL stream abstraction. The consumer/applier is a separate spec.
+
+The WAL is the source of truth for every mutation (CLAUDE.md invariant #1).
+SQLite is a materialized view rebuilt by replaying the WAL. The Go server
+must reproduce the Python producer's durability + ordering contract
+exactly, otherwise replay determinism breaks.
+
+Reference Python sources (port targets):
+- `server/python/entdb_server/wal/base.py` — protocol + types
+- `server/python/entdb_server/wal/{memory,kafka,kinesis,sqs,pubsub,servicebus,eventhubs}.py`
+- `server/python/entdb_server/apply/applier.py:204` — `TransactionEvent`
+- `server/python/entdb_server/api/grpc_server.py:778` — handler-side `wal.append` call site
+- `tests/python/integration/test_wal_replay_determinism.py` — bedrock contract
+- `tests/python/unit/test_wal_memory.py`, `test_wal_backends.py`, `test_wal_backends_config.py`
+
+## TransactionEvent shape
+
+Defined in `apply/applier.py:204-269`. Wire-level it is JSON; on disk it
+is whatever the backend stores (Kafka record value, Kinesis blob, etc).
+Required fields (validated in `from_dict`, `applier.py:256`):
+
+| Field                | Type            | Notes                                                              |
+| -------------------- | --------------- | ------------------------------------------------------------------ |
+| `tenant_id`          | string          | Partition key. Per-tenant isolation invariant.                     |
+| `actor`              | string          | Trusted actor stamped by handler (`grpc_server.py:780`), not client-supplied. Audit-truth. |
+| `idempotency_key`    | string          | Producer-supplied dedupe key. Applier checks `applied_events` table (`applier.py:767,922`). |
+| `schema_fingerprint` | string \| null  | Schema registry hash at write time.                                |
+| `ts_ms`              | int64           | Wall-clock ms; defaults to `time.time()*1000` if missing.          |
+| `ops`                | list[op-dict]   | One or more atomic ops (see below).                                |
+| `stream_pos`         | StreamPos       | NOT serialized; populated by applier from record metadata.         |
+
+`ops[i]` is an open-ended dict keyed by `"op"`. Op types handled by the
+applier today: `create_node`, `update_node`, `delete_node`, `create_edge`,
+`delete_edge`, plus admin/GDPR/transfer/revocation ops registered in
+`Applier.apply_event` (`applier.py:1327`). The Go event struct must keep
+`ops` as a free-form list (`[]map[string]any` or, preferably, a
+`[]*pb.Op` once op types are protobufed) — handlers will mutate ops
+in-place to assign IDs (`grpc_server.py:768-772`).
+
+`StreamPos` (`base.py:65`): `{topic, partition, offset, timestamp_ms}`,
+`String()` form `topic:partition:offset`. This is the receipt the SDK
+returns to clients (`grpc_server.py:799`) and the cursor the applier
+commits.
+
+## Producer contract
+
+Single method, `append(topic, key, value, headers) → StreamPos`
+(`base.py:209`). Semantics:
+
+1. **Durability**: returns *only* after the backend has durably stored
+   the record. Kafka uses `acks=all` + idempotent producer
+   (`kafka.py:55-76`); Kinesis blocks on `PutRecord` post-replication
+   (`kinesis.py:9-13`); SQS FIFO uses content-based dedupe
+   (`sqs.py:21-25`). A returned `StreamPos` is a promise that a future
+   consumer subscribed at offset 0 will see this record.
+2. **Ordering**: total order *within a partition*. The partition is
+   chosen by `key`. Handlers always use `tenant_id` as the key
+   (`grpc_server.py:792`), so the contract reduces to: **per-tenant
+   total order**. No cross-tenant ordering is guaranteed and the
+   applier does not depend on it.
+3. **Idempotency on retry**: two layers.
+   - Backend layer (Kafka idempotent producer, SQS
+     `MessageDeduplicationId`, Kinesis client retry): prevents the same
+     producer call from writing twice on transient failure.
+   - Application layer: the `idempotency_key` field. The applier checks
+     `applied_events` before applying (`applier.py:765-768`). If the
+     producer retries at a higher level (e.g. handler caller retries
+     ExecuteAtomic) it MUST reuse the same `idempotency_key` — the WAL
+     may then contain two copies but the applier dedupes.
+4. **Failure → no partial write**: if `append` raises, the caller must
+   assume nothing was written *or* it was written exactly once. The
+   producer never leaves "half a record" visible to consumers
+   (`wal/__init__.py:17`).
+5. **Headers**: optional `map[string]bytes`. Currently unused by handlers
+   but reserved for tracing / encryption metadata.
+
+## Backend inventory
+
+| Backend                                  | File                       | Intent / when chosen                                                                |
+| ---------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------- |
+| Kafka / Redpanda / MSK                   | `wal/kafka.py`             | Production default. High throughput, multi-partition, mature ecosystem.            |
+| AWS Kinesis Data Streams                 | `wal/kinesis.py`           | AWS-native deployments avoiding MSK. Shard-based ordering.                          |
+| AWS SQS FIFO                             | `wal/sqs.py`               | Low-to-medium throughput AWS deployments; cheaper than MSK; FIFO + dedupe.          |
+| GCP Pub/Sub (with ordering keys)         | `wal/pubsub.py`            | GCP-native deployments.                                                             |
+| Azure Service Bus (sessions)             | `wal/servicebus.py`        | Azure-native, session-ordered.                                                      |
+| Azure Event Hubs (Kafka-compatible)      | `wal/eventhubs.py`         | Azure-native high throughput.                                                       |
+| In-memory                                | `wal/memory.py`            | Tests + local dev. Same ordering guarantees, lost on exit.                          |
+
+Selection happens at startup in `wal/base.py:342` (`create_wal_stream`)
+based on `config.wal_backend` (enum at `config.py:70`,
+values: `kafka|kinesis|pubsub|sqs|servicebus|eventhubs|local`).
+
+S3 is **not** a producer backend. S3 enters the picture downstream:
+archived WAL segments land in S3 with Object Lock (COMPLIANCE mode) for
+tamper-evident audit (`audit/__init__.py:4-8`, `audit/s3_lock.py`,
+`audit/compliance.py`). The Go port keeps that split — producers never
+write to S3 directly.
+
+## Multi-tenancy & ordering
+
+- **Partition key = `tenant_id`** at every call site
+  (`grpc_server.py:792`). All backends honor this:
+  Kafka → record key, Kinesis → `PartitionKey`, SQS → `MessageGroupId`,
+  Pub/Sub → ordering key, Service Bus → `SessionId`, Event Hubs →
+  `partition_key`.
+- **Per-tenant total order**: yes (required for replay determinism).
+- **Global total order**: no, and not needed. The applier indexes
+  `applied_events` by `(tenant_id, idempotency_key)`.
+- Memory backend hashes the key into `num_partitions` (default 4) to
+  simulate the same property (`memory.py:74-88,135`).
+- The applier may shard work by tenant (`_assigned_tenants`,
+  `applier.py:483`); the producer does not need to know.
+
+## Failure modes
+
+- **Partial write / mid-flight crash**: producer must surface an error
+  *or* ensure exactly-once. With Kafka idempotent producer + `acks=all`
+  this is the broker's job; `append` either returns `StreamPos` or
+  raises `WalError`/`WalTimeoutError` (`base.py:41-62`).
+- **Leader loss / broker bounce**: producer reconnects with
+  exponential backoff (`wal/__init__.py:20`); in-flight `append` calls
+  surface `WalConnectionError` so the handler returns a non-OK gRPC
+  status. The client is expected to retry with the same
+  `idempotency_key`.
+- **Slow consumer / WAL backpressure**: producer is decoupled from
+  consumer. Backpressure surfaces as backend-side queue limits (Kafka
+  buffer-memory, SQS quota). Producers must NOT block waiting for the
+  applier — `wait_applied` is a separate, optional, post-append step
+  (`grpc_server.py:804`).
+- **Schema mismatch**: producer does not validate `ops`. The applier
+  is the gate; a poison event halts the applier
+  (`applier.py:430-441,529-533`) but the WAL keeps it (advance-on-poison
+  is forbidden — `test_wal_replay_determinism.py:10-19`). Producers
+  therefore must not retry "unknown op" errors that came from the
+  applier — they're terminal at append time only if validation is added
+  client-side later.
+- **Idempotency-key reuse with different payload**: undefined. Today
+  the applier silently skips on duplicate key (`applier.py:920-924`).
+  The Go port should preserve this and document it as a producer
+  responsibility.
+
+## Go interface
+
+Target package: `server/go/internal/wal/` (does not yet exist).
+
+```go
+package wal
+
+type Event struct {
+    TenantID         string
+    Actor            string
+    IdempotencyKey   string
+    SchemaFingerprint string // empty == nil
+    TsMs             int64
+    Ops              []Op // []*pb.Op once protobufed; []map[string]any meanwhile
+}
+
+type StreamPos struct {
+    Topic       string
+    Partition   int32
+    Offset      int64
+    TimestampMs int64
+}
+
+func (p StreamPos) String() string // "topic:partition:offset"
+
+type Producer interface {
+    Connect(ctx context.Context) error
+    Close(ctx context.Context) error
+    Append(ctx context.Context, topic, key string, value []byte, headers map[string][]byte) (StreamPos, error)
+}
+```
+
+Notes:
+- `Append` takes raw bytes, not `Event`. Encoding (JSON today, proto
+  later) lives in a thin wrapper so the producer stays transport-only.
+  Mirrors `grpc_server.py:789` where the handler json-encodes before
+  calling `wal.append`.
+- `ctx` carries deadlines; Python uses `WalTimeoutError`, Go uses
+  `ctx.Err()` + a typed `*WalTimeout` wrapper.
+- Errors: `WalError`, `WalConnectionError`, `WalTimeoutError`,
+  `WalSerializationError` (`base.py:41-62`) → Go sentinel errors with
+  `errors.Is` support.
+- **Phase 1**: only `InMemoryProducer` (port `memory.py`). Sufficient
+  to bring up handlers + applier behind it and run the integration
+  suite.
+- **Phase 2+**: Kafka first (production critical), then Kinesis, then
+  the rest. Each backend lives in its own subpackage
+  (`internal/wal/kafka`, etc.) so build tags / optional deps mirror
+  Python's `try: import aiokafka` pattern (`kafka.py:42-52`).
+
+## Dependencies
+
+- `context` — replaces Python's implicit asyncio cancellation.
+- `time` — `TsMs` and `TimestampMs` generation.
+- Future: generated `pb` package for typed `Op` once the proto is
+  defined (`proto/entdb/v1/entdb.proto`). Until then, JSON via
+  `encoding/json`.
+- Per-backend SDKs (Phase 2+): `confluent-kafka-go` or `segmentio/kafka-go`,
+  `aws-sdk-go-v2` (kinesis, sqs), `cloud.google.com/go/pubsub`,
+  `azservicebus`, `azeventhubs`. Pick at build-tag granularity to keep
+  a slim default binary.
+- No dependency on the applier package — producer is upstream-only.
+
+## Test surface
+
+Mirror the Python suites:
+
+- `internal/wal/memory_test.go` — port `tests/python/unit/test_wal_memory.py`:
+  append/subscribe roundtrip, partition determinism by key, offset
+  monotonicity, num_partitions validation, `wait_for_records`.
+- `internal/wal/contract_test.go` — port `tests/python/unit/test_wal_backends.go`:
+  shared producer-contract tests run against every backend impl
+  (durability ack, ordering within key, error types).
+- `internal/wal/config_test.go` — `test_wal_backends_config.py`:
+  factory selection from config.
+- Integration parity: a Go version of
+  `tests/python/integration/test_wal_replay_determinism.py` once the
+  Go applier exists. Producer-only fixtures should expose the same
+  helpers `InMemoryProducer` provides today: `GetAllRecords(topic)`,
+  `GetRecordCount(topic)`, `ClearTopic(topic)`, `WaitForRecords(...)`
+  (`memory.py:343-403`). These are the bedrock of cross-implementation
+  contract tests under `tests/contract/`.
+
+Cross-impl contract tests (`tests/contract/`, currently empty) should
+drive the same byte-level WAL through both Python and Go applier
+builds and assert identical SQLite output. The producer half of those
+tests just needs deterministic JSON encoding — keep field ordering
+stable.
+
+## Open questions / risks
+
+- **Backend selection per environment**: today config picks one global
+  backend. Multi-region or multi-cloud deployments may want different
+  backends per tenant shard. Out of scope for the producer port; flag
+  for a future config-routing layer.
+- **WAL compaction**: not implemented. Replay-from-zero is the only
+  recovery path. If compaction is added, the producer may need to
+  emit `tombstone`-style markers — design TBD with the applier team.
+- **Replay determinism vs halt-on-poison**: the applier halts on a
+  poison event and does NOT advance the WAL offset
+  (`applier.py:427-441`, `test_wal_replay_determinism.py:17-19`). The
+  producer is unaware of this — but it means the producer MUST NEVER
+  retry an `append` by writing a *new* event with a new
+  `idempotency_key`; client retries reuse the same key so the applier
+  can dedupe. Document in the SDK contract.
+- **Op typing**: Python keeps `ops` as `list[dict[str, Any]]`. Go
+  benefits from generated proto types but until ops are protobufed,
+  the Go side stores them as `json.RawMessage` or
+  `[]map[string]any`. Decide before the Kafka backend lands — the
+  encoded byte layout becomes the cross-impl contract surface.
+- **Header semantics**: currently unused. If we later add tracing
+  (W3C traceparent) or per-record encryption metadata, headers
+  become load-bearing — producers must propagate them and consumers
+  must not strip them.
+- **Exactly-once across rebalance**: Kafka idempotent producer is
+  per-session; on producer restart with a different `transactional_id`
+  duplicates can re-enter the WAL. Today applier dedupes on
+  `idempotency_key`; verify the Go Kafka client preserves the same
+  semantics before promoting to production.


### PR DESCRIPTION
## Summary

Wave 0 of EPIC #407 (Python → Go server port). 54 parallel research agents (one per gRPC method + one per shared concern) read the Python source and contract tests and produced per-piece implementation specs. The synthesis (`PLAN.md`) turns those into the concrete Wave 1 / Wave 2 PR slates.

No source or build changes — this PR is **docs only**. It unblocks Wave 1 (shared-package implementation) and Wave 2 (44 parallel RPC ports), which are gated on Phase 0 #408 merging first.

## Contents

- `docs/go-port/rpcs/` — **44 RPC specs**, one per method on `entdb.v1.EntDBService`. Each covers:
  1. Wire contract
  2. Auth (Permission, trusted-actor handling)
  3. Side effects (WAL / canonical_store / global_store / quotas)
  4. Exhaustive (gRPC code, trigger) error pairs
  5. Shared Go package deps
  6. Other-RPC deps
  7. Contract tests pinning behavior (file:line)
  8. Implementation outline
  9. Open questions / risks
- `docs/go-port/shared/` — **10 shared-concern specs**: `auth-interceptor`, `wal-producer`, `applier`, `canonical-store`, `global-store`, `error-mapping`, `payload-translation`, `schema-registry`, `acl`, `test-harness`.
- `docs/go-port/PLAN.md` — **synthesis** produced by a 55th agent reading all 54 specs:
  - 13 normative Wave-1 Go packages with a 7-layer dependency graph
  - 7 Wave-2 batches (foundational reads, write path, cross-tenant, sharing/ACL, GDPR, deprecated stubs) covering all 44 RPCs
  - Aggregated drift list (see below)
  - Concrete W1.0–W1.10 and W2.01–W2.44 PR slates with agent prompt outlines

## Drift surfaced from the Python source

The agents flagged real divergence between the Python implementation and CLAUDE.md invariants. Recommendation in `PLAN.md`: the Go port **restores the invariant** rather than preserving parity, with a follow-up file-level issue for each fix-on-port:

- **WAL bypass (CLAUDE.md invariant #1) on 12 RPCs:** ShareNode, RevokeAccess, CreateUser, CreateTenant, ArchiveTenant, AddTenantMember, RemoveTenantMember, ChangeMemberRole, AddGroupMember, RemoveGroupMember, RevokeAllUserAccess, SetLegalHold.
- **Real bug — applier dispatch missing for `admin_delegate_access`:** the `DelegateAccess` handler appends a WAL event that no applier branch consumes, so the event is silently dropped on replay.
- **Trusted-actor enforcement gaps** on several admin RPCs (post-#168).
- **Deprecated empty-stubs preserved as-is** for parity: `SearchMailbox`, `GetMailbox`, `ListMailboxUsers`.

## How to consume

- Reviewers: skim `PLAN.md` first; the per-RPC specs are reference material the implementer reads when picking up an RPC sub-issue.
- Implementers: when claiming a `kind/rpc` sub-issue, the corresponding `docs/go-port/rpcs/<RpcName>.md` is the source of truth for contract + dependencies.
- The W1 / W2 PR slates in §9 / §10 of `PLAN.md` are designed to be fed verbatim to a multi-agent worktree run.

## Test plan

- [x] `find docs/go-port -type f | wc -l` → 55 files (44 + 10 + PLAN)
- [x] `wc -l docs/go-port/**/*.md` → ~13.5k lines total, all under per-file caps
- [x] No source / build / test files modified

Refs #407