### PR TITLE
feat(go-rewrite): errs Go package — Wave 1

### DIFF
--- a/server/go/internal/errs/errs.go
+++ b/server/go/internal/errs/errs.go
@@ -1,0 +1,231 @@
+// Package errs is the typed-error chokepoint for the Go gRPC server.
+//
+// Every handler that needs to emit a gRPC status code MUST do so through this
+// package, so the Python -> Go contract stays in one place. The exported
+// sentinels each implement GRPCStatus() *status.Status, so they round-trip
+// through google.golang.org/grpc/status.FromError and
+// google.golang.org/grpc/status.Code without the caller needing to know the
+// concrete type.
+//
+// Spec: docs/go-port/shared/error-mapping.md (canonical mapping of every
+// status code emitted by server/python/entdb_server, and the Go-side
+// equivalents). Per-RPC specs in docs/go-port/rpcs/*.md reference this file
+// for code semantics; do not duplicate the mapping there.
+//
+// Out-of-scope (deliberate parity with Python):
+//
+//   - google.rpc.ErrorInfo / google.rpc.RetryInfo proto details. The Python
+//     server does not emit these; adding them would de-sync the contract.
+//   - codes.Unknown. If a contract test ever observes Unknown it is a P0
+//     bug -- see error-mapping.md "Open questions / risks" item 4.
+package errs
+
+import (
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// codeError is the concrete sentinel type returned by newCode. It carries a
+// gRPC code plus an optional message and implements GRPCStatus so
+// status.Code(err) and status.FromError(err) work without type-asserting on
+// the concrete type.
+//
+// errors.Is(err, sentinel) returns true for any codeError that shares the
+// same code as sentinel -- this lets handlers wrap a sentinel with a
+// formatted message via Errorf or fmt.Errorf("...: %w", ErrFoo) and still
+// match the sentinel in tests.
+type codeError struct {
+	code codes.Code
+	msg  string
+}
+
+// newCode constructs a sentinel with no message. Used at package level.
+func newCode(c codes.Code) *codeError {
+	return &codeError{code: c}
+}
+
+// Error implements error. Empty message degrades to the lowercase code name
+// (mirrors what status.Errorf produces when given an empty format string).
+func (e *codeError) Error() string {
+	if e.msg == "" {
+		return e.code.String()
+	}
+	return e.msg
+}
+
+// GRPCStatus implements the interface status.FromError checks for. Returning
+// a *status.Status here means callers can do
+//
+//	return errs.ErrNotFound
+//
+// directly from a handler and the gRPC runtime will produce a
+// status.Status{Code: NotFound, Message: ...} without any extra wrapping.
+func (e *codeError) GRPCStatus() *status.Status {
+	return status.New(e.code, e.Error())
+}
+
+// Is reports whether target is a codeError sharing this error's code.
+//
+// This is what makes errors.Is(err, errs.ErrPermission) work after the
+// caller has wrapped the sentinel with a custom message via Errorf:
+//
+//	err := errs.Errorf(codes.PermissionDenied, "actor %q is not admin", a)
+//	errors.Is(err, errs.ErrPermission) // true
+func (e *codeError) Is(target error) bool {
+	t, ok := target.(*codeError)
+	if !ok {
+		return false
+	}
+	return e.code == t.code
+}
+
+// Sentinel errors. One per gRPC code currently emitted by the Python server
+// (per docs/go-port/shared/error-mapping.md "Code catalogue"). Codes the
+// Python server does not raise (OUT_OF_RANGE, CANCELLED, ABORTED, DATA_LOSS)
+// are intentionally not declared here; if a future RPC needs them, add them
+// in the same row as the Python source mapping.
+//
+// ErrInternal and ErrDeadlineExceeded are listed in the spec as "not raised
+// by the server today" but are exported here because handlers may need to
+// surface them (ExecuteAtomic in-band INTERNAL channel, transport-level
+// deadline pass-through). See error-mapping.md notes on these codes.
+var (
+	// ErrInvalidArgument -> codes.InvalidArgument.
+	// Python source: api/grpc_server.py (every required-arg validation site,
+	// see error-mapping.md row "INVALID_ARGUMENT").
+	ErrInvalidArgument = newCode(codes.InvalidArgument)
+
+	// ErrNotFound -> codes.NotFound.
+	// Python source: api/grpc_server.py:505-516 (_check_tenant existence
+	// leak guard).
+	ErrNotFound = newCode(codes.NotFound)
+
+	// ErrAlreadyExists -> codes.AlreadyExists.
+	// Python source: api/grpc_server.py:697,746 (idempotency replay,
+	// unique-constraint violations from apply/canonical_store.py).
+	ErrAlreadyExists = newCode(codes.AlreadyExists)
+
+	// ErrPermission -> codes.PermissionDenied.
+	// Python source: api/grpc_server.py many sites (privilege escalation
+	// guard, ACL deny, admin-only checks).
+	ErrPermission = newCode(codes.PermissionDenied)
+
+	// ErrFailedPrecondition -> codes.FailedPrecondition.
+	// Python source: api/grpc_server.py:520,526 (region-pin mismatch);
+	// schema/compat.py CompatibilityError; crypto-shred state.
+	ErrFailedPrecondition = newCode(codes.FailedPrecondition)
+
+	// ErrResourceExhausted -> codes.ResourceExhausted.
+	// Python source: api/rate_limiter.py:94, auth/quota_interceptor.py:237,
+	// gRPC core (oversized message).
+	ErrResourceExhausted = newCode(codes.ResourceExhausted)
+
+	// ErrUnauthenticated -> codes.Unauthenticated.
+	// Python source: auth/auth_interceptor.py:196,202; api/auth.py:81,131,
+	// 139,152,187 (every auth failure path).
+	ErrUnauthenticated = newCode(codes.Unauthenticated)
+
+	// ErrUnavailable -> codes.Unavailable.
+	// Python source: api/grpc_server.py:392-395 (sharding mismatch; the
+	// server attaches an entdb-redirect-node trailer before returning).
+	ErrUnavailable = newCode(codes.Unavailable)
+
+	// ErrUnimplemented -> codes.Unimplemented.
+	// Python source: api/grpc_server.py many sites (optional-store guards
+	// when global_store / user_registry / compliance is None).
+	ErrUnimplemented = newCode(codes.Unimplemented)
+
+	// ErrInternal -> codes.Internal.
+	// Python source: api/grpc_server.py:824 sets the *string* "INTERNAL" on
+	// ExecuteAtomicResponse.error_code; gRPC status stays OK. The Go port
+	// keeps that in-band channel for ExecuteAtomic specifically (see
+	// error-mapping.md "Swallow patterns" item 3). This sentinel exists for
+	// any future RPC that needs codes.Internal as a real status, and for
+	// the recover-and-wrap fallback discussed in error-mapping.md "Open
+	// questions / risks" item 4.
+	ErrInternal = newCode(codes.Internal)
+
+	// ErrDeadlineExceeded -> codes.DeadlineExceeded.
+	// Python source: not raised by the server -- surfaces only when the
+	// client deadline elapses (transport-level). Exported for completeness
+	// and for handlers that want to translate context.DeadlineExceeded.
+	ErrDeadlineExceeded = newCode(codes.DeadlineExceeded)
+)
+
+// Errorf builds a status-bearing error in one call. Use this in handlers
+// instead of status.Errorf so the Python -> Go contract stays in one place.
+//
+// The returned error implements GRPCStatus() and Is(*codeError), so the
+// caller's tests can do errors.Is(err, errs.ErrNotFound).
+//
+// Empty format strings degrade to the code's name; this matches what
+// status.Errorf produces.
+func Errorf(c codes.Code, format string, a ...any) error {
+	msg := format
+	if len(a) > 0 {
+		msg = fmt.Sprintf(format, a...)
+	}
+	if msg == "" {
+		msg = c.String()
+	}
+	return &codeError{code: c, msg: msg}
+}
+
+// Code unwraps any error to its gRPC code. Returns codes.OK for nil and
+// codes.Unknown for an error that does not carry a status (the standard
+// google.golang.org/grpc/status.Code behavior). Provided as a convenience so
+// handlers that import errs do not also need to import grpc/status just for
+// the code lookup.
+func Code(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+	return status.Code(err)
+}
+
+// PreserveStatusOrSwallow mirrors the Python "re-raise gRPC aborts, swallow
+// the rest" pattern documented in docs/go-port/shared/error-mapping.md
+// "Swallow patterns" item 1.
+//
+// Behavior:
+//
+//   - err == nil -> return nil; dst untouched.
+//   - err carries a gRPC status code (anything other than codes.Unknown)
+//     -> return err unchanged. The handler should propagate this directly
+//     so the SDK observes the original code.
+//   - err is a naked Go error (no status, i.e. status.Code(err) ==
+//     codes.Unknown) -> write err.Error() into dst via dst.SetError, return
+//     nil. The handler then returns its zero/empty response with the gRPC
+//     status implicitly OK -- matching the Python ResponseProto(success=
+//     false, error=str(e)) shape.
+//
+// dst MUST be the response proto being returned (it has SetError generated
+// by go-protobuf for any message with an `error` string field). If dst is
+// nil, the swallow path still returns nil and silently drops the error
+// message; callers SHOULD pass a non-nil dst.
+func PreserveStatusOrSwallow(err error, dst interface{ SetError(string) }) error {
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) != codes.Unknown {
+		return err
+	}
+	if dst != nil {
+		dst.SetError(err.Error())
+	}
+	return nil
+}
+
+// As is a convenience: errors.As specialized to *codeError. Returns the
+// underlying code and true if err carries one of this package's sentinels
+// (or any error built via Errorf). This is mainly useful for tests.
+func As(err error) (codes.Code, bool) {
+	var ce *codeError
+	if errors.As(err, &ce) {
+		return ce.code, true
+	}
+	return codes.OK, false
+}

--- a/server/go/internal/errs/errs_test.go
+++ b/server/go/internal/errs/errs_test.go
@@ -1,0 +1,254 @@
+package errs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Each row asserts (sentinel) -> code round-trip via status.FromError +
+// status.Code, plus errors.Is reflexivity.
+var sentinelTable = []struct {
+	name string
+	err  *codeError
+	code codes.Code
+}{
+	{"InvalidArgument", ErrInvalidArgument, codes.InvalidArgument},
+	{"NotFound", ErrNotFound, codes.NotFound},
+	{"AlreadyExists", ErrAlreadyExists, codes.AlreadyExists},
+	{"Permission", ErrPermission, codes.PermissionDenied},
+	{"FailedPrecondition", ErrFailedPrecondition, codes.FailedPrecondition},
+	{"ResourceExhausted", ErrResourceExhausted, codes.ResourceExhausted},
+	{"Unauthenticated", ErrUnauthenticated, codes.Unauthenticated},
+	{"Unavailable", ErrUnavailable, codes.Unavailable},
+	{"Unimplemented", ErrUnimplemented, codes.Unimplemented},
+	{"Internal", ErrInternal, codes.Internal},
+	{"DeadlineExceeded", ErrDeadlineExceeded, codes.DeadlineExceeded},
+}
+
+func TestSentinelGRPCStatusRoundTrip(t *testing.T) {
+	for _, row := range sentinelTable {
+		t.Run(row.name, func(t *testing.T) {
+			st, ok := status.FromError(row.err)
+			if !ok {
+				t.Fatalf("status.FromError(%v): expected ok=true", row.err)
+			}
+			if st.Code() != row.code {
+				t.Fatalf("got code %v, want %v", st.Code(), row.code)
+			}
+			// Empty-message sentinel degrades to the lowercase code name.
+			if st.Message() != row.code.String() {
+				t.Fatalf("got msg %q, want %q", st.Message(), row.code.String())
+			}
+			// status.Code is the most common path callers use.
+			if status.Code(row.err) != row.code {
+				t.Fatalf("status.Code returned %v", status.Code(row.err))
+			}
+			// errors.Is reflexivity.
+			if !errors.Is(row.err, row.err) {
+				t.Fatalf("errors.Is(sentinel, itself) = false")
+			}
+		})
+	}
+}
+
+func TestErrorf_FormatsMessage(t *testing.T) {
+	err := Errorf(codes.PermissionDenied, "actor %q is not admin", "alice")
+	if got, want := status.Code(err), codes.PermissionDenied; got != want {
+		t.Fatalf("code: got %v want %v", got, want)
+	}
+	st, _ := status.FromError(err)
+	want := `actor "alice" is not admin`
+	if st.Message() != want {
+		t.Fatalf("msg: got %q want %q", st.Message(), want)
+	}
+}
+
+func TestErrorf_NoArgsTreatsFormatAsLiteral(t *testing.T) {
+	err := Errorf(codes.InvalidArgument, "missing tenant_id")
+	st, _ := status.FromError(err)
+	if st.Message() != "missing tenant_id" {
+		t.Fatalf("got %q", st.Message())
+	}
+}
+
+func TestErrorf_EmptyMessageDegradesToCodeName(t *testing.T) {
+	err := Errorf(codes.NotFound, "")
+	st, _ := status.FromError(err)
+	if st.Message() != codes.NotFound.String() {
+		t.Fatalf("got %q want %q", st.Message(), codes.NotFound.String())
+	}
+}
+
+func TestErrorf_IsSentinel(t *testing.T) {
+	// errors.Is must match by code so handlers can wrap a sentinel with
+	// a custom message and tests can still assert against the sentinel.
+	err := Errorf(codes.NotFound, "tenant %q does not exist", "t-42")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("errors.Is(Errorf-NotFound, ErrNotFound) = false")
+	}
+	if errors.Is(err, ErrPermission) {
+		t.Fatalf("errors.Is across distinct codes = true (should be false)")
+	}
+}
+
+func TestCode_NilIsOK(t *testing.T) {
+	if Code(nil) != codes.OK {
+		t.Fatalf("Code(nil) = %v", Code(nil))
+	}
+}
+
+func TestCode_NakedErrorIsUnknown(t *testing.T) {
+	if Code(errors.New("boom")) != codes.Unknown {
+		t.Fatalf("Code(plain error) = %v", Code(errors.New("boom")))
+	}
+}
+
+func TestCode_StatusError(t *testing.T) {
+	err := status.Error(codes.AlreadyExists, "dup")
+	if Code(err) != codes.AlreadyExists {
+		t.Fatalf("Code(status) = %v", Code(err))
+	}
+}
+
+func TestAs_ExtractsCode(t *testing.T) {
+	c, ok := As(Errorf(codes.Unimplemented, "no global store"))
+	if !ok || c != codes.Unimplemented {
+		t.Fatalf("As: got (%v,%v) want (Unimplemented,true)", c, ok)
+	}
+	if _, ok := As(errors.New("naked")); ok {
+		t.Fatalf("As(plain error) returned ok=true")
+	}
+	if _, ok := As(nil); ok {
+		t.Fatalf("As(nil) returned ok=true")
+	}
+}
+
+// fakeResponse implements the SetError contract used by
+// PreserveStatusOrSwallow. Real proto messages with an `error` string field
+// generate this method via go-protobuf.
+type fakeResponse struct {
+	err string
+}
+
+func (f *fakeResponse) SetError(s string) { f.err = s }
+
+func TestPreserveStatusOrSwallow_NilReturnsNil(t *testing.T) {
+	dst := &fakeResponse{}
+	if err := PreserveStatusOrSwallow(nil, dst); err != nil {
+		t.Fatalf("nil err: got %v", err)
+	}
+	if dst.err != "" {
+		t.Fatalf("dst written for nil err: %q", dst.err)
+	}
+}
+
+func TestPreserveStatusOrSwallow_StatusErrorPassesThrough(t *testing.T) {
+	dst := &fakeResponse{}
+	in := Errorf(codes.PermissionDenied, "no")
+	out := PreserveStatusOrSwallow(in, dst)
+	if out != in {
+		t.Fatalf("status err not passed through: got %v want %v", out, in)
+	}
+	if dst.err != "" {
+		t.Fatalf("dst written on pass-through: %q", dst.err)
+	}
+}
+
+func TestPreserveStatusOrSwallow_NakedErrorIsSwallowed(t *testing.T) {
+	dst := &fakeResponse{}
+	out := PreserveStatusOrSwallow(errors.New("kaboom"), dst)
+	if out != nil {
+		t.Fatalf("naked err not swallowed: %v", out)
+	}
+	if dst.err != "kaboom" {
+		t.Fatalf("dst not written: %q", dst.err)
+	}
+}
+
+func TestPreserveStatusOrSwallow_NilDstSilentlyDrops(t *testing.T) {
+	// Documented behavior: nil dst is permitted but the message is dropped.
+	out := PreserveStatusOrSwallow(errors.New("kaboom"), nil)
+	if out != nil {
+		t.Fatalf("nil dst should still swallow: %v", out)
+	}
+}
+
+func TestPreserveStatusOrSwallow_WrappedSentinelPassesThrough(t *testing.T) {
+	// fmt.Errorf with %w of a sentinel must still report the sentinel's
+	// code via status.Code -- otherwise PreserveStatusOrSwallow would
+	// wrongly swallow a wrapped sentinel.
+	in := fmt.Errorf("admin guard: %w", ErrPermission)
+	dst := &fakeResponse{}
+	out := PreserveStatusOrSwallow(in, dst)
+	// The status pkg unwraps via GRPCStatus on the wrapped sentinel.
+	// Verify the chain works.
+	if status.Code(in) != codes.PermissionDenied {
+		t.Fatalf("status.Code through %%w wrap: got %v", status.Code(in))
+	}
+	if out != in {
+		t.Fatalf("wrapped sentinel not passed through")
+	}
+	if dst.err != "" {
+		t.Fatalf("dst written for wrapped sentinel: %q", dst.err)
+	}
+}
+
+func TestFromPythonException_KnownClasses(t *testing.T) {
+	cases := []struct {
+		name string
+		want codes.Code
+	}{
+		{"AccessDeniedError", codes.PermissionDenied},
+		{"TenantNotFoundError", codes.NotFound},
+		{"IdempotencyViolationError", codes.AlreadyExists},
+		{"UniqueConstraintError", codes.AlreadyExists},
+		{"CompositeUniqueConstraintError", codes.AlreadyExists},
+		{"QueryFilterError", codes.InvalidArgument},
+		{"CompatibilityError", codes.FailedPrecondition},
+		{"RegistryFrozenError", codes.FailedPrecondition},
+		{"DuplicateRegistrationError", codes.FailedPrecondition},
+		{"AuthenticationError", codes.Unauthenticated},
+		{"SessionError", codes.Unauthenticated},
+		{"ApiKeyError", codes.Unauthenticated},
+		{"AuthError", codes.Unauthenticated},
+		{"CryptoShreddedError", codes.FailedPrecondition},
+		{"TenantShreddedError", codes.FailedPrecondition},
+		{"TenantKeyAlreadyProvisionedError", codes.AlreadyExists},
+		{"WalConnectionError", codes.Unavailable},
+		{"WalTimeoutError", codes.Unavailable},
+		{"WalSerializationError", codes.Internal},
+		{"PermissionError", codes.PermissionDenied},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := FromPythonException(c.name); got != c.want {
+				t.Fatalf("FromPythonException(%q) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFromPythonException_UnknownReturnsUnknown(t *testing.T) {
+	if got := FromPythonException("NonExistentError"); got != codes.Unknown {
+		t.Fatalf("got %v, want Unknown", got)
+	}
+}
+
+func TestFromGoError(t *testing.T) {
+	if FromGoError(nil) != codes.OK {
+		t.Fatalf("nil -> %v", FromGoError(nil))
+	}
+	if FromGoError(ErrAlreadyExists) != codes.AlreadyExists {
+		t.Fatalf("sentinel -> %v", FromGoError(ErrAlreadyExists))
+	}
+	if FromGoError(status.Error(codes.Unavailable, "x")) != codes.Unavailable {
+		t.Fatalf("status err -> %v", FromGoError(status.Error(codes.Unavailable, "x")))
+	}
+	if FromGoError(errors.New("naked")) != codes.Unknown {
+		t.Fatalf("naked -> %v", FromGoError(errors.New("naked")))
+	}
+}

--- a/server/go/internal/errs/map.go
+++ b/server/go/internal/errs/map.go
@@ -1,0 +1,153 @@
+// Python exception -> gRPC code translation table.
+//
+// Source of truth: docs/go-port/shared/error-mapping.md, "Exception -> code
+// mapping". Each row below carries a comment with the Python file:line where
+// the original exception is raised; if the spec is updated, update both.
+//
+// The Go port does not re-implement every Python exception class -- the
+// applier and store packages return errors that this package can classify
+// via FromPythonException (string-keyed for the in-band path) and via
+// FromGoError (sentinel-keyed). Handlers should prefer building errors with
+// errs.Errorf or returning a sentinel directly; this map exists for the
+// applier's swallow / re-raise decision and for cross-language contract
+// tests that replay Python error fixtures.
+
+package errs
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// pythonExceptionCodes is the canonical Python-class-name -> gRPC code
+// table. Keys are the Python class names exactly as they appear in the
+// source (`raise FooError(...)`); values are the gRPC code the Python
+// handler eventually emits via context.abort.
+//
+// Keep this sorted by Python source file for ease of audit against
+// error-mapping.md.
+var pythonExceptionCodes = map[string]codes.Code{
+	// apply/acl.py:44 -- AccessDeniedError -> PERMISSION_DENIED.
+	"AccessDeniedError": codes.PermissionDenied,
+
+	// apply/canonical_store.py:165 -- TenantNotFoundError -> NOT_FOUND
+	// (via _check_tenant existence-leak guard).
+	"TenantNotFoundError": codes.NotFound,
+
+	// apply/canonical_store.py:171 -- IdempotencyViolationError ->
+	// ALREADY_EXISTS.
+	"IdempotencyViolationError": codes.AlreadyExists,
+
+	// apply/applier.py:114 -- UniqueConstraintError -> ALREADY_EXISTS.
+	"UniqueConstraintError": codes.AlreadyExists,
+
+	// apply/applier.py:146 -- CompositeUniqueConstraintError ->
+	// ALREADY_EXISTS.
+	"CompositeUniqueConstraintError": codes.AlreadyExists,
+
+	// apply/query_filter.py:60 -- QueryFilterError -> INVALID_ARGUMENT
+	// (surfaces at api/grpc_server.py:1154-1155).
+	"QueryFilterError": codes.InvalidArgument,
+
+	// schema/compat.py:128 -- CompatibilityError -> FAILED_PRECONDITION
+	// (when surfaced through admin path).
+	"CompatibilityError": codes.FailedPrecondition,
+
+	// schema/registry.py:51 -- RegistryFrozenError -> FAILED_PRECONDITION.
+	"RegistryFrozenError": codes.FailedPrecondition,
+
+	// schema/registry.py:57 -- DuplicateRegistrationError ->
+	// FAILED_PRECONDITION.
+	"DuplicateRegistrationError": codes.FailedPrecondition,
+
+	// auth/oauth_validator.py:44 -- AuthenticationError -> UNAUTHENTICATED
+	// (via auth interceptor).
+	"AuthenticationError": codes.Unauthenticated,
+
+	// auth/session_manager.py:36 -- SessionError -> UNAUTHENTICATED.
+	"SessionError": codes.Unauthenticated,
+
+	// auth/api_key_manager.py:41 -- ApiKeyError -> UNAUTHENTICATED.
+	"ApiKeyError": codes.Unauthenticated,
+
+	// api/jwt_auth.py:40 -- AuthError -> UNAUTHENTICATED.
+	"AuthError": codes.Unauthenticated,
+
+	// crypto/key_manager.py:59 -- CryptoShreddedError ->
+	// FAILED_PRECONDITION (tenant has been crypto-shredded; permanent).
+	"CryptoShreddedError": codes.FailedPrecondition,
+
+	// crypto/tenant_key_vault.py:55 -- TenantShreddedError ->
+	// FAILED_PRECONDITION.
+	"TenantShreddedError": codes.FailedPrecondition,
+
+	// crypto/tenant_key_vault.py:67 -- TenantKeyAlreadyProvisionedError ->
+	// ALREADY_EXISTS.
+	"TenantKeyAlreadyProvisionedError": codes.AlreadyExists,
+
+	// wal/base.py:47 -- WalConnectionError. Python today swallows -> OK
+	// with empty/error response. The Go port may upgrade to UNAVAILABLE
+	// behind a feature flag; until then this row documents the Python
+	// status, NOT the eventual Go status. See error-mapping.md row.
+	"WalConnectionError": codes.Unavailable,
+
+	// wal/base.py:53 -- WalTimeoutError. Same swallow note as
+	// WalConnectionError.
+	"WalTimeoutError": codes.Unavailable,
+
+	// wal/base.py:59 -- WalSerializationError. Swallowed by Python; Go
+	// reports as in-band INTERNAL on ExecuteAtomicResponse.error_code.
+	"WalSerializationError": codes.Internal,
+
+	// schema/validator.py:18 -- SchemaValidationError reported in-band on
+	// ExecuteAtomicResponse, NOT a gRPC code. Mapped to InvalidArgument
+	// here only for cross-language contract tests that drive this path
+	// outside ExecuteAtomic.
+	"SchemaValidationError": codes.InvalidArgument,
+
+	// apply/applier.py:53,59 -- ValidationError /
+	// SchemaFingerprintMismatch. Reported in-band on
+	// ExecuteAtomicResponse, NOT a gRPC code. Same note as
+	// SchemaValidationError.
+	"ValidationError":           codes.InvalidArgument,
+	"SchemaFingerprintMismatch": codes.FailedPrecondition,
+
+	// api/grpc_server.py:1791,1849 -- Python builtin PermissionError
+	// swallowed inside admin paths. Go: route to PermissionDenied.
+	"PermissionError": codes.PermissionDenied,
+}
+
+// FromPythonException returns the gRPC code that the Python server emits
+// (or would emit, modulo swallow patterns) for the given Python exception
+// class name. Returns codes.Unknown if the class name is not in the table;
+// callers should treat Unknown as "swallow / in-band" -- mirroring the
+// Python broad-except behavior.
+//
+// Cross-language contract tests use this to replay Python error fixtures:
+// the test harness sends the exception class name over the wire and the Go
+// server's classifier produces the same status code the Python server
+// would have produced.
+func FromPythonException(name string) codes.Code {
+	if c, ok := pythonExceptionCodes[name]; ok {
+		return c
+	}
+	return codes.Unknown
+}
+
+// FromGoError unwraps any error to its gRPC code. This is the inverse of
+// Errorf and the entry point for the swallow chokepoint -- handlers should
+// route through this rather than calling status.Code directly so the
+// chokepoint can be augmented later (metric labels, logging, etc.) without
+// touching every handler.
+//
+// Behavior:
+//   - nil          -> codes.OK
+//   - *codeError   -> the embedded code
+//   - status.Status-bearing error -> the embedded code
+//   - anything else -> codes.Unknown
+func FromGoError(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+	return status.Code(err)
+}

--- a/server/go/internal/errs/trailers.go
+++ b/server/go/internal/errs/trailers.go
@@ -1,0 +1,103 @@
+// Trailer helpers for the Go gRPC server.
+//
+// Spec: docs/go-port/shared/error-mapping.md "Detail trailers". The Python
+// server attaches trailing metadata in two places only:
+//
+//   - entdb-redirect-node on UNAVAILABLE  (api/grpc_server.py:387-389)
+//   - retry-after        on RESOURCE_EXHAUSTED (auth/quota_interceptor.py:233)
+//
+// Order matters: trailers MUST be set BEFORE the handler returns the status
+// error, otherwise grpc-go flushes trailers along with the closing status
+// and the late call is a no-op (same constraint Python documents at
+// api/grpc_server.py:390).
+//
+// Both helpers wrap grpc.SetTrailer, which writes to the call's trailer set
+// rather than mutating the response -- so the return idiom is
+//
+//	if err := errs.SetRedirectTrailer(ctx, ownerNode); err != nil {
+//	        return nil, err
+//	}
+//	return nil, errs.Errorf(codes.Unavailable, "tenant pinned to %s", ownerNode)
+//
+// SetRedirectTrailer / SetRetryAfter return an error only if the context
+// is not a server-side gRPC call context (grpc.SetTrailer returns
+// "grpc: failed to fetch the stream from the context"), so handlers can
+// treat the error as a bug-detector rather than a normal failure.
+
+package errs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// Trailer key constants. Lower-case per HTTP/2 header rules; grpc-go
+// normalizes these on the wire but we keep the constants in the canonical
+// form so contract tests can compare bytes directly.
+const (
+	// TrailerRedirectNode carries the owning node id the SDK should retry
+	// against on a sharding miss. Python source:
+	// api/grpc_server.py:387-389. Always paired with codes.Unavailable.
+	TrailerRedirectNode = "entdb-redirect-node"
+
+	// TrailerRetryAfter carries the integer-second delay before the SDK
+	// should retry. Python source: auth/quota_interceptor.py:233. Always
+	// paired with codes.ResourceExhausted from the quota interceptor.
+	// Format: decimal integer seconds, no unit suffix (matches HTTP
+	// Retry-After "delta-seconds" form, RFC 7231 §7.1.3).
+	TrailerRetryAfter = "retry-after"
+)
+
+// SetRedirectTrailer attaches the entdb-redirect-node trailer with the
+// given owner node id. Call this immediately before returning a
+// codes.Unavailable error from a handler that detected a sharding mismatch.
+//
+// Empty ownerNode is a programming error -- the SDK redirect cache uses
+// the value as a routing key, and an empty string would cause a redirect
+// loop. We return an error rather than panicking so the caller can fall
+// back to a non-routing failure.
+func SetRedirectTrailer(ctx context.Context, ownerNode string) error {
+	if ownerNode == "" {
+		return fmt.Errorf("errs.SetRedirectTrailer: ownerNode must not be empty")
+	}
+	md := metadata.Pairs(TrailerRedirectNode, ownerNode)
+	return grpc.SetTrailer(ctx, md)
+}
+
+// SetRetryAfter attaches the retry-after trailer with the given duration,
+// rounded UP to the nearest second (zero rounds to 1; matches the Python
+// quota interceptor's str(int(math.ceil(seconds))) shape -- the SDK uses
+// the value as a sleep target, so rounding down would cause an immediate
+// re-hit on the rate limiter).
+//
+// Negative durations are clamped to 1 second.
+//
+// Pair this with a codes.ResourceExhausted error.
+func SetRetryAfter(ctx context.Context, d time.Duration) error {
+	seconds := int64(d / time.Second)
+	if d%time.Second != 0 && d > 0 {
+		seconds++
+	}
+	if seconds < 1 {
+		seconds = 1
+	}
+	md := metadata.Pairs(TrailerRetryAfter, fmt.Sprintf("%d", seconds))
+	return grpc.SetTrailer(ctx, md)
+}
+
+// SetRetryAfterSeconds is the integer-seconds form, matching the Python
+// quota interceptor's call site exactly. Provided so the auth/quota
+// interceptor port can be a one-line change.
+//
+// seconds < 1 is clamped to 1 (see SetRetryAfter rationale).
+func SetRetryAfterSeconds(ctx context.Context, seconds int) error {
+	if seconds < 1 {
+		seconds = 1
+	}
+	md := metadata.Pairs(TrailerRetryAfter, fmt.Sprintf("%d", seconds))
+	return grpc.SetTrailer(ctx, md)
+}

--- a/server/go/internal/errs/trailers_test.go
+++ b/server/go/internal/errs/trailers_test.go
@@ -1,0 +1,201 @@
+package errs
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// trailerFunc is the per-test handler signature: takes the server-side ctx
+// and returns whatever it wants. Trailers set on ctx end up on the wire.
+type trailerFunc func(ctx context.Context) error
+
+// runTrailerTest spins up an in-memory grpc.Server with a single
+// no-codec method, invokes the provided handler with the server-side
+// context, and returns the trailing metadata observed by the client plus
+// the status returned by the call.
+//
+// We use the empty proto-less codec by passing nil decoders; the server
+// answers a single unary call. The lifecycle keeps no goroutines after
+// return.
+func runTrailerTest(t *testing.T, h trailerFunc) (metadata.MD, *status.Status) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer(grpc.ForceServerCodec(rawCodec{}))
+	// Register a single bidi-less unary method via the generic API.
+	desc := &grpc.ServiceDesc{
+		ServiceName: "errs.test.TrailerSvc",
+		HandlerType: (*any)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: "Call",
+				Handler: func(_ any, ctx context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+					var unused []byte
+					if err := dec(&unused); err != nil {
+						return nil, err
+					}
+					if err := h(ctx); err != nil {
+						return nil, err
+					}
+					return []byte{}, nil
+				},
+			},
+		},
+		Metadata: "errs/test.proto",
+	}
+	srv.RegisterService(desc, struct{}{})
+
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	conn, err := grpc.NewClient(
+		lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(rawCodec{})),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var trailer metadata.MD
+	var reply []byte
+	callErr := conn.Invoke(
+		ctx,
+		"/errs.test.TrailerSvc/Call",
+		[]byte{},
+		&reply,
+		grpc.Trailer(&trailer),
+	)
+	st, _ := status.FromError(callErr)
+	return trailer, st
+}
+
+// rawCodec is a do-nothing codec that lets us send/receive raw byte slices
+// without pulling in a proto type. Marshal/Unmarshal are identity on
+// []byte, which is all the trailer tests need.
+type rawCodec struct{}
+
+func (rawCodec) Marshal(v any) ([]byte, error) {
+	if b, ok := v.([]byte); ok {
+		return b, nil
+	}
+	return nil, nil
+}
+func (rawCodec) Unmarshal(data []byte, v any) error {
+	if p, ok := v.(*[]byte); ok {
+		*p = data
+	}
+	return nil
+}
+func (rawCodec) Name() string { return "errs-test-raw" }
+
+func TestSetRedirectTrailer_RoundTrip(t *testing.T) {
+	trailer, st := runTrailerTest(t, func(ctx context.Context) error {
+		if err := SetRedirectTrailer(ctx, "node-7"); err != nil {
+			return err
+		}
+		return Errorf(codes.Unavailable, "tenant pinned to node-7")
+	})
+	if st.Code() != codes.Unavailable {
+		t.Fatalf("code: %v", st.Code())
+	}
+	got := trailer.Get(TrailerRedirectNode)
+	if len(got) != 1 || got[0] != "node-7" {
+		t.Fatalf("trailer %s = %v, want [node-7]", TrailerRedirectNode, got)
+	}
+}
+
+func TestSetRedirectTrailer_RejectsEmpty(t *testing.T) {
+	// We can call this directly with a background ctx because the
+	// validation runs before grpc.SetTrailer.
+	err := SetRedirectTrailer(context.Background(), "")
+	if err == nil {
+		t.Fatalf("empty owner: expected error")
+	}
+}
+
+func TestSetRetryAfter_RoundsUp(t *testing.T) {
+	cases := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"zero clamps to 1", 0, "1"},
+		{"negative clamps to 1", -3 * time.Second, "1"},
+		{"sub-second rounds up", 250 * time.Millisecond, "1"},
+		{"exact second", 5 * time.Second, "5"},
+		{"fraction rounds up", 5500 * time.Millisecond, "6"},
+		{"large", 90 * time.Second, "90"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			trailer, st := runTrailerTest(t, func(ctx context.Context) error {
+				if err := SetRetryAfter(ctx, c.d); err != nil {
+					return err
+				}
+				return Errorf(codes.ResourceExhausted, "quota")
+			})
+			if st.Code() != codes.ResourceExhausted {
+				t.Fatalf("code: %v", st.Code())
+			}
+			got := trailer.Get(TrailerRetryAfter)
+			if len(got) != 1 || got[0] != c.want {
+				t.Fatalf("retry-after: got %v, want [%s]", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSetRetryAfterSeconds(t *testing.T) {
+	trailer, st := runTrailerTest(t, func(ctx context.Context) error {
+		if err := SetRetryAfterSeconds(ctx, 12); err != nil {
+			return err
+		}
+		return Errorf(codes.ResourceExhausted, "quota")
+	})
+	if st.Code() != codes.ResourceExhausted {
+		t.Fatalf("code: %v", st.Code())
+	}
+	if got := trailer.Get(TrailerRetryAfter); len(got) != 1 || got[0] != "12" {
+		t.Fatalf("retry-after seconds=12: got %v", got)
+	}
+}
+
+func TestSetRetryAfterSeconds_ClampsBelowOne(t *testing.T) {
+	trailer, _ := runTrailerTest(t, func(ctx context.Context) error {
+		_ = SetRetryAfterSeconds(ctx, 0)
+		return Errorf(codes.ResourceExhausted, "quota")
+	})
+	if got := trailer.Get(TrailerRetryAfter); len(got) != 1 || got[0] != "1" {
+		t.Fatalf("clamp: got %v", got)
+	}
+}
+
+// TrailerKeysAreLowercase guards against accidental introduction of
+// upper-case header names. HTTP/2 normalizes to lower case anyway, but
+// contract tests compare bytes after normalization and any drift here
+// would surface as a contract-test failure.
+func TestTrailerKeysAreLowercase(t *testing.T) {
+	for _, k := range []string{TrailerRedirectNode, TrailerRetryAfter} {
+		for _, r := range k {
+			if r >= 'A' && r <= 'Z' {
+				t.Fatalf("trailer key %q contains uppercase", k)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements `server/go/internal/errs/` per the Wave 1 spec at
[`docs/go-port/shared/error-mapping.md`](../blob/main/docs/go-port/shared/error-mapping.md).

- `errs.go` — sentinel errors (`ErrInvalidArgument`, `ErrNotFound`,
  `ErrAlreadyExists`, `ErrPermission`, `ErrFailedPrecondition`,
  `ErrResourceExhausted`, `ErrUnauthenticated`, `ErrUnavailable`,
  `ErrUnimplemented`, `ErrInternal`, `ErrDeadlineExceeded`) with
  `GRPCStatus()` so they round-trip through `status.FromError` /
  `status.Code`. Plus `Errorf(code, fmt, args...)`, `Code(err)`,
  `As(err)`, and `PreserveStatusOrSwallow(err, dst)` — the chokepoint
  mirroring Python's "re-raise gRPC aborts, swallow the rest" pattern.
- `map.go` — `FromPythonException` class-name → code table for
  cross-language contract tests; `FromGoError` for Go-side unwrap.
  Each row is annotated with the Python `file:line` it came from.
- `trailers.go` — `SetRedirectTrailer(ctx, ownerNode)` and
  `SetRetryAfter(ctx, d)` / `SetRetryAfterSeconds(ctx, n)` wrapping
  `grpc.SetTrailer` with the canonical key constants
  `entdb-redirect-node` and `retry-after`.

No `google.rpc.ErrorInfo` extensions — deliberate parity with Python
(see error-mapping.md "Open questions / risks" item 4).

Refs #407.

## Test plan

- [x] `cd server/go && go vet ./...` clean
- [x] `cd server/go && go test ./...` passes (all 50+ subtests under
  `internal/errs` green; trailer round-trips exercise a real
  `grpc.Server` with `grpc.SetTrailer`)
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [x] `go mod tidy` produces no diff