### PR TITLE
feat(go-rewrite): schema Go package — Wave 1

### DIFF
--- a/server/go/internal/schema/fingerprint.go
+++ b/server/go/internal/schema/fingerprint.go
@@ -1,0 +1,127 @@
+package schema
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// computeFingerprint mirrors Python schema/registry.py:_compute_fingerprint:
+//
+//	canonical = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+//	hash = sha256(canonical).hexdigest()
+//	return f"sha256:{hash}"
+//
+// We can't rely on encoding/json because Go preserves struct-field
+// declaration order rather than sorting keys, and Python's
+// separators=(",",":") drops the default ", "/": " spaces. We marshal
+// the registry into the same shape as Python's to_dict(), then
+// re-emit it with a custom canonical encoder.
+//
+// Floats: registry data does not include floats today, but the encoder
+// supports them for forward compatibility (using strconv with
+// 'g'/-1 precision, which matches Python's repr-derived output for
+// integral floats — round-trip safety is the contract, not byte
+// equality with Python for arbitrary floats).
+func (r *Registry) computeFingerprint() (string, error) {
+	doc := r.toFile()
+	// Round-trip through encoding/json into a generic value so we can
+	// re-emit with sorted keys exactly as Python does.
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("schema: marshal for fingerprint: %w", err)
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", fmt.Errorf("schema: unmarshal for fingerprint: %w", err)
+	}
+	var sb strings.Builder
+	if err := canonicalEncode(&sb, v); err != nil {
+		return "", fmt.Errorf("schema: canonical encode: %w", err)
+	}
+	sum := sha256.Sum256([]byte(sb.String()))
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// canonicalEncode writes v to sb using Python's
+// `json.dumps(sort_keys=True, separators=(",", ":"))` byte format:
+//   - Object keys sorted by Unicode code point (Python sorted() default).
+//   - No whitespace between separators.
+//   - Strings escaped using the standard ensure_ascii=True semantics
+//     used by Python by default, which matches Go's encoding/json
+//     escaping for ASCII payloads. Schema metadata is ASCII today
+//     (names, descriptions in English), so we use json.Marshal of the
+//     leaf string which is a strict superset (Go always escapes the
+//     same control chars and uses the same backslash sequences).
+//
+// If the schema gains non-ASCII content we will need a custom string
+// encoder that matches Python's `\uXXXX` escapes — flagged in the
+// fingerprint parity test.
+func canonicalEncode(sb *strings.Builder, v any) error {
+	switch x := v.(type) {
+	case nil:
+		sb.WriteString("null")
+	case bool:
+		if x {
+			sb.WriteString("true")
+		} else {
+			sb.WriteString("false")
+		}
+	case string:
+		b, err := json.Marshal(x)
+		if err != nil {
+			return err
+		}
+		sb.Write(b)
+	case float64:
+		// json.Unmarshal lands all numbers in float64. Emit integers
+		// without trailing ".0" to match Python's JSON output.
+		if x == float64(int64(x)) {
+			sb.WriteString(strconv.FormatInt(int64(x), 10))
+		} else {
+			sb.WriteString(strconv.FormatFloat(x, 'g', -1, 64))
+		}
+	case json.Number:
+		sb.WriteString(string(x))
+	case []any:
+		sb.WriteByte('[')
+		for i, e := range x {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			if err := canonicalEncode(sb, e); err != nil {
+				return err
+			}
+		}
+		sb.WriteByte(']')
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		sb.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			kb, err := json.Marshal(k)
+			if err != nil {
+				return err
+			}
+			sb.Write(kb)
+			sb.WriteByte(':')
+			if err := canonicalEncode(sb, x[k]); err != nil {
+				return err
+			}
+		}
+		sb.WriteByte('}')
+	default:
+		return fmt.Errorf("canonicalEncode: unsupported type %T", v)
+	}
+	return nil
+}

--- a/server/go/internal/schema/loader.go
+++ b/server/go/internal/schema/loader.go
@@ -1,0 +1,118 @@
+// Loader and serialiser for the cross-language schema JSON contract.
+//
+// Python's SchemaRegistry.to_json (registry.py:479-488) emits a JSON
+// document with two top-level keys, "node_types" and "edge_types",
+// each a list sorted by id. LoadFromJSON consumes that exact shape;
+// (*Registry).MarshalJSON re-emits it.
+//
+// Field-by-field parity with NodeTypeDef.to_dict / EdgeTypeDef.to_dict
+// / FieldDef.to_dict / CompositeUniqueDef.to_dict / AclEntry.to_dict
+// is enforced by tests/schema in tests/python/unit and the
+// cross-language round-trip in tests/contract.
+
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// schemaFile is the wire shape of the to_dict() / from_dict() document.
+// It is the on-disk envelope for both the JSON loader and the
+// fingerprint canonicaliser.
+type schemaFile struct {
+	NodeTypes []NodeTypeDef `json:"node_types"`
+	EdgeTypes []EdgeTypeDef `json:"edge_types"`
+}
+
+// LoadFromJSON parses the Python-emitted SchemaRegistry.to_json shape
+// into a fresh, mutable *Registry. The returned registry is not yet
+// frozen — callers (typically server boot) call Freeze() once all
+// supplemental registrations are done.
+//
+// Validation runs on every type before insertion, so a malformed type
+// surfaces a typed error here rather than at first request time.
+func LoadFromJSON(data []byte) (*Registry, error) {
+	var f schemaFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("schema: parse JSON: %w", err)
+	}
+	r := NewRegistry()
+	for i := range f.NodeTypes {
+		nt := f.NodeTypes[i]
+		if err := r.RegisterNode(&nt); err != nil {
+			return nil, fmt.Errorf("schema: register node %q: %w", nt.Name, err)
+		}
+	}
+	for i := range f.EdgeTypes {
+		et := f.EdgeTypes[i]
+		if et.OnSubjectExit == "" {
+			et.OnSubjectExit = OnSubjectExitBoth
+		}
+		if err := r.RegisterEdge(&et); err != nil {
+			return nil, fmt.Errorf("schema: register edge %q: %w", et.Name, err)
+		}
+	}
+	return r, nil
+}
+
+// MarshalJSON emits the registry in Python SchemaRegistry.to_dict order
+// (node_types sorted by type_id, edge_types sorted by edge_id). The
+// output is suitable for round-tripping through LoadFromJSON and as
+// input to the fingerprint canonicaliser.
+//
+// MarshalJSON is also implicitly called by encoding/json so callers can
+// json.Marshal(reg) directly.
+func (r *Registry) MarshalJSON() ([]byte, error) {
+	doc := r.toFile()
+	return json.Marshal(doc)
+}
+
+// toFile is the shared lowering used by both MarshalJSON and the
+// fingerprint canonicaliser. Sorting by id mirrors Python's
+// SchemaRegistry.to_dict. Nil Fields / Props slices are normalised to
+// empty slices so the output emits `[]` not `null` (Python's to_dict
+// always emits the array, even when empty — registry.py / types.py).
+func (r *Registry) toFile() schemaFile {
+	doc := schemaFile{
+		NodeTypes: make([]NodeTypeDef, 0, len(r.nodes)),
+		EdgeTypes: make([]EdgeTypeDef, 0, len(r.edges)),
+	}
+	ids := make([]int32, 0, len(r.nodes))
+	for id := range r.nodes {
+		ids = append(ids, id)
+	}
+	sortInt32(ids)
+	for _, id := range ids {
+		n := *r.nodes[id]
+		if n.Fields == nil {
+			n.Fields = []FieldDef{}
+		}
+		doc.NodeTypes = append(doc.NodeTypes, n)
+	}
+	eids := make([]int32, 0, len(r.edges))
+	for id := range r.edges {
+		eids = append(eids, id)
+	}
+	sortInt32(eids)
+	for _, id := range eids {
+		e := *r.edges[id]
+		if e.Props == nil {
+			e.Props = []FieldDef{}
+		}
+		// Python always emits on_subject_exit (defaults to "both").
+		if e.OnSubjectExit == "" {
+			e.OnSubjectExit = OnSubjectExitBoth
+		}
+		doc.EdgeTypes = append(doc.EdgeTypes, e)
+	}
+	return doc
+}
+
+func sortInt32(s []int32) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/server/go/internal/schema/registry.go
+++ b/server/go/internal/schema/registry.go
@@ -1,0 +1,401 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+// ErrFrozen is returned when a mutation is attempted on a frozen
+// registry. Mirrors Python schema/registry.py RegistryFrozenError. The
+// errs package maps this to FAILED_PRECONDITION at the gRPC boundary.
+var ErrFrozen = errors.New("schema: registry is frozen")
+
+// ErrDuplicateRegistration is returned by RegisterNode/RegisterEdge
+// when the type_id or name collides with an already-registered type.
+// Mirrors Python DuplicateRegistrationError.
+var ErrDuplicateRegistration = errors.New("schema: duplicate registration")
+
+// Registry is the process-wide singleton populated at boot, frozen
+// before serving. Mirrors Python SchemaRegistry.
+//
+// After Freeze() returns, all read methods are lock-free — the
+// applier and gRPC handlers hold a *Registry reference without
+// further synchronization (mirrors registry.py:69-72).
+type Registry struct {
+	mu sync.Mutex // held only during registration / freeze
+
+	nodes       map[int32]*NodeTypeDef
+	nodesByName map[string]*NodeTypeDef
+	edges       map[int32]*EdgeTypeDef
+	edgesByName map[string]*EdgeTypeDef
+
+	// Per-type field name<->id maps, populated lazily on first lookup
+	// after Freeze. Translation lives in translate.go.
+	fieldNameToID map[int32]map[string]uint32
+	fieldIDToName map[int32]map[uint32]string
+
+	frozen      atomic.Bool
+	fingerprint atomic.Pointer[string]
+}
+
+// NewRegistry returns an empty, mutable registry. Production code paths
+// take *Registry as a constructor argument (so tests can inject
+// fixtures without touching package-level state).
+func NewRegistry() *Registry {
+	return &Registry{
+		nodes:       map[int32]*NodeTypeDef{},
+		nodesByName: map[string]*NodeTypeDef{},
+		edges:       map[int32]*EdgeTypeDef{},
+		edgesByName: map[string]*EdgeTypeDef{},
+	}
+}
+
+// Frozen reports whether Freeze has been called.
+func (r *Registry) Frozen() bool { return r.frozen.Load() }
+
+// Fingerprint returns the post-freeze schema fingerprint, e.g.
+// "sha256:abc123…". Returns the empty string before Freeze.
+//
+// The actual SHA computation lives in fingerprint.go; this accessor is
+// here so registry.go owns the public surface.
+func (r *Registry) Fingerprint() string {
+	if p := r.fingerprint.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// RegisterNode adds nt to the registry. Returns ErrFrozen if the
+// registry is frozen, ErrDuplicateRegistration if the type_id or name
+// is already taken, or a validation error if nt is malformed.
+//
+// nt is validated before insertion; on error the registry is unchanged.
+func (r *Registry) RegisterNode(nt *NodeTypeDef) error {
+	if nt == nil {
+		return errors.New("schema: nil NodeTypeDef")
+	}
+	if err := nt.Validate(); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.frozen.Load() {
+		return fmt.Errorf("%w: cannot register node type %q", ErrFrozen, nt.Name)
+	}
+	if existing, ok := r.nodes[nt.TypeID]; ok {
+		return fmt.Errorf(
+			"%w: type_id %d already registered as %q",
+			ErrDuplicateRegistration, nt.TypeID, existing.Name,
+		)
+	}
+	if existing, ok := r.nodesByName[nt.Name]; ok {
+		return fmt.Errorf(
+			"%w: node type name %q already registered with type_id %d",
+			ErrDuplicateRegistration, nt.Name, existing.TypeID,
+		)
+	}
+	r.nodes[nt.TypeID] = nt
+	r.nodesByName[nt.Name] = nt
+	return nil
+}
+
+// RegisterEdge adds et to the registry. Same error semantics as
+// RegisterNode. Edge from_type_id / to_type_id need not be registered
+// yet — the cross-reference check runs in ValidateAll.
+func (r *Registry) RegisterEdge(et *EdgeTypeDef) error {
+	if et == nil {
+		return errors.New("schema: nil EdgeTypeDef")
+	}
+	if err := et.Validate(); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.frozen.Load() {
+		return fmt.Errorf("%w: cannot register edge type %q", ErrFrozen, et.Name)
+	}
+	if existing, ok := r.edges[et.EdgeID]; ok {
+		return fmt.Errorf(
+			"%w: edge_id %d already registered as %q",
+			ErrDuplicateRegistration, et.EdgeID, existing.Name,
+		)
+	}
+	if existing, ok := r.edgesByName[et.Name]; ok {
+		return fmt.Errorf(
+			"%w: edge type name %q already registered with edge_id %d",
+			ErrDuplicateRegistration, et.Name, existing.EdgeID,
+		)
+	}
+	if et.OnSubjectExit == "" {
+		et.OnSubjectExit = OnSubjectExitBoth
+	}
+	r.edges[et.EdgeID] = et
+	r.edgesByName[et.Name] = et
+	return nil
+}
+
+// Freeze computes the deterministic fingerprint and flips the frozen
+// flag atomically. Subsequent RegisterNode/RegisterEdge calls return
+// ErrFrozen. Calling Freeze twice returns ErrFrozen on the second
+// call (mirrors Python SchemaRegistry.freeze).
+//
+// After Freeze returns, the per-type field name<->id maps are
+// pre-built so translate.FieldIDByName / translate.FieldNameByID
+// stay lock-free on the hot path.
+func (r *Registry) Freeze() (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.frozen.Load() {
+		return "", fmt.Errorf("%w: already frozen", ErrFrozen)
+	}
+	fp, err := r.computeFingerprint()
+	if err != nil {
+		return "", err
+	}
+	// Pre-build translation maps before flipping frozen so reads are
+	// lock-free post-freeze.
+	r.fieldNameToID = make(map[int32]map[string]uint32, len(r.nodes))
+	r.fieldIDToName = make(map[int32]map[uint32]string, len(r.nodes))
+	for tid, n := range r.nodes {
+		nm := make(map[string]uint32, len(n.Fields))
+		im := make(map[uint32]string, len(n.Fields))
+		for i := range n.Fields {
+			f := &n.Fields[i]
+			nm[f.Name] = f.FieldID
+			im[f.FieldID] = f.Name
+		}
+		r.fieldNameToID[tid] = nm
+		r.fieldIDToName[tid] = im
+	}
+	r.fingerprint.Store(&fp)
+	r.frozen.Store(true)
+	return fp, nil
+}
+
+// NodeType returns the node type by id (int / int32) or name (string).
+// Returns nil if not found. Lock-free after Freeze.
+//
+// Accepting an `any` mirrors Python's get_node_type(int|str). Callers
+// that already have a typed argument should prefer the explicit
+// helpers below for compile-time safety.
+func (r *Registry) NodeType(idOrName any) *NodeTypeDef {
+	switch v := idOrName.(type) {
+	case int32:
+		return r.nodes[v]
+	case int:
+		return r.nodes[int32(v)]
+	case int64:
+		return r.nodes[int32(v)]
+	case uint32:
+		return r.nodes[int32(v)]
+	case string:
+		return r.nodesByName[v]
+	}
+	return nil
+}
+
+// NodeTypeByID is the explicit-id helper.
+func (r *Registry) NodeTypeByID(id int32) *NodeTypeDef { return r.nodes[id] }
+
+// NodeTypeByName is the explicit-name helper.
+func (r *Registry) NodeTypeByName(name string) *NodeTypeDef { return r.nodesByName[name] }
+
+// EdgeType is the edge counterpart of NodeType.
+func (r *Registry) EdgeType(idOrName any) *EdgeTypeDef {
+	switch v := idOrName.(type) {
+	case int32:
+		return r.edges[v]
+	case int:
+		return r.edges[int32(v)]
+	case int64:
+		return r.edges[int32(v)]
+	case uint32:
+		return r.edges[int32(v)]
+	case string:
+		return r.edgesByName[v]
+	}
+	return nil
+}
+
+// EdgeTypeByID is the explicit-id helper.
+func (r *Registry) EdgeTypeByID(id int32) *EdgeTypeDef { return r.edges[id] }
+
+// EdgeTypeByName is the explicit-name helper.
+func (r *Registry) EdgeTypeByName(name string) *EdgeTypeDef { return r.edgesByName[name] }
+
+// NodeTypes returns the registered node types in deterministic order
+// (sorted by type_id). The returned slice is a copy; callers may
+// mutate it freely.
+func (r *Registry) NodeTypes() []*NodeTypeDef {
+	out := make([]*NodeTypeDef, 0, len(r.nodes))
+	ids := make([]int32, 0, len(r.nodes))
+	for id := range r.nodes {
+		ids = append(ids, id)
+	}
+	sortInt32(ids)
+	for _, id := range ids {
+		out = append(out, r.nodes[id])
+	}
+	return out
+}
+
+// EdgeTypes is the edge counterpart of NodeTypes.
+func (r *Registry) EdgeTypes() []*EdgeTypeDef {
+	out := make([]*EdgeTypeDef, 0, len(r.edges))
+	ids := make([]int32, 0, len(r.edges))
+	for id := range r.edges {
+		ids = append(ids, id)
+	}
+	sortInt32(ids)
+	for _, id := range ids {
+		out = append(out, r.edges[id])
+	}
+	return out
+}
+
+// UniqueFieldIDs returns ids of fields declared unique on the node
+// type. Returns nil for unknown types (mirrors Python's soft
+// fall-through). Excludes deprecated fields.
+func (r *Registry) UniqueFieldIDs(typeID int32) []uint32 {
+	n := r.nodes[typeID]
+	if n == nil {
+		return nil
+	}
+	out := make([]uint32, 0)
+	for i := range n.Fields {
+		f := &n.Fields[i]
+		if f.Unique && !f.Deprecated {
+			out = append(out, f.FieldID)
+		}
+	}
+	return out
+}
+
+// CompositeUnique returns the composite-unique constraints for a node
+// type (in declaration order). Returns nil for unknown types.
+func (r *Registry) CompositeUnique(typeID int32) []CompositeUniqueDef {
+	n := r.nodes[typeID]
+	if n == nil {
+		return nil
+	}
+	out := make([]CompositeUniqueDef, len(n.CompositeUnique))
+	copy(out, n.CompositeUnique)
+	return out
+}
+
+// IndexedFieldIDs returns ids of fields declared indexed but not
+// unique (unique fields already get a unique expression index). Mirrors
+// Python registry.get_indexed_field_ids.
+func (r *Registry) IndexedFieldIDs(typeID int32) []uint32 {
+	n := r.nodes[typeID]
+	if n == nil {
+		return nil
+	}
+	out := make([]uint32, 0)
+	for i := range n.Fields {
+		f := &n.Fields[i]
+		if f.Indexed && !f.Unique && !f.Deprecated {
+			out = append(out, f.FieldID)
+		}
+	}
+	return out
+}
+
+// SearchableFieldIDs returns ids of STRING fields declared searchable.
+// Non-string searchable fields are silently excluded (the warning is
+// emitted at registration time by the SDK codegen). Mirrors Python
+// registry.get_searchable_field_ids.
+func (r *Registry) SearchableFieldIDs(typeID int32) []uint32 {
+	n := r.nodes[typeID]
+	if n == nil {
+		return nil
+	}
+	out := make([]uint32, 0)
+	for i := range n.Fields {
+		f := &n.Fields[i]
+		if f.Searchable && !f.Deprecated && f.Kind == KindString {
+			out = append(out, f.FieldID)
+		}
+	}
+	return out
+}
+
+// PIIFields returns the names of PII-marked, non-deprecated fields on
+// the type. Returns nil for unknown types.
+func (r *Registry) PIIFields(typeID int32) []string {
+	n := r.nodes[typeID]
+	if n == nil {
+		return nil
+	}
+	out := make([]string, 0)
+	for i := range n.Fields {
+		f := &n.Fields[i]
+		if f.PII && !f.Deprecated {
+			out = append(out, f.Name)
+		}
+	}
+	return out
+}
+
+// DataPolicyOf returns the data policy for a node type, defaulting to
+// PERSONAL when unset (mirrors Python registry.get_data_policy).
+// Returns the zero value for unknown types — callers that need a
+// distinguished error should check NodeTypeByID first.
+func (r *Registry) DataPolicyOf(typeID int32) DataPolicy {
+	n := r.nodes[typeID]
+	if n == nil {
+		return ""
+	}
+	if n.DataPolicy != nil {
+		return *n.DataPolicy
+	}
+	return DataPolicyPersonal
+}
+
+// SubjectField returns the subject field name for a node type, or
+// empty string if unset / unknown.
+func (r *Registry) SubjectField(typeID int32) string {
+	n := r.nodes[typeID]
+	if n == nil || n.SubjectField == nil {
+		return ""
+	}
+	return *n.SubjectField
+}
+
+// ValidateAll runs the same cross-reference checks as Python
+// registry.validate_all: every edge from_type_id / to_type_id must
+// reference a registered node, and every FieldDef.RefTypeID must point
+// at a registered node.
+func (r *Registry) ValidateAll() []string {
+	var errs []string
+	for _, e := range r.edges {
+		if _, ok := r.nodes[e.FromTypeID]; !ok {
+			errs = append(errs, fmt.Sprintf(
+				"edge %q (edge_id=%d) references unknown from_type_id %d",
+				e.Name, e.EdgeID, e.FromTypeID,
+			))
+		}
+		if _, ok := r.nodes[e.ToTypeID]; !ok {
+			errs = append(errs, fmt.Sprintf(
+				"edge %q (edge_id=%d) references unknown to_type_id %d",
+				e.Name, e.EdgeID, e.ToTypeID,
+			))
+		}
+	}
+	for _, n := range r.nodes {
+		for i := range n.Fields {
+			f := &n.Fields[i]
+			if f.RefTypeID != nil {
+				if _, ok := r.nodes[*f.RefTypeID]; !ok {
+					errs = append(errs, fmt.Sprintf(
+						"field %q in node type %q references unknown type_id %d",
+						f.Name, n.Name, *f.RefTypeID,
+					))
+				}
+			}
+		}
+	}
+	return errs
+}

--- a/server/go/internal/schema/schema_test.go
+++ b/server/go/internal/schema/schema_test.go
@@ -1,0 +1,521 @@
+// Tests for the schema package. Covers JSON round-trip parity with the
+// Python SchemaRegistry.to_json shape, freeze semantics, fingerprint
+// determinism, and field-id <-> name lookup.
+
+package schema
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// pythonSampleJSON mirrors the fixture used in
+// server/python/entdb_server/schema fixtures and the Python fingerprint
+// reference computed in tests/contract. Two node types (User, Task)
+// plus one edge type (AssignedTo). Sorted-key, compact-separator
+// canonical form.
+const pythonSampleJSON = `{
+  "node_types": [
+    {
+      "type_id": 1,
+      "name": "User",
+      "fields": [
+        {"field_id": 1, "name": "email", "kind": "str", "required": true, "indexed": true, "unique": true, "pii": true},
+        {"field_id": 2, "name": "display_name", "kind": "str", "searchable": true},
+        {"field_id": 3, "name": "status", "kind": "enum", "enum_values": ["active", "inactive", "banned"]}
+      ],
+      "default_acl": [{"principal": "role:admin", "permission": "admin"}],
+      "data_policy": "personal",
+      "subject_field": "email"
+    },
+    {
+      "type_id": 2,
+      "name": "Task",
+      "fields": [
+        {"field_id": 1, "name": "title", "kind": "str", "required": true, "searchable": true},
+        {"field_id": 2, "name": "owner_id", "kind": "ref", "ref_type_id": 1},
+        {"field_id": 3, "name": "priority", "kind": "int", "indexed": true},
+        {"field_id": 4, "name": "tag", "kind": "str"}
+      ],
+      "composite_unique": [{"name": "owner_title", "field_ids": [2, 1]}]
+    }
+  ],
+  "edge_types": [
+    {
+      "edge_id": 10,
+      "name": "AssignedTo",
+      "from_type_id": 2,
+      "to_type_id": 1,
+      "props": [
+        {"field_id": 1, "name": "role", "kind": "enum", "enum_values": ["primary", "reviewer"]}
+      ],
+      "on_subject_exit": "both"
+    }
+  ]
+}`
+
+// Reference fingerprint computed by Python's SchemaRegistry.freeze()
+// over the same logical content as pythonSampleJSON. Keep in sync with
+// the Python fixture; if Python's emission ever changes the two must
+// be regenerated together.
+const pythonReferenceFingerprint = "sha256:5822499c748bb30ab35473658f8000f9cba89250d6bafdeabc6ca833fcc85fe2"
+
+func TestLoadFromJSON_Sample(t *testing.T) {
+	r, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("LoadFromJSON: %v", err)
+	}
+
+	user := r.NodeTypeByName("User")
+	if user == nil {
+		t.Fatal("User node type missing")
+	}
+	if user.TypeID != 1 {
+		t.Errorf("User.TypeID = %d, want 1", user.TypeID)
+	}
+	if got := r.NodeTypeByID(1); got != user {
+		t.Errorf("NodeTypeByID(1) returned different pointer than ByName")
+	}
+	if dp := r.DataPolicyOf(1); dp != DataPolicyPersonal {
+		t.Errorf("DataPolicyOf(1) = %q, want %q", dp, DataPolicyPersonal)
+	}
+	if sf := r.SubjectField(1); sf != "email" {
+		t.Errorf("SubjectField(1) = %q, want email", sf)
+	}
+
+	if got := r.UniqueFieldIDs(1); len(got) != 1 || got[0] != 1 {
+		t.Errorf("UniqueFieldIDs(1) = %v, want [1]", got)
+	}
+	if got := r.IndexedFieldIDs(1); len(got) != 0 {
+		// "email" is indexed AND unique → excluded from indexed list.
+		t.Errorf("IndexedFieldIDs(1) = %v, want []", got)
+	}
+	if got := r.SearchableFieldIDs(1); len(got) != 1 || got[0] != 2 {
+		t.Errorf("SearchableFieldIDs(1) = %v, want [2]", got)
+	}
+	if got := r.PIIFields(1); len(got) != 1 || got[0] != "email" {
+		t.Errorf("PIIFields(1) = %v, want [email]", got)
+	}
+
+	task := r.NodeTypeByName("Task")
+	if task == nil {
+		t.Fatal("Task node type missing")
+	}
+	cu := r.CompositeUnique(2)
+	if len(cu) != 1 || cu[0].Name != "owner_title" || len(cu[0].FieldIDs) != 2 {
+		t.Errorf("CompositeUnique(2) = %+v", cu)
+	}
+
+	edge := r.EdgeTypeByName("AssignedTo")
+	if edge == nil {
+		t.Fatal("AssignedTo edge type missing")
+	}
+	if edge.EdgeID != 10 || edge.FromTypeID != 2 || edge.ToTypeID != 1 {
+		t.Errorf("AssignedTo: %+v", edge)
+	}
+	if edge.OnSubjectExit != OnSubjectExitBoth {
+		t.Errorf("OnSubjectExit = %q, want both", edge.OnSubjectExit)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	r, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("LoadFromJSON: %v", err)
+	}
+	out, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	r2, err := LoadFromJSON(out)
+	if err != nil {
+		t.Fatalf("LoadFromJSON (round-trip): %v\n%s", err, out)
+	}
+	if _, err := r.Freeze(); err != nil {
+		t.Fatalf("Freeze r: %v", err)
+	}
+	if _, err := r2.Freeze(); err != nil {
+		t.Fatalf("Freeze r2: %v", err)
+	}
+	if r.Fingerprint() != r2.Fingerprint() {
+		t.Errorf(
+			"fingerprint changed across round-trip:\n  before=%s\n   after=%s",
+			r.Fingerprint(), r2.Fingerprint(),
+		)
+	}
+}
+
+func TestFingerprint_DeterministicAcrossLoads(t *testing.T) {
+	r1, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load 1: %v", err)
+	}
+	r2, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load 2: %v", err)
+	}
+	fp1, err := r1.Freeze()
+	if err != nil {
+		t.Fatalf("freeze 1: %v", err)
+	}
+	fp2, err := r2.Freeze()
+	if err != nil {
+		t.Fatalf("freeze 2: %v", err)
+	}
+	if fp1 != fp2 {
+		t.Errorf("fingerprint differs across loads: %s vs %s", fp1, fp2)
+	}
+	if !strings.HasPrefix(fp1, "sha256:") {
+		t.Errorf("fingerprint missing sha256: prefix: %s", fp1)
+	}
+}
+
+func TestFingerprint_PythonByteParity(t *testing.T) {
+	// This test pins byte-for-byte parity with Python's
+	// SchemaRegistry.freeze() output for the shared fixture. If it
+	// breaks, the canonical encoder in fingerprint.go has drifted from
+	// json.dumps(sort_keys=True, separators=(",", ":")).
+	r, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	fp, err := r.Freeze()
+	if err != nil {
+		t.Fatalf("freeze: %v", err)
+	}
+	if fp != pythonReferenceFingerprint {
+		t.Errorf(
+			"fingerprint mismatch:\n  Go    = %s\n  Python= %s",
+			fp, pythonReferenceFingerprint,
+		)
+	}
+}
+
+func TestFingerprint_ChangesOnFieldAdd(t *testing.T) {
+	r1, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	fp1, err := r1.Freeze()
+	if err != nil {
+		t.Fatalf("freeze 1: %v", err)
+	}
+
+	r2, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load 2: %v", err)
+	}
+	user := r2.NodeTypeByName("User")
+	user.Fields = append(user.Fields, FieldDef{
+		FieldID: 99, Name: "extra", Kind: KindString,
+	})
+	fp2, err := r2.Freeze()
+	if err != nil {
+		t.Fatalf("freeze 2: %v", err)
+	}
+	if fp1 == fp2 {
+		t.Errorf("fingerprint unchanged after adding field: %s", fp1)
+	}
+}
+
+func TestFingerprint_ChangesOnFieldRename(t *testing.T) {
+	r1, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	fp1, err := r1.Freeze()
+	if err != nil {
+		t.Fatalf("freeze 1: %v", err)
+	}
+
+	r2, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load 2: %v", err)
+	}
+	user := r2.NodeTypeByName("User")
+	user.Fields[0].Name = "email_addr"
+	// Rebuild byName map entry not needed — Freeze rebuilds the
+	// translation maps from scratch and the fingerprint is computed
+	// over the fields directly.
+	fp2, err := r2.Freeze()
+	if err != nil {
+		t.Fatalf("freeze 2: %v", err)
+	}
+	if fp1 == fp2 {
+		t.Errorf("fingerprint unchanged after renaming field: %s", fp1)
+	}
+}
+
+func TestFreeze_PreventsRegistration(t *testing.T) {
+	r, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if _, err := r.Freeze(); err != nil {
+		t.Fatalf("freeze: %v", err)
+	}
+
+	err = r.RegisterNode(&NodeTypeDef{
+		TypeID: 99, Name: "Late",
+		Fields: []FieldDef{{FieldID: 1, Name: "x", Kind: KindString}},
+	})
+	if err == nil || !errors.Is(err, ErrFrozen) {
+		t.Errorf("RegisterNode after freeze err = %v, want ErrFrozen", err)
+	}
+
+	err = r.RegisterEdge(&EdgeTypeDef{
+		EdgeID: 99, Name: "LateEdge", FromTypeID: 1, ToTypeID: 2,
+	})
+	if err == nil || !errors.Is(err, ErrFrozen) {
+		t.Errorf("RegisterEdge after freeze err = %v, want ErrFrozen", err)
+	}
+
+	if _, err := r.Freeze(); err == nil || !errors.Is(err, ErrFrozen) {
+		t.Errorf("second Freeze err = %v, want ErrFrozen", err)
+	}
+}
+
+func TestRegister_DuplicateTypeID(t *testing.T) {
+	r := NewRegistry()
+	a := &NodeTypeDef{
+		TypeID: 1, Name: "A",
+		Fields: []FieldDef{{FieldID: 1, Name: "x", Kind: KindString}},
+	}
+	b := &NodeTypeDef{
+		TypeID: 1, Name: "B",
+		Fields: []FieldDef{{FieldID: 1, Name: "y", Kind: KindString}},
+	}
+	if err := r.RegisterNode(a); err != nil {
+		t.Fatalf("register A: %v", err)
+	}
+	err := r.RegisterNode(b)
+	if err == nil || !errors.Is(err, ErrDuplicateRegistration) {
+		t.Errorf("duplicate type_id err = %v, want ErrDuplicateRegistration", err)
+	}
+}
+
+func TestRegister_DuplicateName(t *testing.T) {
+	r := NewRegistry()
+	a := &NodeTypeDef{
+		TypeID: 1, Name: "A",
+		Fields: []FieldDef{{FieldID: 1, Name: "x", Kind: KindString}},
+	}
+	b := &NodeTypeDef{
+		TypeID: 2, Name: "A",
+		Fields: []FieldDef{{FieldID: 1, Name: "y", Kind: KindString}},
+	}
+	if err := r.RegisterNode(a); err != nil {
+		t.Fatalf("register A: %v", err)
+	}
+	err := r.RegisterNode(b)
+	if err == nil || !errors.Is(err, ErrDuplicateRegistration) {
+		t.Errorf("duplicate name err = %v, want ErrDuplicateRegistration", err)
+	}
+}
+
+func TestFieldIDByName_AndInverse(t *testing.T) {
+	r, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Pre-freeze (linear scan path).
+	id, ok := r.FieldIDByName("User", "email")
+	if !ok || id != 1 {
+		t.Errorf("pre-freeze FieldIDByName(User,email) = %d,%v", id, ok)
+	}
+	name, ok := r.FieldNameByID("User", 2)
+	if !ok || name != "display_name" {
+		t.Errorf("pre-freeze FieldNameByID(User,2) = %q,%v", name, ok)
+	}
+
+	if _, err := r.Freeze(); err != nil {
+		t.Fatalf("freeze: %v", err)
+	}
+
+	// Post-freeze (map path).
+	id, ok = r.FieldIDByName("User", "email")
+	if !ok || id != 1 {
+		t.Errorf("post-freeze FieldIDByName(User,email) = %d,%v", id, ok)
+	}
+	id, ok = r.FieldIDByName("User", "status")
+	if !ok || id != 3 {
+		t.Errorf("post-freeze FieldIDByName(User,status) = %d,%v", id, ok)
+	}
+	if _, ok := r.FieldIDByName("User", "nope"); ok {
+		t.Errorf("FieldIDByName(User,nope) ok = true, want false")
+	}
+	if _, ok := r.FieldIDByName("Nope", "email"); ok {
+		t.Errorf("FieldIDByName(Nope,email) ok = true, want false")
+	}
+
+	name, ok = r.FieldNameByID("User", 1)
+	if !ok || name != "email" {
+		t.Errorf("post-freeze FieldNameByID(User,1) = %q,%v", name, ok)
+	}
+	if _, ok := r.FieldNameByID("User", 999); ok {
+		t.Errorf("FieldNameByID(User,999) ok = true, want false")
+	}
+
+	// Type-id-keyed variants.
+	id, ok = r.FieldIDByNameForType(1, "email")
+	if !ok || id != 1 {
+		t.Errorf("FieldIDByNameForType(1,email) = %d,%v", id, ok)
+	}
+	name, ok = r.FieldNameByIDForType(1, 3)
+	if !ok || name != "status" {
+		t.Errorf("FieldNameByIDForType(1,3) = %q,%v", name, ok)
+	}
+}
+
+func TestNodeType_GenericLookup(t *testing.T) {
+	r, err := LoadFromJSON([]byte(pythonSampleJSON))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	cases := []struct {
+		key  any
+		want string
+	}{
+		{int32(1), "User"},
+		{int(1), "User"},
+		{int64(1), "User"},
+		{uint32(1), "User"},
+		{"User", "User"},
+		{int32(99), ""},
+		{"missing", ""},
+	}
+	for _, tc := range cases {
+		got := r.NodeType(tc.key)
+		var name string
+		if got != nil {
+			name = got.Name
+		}
+		if name != tc.want {
+			t.Errorf("NodeType(%v) = %q, want %q", tc.key, name, tc.want)
+		}
+	}
+}
+
+func TestValidate_DuplicateFieldID(t *testing.T) {
+	bad := &NodeTypeDef{
+		TypeID: 1, Name: "Bad",
+		Fields: []FieldDef{
+			{FieldID: 1, Name: "a", Kind: KindString},
+			{FieldID: 1, Name: "b", Kind: KindString},
+		},
+	}
+	if err := bad.Validate(); err == nil {
+		t.Errorf("duplicate field_id should fail")
+	}
+}
+
+func TestValidate_CompositeUniqueRules(t *testing.T) {
+	cases := []struct {
+		name string
+		nt   *NodeTypeDef
+	}{
+		{
+			name: "single-field-composite",
+			nt: &NodeTypeDef{
+				TypeID: 1, Name: "X",
+				Fields: []FieldDef{
+					{FieldID: 1, Name: "a", Kind: KindString},
+					{FieldID: 2, Name: "b", Kind: KindString},
+				},
+				CompositeUnique: []CompositeUniqueDef{{Name: "c", FieldIDs: []uint32{1}}},
+			},
+		},
+		{
+			name: "unknown-field-id",
+			nt: &NodeTypeDef{
+				TypeID: 1, Name: "X",
+				Fields: []FieldDef{
+					{FieldID: 1, Name: "a", Kind: KindString},
+				},
+				CompositeUnique: []CompositeUniqueDef{{Name: "c", FieldIDs: []uint32{1, 99}}},
+			},
+		},
+		{
+			name: "duplicate-name",
+			nt: &NodeTypeDef{
+				TypeID: 1, Name: "X",
+				Fields: []FieldDef{
+					{FieldID: 1, Name: "a", Kind: KindString},
+					{FieldID: 2, Name: "b", Kind: KindString},
+					{FieldID: 3, Name: "c", Kind: KindString},
+				},
+				CompositeUnique: []CompositeUniqueDef{
+					{Name: "dup", FieldIDs: []uint32{1, 2}},
+					{Name: "dup", FieldIDs: []uint32{2, 3}},
+				},
+			},
+		},
+		{
+			name: "duplicate-signature",
+			nt: &NodeTypeDef{
+				TypeID: 1, Name: "X",
+				Fields: []FieldDef{
+					{FieldID: 1, Name: "a", Kind: KindString},
+					{FieldID: 2, Name: "b", Kind: KindString},
+				},
+				CompositeUnique: []CompositeUniqueDef{
+					{Name: "ab", FieldIDs: []uint32{1, 2}},
+					{Name: "ba", FieldIDs: []uint32{2, 1}},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.nt.Validate(); err == nil {
+				t.Errorf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestValidateAll_CrossReferences(t *testing.T) {
+	r := NewRegistry()
+	if err := r.RegisterNode(&NodeTypeDef{
+		TypeID: 1, Name: "User",
+		Fields: []FieldDef{{FieldID: 1, Name: "x", Kind: KindString}},
+	}); err != nil {
+		t.Fatalf("register user: %v", err)
+	}
+	// Edge points at unregistered type 2.
+	if err := r.RegisterEdge(&EdgeTypeDef{
+		EdgeID: 1, Name: "E", FromTypeID: 1, ToTypeID: 2,
+		OnSubjectExit: OnSubjectExitBoth,
+	}); err != nil {
+		t.Fatalf("register edge: %v", err)
+	}
+	errsList := r.ValidateAll()
+	if len(errsList) == 0 {
+		t.Errorf("ValidateAll should report dangling to_type_id")
+	}
+}
+
+func TestEdge_OnSubjectExitDefault(t *testing.T) {
+	// Loader fills in OnSubjectExit when JSON omits it.
+	body := `{"node_types": [
+		{"type_id": 1, "name": "A", "fields": [{"field_id": 1, "name": "x", "kind": "str"}]},
+		{"type_id": 2, "name": "B", "fields": [{"field_id": 1, "name": "y", "kind": "str"}]}
+	],
+	"edge_types": [
+		{"edge_id": 1, "name": "E", "from_type_id": 1, "to_type_id": 2, "props": []}
+	]}`
+	r, err := LoadFromJSON([]byte(body))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	e := r.EdgeTypeByName("E")
+	if e == nil {
+		t.Fatal("edge missing")
+	}
+	if e.OnSubjectExit != OnSubjectExitBoth {
+		t.Errorf("OnSubjectExit = %q, want both", e.OnSubjectExit)
+	}
+}

--- a/server/go/internal/schema/translate.go
+++ b/server/go/internal/schema/translate.go
@@ -1,0 +1,89 @@
+package schema
+
+// FieldIDByName resolves a field name to its stable field_id within the
+// node type identified by typeName (or empty / unknown name returns
+// (0, false)). This is the lookup primitive payload-translation
+// (Wave 1.6) calls on the ingress hot path.
+//
+// Lock-free post-Freeze; before Freeze it falls back to a linear scan
+// of NodeTypeDef.Fields. The Wave-1.6 payload package is expected to
+// run after Freeze, but the pre-freeze path keeps unit tests simple.
+func (r *Registry) FieldIDByName(typeName, fieldName string) (uint32, bool) {
+	n := r.nodesByName[typeName]
+	if n == nil {
+		return 0, false
+	}
+	if r.frozen.Load() {
+		if m := r.fieldNameToID[n.TypeID]; m != nil {
+			id, ok := m[fieldName]
+			return id, ok
+		}
+	}
+	if f := n.GetField(fieldName); f != nil {
+		return f.FieldID, true
+	}
+	return 0, false
+}
+
+// FieldIDByNameForType is the type-id-keyed counterpart of
+// FieldIDByName. Used by callers (ExecuteAtomic, GetNodeByKey) that
+// already have a type_id in hand and want to skip the name lookup.
+func (r *Registry) FieldIDByNameForType(typeID int32, fieldName string) (uint32, bool) {
+	if r.frozen.Load() {
+		if m := r.fieldNameToID[typeID]; m != nil {
+			id, ok := m[fieldName]
+			return id, ok
+		}
+	}
+	n := r.nodes[typeID]
+	if n == nil {
+		return 0, false
+	}
+	if f := n.GetField(fieldName); f != nil {
+		return f.FieldID, true
+	}
+	return 0, false
+}
+
+// FieldNameByID is the inverse of FieldIDByName. Egress payload
+// translation calls this to rewrite stored field-id-keyed payloads
+// back into name-keyed JSON for the gRPC response.
+//
+// Unknown ids return (empty, false) — the egress translator keeps the
+// id key as-is for forward compatibility (per the schema-registry
+// spec, "unknown ids on egress are kept as-is").
+func (r *Registry) FieldNameByID(typeName string, fieldID uint32) (string, bool) {
+	n := r.nodesByName[typeName]
+	if n == nil {
+		return "", false
+	}
+	if r.frozen.Load() {
+		if m := r.fieldIDToName[n.TypeID]; m != nil {
+			name, ok := m[fieldID]
+			return name, ok
+		}
+	}
+	if f := n.GetFieldByID(fieldID); f != nil {
+		return f.Name, true
+	}
+	return "", false
+}
+
+// FieldNameByIDForType is the type-id-keyed counterpart of
+// FieldNameByID.
+func (r *Registry) FieldNameByIDForType(typeID int32, fieldID uint32) (string, bool) {
+	if r.frozen.Load() {
+		if m := r.fieldIDToName[typeID]; m != nil {
+			name, ok := m[fieldID]
+			return name, ok
+		}
+	}
+	n := r.nodes[typeID]
+	if n == nil {
+		return "", false
+	}
+	if f := n.GetFieldByID(fieldID); f != nil {
+		return f.Name, true
+	}
+	return "", false
+}

--- a/server/go/internal/schema/types.go
+++ b/server/go/internal/schema/types.go
@@ -1,0 +1,363 @@
+// Package schema is the Go port of server/python/entdb_server/schema.
+//
+// It defines the node/edge type system, the registry singleton populated
+// at boot and frozen before serving, and the lookup primitives the
+// applier and gRPC handlers consult on every request.
+//
+// Spec: docs/go-port/shared/schema-registry.md.
+//
+// Cross-language contract: LoadFromJSON consumes the exact JSON shape
+// produced by Python's SchemaRegistry.to_json (via NodeTypeDef.to_dict /
+// EdgeTypeDef.to_dict), and (*Registry).Fingerprint must agree with
+// Python's _compute_fingerprint byte-for-byte over the same registry
+// contents. The single source of truth for type metadata is the proto
+// descriptor surface (CLAUDE.md invariant #5); JSON is the bootstrap
+// channel for environments where the Go server does not import the
+// proto module directly.
+//
+// Wave-1 scope: types + JSON loader + freeze + fingerprint + name<->id
+// translation. The proto-descriptor loader (LoadFromDescriptors) and
+// the compat package are intentionally deferred to Phase 2.
+package schema
+
+import (
+	"errors"
+	"fmt"
+)
+
+// FieldKind enumerates the storage-and-validation kinds a FieldDef can
+// take. Wire values mirror server/python/entdb_server/schema/types.py
+// FieldKind verbatim so the JSON contract round-trips.
+type FieldKind string
+
+const (
+	KindString    FieldKind = "str"
+	KindInteger   FieldKind = "int"
+	KindFloat     FieldKind = "float"
+	KindBoolean   FieldKind = "bool"
+	KindTimestamp FieldKind = "timestamp"
+	KindJSON      FieldKind = "json"
+	KindBytes     FieldKind = "bytes"
+	KindEnum      FieldKind = "enum"
+	KindReference FieldKind = "ref"
+	KindListStr   FieldKind = "list_str"
+	KindListInt   FieldKind = "list_int"
+	KindListRef   FieldKind = "list_ref"
+)
+
+// Valid reports whether k is one of the declared FieldKind values.
+func (k FieldKind) Valid() bool {
+	switch k {
+	case KindString, KindInteger, KindFloat, KindBoolean,
+		KindTimestamp, KindJSON, KindBytes, KindEnum,
+		KindReference, KindListStr, KindListInt, KindListRef:
+		return true
+	}
+	return false
+}
+
+// AclPermission mirrors schema/types.py AclPermission. Stored on
+// AclEntry; ACL evaluation lives in the acl package, not here.
+type AclPermission string
+
+const (
+	PermissionRead   AclPermission = "read"
+	PermissionWrite  AclPermission = "write"
+	PermissionDelete AclPermission = "delete"
+	PermissionAdmin  AclPermission = "admin"
+)
+
+// OnSubjectExit mirrors schema/types.py OnSubjectExit. Drives GDPR
+// edge-cleanup behaviour when a data subject is deleted/anonymized.
+type OnSubjectExit string
+
+const (
+	OnSubjectExitFrom OnSubjectExit = "from"
+	OnSubjectExitTo   OnSubjectExit = "to"
+	OnSubjectExitBoth OnSubjectExit = "both"
+)
+
+// DataPolicy mirrors entdb_server/data_policy.py DataPolicy. Wire
+// values match the Python enum so the JSON contract round-trips.
+type DataPolicy string
+
+const (
+	DataPolicyPersonal   DataPolicy = "personal"
+	DataPolicyBusiness   DataPolicy = "business"
+	DataPolicyFinancial  DataPolicy = "financial"
+	DataPolicyAudit      DataPolicy = "audit"
+	DataPolicyEphemeral  DataPolicy = "ephemeral"
+	DataPolicyHealthcare DataPolicy = "healthcare"
+)
+
+// AclEntry is one entry in NodeTypeDef.DefaultAcl.
+type AclEntry struct {
+	Principal  string        `json:"principal"`
+	Permission AclPermission `json:"permission"`
+}
+
+// FieldDef is the Go counterpart of schema/types.py FieldDef. Field
+// names match the Python JSON keys (snake_case) so a Python-emitted
+// schema file boots a Go server unchanged.
+//
+// Invariants enforced by Validate:
+//   - FieldID in [1, 65535]
+//   - Name non-empty
+//   - EnumValues non-empty when Kind == KindEnum
+//   - RefTypeID set when Kind == KindReference
+type FieldDef struct {
+	FieldID     uint32    `json:"field_id"`
+	Name        string    `json:"name"`
+	Kind        FieldKind `json:"kind"`
+	Required    bool      `json:"required,omitempty"`
+	Default     any       `json:"default,omitempty"`
+	EnumValues  []string  `json:"enum_values,omitempty"`
+	RefTypeID   *int32    `json:"ref_type_id,omitempty"`
+	Indexed     bool      `json:"indexed,omitempty"`
+	Searchable  bool      `json:"searchable,omitempty"`
+	Deprecated  bool      `json:"deprecated,omitempty"`
+	Description string    `json:"description,omitempty"`
+	PII         bool      `json:"pii,omitempty"`
+	Unique      bool      `json:"unique,omitempty"`
+}
+
+// Validate checks the field invariants. Returns an error rather than
+// panicking so loader callers can collect every violation in a single
+// pass (mirrors Python __post_init__ but composable with the loader).
+func (f *FieldDef) Validate() error {
+	if f.FieldID == 0 {
+		return fmt.Errorf("field_id must be positive, got %d", f.FieldID)
+	}
+	if f.FieldID > 65535 {
+		return fmt.Errorf("field_id must be <= 65535, got %d", f.FieldID)
+	}
+	if f.Name == "" {
+		return errors.New("field name cannot be empty")
+	}
+	if !f.Kind.Valid() {
+		return fmt.Errorf("invalid field kind %q for field %q", f.Kind, f.Name)
+	}
+	if f.Kind == KindEnum && len(f.EnumValues) == 0 {
+		return fmt.Errorf("enum_values required for ENUM field %q", f.Name)
+	}
+	if f.Kind == KindReference && f.RefTypeID == nil {
+		return fmt.Errorf("ref_type_id required for REFERENCE field %q", f.Name)
+	}
+	return nil
+}
+
+// CompositeUniqueDef is the Go counterpart of schema/types.py
+// CompositeUniqueDef. Wire field names match the Python JSON keys so
+// the contract round-trips.
+type CompositeUniqueDef struct {
+	Name     string   `json:"name"`
+	FieldIDs []uint32 `json:"field_ids"`
+}
+
+// Validate enforces the same three invariants as Python __post_init__.
+func (c *CompositeUniqueDef) Validate() error {
+	if c.Name == "" {
+		return errors.New("CompositeUniqueDef name cannot be empty")
+	}
+	if len(c.FieldIDs) < 2 {
+		return fmt.Errorf(
+			"CompositeUniqueDef %q must reference at least 2 fields, got %d",
+			c.Name, len(c.FieldIDs),
+		)
+	}
+	seen := make(map[uint32]struct{}, len(c.FieldIDs))
+	for _, fid := range c.FieldIDs {
+		if _, dup := seen[fid]; dup {
+			return fmt.Errorf(
+				"CompositeUniqueDef %q has duplicate field_id %d",
+				c.Name, fid,
+			)
+		}
+		seen[fid] = struct{}{}
+	}
+	return nil
+}
+
+// NodeTypeDef is the Go counterpart of schema/types.py NodeTypeDef.
+type NodeTypeDef struct {
+	TypeID int32  `json:"type_id"`
+	Name   string `json:"name"`
+	// Fields is always emitted (even when empty) to match Python
+	// NodeTypeDef.to_dict, which always includes the "fields" key.
+	Fields          []FieldDef           `json:"fields"`
+	Deprecated      bool                 `json:"deprecated,omitempty"`
+	Description     string               `json:"description,omitempty"`
+	DefaultACL      []AclEntry           `json:"default_acl,omitempty"`
+	DataPolicy      *DataPolicy          `json:"data_policy,omitempty"`
+	SubjectField    *string              `json:"subject_field,omitempty"`
+	LegalBasis      *string              `json:"legal_basis,omitempty"`
+	CompositeUnique []CompositeUniqueDef `json:"composite_unique,omitempty"`
+}
+
+// Validate checks the same invariants as Python __post_init__:
+// positive type_id, non-empty name, no duplicate field_ids/names, and
+// composite_unique constraints reference known fields with unique
+// names and unique field-id signatures.
+func (n *NodeTypeDef) Validate() error {
+	if n.TypeID <= 0 {
+		return fmt.Errorf("type_id must be positive, got %d", n.TypeID)
+	}
+	if n.Name == "" {
+		return errors.New("node type name cannot be empty")
+	}
+
+	fieldIDs := make(map[uint32]struct{}, len(n.Fields))
+	fieldNames := make(map[string]struct{}, len(n.Fields))
+	for i := range n.Fields {
+		f := &n.Fields[i]
+		if err := f.Validate(); err != nil {
+			return fmt.Errorf("node type %q: %w", n.Name, err)
+		}
+		if _, dup := fieldIDs[f.FieldID]; dup {
+			return fmt.Errorf("duplicate field_id %d in node type %q", f.FieldID, n.Name)
+		}
+		fieldIDs[f.FieldID] = struct{}{}
+		if _, dup := fieldNames[f.Name]; dup {
+			return fmt.Errorf("duplicate field name %q in node type %q", f.Name, n.Name)
+		}
+		fieldNames[f.Name] = struct{}{}
+	}
+
+	if len(n.CompositeUnique) > 0 {
+		seenNames := make(map[string]struct{}, len(n.CompositeUnique))
+		seenSig := make(map[string]struct{}, len(n.CompositeUnique))
+		for i := range n.CompositeUnique {
+			cu := &n.CompositeUnique[i]
+			if err := cu.Validate(); err != nil {
+				return fmt.Errorf("node type %q: %w", n.Name, err)
+			}
+			for _, fid := range cu.FieldIDs {
+				if _, ok := fieldIDs[fid]; !ok {
+					return fmt.Errorf(
+						"composite_unique %q on node type %q references unknown field_id %d",
+						cu.Name, n.Name, fid,
+					)
+				}
+			}
+			if _, dup := seenNames[cu.Name]; dup {
+				return fmt.Errorf(
+					"duplicate composite_unique name %q on node type %q",
+					cu.Name, n.Name,
+				)
+			}
+			seenNames[cu.Name] = struct{}{}
+			sig := signature(cu.FieldIDs)
+			if _, dup := seenSig[sig]; dup {
+				return fmt.Errorf(
+					"duplicate composite_unique constraint on node type %q: fields %s already declared",
+					n.Name, sig,
+				)
+			}
+			seenSig[sig] = struct{}{}
+		}
+	}
+	return nil
+}
+
+// GetField returns the named field (or nil if absent). Linear scan;
+// the registry caches per-type name->field maps for hot-path lookups.
+func (n *NodeTypeDef) GetField(name string) *FieldDef {
+	for i := range n.Fields {
+		if n.Fields[i].Name == name {
+			return &n.Fields[i]
+		}
+	}
+	return nil
+}
+
+// GetFieldByID is the field-id counterpart of GetField.
+func (n *NodeTypeDef) GetFieldByID(id uint32) *FieldDef {
+	for i := range n.Fields {
+		if n.Fields[i].FieldID == id {
+			return &n.Fields[i]
+		}
+	}
+	return nil
+}
+
+// EdgeTypeDef is the Go counterpart of schema/types.py EdgeTypeDef.
+// JSON keys match Python's to_dict (which serialises from_type_id /
+// to_type_id, not the NodeTypeDef pointer).
+type EdgeTypeDef struct {
+	EdgeID        int32         `json:"edge_id"`
+	Name          string        `json:"name"`
+	FromTypeID    int32         `json:"from_type_id"`
+	ToTypeID      int32         `json:"to_type_id"`
+	Props         []FieldDef    `json:"props"`
+	UniquePerFrom bool          `json:"unique_per_from,omitempty"`
+	Deprecated    bool          `json:"deprecated,omitempty"`
+	Description   string        `json:"description,omitempty"`
+	DataPolicy    *DataPolicy   `json:"data_policy,omitempty"`
+	// OnSubjectExit is always emitted (defaults to "both"); mirrors
+	// Python EdgeTypeDef.to_dict which writes the key unconditionally.
+	OnSubjectExit OnSubjectExit `json:"on_subject_exit"`
+}
+
+// Validate checks the same invariants as Python __post_init__:
+// positive edge_id, non-empty name, no duplicate prop field_ids.
+func (e *EdgeTypeDef) Validate() error {
+	if e.EdgeID <= 0 {
+		return fmt.Errorf("edge_id must be positive, got %d", e.EdgeID)
+	}
+	if e.Name == "" {
+		return errors.New("edge type name cannot be empty")
+	}
+	propIDs := make(map[uint32]struct{}, len(e.Props))
+	for i := range e.Props {
+		p := &e.Props[i]
+		if err := p.Validate(); err != nil {
+			return fmt.Errorf("edge type %q: %w", e.Name, err)
+		}
+		if _, dup := propIDs[p.FieldID]; dup {
+			return fmt.Errorf("duplicate field_id %d in edge type %q", p.FieldID, e.Name)
+		}
+		propIDs[p.FieldID] = struct{}{}
+	}
+	if e.OnSubjectExit == "" {
+		// Python defaults to BOTH; preserve that on parse but do not
+		// rewrite the source field — the loader normalises.
+	}
+	return nil
+}
+
+// signature renders a sorted-field-id signature for composite-unique
+// duplicate detection. Stable across Go versions because we sort.
+func signature(ids []uint32) string {
+	cp := make([]uint32, len(ids))
+	copy(cp, ids)
+	// insertion sort (n is small, typically 2-4)
+	for i := 1; i < len(cp); i++ {
+		for j := i; j > 0 && cp[j-1] > cp[j]; j-- {
+			cp[j-1], cp[j] = cp[j], cp[j-1]
+		}
+	}
+	var buf []byte
+	buf = append(buf, '(')
+	for i, v := range cp {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+		buf = appendUint(buf, uint64(v))
+	}
+	buf = append(buf, ')')
+	return string(buf)
+}
+
+func appendUint(buf []byte, v uint64) []byte {
+	if v == 0 {
+		return append(buf, '0')
+	}
+	var tmp [20]byte
+	i := len(tmp)
+	for v > 0 {
+		i--
+		tmp[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return append(buf, tmp[i:]...)
+}


### PR DESCRIPTION
## Summary

Implements `server/go/internal/schema` per the Wave-0 spec at
[`docs/go-port/shared/schema-registry.md`](docs/go-port/shared/schema-registry.md)
(refs #407, Wave 1.3 in `docs/go-port/PLAN.md`).

- `types.go` — `NodeTypeDef` / `EdgeTypeDef` / `FieldDef` /
  `CompositeUniqueDef` (and `FieldKind`, `OnSubjectExit`, `DataPolicy`,
  `AclEntry` / `AclPermission`). JSON keys mirror Python's
  `SchemaRegistry.to_json` exactly so a Python-emitted schema file
  boots a Go server unchanged.
- `loader.go` — `LoadFromJSON([]byte) (*Registry, error)` consuming the
  Python `to_dict()` shape; `(*Registry).MarshalJSON` for symmetry.
  Sorts node/edge types by id and normalises empty `fields`/`props` /
  default `on_subject_exit` to match Python's emission.
- `registry.go` — `RegisterNode`/`RegisterEdge`/`Freeze`; lock-free
  reads after freeze; lookups by id-or-name (`NodeType` / `EdgeType` /
  `…ByID` / `…ByName`); helper accessors (`UniqueFieldIDs`,
  `IndexedFieldIDs`, `SearchableFieldIDs`, `CompositeUnique`,
  `PIIFields`, `DataPolicyOf`, `SubjectField`, `ValidateAll`).
- `fingerprint.go` — deterministic SHA-256 over a canonical JSON
  encoder that reproduces Python's
  `json.dumps(sort_keys=True, separators=(",", ":"))` byte-for-byte.
- `translate.go` — `FieldIDByName` / `FieldNameByID` (and
  `…ForType` variants), the lookup primitives W1.6 payload will use.

The `compat` sub-package and `LoadFromDescriptors` (proto-reflection
loader) are intentionally deferred to Phase 2 per the W1.3 scope note.

## Test plan

- [x] `cd server/go && go vet ./... && go test ./...` — schema +
  existing packages all pass.
- [x] `uvx ruff@0.15.7 check .` and `uvx ruff@0.15.7 format --check .`
  — clean.
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q`
  — 2529 passed.
- [x] `TestFingerprint_PythonByteParity` pins the Go fingerprint
  against the Python reference for the shared fixture (regenerate both
  together if Python's emission ever changes).
- [x] Round-trip: `LoadFromJSON` → `Marshal` → `LoadFromJSON` produces
  the same fingerprint.
- [x] Freeze prevents subsequent `RegisterNode` / `RegisterEdge` /
  `Freeze` (returns `ErrFrozen`).
- [x] Fingerprint changes when a field is added or renamed.
- [x] Field-id ↔ name lookup works pre- and post-freeze; type-id-keyed
  variants covered.
- [x] Composite-unique validation rejects single-field, unknown-id,
  duplicate-name, and duplicate-signature constraints.