### PR TITLE
feat(go-rewrite): wal Go package — Wave 1

### DIFF
--- a/server/go/internal/wal/doc.go
+++ b/server/go/internal/wal/doc.go
@@ -1,7 +1,0 @@
-// Package wal will host the write-ahead-log producer/consumer
-// abstractions ported from server/python/entdb_server/wal/. The WAL is
-// the source of truth for all mutations (CLAUDE.md invariant #1);
-// SQLite is a materialized view rebuilt by replaying it. Concrete
-// backends (Kafka, Kinesis, SQS, in-memory) land here as their RPC
-// sub-issues are picked up.
-package wal

--- a/server/go/internal/wal/event.go
+++ b/server/go/internal/wal/event.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package wal
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Event mirrors server/python/entdb_server/apply/applier.py:204
+// (TransactionEvent). It is the wire-level payload appended to the WAL
+// for every mutation. Required fields: TenantID, Actor, IdempotencyKey,
+// Ops. SchemaFingerprint may be empty when the schema registry has not
+// stamped a fingerprint yet. TsMs defaults to the current wall clock
+// when zero (see NewEvent / Encode).
+//
+// Ops is intentionally typed as []map[string]any: until the op proto
+// lands (see docs/go-port/shared/wal-producer.md "Op typing"), the
+// Python side stores ops as list[dict[str, Any]] and the Go port must
+// preserve the same encoded byte layout for cross-impl contract tests.
+type Event struct {
+	TenantID          string           `json:"tenant_id"`
+	Actor             string           `json:"actor"`
+	IdempotencyKey    string           `json:"idempotency_key"`
+	SchemaFingerprint string           `json:"schema_fingerprint,omitempty"`
+	TsMs              int64            `json:"ts_ms"`
+	Ops               []map[string]any `json:"ops"`
+}
+
+// Encode serializes e to JSON. Field ordering is fixed by the struct
+// tags above; encoding/json emits keys in struct-field order, which
+// keeps the byte layout deterministic for cross-impl contract tests.
+//
+// If TsMs is zero, it is replaced with the current wall-clock time in
+// milliseconds (mirrors applier.py:266 default).
+func (e Event) Encode() ([]byte, error) {
+	if e.TsMs == 0 {
+		e.TsMs = time.Now().UnixMilli()
+	}
+	return json.Marshal(e)
+}
+
+// DecodeEvent parses a JSON-encoded Event from a record value. Mirrors
+// applier.py:241 (TransactionEvent.from_dict): tenant_id, actor,
+// idempotency_key, ops are required; missing fields surface as a
+// non-nil error so the applier can halt rather than silently
+// proceeding.
+func DecodeEvent(value []byte) (Event, error) {
+	var e Event
+	if err := json.Unmarshal(value, &e); err != nil {
+		return Event{}, fmt.Errorf("wal: decode event: %w", err)
+	}
+	missing := make([]string, 0, 4)
+	if e.TenantID == "" {
+		missing = append(missing, "tenant_id")
+	}
+	if e.Actor == "" {
+		missing = append(missing, "actor")
+	}
+	if e.IdempotencyKey == "" {
+		missing = append(missing, "idempotency_key")
+	}
+	if e.Ops == nil {
+		missing = append(missing, "ops")
+	}
+	if len(missing) > 0 {
+		return Event{}, fmt.Errorf("wal: missing required fields: %v", missing)
+	}
+	return e, nil
+}
+
+// StreamPos is a position in the WAL stream. Mirrors
+// server/python/entdb_server/wal/base.py:65 (StreamPos). The String()
+// form is "topic:partition:offset"; TimestampMs is record metadata,
+// not part of the position identity.
+type StreamPos struct {
+	Topic       string
+	Partition   int32
+	Offset      int64
+	TimestampMs int64
+}
+
+// String returns the canonical "topic:partition:offset" form. Used as
+// the stream-position receipt the SDK returns to clients (see Python
+// grpc_server.py:799).
+func (p StreamPos) String() string {
+	return fmt.Sprintf("%s:%d:%d", p.Topic, p.Partition, p.Offset)
+}
+
+// Record is a record consumed from the WAL stream. Mirrors
+// server/python/entdb_server/wal/base.py:111 (StreamRecord). Headers
+// is map[string][]byte to match the Python dict[str, bytes] type and
+// the Go interface spec in docs/go-port/shared/wal-producer.md.
+type Record struct {
+	Key      string
+	Value    []byte
+	Position StreamPos
+	Headers  map[string][]byte
+}

--- a/server/go/internal/wal/memory.go
+++ b/server/go/internal/wal/memory.go
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package wal
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// DefaultNumPartitions matches server/python/entdb_server/wal/memory.py:74
+// (num_partitions=4). Cross-impl contract tests rely on identical
+// partitioning, so do not change without updating the Python default.
+const DefaultNumPartitions = 4
+
+// InMemory is the in-memory implementation of Producer + Consumer.
+// Mirrors server/python/entdb_server/wal/memory.py:49 (InMemoryWalStream).
+//
+// Guarantees:
+//
+//   - Per-tenant total order: records appended with the same key land
+//     in the same partition (md5(key) % numPartitions) and partitions
+//     are append-only with monotonically-increasing offsets.
+//   - Idempotent Append: the (topic, key, HeaderIdempotencyKey) tuple
+//     is the dedupe identity. A duplicate Append returns the original
+//     StreamPos without writing a new record.
+//   - Test helpers (GetAllRecords, ClearTopic, WaitForRecords) are
+//     loud-and-public so cross-impl contract tests can introspect the
+//     log without dropping into package-internal access.
+//
+// The zero value is NOT usable; construct via NewInMemory.
+type InMemory struct {
+	numPartitions int
+
+	mu     sync.Mutex
+	cond   *sync.Cond
+	closed bool
+
+	// topics[topic][partition] -> ordered list of records.
+	topics map[string]map[int32][]Record
+
+	// committed[groupID][topic][partition] -> next offset to deliver.
+	committed map[string]map[string]map[int32]int64
+
+	// idemp[topic][key][idempotencyKey] -> previously-issued StreamPos.
+	// Scope is (topic, key) so two tenants reusing the same uuid for
+	// distinct events (unlikely but legal) do not collide.
+	idemp map[string]map[string]map[string]StreamPos
+}
+
+// NewInMemory constructs an InMemory backend with numPartitions
+// partitions per topic. Pass 0 (or any value < 1) to use
+// DefaultNumPartitions.
+func NewInMemory(numPartitions int) *InMemory {
+	if numPartitions < 1 {
+		numPartitions = DefaultNumPartitions
+	}
+	m := &InMemory{
+		numPartitions: numPartitions,
+		topics:        make(map[string]map[int32][]Record),
+		committed:     make(map[string]map[string]map[int32]int64),
+		idemp:         make(map[string]map[string]map[string]StreamPos),
+	}
+	m.cond = sync.NewCond(&m.mu)
+	return m
+}
+
+// Connect is a no-op for the in-memory backend; it exists to satisfy
+// the Producer/Consumer interface contract.
+func (m *InMemory) Connect(ctx context.Context) error {
+	return nil
+}
+
+// Close marks the backend as closed and wakes any blocked PollBatch
+// or Subscribe consumers so they can observe ctx.Done() / the closed
+// flag and return.
+func (m *InMemory) Close(ctx context.Context) error {
+	m.mu.Lock()
+	m.closed = true
+	m.mu.Unlock()
+	m.cond.Broadcast()
+	return nil
+}
+
+// Append writes value to topic under key. See Producer.Append for the
+// full contract; this implementation enforces:
+//
+//   - Per-tenant order via partitionFor(key).
+//   - Idempotency via the HeaderIdempotencyKey header.
+//   - No partial writes: the lock is held for the read-or-insert
+//     critical section, so a concurrent retry sees the original
+//     position rather than racing past it.
+func (m *InMemory) Append(
+	ctx context.Context,
+	topic, key string,
+	value []byte,
+	headers map[string][]byte,
+) (StreamPos, error) {
+	if err := ctx.Err(); err != nil {
+		return StreamPos{}, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.closed {
+		return StreamPos{}, fmt.Errorf("%w: closed", ErrConnection)
+	}
+
+	// Application-layer idempotent retry. Mirrors the dedupe the
+	// Python applier does at apply time; we do it at append time too
+	// because (a) the spec calls for it on PLAN.md, and (b) it lets
+	// callers safely retry without polluting the log.
+	idempKey := ""
+	if h, ok := headers[HeaderIdempotencyKey]; ok && len(h) > 0 {
+		idempKey = string(h)
+	}
+	if idempKey != "" {
+		if byTopic, ok := m.idemp[topic]; ok {
+			if byKey, ok := byTopic[key]; ok {
+				if pos, ok := byKey[idempKey]; ok {
+					return pos, nil
+				}
+			}
+		}
+	}
+
+	partition := m.partitionFor(key)
+
+	parts, ok := m.topics[topic]
+	if !ok {
+		parts = make(map[int32][]Record, m.numPartitions)
+		m.topics[topic] = parts
+	}
+	offset := int64(len(parts[partition]))
+
+	// Copy headers so the caller mutating their map after Append does
+	// not corrupt the stored record.
+	storedHeaders := copyHeaders(headers)
+	// Copy value bytes for the same reason.
+	storedValue := append([]byte(nil), value...)
+
+	pos := StreamPos{
+		Topic:       topic,
+		Partition:   partition,
+		Offset:      offset,
+		TimestampMs: time.Now().UnixMilli(),
+	}
+
+	rec := Record{
+		Key:      key,
+		Value:    storedValue,
+		Position: pos,
+		Headers:  storedHeaders,
+	}
+	parts[partition] = append(parts[partition], rec)
+
+	if idempKey != "" {
+		byTopic, ok := m.idemp[topic]
+		if !ok {
+			byTopic = make(map[string]map[string]StreamPos)
+			m.idemp[topic] = byTopic
+		}
+		byKey, ok := byTopic[key]
+		if !ok {
+			byKey = make(map[string]StreamPos)
+			byTopic[key] = byKey
+		}
+		byKey[idempKey] = pos
+	}
+
+	m.cond.Broadcast()
+	return pos, nil
+}
+
+// PollBatch returns up to maxRecords currently uncommitted records
+// for (topic, groupID). Walks partitions in deterministic order so
+// repeated calls with the same input produce the same output for an
+// otherwise-quiet log. If nothing is available, blocks until a new
+// record arrives, the timeout fires, or ctx is cancelled.
+func (m *InMemory) PollBatch(
+	ctx context.Context,
+	topic, groupID string,
+	maxRecords int,
+	timeout time.Duration,
+) ([]Record, error) {
+	if maxRecords <= 0 {
+		return nil, nil
+	}
+
+	deadline := time.Now().Add(timeout)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for {
+		if m.closed {
+			return nil, fmt.Errorf("%w: closed", ErrConnection)
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		records := m.collectAvailableLocked(topic, groupID, maxRecords)
+		if len(records) > 0 {
+			return records, nil
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, nil
+		}
+		m.waitWithDeadline(ctx, deadline)
+	}
+}
+
+// Subscribe yields records as they arrive. The returned channels are
+// closed when ctx is cancelled, the backend is closed, or a fatal
+// error occurs. Records are delivered in offset order within a
+// partition; partitions are walked round-robin so a busy tenant
+// cannot starve a quiet one.
+func (m *InMemory) Subscribe(
+	ctx context.Context,
+	topic, groupID string,
+) (<-chan Record, <-chan error, error) {
+	out := make(chan Record)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(out)
+		defer close(errCh)
+		for {
+			if err := ctx.Err(); err != nil {
+				return
+			}
+			records, err := m.PollBatch(ctx, topic, groupID, 32, 100*time.Millisecond)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				errCh <- err
+				return
+			}
+			for _, r := range records {
+				select {
+				case <-ctx.Done():
+					return
+				case out <- r:
+					// Subscribe auto-commits per record. Callers wanting
+					// at-least-once semantics with manual commits should
+					// use PollBatch + Commit directly.
+					_ = m.commitLocked(groupID, r)
+				}
+			}
+		}
+	}()
+
+	return out, errCh, nil
+}
+
+// Commit advances the stored offset for (topic, groupID) to one past
+// record.Position.Offset. Mirrors the Python in-memory backend's
+// commit (memory.py:304-312) but is keyed by groupID so two consumer
+// groups can independently iterate the same topic.
+func (m *InMemory) Commit(ctx context.Context, groupID string, record Record) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.commitLocked(groupID, record)
+}
+
+func (m *InMemory) commitLocked(groupID string, record Record) error {
+	byGroup, ok := m.committed[groupID]
+	if !ok {
+		byGroup = make(map[string]map[int32]int64)
+		m.committed[groupID] = byGroup
+	}
+	byTopic, ok := byGroup[record.Position.Topic]
+	if !ok {
+		byTopic = make(map[int32]int64)
+		byGroup[record.Position.Topic] = byTopic
+	}
+	next := record.Position.Offset + 1
+	if cur := byTopic[record.Position.Partition]; next > cur {
+		byTopic[record.Position.Partition] = next
+	}
+	return nil
+}
+
+// collectAvailableLocked walks partitions in id order and returns up
+// to maxRecords records that have offset >= committed offset for
+// (topic, groupID). Caller must hold m.mu.
+func (m *InMemory) collectAvailableLocked(topic, groupID string, maxRecords int) []Record {
+	parts, ok := m.topics[topic]
+	if !ok {
+		return nil
+	}
+	var byTopic map[int32]int64
+	if g, ok := m.committed[groupID]; ok {
+		byTopic = g[topic]
+	}
+
+	out := make([]Record, 0, maxRecords)
+	for p := int32(0); p < int32(m.numPartitions); p++ {
+		recs := parts[p]
+		if len(recs) == 0 {
+			continue
+		}
+		start := byTopic[p]
+		for i := start; i < int64(len(recs)) && len(out) < maxRecords; i++ {
+			out = append(out, recs[i])
+		}
+		if len(out) >= maxRecords {
+			break
+		}
+	}
+	return out
+}
+
+// waitWithDeadline parks the caller on m.cond until either a
+// Broadcast wakes it, ctx fires, or deadline elapses. m.mu must be
+// held; on return it is still held. The implementation spawns a
+// helper goroutine to broadcast on ctx/deadline so we do not deadlock
+// on a quiet log.
+func (m *InMemory) waitWithDeadline(ctx context.Context, deadline time.Time) {
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		t := time.NewTimer(time.Until(deadline))
+		defer t.Stop()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			m.cond.Broadcast()
+		case <-t.C:
+			m.cond.Broadcast()
+		}
+	}()
+
+	m.cond.Wait()
+}
+
+func (m *InMemory) partitionFor(key string) int32 {
+	sum := md5.Sum([]byte(key))
+	// Match Python's int.from_bytes(hash_bytes[:4], "big") % num_partitions
+	// at memory.py:337-339.
+	hashInt := binary.BigEndian.Uint32(sum[:4])
+	return int32(hashInt % uint32(m.numPartitions))
+}
+
+func copyHeaders(in map[string][]byte) map[string][]byte {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]byte, len(in))
+	for k, v := range in {
+		cp := append([]byte(nil), v...)
+		out[k] = cp
+	}
+	return out
+}
+
+// --- Test helpers (mirroring memory.py:343-403) ---
+
+// GetAllRecords returns every record in topic, in (partition, offset)
+// order. Cross-impl contract tests rely on this for log introspection.
+func (m *InMemory) GetAllRecords(topic string) []Record {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	parts, ok := m.topics[topic]
+	if !ok {
+		return nil
+	}
+	var out []Record
+	for p := int32(0); p < int32(m.numPartitions); p++ {
+		out = append(out, parts[p]...)
+	}
+	return out
+}
+
+// GetRecordCount returns the total number of records across all
+// partitions of topic.
+func (m *InMemory) GetRecordCount(topic string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	parts, ok := m.topics[topic]
+	if !ok {
+		return 0
+	}
+	total := 0
+	for _, recs := range parts {
+		total += len(recs)
+	}
+	return total
+}
+
+// ClearTopic drops every record in topic and resets per-group
+// committed offsets for it. Useful between test cases that share a
+// backend instance.
+func (m *InMemory) ClearTopic(topic string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.topics, topic)
+	delete(m.idemp, topic)
+	for _, byGroup := range m.committed {
+		delete(byGroup, topic)
+	}
+}
+
+// WaitForRecords blocks until topic has at least count records or
+// ctx is cancelled. Returns true on success, false on ctx timeout /
+// cancel. Mirrors memory.py:382 (wait_for_records).
+func (m *InMemory) WaitForRecords(ctx context.Context, topic string, count int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for {
+		if m.closed {
+			return m.recordCountLocked(topic) >= count
+		}
+		if m.recordCountLocked(topic) >= count {
+			return true
+		}
+		if err := ctx.Err(); err != nil {
+			return false
+		}
+		// Re-check every 50ms in case Append is happening on another
+		// goroutine that didn't broadcast yet (defensive — Append does
+		// broadcast, but we don't want a slow test to hang).
+		deadline := time.Now().Add(50 * time.Millisecond)
+		m.waitWithDeadline(ctx, deadline)
+	}
+}
+
+func (m *InMemory) recordCountLocked(topic string) int {
+	parts, ok := m.topics[topic]
+	if !ok {
+		return 0
+	}
+	total := 0
+	for _, recs := range parts {
+		total += len(recs)
+	}
+	return total
+}

--- a/server/go/internal/wal/memory_test.go
+++ b/server/go/internal/wal/memory_test.go
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package wal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newConnected(t *testing.T) *InMemory {
+	t.Helper()
+	m := NewInMemory(0)
+	if err := m.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close(context.Background()) })
+	return m
+}
+
+func TestStreamPosString(t *testing.T) {
+	pos := StreamPos{Topic: "wal", Partition: 2, Offset: 7}
+	if got, want := pos.String(), "wal:2:7"; got != want {
+		t.Fatalf("StreamPos.String() = %q, want %q", got, want)
+	}
+}
+
+func TestEventEncodeDecodeRoundTrip(t *testing.T) {
+	ev := Event{
+		TenantID:          "t1",
+		Actor:             "user:alice",
+		IdempotencyKey:    "abc",
+		SchemaFingerprint: "sha256:deadbeef",
+		TsMs:              1700000000000,
+		Ops: []map[string]any{
+			{"op": "create_node", "type_id": float64(101)},
+		},
+	}
+	b, err := ev.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := DecodeEvent(b)
+	if err != nil {
+		t.Fatalf("DecodeEvent: %v", err)
+	}
+	if got.TenantID != ev.TenantID || got.Actor != ev.Actor || got.IdempotencyKey != ev.IdempotencyKey {
+		t.Fatalf("round-trip mismatch: %+v vs %+v", got, ev)
+	}
+	if got.TsMs != ev.TsMs {
+		t.Fatalf("ts_ms: got %d want %d", got.TsMs, ev.TsMs)
+	}
+	if len(got.Ops) != 1 {
+		t.Fatalf("ops len = %d want 1", len(got.Ops))
+	}
+}
+
+func TestEventEncodeDefaultsTsMs(t *testing.T) {
+	ev := Event{
+		TenantID:       "t1",
+		Actor:          "user:alice",
+		IdempotencyKey: "abc",
+		Ops:            []map[string]any{{"op": "noop"}},
+	}
+	before := time.Now().UnixMilli()
+	b, err := ev.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	after := time.Now().UnixMilli()
+	got, err := DecodeEvent(b)
+	if err != nil {
+		t.Fatalf("DecodeEvent: %v", err)
+	}
+	if got.TsMs < before || got.TsMs > after {
+		t.Fatalf("TsMs %d not in [%d,%d]", got.TsMs, before, after)
+	}
+}
+
+func TestDecodeEventRejectsMissingFields(t *testing.T) {
+	_, err := DecodeEvent([]byte(`{"tenant_id":"t1"}`))
+	if err == nil {
+		t.Fatal("expected error on missing required fields")
+	}
+}
+
+func TestAppendRequiresConnection(t *testing.T) {
+	m := NewInMemory(0)
+	_ = m.Close(context.Background())
+	_, err := m.Append(context.Background(), "wal", "k", []byte("v"), nil)
+	if !errors.Is(err, ErrConnection) {
+		t.Fatalf("err = %v, want ErrConnection", err)
+	}
+}
+
+func TestAppendPollRoundTrip(t *testing.T) {
+	m := newConnected(t)
+	ctx := context.Background()
+
+	pos, err := m.Append(ctx, "wal", "tenant_a", []byte("hello"), nil)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if pos.Offset != 0 {
+		t.Fatalf("first offset = %d, want 0", pos.Offset)
+	}
+
+	got, err := m.PollBatch(ctx, "wal", "g1", 10, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("PollBatch: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if string(got[0].Value) != "hello" {
+		t.Fatalf("value = %q, want %q", got[0].Value, "hello")
+	}
+	if got[0].Position != pos {
+		t.Fatalf("position = %+v, want %+v", got[0].Position, pos)
+	}
+}
+
+func TestAppendIdempotentSameKey(t *testing.T) {
+	m := newConnected(t)
+	ctx := context.Background()
+
+	headers := map[string][]byte{HeaderIdempotencyKey: []byte("uuid-1")}
+	pos1, err := m.Append(ctx, "wal", "tenant_a", []byte("payload-1"), headers)
+	if err != nil {
+		t.Fatalf("Append #1: %v", err)
+	}
+
+	// Same idempotency key, even with different payload, returns the
+	// original pos. The applier is the gate for "different payload
+	// with same idempotency_key" -- producer just dedupes.
+	pos2, err := m.Append(ctx, "wal", "tenant_a", []byte("payload-2"), headers)
+	if err != nil {
+		t.Fatalf("Append #2: %v", err)
+	}
+	if pos1 != pos2 {
+		t.Fatalf("idempotent retry: pos1=%+v pos2=%+v", pos1, pos2)
+	}
+	if got := m.GetRecordCount("wal"); got != 1 {
+		t.Fatalf("record count = %d, want 1 (no duplicate)", got)
+	}
+
+	// Different idempotency key under the same partition key produces
+	// a fresh record.
+	headers2 := map[string][]byte{HeaderIdempotencyKey: []byte("uuid-2")}
+	pos3, err := m.Append(ctx, "wal", "tenant_a", []byte("payload-3"), headers2)
+	if err != nil {
+		t.Fatalf("Append #3: %v", err)
+	}
+	if pos3 == pos1 {
+		t.Fatalf("distinct idempotency keys collapsed to same pos")
+	}
+	if got := m.GetRecordCount("wal"); got != 2 {
+		t.Fatalf("record count = %d, want 2", got)
+	}
+}
+
+func TestAppendNoIdempotencyKeyAlwaysWrites(t *testing.T) {
+	m := newConnected(t)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if _, err := m.Append(ctx, "wal", "tenant_a", []byte("x"), nil); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	if got := m.GetRecordCount("wal"); got != 3 {
+		t.Fatalf("record count = %d, want 3", got)
+	}
+}
+
+func TestPerTenantOrderUnderConcurrency(t *testing.T) {
+	m := newConnected(t)
+	ctx := context.Background()
+
+	const tenants = 4
+	const perTenant = 50
+	var wg sync.WaitGroup
+	wg.Add(tenants)
+	for tt := 0; tt < tenants; tt++ {
+		tenant := fmt.Sprintf("tenant_%d", tt)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perTenant; i++ {
+				val := fmt.Sprintf("%s:%d", tenant, i)
+				if _, err := m.Append(ctx, "wal", tenant, []byte(val), nil); err != nil {
+					t.Errorf("Append: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := m.GetRecordCount("wal"); got != tenants*perTenant {
+		t.Fatalf("record count = %d, want %d", got, tenants*perTenant)
+	}
+
+	// Verify per-tenant order: for each tenant, the values
+	// "tenant_X:0", "tenant_X:1", ... appear in increasing offset
+	// order within the tenant's partition.
+	all := m.GetAllRecords("wal")
+	perTenantSeen := make(map[string][]string)
+	for _, r := range all {
+		perTenantSeen[r.Key] = append(perTenantSeen[r.Key], string(r.Value))
+	}
+	for tenant, vals := range perTenantSeen {
+		if len(vals) != perTenant {
+			t.Fatalf("tenant %s: got %d records, want %d", tenant, len(vals), perTenant)
+		}
+		for i, v := range vals {
+			want := fmt.Sprintf("%s:%d", tenant, i)
+			if v != want {
+				t.Fatalf("tenant %s: record %d = %q, want %q (per-tenant order broken)", tenant, i, v, want)
+			}
+		}
+	}
+}
+
+func TestPollBatchRespectsMaxAndCommitAdvances(t *testing.T) {
+	m := newConnected(t)
+	ctx := context.Background()
+
+	// Append 5 records under the same key -> same partition.
+	for i := 0; i < 5; i++ {
+		if _, err := m.Append(ctx, "wal", "tenant_a", []byte(fmt.Sprintf("v%d", i)), nil); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+
+	first, err := m.PollBatch(ctx, "wal", "g1", 2, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("PollBatch #1: %v", err)
+	}
+	if len(first) != 2 {
+		t.Fatalf("got %d, want 2", len(first))
+	}
+
+	// Without commit, PollBatch returns the same prefix.
+	again, err := m.PollBatch(ctx, "wal", "g1", 2, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("PollBatch #2: %v", err)
+	}
+	if len(again) != 2 || again[0].Position != first[0].Position {
+		t.Fatalf("uncommitted records did not replay: got %+v", again)
+	}
+
+	// Commit the second record -> next poll starts at offset 2.
+	if err := m.Commit(ctx, "g1", first[1]); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	rest, err := m.PollBatch(ctx, "wal", "g1", 10, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("PollBatch #3: %v", err)
+	}
+	if len(rest) != 3 {
+		t.Fatalf("got %d, want 3", len(rest))
+	}
+	if rest[0].Position.Offset != 2 {
+		t.Fatalf("first uncommitted offset = %d, want 2", rest[0].Position.Offset)
+	}
+}
+
+func TestPollBatchBlocksThenReturnsAfterAppend(t *testing.T) {
+	m := newConnected(t)
+	ctx := context.Background()
+
+	doneCh := make(chan []Record, 1)
+	go func() {
+		recs, err := m.PollBatch(ctx, "wal", "g1", 5, 2*time.Second)
+		if err != nil {
+			t.Errorf("PollBatch: %v", err)
+		}
+		doneCh <- recs
+	}()
+
+	// Give the poller a moment to park on the cond.
+	time.Sleep(50 * time.Millisecond)
+
+	if _, err := m.Append(ctx, "wal", "tenant_a", []byte("late"), nil); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	select {
+	case recs := <-doneCh:
+		if len(recs) != 1 || string(recs[0].Value) != "late" {
+			t.Fatalf("got %+v, want one record 'late'", recs)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("PollBatch did not unblock after Append")
+	}
+}
+
+func TestPollBatchTimeoutReturnsEmpty(t *testing.T) {
+	m := newConnected(t)
+	ctx := context.Background()
+	start := time.Now()
+	recs, err := m.PollBatch(ctx, "wal", "g1", 5, 100*time.Millisecond)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("PollBatch: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("got %d records, want 0", len(recs))
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("returned in %v, expected to wait at least 100ms", elapsed)
+	}
+}
+
+func TestWaitForRecords(t *testing.T) {
+	m := newConnected(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		for i := 0; i < 3; i++ {
+			_, _ = m.Append(context.Background(), "wal", "tenant_a", []byte("x"), nil)
+		}
+	}()
+
+	if !m.WaitForRecords(ctx, "wal", 3) {
+		t.Fatal("WaitForRecords timed out")
+	}
+}
+
+func TestWaitForRecordsTimeout(t *testing.T) {
+	m := newConnected(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if m.WaitForRecords(ctx, "wal", 1) {
+		t.Fatal("expected timeout, got success")
+	}
+}
+
+func TestClearTopic(t *testing.T) {
+	m := newConnected(t)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if _, err := m.Append(ctx, "wal", "tenant_a", []byte("x"), nil); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+	if got := m.GetRecordCount("wal"); got != 3 {
+		t.Fatalf("pre-clear count = %d", got)
+	}
+	m.ClearTopic("wal")
+	if got := m.GetRecordCount("wal"); got != 0 {
+		t.Fatalf("post-clear count = %d", got)
+	}
+	// And appending after clear works fresh from offset 0.
+	pos, err := m.Append(ctx, "wal", "tenant_a", []byte("fresh"), nil)
+	if err != nil {
+		t.Fatalf("Append after clear: %v", err)
+	}
+	if pos.Offset != 0 {
+		t.Fatalf("offset after clear = %d, want 0", pos.Offset)
+	}
+}
+
+func TestSubscribeStreamsRecords(t *testing.T) {
+	m := newConnected(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out, errCh, err := m.Subscribe(ctx, "wal", "g1")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	const n = 5
+	go func() {
+		for i := 0; i < n; i++ {
+			_, _ = m.Append(context.Background(), "wal", "tenant_a", []byte(fmt.Sprintf("v%d", i)), nil)
+		}
+	}()
+
+	got := make([]Record, 0, n)
+	timeout := time.After(2 * time.Second)
+	for len(got) < n {
+		select {
+		case r, ok := <-out:
+			if !ok {
+				t.Fatalf("Subscribe channel closed early; got %d", len(got))
+			}
+			got = append(got, r)
+		case e := <-errCh:
+			if e != nil {
+				t.Fatalf("Subscribe error: %v", e)
+			}
+		case <-timeout:
+			t.Fatalf("Subscribe timeout; got %d", len(got))
+		}
+	}
+	for i, r := range got {
+		want := fmt.Sprintf("v%d", i)
+		if string(r.Value) != want {
+			t.Fatalf("got[%d] = %q, want %q", i, r.Value, want)
+		}
+	}
+}
+
+func TestPartitionForKeyDeterministic(t *testing.T) {
+	m := NewInMemory(4)
+	// Same key -> same partition every call.
+	first := m.partitionFor("tenant_a")
+	for i := 0; i < 100; i++ {
+		if got := m.partitionFor("tenant_a"); got != first {
+			t.Fatalf("non-deterministic partition: %d vs %d", got, first)
+		}
+	}
+}
+
+func TestCloseUnblocksPoll(t *testing.T) {
+	m := newConnected(t)
+	doneCh := make(chan error, 1)
+	go func() {
+		_, err := m.PollBatch(context.Background(), "wal", "g1", 5, 5*time.Second)
+		doneCh <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	_ = m.Close(context.Background())
+	select {
+	case err := <-doneCh:
+		if !errors.Is(err, ErrConnection) {
+			t.Fatalf("err = %v, want ErrConnection", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("PollBatch did not unblock on Close")
+	}
+}

--- a/server/go/internal/wal/wal.go
+++ b/server/go/internal/wal/wal.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package wal hosts the write-ahead-log producer/consumer
+// abstractions ported from server/python/entdb_server/wal/. The WAL
+// is the source of truth for all mutations (CLAUDE.md invariant #1);
+// SQLite is a materialized view rebuilt by replaying it.
+//
+// Spec: docs/go-port/shared/wal-producer.md. Phase 1 of EPIC #407
+// only ships the in-memory backend (sufficient to bring up the Go
+// handlers + applier behind it and run the integration suite). Real
+// backends (Kafka, Kinesis, SQS, Pub/Sub, Service Bus, Event Hubs)
+// land in Phase 2 as their own sub-packages.
+//
+// The producer contract this package enforces:
+//
+//   - Append returns only after the record is durably stored.
+//   - Per-partition (and therefore per-tenant, since handlers always
+//     key by tenant_id) total order.
+//   - Idempotent retries: appending with the same Event.IdempotencyKey
+//     within the same topic returns the original StreamPos and does
+//     not create a duplicate record.
+//   - No partial writes: Append either returns a StreamPos or a typed
+//     error (ErrConnection, ErrTimeout, ErrSerialization, or a wrapped
+//     ErrWal).
+//
+// The consumer contract:
+//
+//   - Subscribe yields records in offset order within a partition.
+//   - PollBatch returns up to maxRecords currently available; it does
+//     not block the producer (decoupled queues, not request/response).
+//   - Commit advances the stored offset for (topic, group_id) so
+//     subsequent PollBatch / Subscribe calls resume after the
+//     committed record.
+package wal
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Sentinel errors. Mirrors server/python/entdb_server/wal/base.py:41
+// (WalError, WalConnectionError, WalTimeoutError,
+// WalSerializationError). Wrap with fmt.Errorf("...: %w", ErrFoo) and
+// callers check via errors.Is.
+var (
+	// ErrWal is the umbrella error for WAL operations. Other sentinels
+	// in this package wrap this so errors.Is(err, ErrWal) is true for
+	// every WAL-origin failure.
+	ErrWal = errors.New("wal: error")
+
+	// ErrConnection signals the WAL backend is not reachable. Returned
+	// from Append/Subscribe/PollBatch/Commit when the producer or
+	// consumer has not been Connect()ed (or Close()d in flight).
+	ErrConnection = errors.New("wal: connection error")
+
+	// ErrTimeout signals an operation exceeded its deadline. Honors
+	// ctx.Err() in callers; this sentinel is returned when the failure
+	// is a backend-side timeout rather than caller cancellation.
+	ErrTimeout = errors.New("wal: timeout")
+
+	// ErrSerialization signals an event payload could not be encoded
+	// or decoded. Mirrors WalSerializationError in the Python tree.
+	ErrSerialization = errors.New("wal: serialization error")
+)
+
+// HeaderIdempotencyKey is the reserved header key under which Append
+// implementations look for the application-layer idempotency key.
+// Producers wishing to use Append's idempotent-retry guarantee MUST
+// set this header (mirrors the Python applier-layer dedupe in
+// applier.py:765 against TransactionEvent.idempotency_key).
+const HeaderIdempotencyKey = "idempotency-key"
+
+// Producer is the producer half of the WAL stream. The Append byte
+// signature mirrors docs/go-port/shared/wal-producer.md "Go interface"
+// section: encoding lives in a thin wrapper (Event.Encode), the
+// producer stays transport-only.
+type Producer interface {
+	// Connect opens the producer's underlying transport. Implementations
+	// that have no setup (in-memory) may treat this as a no-op but must
+	// still flip an internal "connected" flag so subsequent Append
+	// calls succeed.
+	Connect(ctx context.Context) error
+
+	// Close releases producer resources. After Close, Append must
+	// return ErrConnection. Calling Close twice is a no-op.
+	Close(ctx context.Context) error
+
+	// Append durably stores value under key in topic. Returns the
+	// StreamPos receipt. Headers are optional; pass nil if unused.
+	//
+	// Idempotency: implementations MUST treat (topic, key,
+	// idempotencyKey) as a dedupe identity. The idempotency key is
+	// taken from the headers map under HeaderIdempotencyKey -- callers
+	// should set it (typically by passing through Event.IdempotencyKey
+	// at the encode boundary). If the same key has already been
+	// appended for the same (topic, key) pair, Append returns the
+	// previously-issued StreamPos and does not write a new record.
+	Append(ctx context.Context, topic, key string, value []byte, headers map[string][]byte) (StreamPos, error)
+}
+
+// Consumer is the consumer half of the WAL stream.
+type Consumer interface {
+	// Subscribe yields records from topic for the given consumer group.
+	// Records are delivered in offset order within a partition. The
+	// returned channel is closed when ctx is cancelled or the consumer
+	// is closed; the error channel surfaces a single terminal error
+	// (or is closed cleanly).
+	//
+	// Callers must Commit each record to advance the consumer group's
+	// stored offset. Uncommitted records are re-delivered on the next
+	// Subscribe / PollBatch call.
+	Subscribe(ctx context.Context, topic, groupID string) (<-chan Record, <-chan error, error)
+
+	// PollBatch returns up to maxRecords currently available for
+	// (topic, groupID). If no records are available it blocks up to
+	// timeout (or ctx deadline, whichever fires first) waiting for new
+	// records, then returns whatever showed up. Returning an empty
+	// slice with a nil error is a normal "no records yet" signal and
+	// is NOT an error.
+	PollBatch(ctx context.Context, topic, groupID string, maxRecords int, timeout time.Duration) ([]Record, error)
+
+	// Commit advances the stored offset for (topic, groupID) past
+	// record.Position. Subsequent PollBatch / Subscribe calls for the
+	// same group resume after this position.
+	Commit(ctx context.Context, groupID string, record Record) error
+}


### PR DESCRIPTION
## Summary

Port the WAL producer/consumer abstraction from `server/python/entdb_server/wal/` to `server/go/internal/wal/`. Ships the in-memory backend only — Phase 1 scope per `docs/go-port/shared/wal-producer.md`. Kafka, Kinesis, SQS, Pub/Sub, Service Bus, and Event Hubs land in Phase 2.

- `event.go` — `Event` (TransactionEvent equivalent), `StreamPos` (`topic:partition:offset`), `Record`. JSON encode/decode mirrors `applier.py:204` field semantics including required-field validation.
- `wal.go` — package doc + `Producer` / `Consumer` interfaces + sentinel errors (`ErrWal`, `ErrConnection`, `ErrTimeout`, `ErrSerialization`) + `HeaderIdempotencyKey` constant.
- `memory.go` — `InMemory` backend implementing both interfaces. md5-based partitioning matches the Python `memory.py:337` formula, per-tenant total order, application-layer idempotent `Append` keyed by `HeaderIdempotencyKey`, deadline-respecting `PollBatch`, auto-committing `Subscribe`, and `GetAllRecords` / `GetRecordCount` / `ClearTopic` / `WaitForRecords` test helpers.
- Replaces the Phase 0 `doc.go` placeholder.

refs #407 · spec: `docs/go-port/shared/wal-producer.md`

## Test plan

- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...` (all packages green)
- [x] `cd server/go && go test -race ./internal/wal/...`
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .`
- [x] Append → poll round-trip
- [x] Idempotent retry returns identical `StreamPos` and does not duplicate the record
- [x] Per-tenant order preserved across 4 concurrent appenders × 50 records each
- [x] `PollBatch` respects max, `Commit` advances offset, subsequent poll resumes after commit
- [x] `WaitForRecords` blocks until count met / context deadline
- [x] `Close` unblocks parked `PollBatch` callers with `ErrConnection`