### PR TITLE
feat(go-rewrite): auth Go package — Wave 1

### DIFF
--- a/server/go/internal/auth/actor.go
+++ b/server/go/internal/auth/actor.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import "strings"
+
+// Kind is the prefix-encoded category of an Actor identity.
+//
+// Mirrors the prefix scheme documented in
+// docs/go-port/shared/auth-interceptor.md "Trusted-actor contract":
+//
+//   - user:<id>     -- a real authenticated user.
+//   - system:<svc>  -- internal service identity; bypasses tenant-membership
+//     checks (server/python/entdb_server/api/grpc_server.py:498-499).
+//   - admin:<id>    -- operator/admin identity; same bypass as system:.
+//   - group:<id>    -- only valid in ACL grant subjects, never as a caller.
+//
+// The literal "__system__" actor used by the Applier as a bootstrap/replay
+// identity never appears on the wire and is not modelled here; if a future
+// caller needs it, expose a dedicated constant rather than smuggling it
+// through Kind.
+type Kind int
+
+const (
+	// KindUnknown is the zero value. An Actor with KindUnknown carries an
+	// ID that did not match any known prefix; treat it as untrusted.
+	KindUnknown Kind = iota
+	// KindUser is the user:<id> prefix.
+	KindUser
+	// KindSystem is the system:<svc> prefix.
+	KindSystem
+	// KindAdmin is the admin:<id> prefix.
+	KindAdmin
+	// KindGroup is the group:<id> prefix (ACL subjects only).
+	KindGroup
+)
+
+// String returns the canonical prefix for the kind without the trailing
+// colon. Mirrors the Python prefix strings used in
+// server/python/entdb_server/auth/auth_interceptor.py:108-115.
+func (k Kind) String() string {
+	switch k {
+	case KindUser:
+		return "user"
+	case KindSystem:
+		return "system"
+	case KindAdmin:
+		return "admin"
+	case KindGroup:
+		return "group"
+	default:
+		return "unknown"
+	}
+}
+
+// Actor is a prefix-encoded caller identity. It is a value type whose
+// String form (kind:id) is exactly what the Python server stores in the WAL
+// and in ACL subjects.
+//
+// Construct via User / System / Admin / Group. Parse via ParseActor for
+// strings coming off the wire or out of the WAL.
+//
+// The zero value is the "unknown" actor and is never equal to a valid one;
+// callers should treat it the way the Python server treats a None
+// identity -- no claimed prefix, no privileges.
+type Actor struct {
+	kind Kind
+	id   string
+}
+
+// User returns a user:<id> actor. Mirrors Actor.user(id) in the Python SDK.
+func User(id string) Actor { return Actor{kind: KindUser, id: id} }
+
+// System returns a system:<id> actor.
+func System(id string) Actor { return Actor{kind: KindSystem, id: id} }
+
+// Admin returns an admin:<id> actor.
+func Admin(id string) Actor { return Actor{kind: KindAdmin, id: id} }
+
+// Group returns a group:<id> actor. Group actors are only meaningful as
+// ACL grant subjects; they MUST NOT be accepted as caller identities by
+// the auth interceptor.
+func Group(id string) Actor { return Actor{kind: KindGroup, id: id} }
+
+// Kind returns the Actor's kind enum. Use the Is* predicates instead for
+// the common case.
+func (a Actor) Kind() Kind { return a.kind }
+
+// ID returns the bare identifier (no prefix). For example, User("alice").ID()
+// is "alice", not "user:alice".
+func (a Actor) ID() string { return a.id }
+
+// IsUser reports whether the actor is a user:<id>.
+func (a Actor) IsUser() bool { return a.kind == KindUser }
+
+// IsSystem reports whether the actor is a system:<svc>.
+func (a Actor) IsSystem() bool { return a.kind == KindSystem }
+
+// IsAdmin reports whether the actor is an admin:<id>.
+func (a Actor) IsAdmin() bool { return a.kind == KindAdmin }
+
+// IsGroup reports whether the actor is a group:<id>. Caller identities
+// should never be groups; this predicate exists for ACL-subject parsing.
+func (a Actor) IsGroup() bool { return a.kind == KindGroup }
+
+// IsZero reports whether the actor carries no kind and no id. Equivalent
+// to a == Actor{}.
+func (a Actor) IsZero() bool { return a.kind == KindUnknown && a.id == "" }
+
+// String renders the actor in the canonical wire form, "kind:id". For the
+// zero value this returns the empty string -- callers that need a stable
+// non-empty representation should range over Kind/ID directly.
+func (a Actor) String() string {
+	if a.IsZero() {
+		return ""
+	}
+	if a.kind == KindUnknown {
+		// Best-effort: surface the raw id we never managed to classify.
+		return a.id
+	}
+	return a.kind.String() + ":" + a.id
+}
+
+// ParseActor parses a "kind:id" string into an Actor. Unknown prefixes
+// produce an Actor{Kind: KindUnknown, id: s} so the original raw string is
+// preserved for logging / error messages; callers can detect this via
+// Kind() == KindUnknown.
+//
+// An empty input returns the zero Actor (IsZero() == true).
+func ParseActor(s string) Actor {
+	if s == "" {
+		return Actor{}
+	}
+	idx := strings.IndexByte(s, ':')
+	if idx <= 0 || idx == len(s)-1 {
+		return Actor{kind: KindUnknown, id: s}
+	}
+	prefix, id := s[:idx], s[idx+1:]
+	switch prefix {
+	case "user":
+		return Actor{kind: KindUser, id: id}
+	case "system":
+		return Actor{kind: KindSystem, id: id}
+	case "admin":
+		return Actor{kind: KindAdmin, id: id}
+	case "group":
+		return Actor{kind: KindGroup, id: id}
+	default:
+		return Actor{kind: KindUnknown, id: s}
+	}
+}

--- a/server/go/internal/auth/actor_test.go
+++ b/server/go/internal/auth/actor_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import "testing"
+
+func TestActorConstructors(t *testing.T) {
+	tests := []struct {
+		name string
+		a    Actor
+		want string
+		kind Kind
+	}{
+		{"user", User("alice"), "user:alice", KindUser},
+		{"system", System("gdpr-worker"), "system:gdpr-worker", KindSystem},
+		{"admin", Admin("root"), "admin:root", KindAdmin},
+		{"group", Group("admins"), "group:admins", KindGroup},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+			if tt.a.Kind() != tt.kind {
+				t.Errorf("Kind() = %v, want %v", tt.a.Kind(), tt.kind)
+			}
+		})
+	}
+}
+
+func TestActorPredicates(t *testing.T) {
+	cases := []struct {
+		a        Actor
+		isUser   bool
+		isSystem bool
+		isAdmin  bool
+		isGroup  bool
+	}{
+		{User("a"), true, false, false, false},
+		{System("s"), false, true, false, false},
+		{Admin("r"), false, false, true, false},
+		{Group("g"), false, false, false, true},
+		{Actor{}, false, false, false, false},
+	}
+	for _, c := range cases {
+		if got := c.a.IsUser(); got != c.isUser {
+			t.Errorf("%v.IsUser()=%v want %v", c.a, got, c.isUser)
+		}
+		if got := c.a.IsSystem(); got != c.isSystem {
+			t.Errorf("%v.IsSystem()=%v want %v", c.a, got, c.isSystem)
+		}
+		if got := c.a.IsAdmin(); got != c.isAdmin {
+			t.Errorf("%v.IsAdmin()=%v want %v", c.a, got, c.isAdmin)
+		}
+		if got := c.a.IsGroup(); got != c.isGroup {
+			t.Errorf("%v.IsGroup()=%v want %v", c.a, got, c.isGroup)
+		}
+	}
+}
+
+func TestActorZeroValue(t *testing.T) {
+	var z Actor
+	if !z.IsZero() {
+		t.Fatalf("zero Actor should report IsZero")
+	}
+	if z.String() != "" {
+		t.Errorf("zero Actor String() = %q, want empty", z.String())
+	}
+	if User("alice").IsZero() {
+		t.Errorf("User actor should not be zero")
+	}
+}
+
+func TestParseActor(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantKind Kind
+		wantID   string
+	}{
+		{"user:alice", KindUser, "alice"},
+		{"system:gdpr-worker", KindSystem, "gdpr-worker"},
+		{"admin:root", KindAdmin, "root"},
+		{"group:admins", KindGroup, "admins"},
+		{"", KindUnknown, ""},           // zero value
+		{"alice", KindUnknown, "alice"}, // bare id, no prefix
+		{"user:", KindUnknown, "user:"}, // empty id is rejected
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := ParseActor(tt.in)
+			if got.Kind() != tt.wantKind {
+				t.Errorf("Kind = %v, want %v", got.Kind(), tt.wantKind)
+			}
+			if got.ID() != tt.wantID {
+				t.Errorf("ID = %q, want %q", got.ID(), tt.wantID)
+			}
+		})
+	}
+}
+
+func TestKindString(t *testing.T) {
+	cases := []struct {
+		k    Kind
+		want string
+	}{
+		{KindUser, "user"},
+		{KindSystem, "system"},
+		{KindAdmin, "admin"},
+		{KindGroup, "group"},
+		{KindUnknown, "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.k.String(); got != c.want {
+			t.Errorf("Kind(%d).String() = %q, want %q", c.k, got, c.want)
+		}
+	}
+}

--- a/server/go/internal/auth/apikey.go
+++ b/server/go/internal/auth/apikey.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// APIKeyManager validates an opaque API key (the value of the
+// x-api-key header) and returns the key's metadata. The interceptor
+// calls Validate once per request when the API-key header is present.
+type APIKeyManager interface {
+	Validate(ctx context.Context, key string) (APIKeyInfo, error)
+}
+
+// APIKeyInfo is the metadata surfaced for a successfully validated API
+// key. The Name is what the interceptor uses as the Identity.Subject;
+// the Scopes flow through to AuthContext.Scopes for the quota
+// interceptor and any future scope-gated RPC.
+//
+// Mirrors the dict returned by ApiKeyManager.validate_key in
+// server/python/entdb_server/auth/api_key_manager.py:124-158.
+type APIKeyInfo struct {
+	KeyID  string
+	Name   string
+	Scopes []string
+}
+
+// MemoryAPIKeyManager is the in-memory APIKeyManager used by tests and
+// the no-auth dev server. Keys are stored as SHA-256 hashes -- no
+// plaintext secret is retained -- to match the Python implementation's
+// disk-write surface. Validation uses subtle.ConstantTimeCompare on the
+// hash to avoid timing leaks (TODO carried over from
+// api_key_manager.py:23).
+type MemoryAPIKeyManager struct {
+	mu      sync.RWMutex
+	byHash  map[string]*apiKeyEntry
+	byKeyID map[string]*apiKeyEntry
+}
+
+type apiKeyEntry struct {
+	keyID     string
+	name      string
+	scopes    []string
+	hash      []byte
+	expiresAt time.Time // zero means "never"
+	revoked   bool
+}
+
+// NewMemoryAPIKeyManager returns an empty in-memory key store. Add keys
+// with Add.
+func NewMemoryAPIKeyManager() *MemoryAPIKeyManager {
+	return &MemoryAPIKeyManager{
+		byHash:  make(map[string]*apiKeyEntry),
+		byKeyID: make(map[string]*apiKeyEntry),
+	}
+}
+
+// Add registers a plaintext key. The plaintext is hashed and dropped;
+// callers retain it themselves (or print it once and forget it, like
+// the real key-create flow). The returned key_id matches the
+// "ek_<hex>" format the Python store hands out and lets callers
+// Revoke later without remembering the plaintext.
+//
+// keyID is generated from the hash so the same plaintext is idempotent
+// across calls; the test surface doesn't need a separate ID generator.
+func (m *MemoryAPIKeyManager) Add(plaintext, name string, scopes []string) string {
+	hash := sha256Sum(plaintext)
+	keyID := "ek_" + hex.EncodeToString(hash[:8])
+	entry := &apiKeyEntry{
+		keyID:  keyID,
+		name:   name,
+		scopes: append([]string(nil), scopes...),
+		hash:   hash,
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.byHash[string(hash)] = entry
+	m.byKeyID[keyID] = entry
+	return keyID
+}
+
+// Revoke marks a key as revoked. Subsequent Validate calls return an
+// UNAUTHENTICATED error.
+func (m *MemoryAPIKeyManager) Revoke(keyID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.byKeyID[keyID]; ok {
+		e.revoked = true
+		// Drop from the hash index so Validate fails fast with a
+		// constant-time miss, matching api_key_manager.py:222.
+		delete(m.byHash, string(e.hash))
+	}
+}
+
+// Validate looks up the plaintext key, checks revocation and expiry,
+// and returns the key info. The lookup itself is a hash-table read;
+// the constant-time compare here is defence-in-depth -- map lookup is
+// already O(1) but does allocate, so the timing channel is small.
+func (m *MemoryAPIKeyManager) Validate(_ context.Context, plaintext string) (APIKeyInfo, error) {
+	if plaintext == "" {
+		return APIKeyInfo{}, unauthenticatedf("missing API key")
+	}
+	hash := sha256Sum(plaintext)
+	m.mu.RLock()
+	entry, ok := m.byHash[string(hash)]
+	m.mu.RUnlock()
+	if !ok || entry == nil {
+		return APIKeyInfo{}, unauthenticatedf("invalid API key")
+	}
+	// Belt-and-suspenders constant-time compare against the stored
+	// hash. If the map index hash collides (it won't with SHA-256 on
+	// the universe of inputs we see, but the assertion is cheap) this
+	// catches it.
+	if subtle.ConstantTimeCompare(entry.hash, hash) != 1 {
+		return APIKeyInfo{}, unauthenticatedf("invalid API key")
+	}
+	if entry.revoked {
+		return APIKeyInfo{}, unauthenticatedf("API key has been revoked")
+	}
+	if !entry.expiresAt.IsZero() && !time.Now().Before(entry.expiresAt) {
+		return APIKeyInfo{}, unauthenticatedf("API key has expired")
+	}
+	return APIKeyInfo{
+		KeyID:  entry.keyID,
+		Name:   entry.name,
+		Scopes: append([]string(nil), entry.scopes...),
+	}, nil
+}
+
+func sha256Sum(s string) []byte {
+	h := sha256.Sum256([]byte(s))
+	return h[:]
+}

--- a/server/go/internal/auth/apikey_test.go
+++ b/server/go/internal/auth/apikey_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+func TestMemoryAPIKeyManager_ValidateRoundTrip(t *testing.T) {
+	m := NewMemoryAPIKeyManager()
+	keyID := m.Add("plaintext-secret", "ci-bot", []string{"read", "write"})
+	if keyID == "" {
+		t.Fatal("expected non-empty keyID")
+	}
+	info, err := m.Validate(context.Background(), "plaintext-secret")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if info.Name != "ci-bot" {
+		t.Errorf("Name = %q, want ci-bot", info.Name)
+	}
+	if len(info.Scopes) != 2 || info.Scopes[0] != "read" || info.Scopes[1] != "write" {
+		t.Errorf("Scopes = %v, want [read write]", info.Scopes)
+	}
+}
+
+func TestMemoryAPIKeyManager_RejectsUnknown(t *testing.T) {
+	m := NewMemoryAPIKeyManager()
+	_, err := m.Validate(context.Background(), "nope")
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+	if errs.Code(err) != codes.Unauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", errs.Code(err))
+	}
+}
+
+func TestMemoryAPIKeyManager_RevokedKeyFails(t *testing.T) {
+	m := NewMemoryAPIKeyManager()
+	id := m.Add("s", "n", nil)
+	m.Revoke(id)
+	if _, err := m.Validate(context.Background(), "s"); err == nil {
+		t.Fatal("expected revoked key to fail")
+	}
+}
+
+func TestMemoryAPIKeyManager_EmptyKeyFails(t *testing.T) {
+	m := NewMemoryAPIKeyManager()
+	if _, err := m.Validate(context.Background(), ""); err == nil {
+		t.Fatal("expected empty key to fail")
+	}
+}

--- a/server/go/internal/auth/authoritative.go
+++ b/server/go/internal/auth/authoritative.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import "context"
+
+// Authoritative is the SINGLE choke point for the trusted-actor pattern.
+// Every handler that performs authorization MUST call this once at the
+// top, with the actor claimed in the request payload, and rebind the
+// local variable to the result.
+//
+// This function mirrors get_authoritative_actor in
+// server/python/entdb_server/auth/auth_interceptor.py:92-115. The
+// behavioural pin is tests/python/integration/test_privilege_escalation.py
+// (34 cases across 8 RPCs).
+//
+// Resolution rules, in order:
+//
+//  1. If the interceptor populated a trusted Identity on ctx, that
+//     Identity wins -- regardless of what the request payload claims.
+//     This is the privilege-escalation fix: a malicious caller can
+//     authenticate as themselves and still claim
+//     actor: "system:admin" in the request body, and we MUST NOT
+//     honour the body claim.
+//
+//     The trusted Subject is normalised to an Actor:
+//     - If it already starts with user:, system:, or admin:, ParseActor
+//     gives us the right kind verbatim.
+//     - Otherwise it is wrapped as user:<subject>. This matches Python's
+//     fall-through at auth_interceptor.py:108-115: a JWT
+//     sub: "alice" becomes user:alice; a session for
+//     user_id: "user:alice" stays user:alice.
+//
+//  2. If no trusted Identity is on ctx (interceptor disabled, unit tests,
+//     or no-auth deployment mode), claimed is returned unchanged. This
+//     is the documented fallback. A production server MUST run the
+//     interceptor; without it, every handler trusts the wire payload,
+//     which is exactly the privilege-escalation hole this package
+//     exists to plug. See docs/go-port/shared/auth-interceptor.md
+//     "Trusted-actor contract" final paragraph.
+//
+// Special case: the literal "__system__" Python identity is not modelled
+// here because it is the bootstrap/replay actor used by the Applier and
+// never appears on the wire (auth_interceptor.py:111-112). The Go
+// Applier will construct that actor directly via a dedicated constant
+// rather than route it through Authoritative.
+//
+// Defence in depth: subsequent helpers (admin checks, tenant-access
+// checks, cross-tenant-read checks) also re-call Authoritative to
+// re-derive the trusted actor from ctx -- mirroring the Python belt-and-
+// suspenders pattern at grpc_server.py:493 / 586-588 / 2671-2673.
+func Authoritative(ctx context.Context, claimed Actor) Actor {
+	id, ok := IdentityFromContext(ctx)
+	if !ok {
+		return claimed
+	}
+	// Subject may already be a prefixed actor string ("user:alice",
+	// "system:gdpr-worker") -- common when the credential carrier is a
+	// session for a tenant_principal value. Try ParseActor first so we
+	// preserve the kind.
+	if parsed := ParseActor(id.Subject); parsed.Kind() == KindUser ||
+		parsed.Kind() == KindSystem ||
+		parsed.Kind() == KindAdmin {
+		return parsed
+	}
+	// No recognised prefix -- wrap as user:<subject>. This matches the
+	// JWT sub: "alice" -> user:alice path in the Python source.
+	return User(id.Subject)
+}

--- a/server/go/internal/auth/authoritative_test.go
+++ b/server/go/internal/auth/authoritative_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+// TestAuthoritative_TrustedWinsOverClaim is the privilege-escalation
+// guard: when the interceptor has installed a trusted Identity, the
+// claim from the request payload MUST be ignored, even if it tries to
+// upgrade to system: or admin:.
+func TestAuthoritative_TrustedWinsOverClaim(t *testing.T) {
+	cases := []struct {
+		name    string
+		trusted Identity
+		claimed Actor
+		want    Actor
+	}{
+		{
+			name:    "bare sub becomes user:",
+			trusted: Identity{Method: MethodOAuth, Subject: "alice"},
+			claimed: System("admin"), // attacker tries to claim system:admin
+			want:    User("alice"),
+		},
+		{
+			name:    "prefixed sub stays prefixed",
+			trusted: Identity{Method: MethodSession, Subject: "user:alice"},
+			claimed: Admin("root"),
+			want:    User("alice"),
+		},
+		{
+			name:    "system identity preserved",
+			trusted: Identity{Method: MethodAPIKey, Subject: "system:gdpr-worker"},
+			claimed: User("eve"),
+			want:    System("gdpr-worker"),
+		},
+		{
+			name:    "admin identity preserved",
+			trusted: Identity{Method: MethodOAuth, Subject: "admin:root"},
+			claimed: User("eve"),
+			want:    Admin("root"),
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithIdentity(context.Background(), tt.trusted)
+			got := Authoritative(ctx, tt.claimed)
+			if got != tt.want {
+				t.Errorf("Authoritative = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAuthoritative_FallbackToClaimed pins the documented fallback:
+// when no interceptor ran (bare context), the claimed actor flows
+// through unchanged. This is the no-auth dev-mode / unit-test path.
+func TestAuthoritative_FallbackToClaimed(t *testing.T) {
+	ctx := context.Background()
+	got := Authoritative(ctx, User("alice"))
+	if got != User("alice") {
+		t.Errorf("fallback Authoritative = %v, want User(alice)", got)
+	}
+	// Claimed admin in a no-auth context is also passed through; this
+	// is acceptable because no-auth mode is documented as for dev/test
+	// only.
+	got = Authoritative(ctx, Admin("root"))
+	if got != Admin("root") {
+		t.Errorf("fallback Authoritative = %v, want Admin(root)", got)
+	}
+}
+
+// TestAuthoritative_GroupSubjectIsTreatedAsUser pins that a group:
+// prefix coming through as a credential subject is NOT trusted as a
+// caller "group" identity (groups are ACL subjects only). It falls
+// through to the user:<subject> wrapping, mirroring Python.
+func TestAuthoritative_GroupSubjectIsTreatedAsUser(t *testing.T) {
+	id := Identity{Method: MethodSession, Subject: "group:admins"}
+	ctx := WithIdentity(context.Background(), id)
+	got := Authoritative(ctx, User("eve"))
+	want := User("group:admins")
+	if got != want {
+		t.Errorf("Authoritative for group: subject = %v, want %v", got, want)
+	}
+}
+
+func TestIdentityFromContext(t *testing.T) {
+	// Empty context -> not found.
+	if _, ok := IdentityFromContext(context.Background()); ok {
+		t.Errorf("expected no identity on bare context")
+	}
+	// Zero identity is treated as not-set.
+	ctx := WithIdentity(context.Background(), Identity{})
+	if _, ok := IdentityFromContext(ctx); ok {
+		t.Errorf("expected zero Identity to read as absent")
+	}
+	// Populated identity round-trips.
+	id := Identity{Method: MethodOAuth, Subject: "alice"}
+	ctx = WithIdentity(context.Background(), id)
+	got, ok := IdentityFromContext(ctx)
+	if !ok {
+		t.Fatalf("expected identity to round-trip")
+	}
+	if got.Subject != "alice" || got.Method != MethodOAuth {
+		t.Errorf("round-trip = %+v, want %+v", got, id)
+	}
+}

--- a/server/go/internal/auth/doc.go
+++ b/server/go/internal/auth/doc.go
@@ -1,8 +1,27 @@
-// Package auth will host the gRPC auth interceptor that produces a
-// trusted Actor on the request context, ported from
-// server/python/entdb_server/auth/auth_interceptor.py. CLAUDE.md
-// invariant: request.actor / request.context.actor on the wire is
-// UNTRUSTED — verified identity comes from the interceptor.
-// tests/python/integration/test_privilege_escalation.py is the
-// behavioural contract.
+// Package auth is the gRPC authentication / trusted-actor chokepoint for
+// the Go server. Ported from server/python/entdb_server/auth/, EPIC #407.
+//
+// CLAUDE.md invariant: request.actor / request.context.actor on the wire
+// is UNTRUSTED. The verified caller identity is established by the
+// Interceptor in this package and parked on the request context; every
+// authorization decision MUST consult that trusted identity via
+// Authoritative, never the request payload directly. The behavioural
+// pin is tests/python/integration/test_privilege_escalation.py (34
+// cases across 8 RPCs); the spec is
+// docs/go-port/shared/auth-interceptor.md.
+//
+// Layout:
+//
+//	actor.go          Actor type + Kind enum + prefix constructors.
+//	identity.go       Identity struct + context.Context plumbing.
+//	authoritative.go  Authoritative() -- the SINGLE trusted-actor chokepoint.
+//	interceptor.go    Unary + Stream gRPC interceptors; Health bypass list.
+//	oauth.go          In-memory OAuthValidator (HS256 / RS256).
+//	apikey.go         In-memory APIKeyManager.
+//	session.go        In-memory SessionManager.
+//	errors.go         UNAUTHENTICATED / PERMISSION_DENIED wrappers.
+//
+// Wave 1 ships only the in-memory validators; production OAuth (real
+// JWKS rotation, network discovery), Redis-backed sessions, and the
+// quota interceptor are deferred to Phase 2.
 package auth

--- a/server/go/internal/auth/errors.go
+++ b/server/go/internal/auth/errors.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// unauthenticatedf wraps a formatted message in errs.ErrUnauthenticated.
+// All credential-validation failures (bad JWT, unknown API key, expired
+// session, etc.) funnel through this so the interceptor returns a
+// consistent codes.Unauthenticated.
+//
+// Mirrors the Python except (AuthenticationError, ApiKeyError, SessionError)
+// catch in server/python/entdb_server/auth/auth_interceptor.py:193-198.
+func unauthenticatedf(format string, a ...any) error {
+	return errs.Errorf(codes.Unauthenticated, format, a...)
+}
+
+// permissionDeniedf wraps a formatted message in errs.ErrPermission. Used
+// when credentials validate but the caller lacks the privilege to
+// perform the requested action -- this package emits PERMISSION_DENIED
+// only for the "valid creds, insufficient scope" path; tenant/ACL checks
+// live in their own packages.
+func permissionDeniedf(format string, a ...any) error {
+	return errs.Errorf(codes.PermissionDenied, format, a...)
+}

--- a/server/go/internal/auth/identity.go
+++ b/server/go/internal/auth/identity.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import "context"
+
+// Identity is the verified caller's claims as established by the
+// interceptor. It mirrors AuthContext in
+// server/python/entdb_server/auth/auth_interceptor.py:118-137.
+//
+// Subject is the raw verified identifier (JWT sub, API-key name, or
+// session user_id). It is NOT prefix-normalised here; normalisation to a
+// canonical Actor happens once, at the Authoritative() chokepoint, so the
+// raw subject stays available for logging and quota labelling.
+//
+// Scopes is populated only for API-key auth; OAuth and session methods
+// leave it nil.
+//
+// Claims carries raw JWT claims for OAuth; nil/empty for the other two
+// methods. It is a generic map so handlers don't take a hard dependency on
+// any particular JWT library.
+type Identity struct {
+	// Method is "oauth" | "api_key" | "session". Constants below match
+	// the Python AuthContext.method values verbatim.
+	Method   string
+	Subject  string
+	Scopes   []string
+	Claims   map[string]any
+	Metadata map[string]any
+}
+
+// Auth method names. These strings are part of the public contract --
+// metrics and logs key off them, mirroring the Python AuthContext.method
+// field.
+const (
+	MethodOAuth   = "oauth"
+	MethodAPIKey  = "api_key"
+	MethodSession = "session"
+)
+
+// IsZero reports whether the Identity carries no method and no subject.
+// Used by Authoritative to detect "no interceptor ran" without having to
+// distinguish a missing context value from a populated-but-empty one.
+func (i Identity) IsZero() bool {
+	return i.Method == "" && i.Subject == ""
+}
+
+// contextKey is the unexported type used as the context.Context value key
+// for the trusted Identity. Following the documented Go idiom, the type is
+// unexported and a singleton zero-value sentinel is held in identityKey;
+// no other package can collide on this key. See
+// docs/go-port/shared/auth-interceptor.md "Go interface".
+type contextKey struct{}
+
+var identityKey = contextKey{}
+
+// WithIdentity returns a new context that carries id as the trusted
+// Identity. The interceptor calls this exactly once per request, after
+// successful authentication. Tests that need to simulate an authenticated
+// request also call this directly -- there is no global ContextVar
+// equivalent in Go (and ContextVars are exactly what the Python port is
+// trying to leave behind, see
+// docs/go-port/shared/auth-interceptor.md "Wire-level mechanics" tail).
+func WithIdentity(ctx context.Context, id Identity) context.Context {
+	return context.WithValue(ctx, identityKey, id)
+}
+
+// IdentityFromContext returns the trusted Identity attached to ctx by the
+// interceptor. The bool is false (and the Identity is the zero value) when
+// no interceptor ran for this request -- a no-auth deployment, a unit test
+// that called the handler directly, or a Health RPC on the bypass list.
+//
+// Mirrors get_current_identity in
+// server/python/entdb_server/auth/auth_interceptor.py:66-74, except that
+// the absent case returns (Identity{}, false) instead of None so callers
+// can use the standard ", ok" idiom.
+func IdentityFromContext(ctx context.Context) (Identity, bool) {
+	v, ok := ctx.Value(identityKey).(Identity)
+	if !ok {
+		return Identity{}, false
+	}
+	if v.IsZero() {
+		return Identity{}, false
+	}
+	return v, true
+}

--- a/server/go/internal/auth/interceptor.go
+++ b/server/go/internal/auth/interceptor.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// Metadata header names. Lower-case because gRPC normalises metadata
+// keys to lower-case on the wire; using lower-case here lets us read
+// directly without normalising.
+const (
+	headerAuthorization = "authorization"
+	headerAPIKey        = "x-api-key"
+	headerSessionToken  = "x-session-token"
+
+	bearerPrefix = "Bearer "
+)
+
+// unauthenticatedMethods is the allow-list of gRPC methods that bypass
+// authentication. It MUST mirror the Python set verbatim
+// (server/python/entdb_server/auth/auth_interceptor.py:157-162) --
+// orchestrators (k8s, ECS) probe the standard health service without
+// credentials, and the EntDB-namespaced Health RPC is documented in
+// docs/go-port/rpcs/Health.md as unauthenticated.
+var unauthenticatedMethods = map[string]struct{}{
+	"/entdb.v1.EntDBService/Health": {},
+	"/grpc.health.v1.Health/Check":  {},
+}
+
+// Interceptor is the gRPC unary+stream auth interceptor. It reads
+// credentials from request metadata in a fixed order (bearer -> API key
+// -> session) and parks the verified Identity on the request context
+// via WithIdentity, where every handler retrieves it through
+// Authoritative.
+//
+// Mirrors AuthInterceptor in
+// server/python/entdb_server/auth/auth_interceptor.py:140-220. Each of
+// OAuth, APIKeys, Sessions is optional; a nil validator simply means
+// that credential type is not accepted (the request continues to the
+// next type in the chain).
+//
+// This struct is safe for concurrent use as long as the configured
+// validators are -- the in-memory implementations in this package are.
+type Interceptor struct {
+	OAuth    OAuthValidator
+	APIKeys  APIKeyManager
+	Sessions SessionManager
+}
+
+// NewInterceptor returns an Interceptor wired with the given backends.
+// Any backend may be nil; nil simply disables that auth method.
+func NewInterceptor(oauth OAuthValidator, keys APIKeyManager, sessions SessionManager) *Interceptor {
+	return &Interceptor{OAuth: oauth, APIKeys: keys, Sessions: sessions}
+}
+
+// Unary returns a grpc.UnaryServerInterceptor that authenticates every
+// inbound request before handing it to the next interceptor in the
+// chain. Health and grpc.health.v1.Health/Check bypass auth entirely.
+//
+// Order matters: install this BEFORE any quota or authorization
+// interceptor so they can read the verified Identity off the context.
+// See docs/go-port/shared/auth-interceptor.md "Dependencies".
+func (i *Interceptor) Unary() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if _, bypass := unauthenticatedMethods[info.FullMethod]; bypass {
+			return handler(ctx, req)
+		}
+		newCtx, err := i.authenticate(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return handler(newCtx, req)
+	}
+}
+
+// Stream returns a grpc.StreamServerInterceptor with the same
+// behaviour as Unary, wrapping the ServerStream so its Context()
+// returns the augmented context for the duration of the stream.
+func (i *Interceptor) Stream() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if _, bypass := unauthenticatedMethods[info.FullMethod]; bypass {
+			return handler(srv, ss)
+		}
+		newCtx, err := i.authenticate(ss.Context())
+		if err != nil {
+			return err
+		}
+		return handler(srv, &serverStreamWithContext{ServerStream: ss, ctx: newCtx})
+	}
+}
+
+// authenticate runs the credential chain. It returns either the
+// augmented context (carrying a trusted Identity) or an
+// UNAUTHENTICATED error. Mirrors AuthInterceptor.authenticate in
+// auth_interceptor.py:222-276.
+func (i *Interceptor) authenticate(ctx context.Context) (context.Context, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	// 1. Bearer token (OAuth/OIDC). Only treated as a JWT if it has
+	//    the two-dot shape -- this matches _is_jwt at
+	//    auth_interceptor.py:278-281, which lets us coexist with
+	//    other authorization schemes a future deployment might add
+	//    without misclassifying them as malformed JWTs.
+	if raw := firstHeader(md, headerAuthorization); raw != "" {
+		bearer := strings.TrimPrefix(raw, bearerPrefix)
+		if bearer != "" && i.OAuth != nil && isJWT(bearer) {
+			claims, err := i.OAuth.Validate(ctx, bearer)
+			if err != nil {
+				return nil, err
+			}
+			subject := identityFromClaims(claims)
+			id := Identity{
+				Method:  MethodOAuth,
+				Subject: subject,
+				Claims:  claims,
+			}
+			return WithIdentity(ctx, id), nil
+		}
+	}
+
+	// 2. API key.
+	if key := firstHeader(md, headerAPIKey); key != "" && i.APIKeys != nil {
+		info, err := i.APIKeys.Validate(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		id := Identity{
+			Method:   MethodAPIKey,
+			Subject:  info.Name,
+			Scopes:   info.Scopes,
+			Metadata: map[string]any{"key_id": info.KeyID},
+		}
+		return WithIdentity(ctx, id), nil
+	}
+
+	// 3. Session token.
+	if tok := firstHeader(md, headerSessionToken); tok != "" && i.Sessions != nil {
+		info, err := i.Sessions.Validate(ctx, tok)
+		if err != nil {
+			return nil, err
+		}
+		id := Identity{
+			Method:   MethodSession,
+			Subject:  info.UserID,
+			Metadata: info.Metadata,
+		}
+		return WithIdentity(ctx, id), nil
+	}
+
+	return nil, unauthenticatedf("no valid authentication credentials provided")
+}
+
+// identityFromClaims picks the identity string out of a claims map.
+// Mirrors auth_interceptor.py:248: prefer sub, fall back to email,
+// fall back to the literal "unknown".
+func identityFromClaims(claims map[string]any) string {
+	if s, ok := claims["sub"].(string); ok && s != "" {
+		return s
+	}
+	if s, ok := claims["email"].(string); ok && s != "" {
+		return s
+	}
+	return "unknown"
+}
+
+// isJWT is the same heuristic Python uses: a JWT has exactly two dots
+// (header.payload.signature). See auth_interceptor.py:278-281.
+func isJWT(s string) bool {
+	return strings.Count(s, ".") == 2
+}
+
+// firstHeader returns the first value for name in md, or "" if absent.
+// gRPC metadata keys are lower-case on the wire; metadata.MD's lookup
+// is case-insensitive but returns a slice, so we normalise that here.
+func firstHeader(md metadata.MD, name string) string {
+	if md == nil {
+		return ""
+	}
+	vs := md.Get(name)
+	if len(vs) == 0 {
+		return ""
+	}
+	return vs[0]
+}
+
+// serverStreamWithContext wraps a grpc.ServerStream so Context() returns
+// the augmented context.
+type serverStreamWithContext struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *serverStreamWithContext) Context() context.Context { return s.ctx }

--- a/server/go/internal/auth/interceptor_test.go
+++ b/server/go/internal/auth/interceptor_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// invoke runs the unary interceptor against a fake gRPC method and
+// returns the augmented context (or error). The handler simply
+// captures the context for the test to inspect.
+func invoke(t *testing.T, i *Interceptor, fullMethod string, md metadata.MD) (context.Context, error) {
+	t.Helper()
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	info := &grpc.UnaryServerInfo{FullMethod: fullMethod}
+	var captured context.Context
+	handler := func(ctx context.Context, req any) (any, error) {
+		captured = ctx
+		return nil, nil
+	}
+	_, err := i.Unary()(ctx, struct{}{}, info, handler)
+	if err != nil {
+		return nil, err
+	}
+	return captured, nil
+}
+
+func TestInterceptor_HealthBypass(t *testing.T) {
+	i := NewInterceptor(nil, nil, nil) // no validators -> any other RPC fails
+	for _, m := range []string{
+		"/entdb.v1.EntDBService/Health",
+		"/grpc.health.v1.Health/Check",
+	} {
+		ctx, err := invoke(t, i, m, nil)
+		if err != nil {
+			t.Errorf("%s: expected bypass, got err=%v", m, err)
+			continue
+		}
+		// Health bypass MUST NOT install an Identity on context.
+		if _, ok := IdentityFromContext(ctx); ok {
+			t.Errorf("%s: expected no identity on bypassed context", m)
+		}
+	}
+}
+
+func TestInterceptor_NoCredentials(t *testing.T) {
+	i := NewInterceptor(nil, nil, nil)
+	_, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", nil)
+	if err == nil {
+		t.Fatal("expected UNAUTHENTICATED")
+	}
+	if errs.Code(err) != codes.Unauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", errs.Code(err))
+	}
+}
+
+func TestInterceptor_OAuthHappyPath(t *testing.T) {
+	secret := []byte("oauth-secret")
+	v := NewMemoryOAuthValidator("https://issuer.test", "entdb-test")
+	v.AddKey("k1", JWKKey{Alg: "HS256", HS256Secret: secret})
+	i := NewInterceptor(v, nil, nil)
+
+	tok, err := SignHS256ForTest(secret, "k1", map[string]any{
+		"sub": "alice",
+		"iss": "https://issuer.test",
+		"aud": "entdb-test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	md := metadata.Pairs("authorization", "Bearer "+tok)
+	ctx, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", md)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	id, ok := IdentityFromContext(ctx)
+	if !ok {
+		t.Fatal("expected identity on context")
+	}
+	if id.Method != MethodOAuth || id.Subject != "alice" {
+		t.Errorf("identity = %+v", id)
+	}
+	// Authoritative wraps a bare sub as user:.
+	if got := Authoritative(ctx, System("admin")); got != User("alice") {
+		t.Errorf("Authoritative = %v, want User(alice)", got)
+	}
+}
+
+func TestInterceptor_OAuthInvalidToken(t *testing.T) {
+	v := NewMemoryOAuthValidator("iss", "aud")
+	v.AddKey("k", JWKKey{Alg: "HS256", HS256Secret: []byte("right")})
+	i := NewInterceptor(v, nil, nil)
+
+	bad, _ := SignHS256ForTest([]byte("wrong"), "k", map[string]any{
+		"sub": "alice", "iss": "iss", "aud": "aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	md := metadata.Pairs("authorization", "Bearer "+bad)
+	_, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", md)
+	if err == nil || errs.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want UNAUTHENTICATED, got %v", err)
+	}
+}
+
+func TestInterceptor_APIKeyHappyPath(t *testing.T) {
+	keys := NewMemoryAPIKeyManager()
+	keys.Add("k-secret", "ci-bot", []string{"read"})
+	i := NewInterceptor(nil, keys, nil)
+
+	md := metadata.Pairs("x-api-key", "k-secret")
+	ctx, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", md)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	id, _ := IdentityFromContext(ctx)
+	if id.Method != MethodAPIKey || id.Subject != "ci-bot" {
+		t.Errorf("identity = %+v", id)
+	}
+	if len(id.Scopes) != 1 || id.Scopes[0] != "read" {
+		t.Errorf("scopes = %v", id.Scopes)
+	}
+}
+
+func TestInterceptor_APIKeyInvalid(t *testing.T) {
+	keys := NewMemoryAPIKeyManager()
+	i := NewInterceptor(nil, keys, nil)
+	md := metadata.Pairs("x-api-key", "nope")
+	_, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", md)
+	if err == nil || errs.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want UNAUTHENTICATED, got %v", err)
+	}
+}
+
+func TestInterceptor_SessionHappyPath(t *testing.T) {
+	sess := NewMemorySessionManager(time.Hour)
+	tok, _ := sess.Create("user:alice", nil)
+	i := NewInterceptor(nil, nil, sess)
+
+	md := metadata.Pairs("x-session-token", tok)
+	ctx, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", md)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	id, _ := IdentityFromContext(ctx)
+	if id.Method != MethodSession || id.Subject != "user:alice" {
+		t.Errorf("identity = %+v", id)
+	}
+	// A session for "user:alice" stays user:alice through Authoritative.
+	if got := Authoritative(ctx, Admin("root")); got != User("alice") {
+		t.Errorf("Authoritative = %v, want User(alice)", got)
+	}
+}
+
+func TestInterceptor_SessionInvalid(t *testing.T) {
+	sess := NewMemorySessionManager(time.Hour)
+	i := NewInterceptor(nil, nil, sess)
+	md := metadata.Pairs("x-session-token", "nope")
+	_, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", md)
+	if err == nil || errs.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want UNAUTHENTICATED, got %v", err)
+	}
+}
+
+// TestInterceptor_OrderBearerBeatsAPIKey pins the priority chain:
+// when both Authorization (with a JWT shape) and x-api-key are
+// present, the bearer path is taken. Mirrors auth_interceptor.py:243-264.
+func TestInterceptor_OrderBearerBeatsAPIKey(t *testing.T) {
+	secret := []byte("s")
+	v := NewMemoryOAuthValidator("iss", "aud")
+	v.AddKey("k", JWKKey{Alg: "HS256", HS256Secret: secret})
+	keys := NewMemoryAPIKeyManager()
+	keys.Add("api-secret", "ci-bot", nil)
+	i := NewInterceptor(v, keys, nil)
+
+	tok, _ := SignHS256ForTest(secret, "k", map[string]any{
+		"sub": "alice", "iss": "iss", "aud": "aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	md := metadata.Pairs("authorization", "Bearer "+tok, "x-api-key", "api-secret")
+	ctx, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", md)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	id, _ := IdentityFromContext(ctx)
+	if id.Method != MethodOAuth {
+		t.Errorf("expected oauth to win, got %s", id.Method)
+	}
+}
+
+// TestInterceptor_NonJWTBearerFallsThrough pins the _is_jwt heuristic:
+// an opaque (non-JWT) authorization value must NOT be treated as a JWT
+// and the chain must fall through to API-key / session. Mirrors
+// auth_interceptor.py:246 / :278-281.
+func TestInterceptor_NonJWTBearerFallsThrough(t *testing.T) {
+	keys := NewMemoryAPIKeyManager()
+	keys.Add("api-secret", "ci-bot", nil)
+	i := NewInterceptor(NewMemoryOAuthValidator("iss", "aud"), keys, nil)
+
+	md := metadata.Pairs("authorization", "Bearer not-a-jwt-no-dots", "x-api-key", "api-secret")
+	ctx, err := invoke(t, i, "/entdb.v1.EntDBService/GetNode", md)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	id, _ := IdentityFromContext(ctx)
+	if id.Method != MethodAPIKey {
+		t.Errorf("expected api_key fallback, got %s", id.Method)
+	}
+}
+
+// fakeServerStream implements grpc.ServerStream just enough for the
+// stream interceptor test.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeServerStream) Context() context.Context { return f.ctx }
+
+func TestInterceptor_StreamInstallsIdentity(t *testing.T) {
+	keys := NewMemoryAPIKeyManager()
+	keys.Add("k", "bot", nil)
+	i := NewInterceptor(nil, keys, nil)
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-api-key", "k"))
+	ss := &fakeServerStream{ctx: ctx}
+	info := &grpc.StreamServerInfo{FullMethod: "/entdb.v1.EntDBService/StreamThing"}
+	var captured context.Context
+	handler := func(srv any, stream grpc.ServerStream) error {
+		captured = stream.Context()
+		return nil
+	}
+	if err := i.Stream()(nil, ss, info, handler); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if _, ok := IdentityFromContext(captured); !ok {
+		t.Fatal("expected identity on stream context")
+	}
+}
+
+func TestInterceptor_StreamHealthBypass(t *testing.T) {
+	i := NewInterceptor(nil, nil, nil)
+	ss := &fakeServerStream{ctx: context.Background()}
+	info := &grpc.StreamServerInfo{FullMethod: "/grpc.health.v1.Health/Check"}
+	called := false
+	handler := func(srv any, stream grpc.ServerStream) error {
+		called = true
+		return nil
+	}
+	if err := i.Stream()(nil, ss, info, handler); err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if !called {
+		t.Error("expected handler to run on health bypass")
+	}
+}

--- a/server/go/internal/auth/oauth.go
+++ b/server/go/internal/auth/oauth.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"crypto"
+	"crypto/hmac"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OAuthValidator validates an OAuth/OIDC bearer JWT and returns the
+// decoded claims. The interceptor calls Validate exactly once per
+// request, with the value of the Authorization header after the leading
+// "Bearer " has been stripped.
+//
+// Implementations must:
+//
+//   - Verify signature, expiry, issuer, and audience.
+//   - Return an error wrapping codes.Unauthenticated on any failure.
+//
+// Wave 1 ships only the in-memory implementation below. Real JWKS
+// rotation, network discovery, and ES256 land in Phase 2 -- see
+// docs/go-port/shared/auth-interceptor.md "Open questions / risks"
+// items "JWKS rotation thundering herd" and "sub collisions across
+// providers".
+type OAuthValidator interface {
+	Validate(ctx context.Context, token string) (map[string]any, error)
+}
+
+// JWKKey is one entry in an in-memory JWKS used by the in-memory
+// validator. Exactly one of HS256Secret or RS256Public is populated; the
+// validator picks the algorithm based on the JWT header.
+//
+// This is deliberately simpler than the JWK spec -- no kty, no crv, no
+// PEM parsing -- because the in-memory validator is only used by tests
+// and dev-mode servers. Production OAuth (real JWKS fetched over the
+// network) is Phase 2.
+type JWKKey struct {
+	// Alg is "HS256" or "RS256". Mirrors the SUPPORTED_ALGORITHMS list
+	// in server/python/entdb_server/auth/oauth_validator.py:41 minus
+	// ES256 (deferred to Phase 2).
+	Alg string
+	// HS256Secret is the shared secret for HS256 verification.
+	// Populated iff Alg == "HS256".
+	HS256Secret []byte
+	// RS256Public is the RSA public key for RS256 verification.
+	// Populated iff Alg == "RS256".
+	RS256Public *rsa.PublicKey
+}
+
+// MemoryOAuthValidator is the in-memory OAuthValidator used by tests
+// and the no-auth dev server. It accepts a fixed issuer/audience pair
+// and a static map of kid -> JWKKey. Concurrent reads are safe; writes
+// (AddKey) take a write lock.
+//
+// It supports HS256 and RS256. ES256 is deferred to Phase 2 with the
+// rest of the production OAuth surface -- see
+// docs/go-port/shared/auth-interceptor.md "Open questions / risks".
+type MemoryOAuthValidator struct {
+	issuer   string
+	audience string
+
+	mu   sync.RWMutex
+	keys map[string]JWKKey
+
+	// Now lets tests pin a synthetic clock. nil -> time.Now.
+	Now func() time.Time
+}
+
+// NewMemoryOAuthValidator returns an in-memory validator pinned to the
+// given issuer and audience. Add keys with AddKey before validating.
+func NewMemoryOAuthValidator(issuer, audience string) *MemoryOAuthValidator {
+	return &MemoryOAuthValidator{
+		issuer:   issuer,
+		audience: audience,
+		keys:     make(map[string]JWKKey),
+	}
+}
+
+// AddKey registers a verification key under a kid. The kid in the JWT
+// header is used to pick the key, mirroring real JWKS lookup but
+// without any of the network plumbing.
+func (v *MemoryOAuthValidator) AddKey(kid string, key JWKKey) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.keys[kid] = key
+}
+
+func (v *MemoryOAuthValidator) now() time.Time {
+	if v.Now != nil {
+		return v.Now()
+	}
+	return time.Now()
+}
+
+// Validate parses, verifies, and decodes a compact-serialisation JWT.
+// Returns the decoded claims on success. On any failure (malformed,
+// unsupported algorithm, unknown kid, bad signature, expired, wrong
+// issuer/audience) it returns an error that wraps
+// codes.Unauthenticated.
+//
+// Mirrors OAuthValidator.validate_token in
+// server/python/entdb_server/auth/oauth_validator.py:91-169.
+func (v *MemoryOAuthValidator) Validate(_ context.Context, token string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, unauthenticatedf("malformed JWT: expected 3 segments, got %d", len(parts))
+	}
+	headerB, err := decodeSegment(parts[0])
+	if err != nil {
+		return nil, unauthenticatedf("malformed JWT header: %v", err)
+	}
+	payloadB, err := decodeSegment(parts[1])
+	if err != nil {
+		return nil, unauthenticatedf("malformed JWT payload: %v", err)
+	}
+	sigB, err := decodeSegment(parts[2])
+	if err != nil {
+		return nil, unauthenticatedf("malformed JWT signature: %v", err)
+	}
+
+	var hdr struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerB, &hdr); err != nil {
+		return nil, unauthenticatedf("malformed JWT header: %v", err)
+	}
+	if hdr.Kid == "" {
+		return nil, unauthenticatedf("JWT missing 'kid' header")
+	}
+	if hdr.Alg != "HS256" && hdr.Alg != "RS256" {
+		// Reject "none" explicitly along with everything else we
+		// don't understand. ES256 is deferred to Phase 2.
+		return nil, unauthenticatedf("unsupported JWT algorithm: %q", hdr.Alg)
+	}
+
+	v.mu.RLock()
+	key, ok := v.keys[hdr.Kid]
+	v.mu.RUnlock()
+	if !ok {
+		return nil, unauthenticatedf("no JWKS key found for kid %q", hdr.Kid)
+	}
+	if key.Alg != hdr.Alg {
+		// Algorithm-confusion guard: if a key is registered as RS256
+		// but the JWT claims HS256, reject. Otherwise an attacker
+		// could sign a token with the RSA public bytes treated as an
+		// HMAC secret.
+		return nil, unauthenticatedf("algorithm mismatch: token=%s, key=%s", hdr.Alg, key.Alg)
+	}
+
+	signed := []byte(parts[0] + "." + parts[1])
+	switch hdr.Alg {
+	case "HS256":
+		if !verifyHS256(key.HS256Secret, signed, sigB) {
+			return nil, unauthenticatedf("invalid JWT signature")
+		}
+	case "RS256":
+		if key.RS256Public == nil {
+			return nil, unauthenticatedf("kid %q has no RS256 public key", hdr.Kid)
+		}
+		if err := verifyRS256(key.RS256Public, signed, sigB); err != nil {
+			return nil, unauthenticatedf("invalid JWT signature: %v", err)
+		}
+	}
+
+	var claims map[string]any
+	if err := json.Unmarshal(payloadB, &claims); err != nil {
+		return nil, unauthenticatedf("malformed JWT claims: %v", err)
+	}
+
+	now := v.now()
+	if exp, ok := numericClaim(claims, "exp"); ok {
+		if now.Unix() >= exp {
+			return nil, unauthenticatedf("token has expired")
+		}
+	}
+	if nbf, ok := numericClaim(claims, "nbf"); ok {
+		if now.Unix() < nbf {
+			return nil, unauthenticatedf("token not yet valid")
+		}
+	}
+	if v.issuer != "" {
+		iss, _ := claims["iss"].(string)
+		if iss != v.issuer {
+			return nil, unauthenticatedf("invalid issuer: got %q, want %q", iss, v.issuer)
+		}
+	}
+	if v.audience != "" {
+		if !audienceMatches(claims["aud"], v.audience) {
+			return nil, unauthenticatedf("invalid audience: want %q", v.audience)
+		}
+	}
+
+	return claims, nil
+}
+
+// audienceMatches accepts either a string aud or a list-of-strings aud,
+// matching the OIDC spec and what jwt.decode does in Python.
+func audienceMatches(raw any, want string) bool {
+	switch v := raw.(type) {
+	case string:
+		return v == want
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// numericClaim extracts a numeric claim (exp, nbf, iat) as int64. JSON
+// numbers come out of encoding/json as float64, so cast through that.
+func numericClaim(claims map[string]any, name string) (int64, bool) {
+	raw, ok := claims[name]
+	if !ok {
+		return 0, false
+	}
+	switch v := raw.(type) {
+	case float64:
+		return int64(v), true
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	default:
+		return 0, false
+	}
+}
+
+// decodeSegment decodes a base64url-without-padding JWT segment.
+func decodeSegment(s string) ([]byte, error) {
+	if pad := len(s) % 4; pad != 0 {
+		s += strings.Repeat("=", 4-pad)
+	}
+	return base64.URLEncoding.DecodeString(s)
+}
+
+// verifyHS256 returns true iff sig is a valid HMAC-SHA256 of signed
+// under the given secret. Uses hmac.Equal for constant-time comparison.
+func verifyHS256(secret, signed, sig []byte) bool {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(signed)
+	return hmac.Equal(mac.Sum(nil), sig)
+}
+
+// verifyRS256 verifies an RS256 (RSA-PKCS#1 v1.5 with SHA-256) signature.
+func verifyRS256(pub *rsa.PublicKey, signed, sig []byte) error {
+	h := sha256.Sum256(signed)
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, h[:], sig); err != nil {
+		return errors.New("rsa verify failed")
+	}
+	return nil
+}
+
+// SignHS256ForTest is a tiny helper that produces a compact-serialisation
+// HS256 JWT given the raw header and claims. It exists so the package's
+// own unit tests can mint tokens without pulling in a third-party JWT
+// library; production code MUST NOT call it.
+//
+// Exported with a "ForTest" suffix so misuse is loud at the call site.
+// Returns the compact JWT string.
+func SignHS256ForTest(secret []byte, kid string, claims map[string]any) (string, error) {
+	hdr := map[string]any{"alg": "HS256", "kid": kid, "typ": "JWT"}
+	hdrB, err := json.Marshal(hdr)
+	if err != nil {
+		return "", fmt.Errorf("marshal header: %w", err)
+	}
+	payloadB, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal claims: %w", err)
+	}
+	encHdr := base64.RawURLEncoding.EncodeToString(hdrB)
+	encPayload := base64.RawURLEncoding.EncodeToString(payloadB)
+	signed := encHdr + "." + encPayload
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signed))
+	sig := mac.Sum(nil)
+	return signed + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// SignRS256ForTest mints an RS256 JWT for the package's own tests. As
+// with SignHS256ForTest, production code MUST NOT call it.
+func SignRS256ForTest(priv *rsa.PrivateKey, kid string, claims map[string]any) (string, error) {
+	hdr := map[string]any{"alg": "RS256", "kid": kid, "typ": "JWT"}
+	hdrB, err := json.Marshal(hdr)
+	if err != nil {
+		return "", fmt.Errorf("marshal header: %w", err)
+	}
+	payloadB, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal claims: %w", err)
+	}
+	encHdr := base64.RawURLEncoding.EncodeToString(hdrB)
+	encPayload := base64.RawURLEncoding.EncodeToString(payloadB)
+	signed := encHdr + "." + encPayload
+	h := sha256.Sum256([]byte(signed))
+	sig, err := rsa.SignPKCS1v15(nil, priv, crypto.SHA256, h[:])
+	if err != nil {
+		return "", fmt.Errorf("sign rs256: %w", err)
+	}
+	return signed + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}

--- a/server/go/internal/auth/oauth_test.go
+++ b/server/go/internal/auth/oauth_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+func TestMemoryOAuthValidator_HS256_Valid(t *testing.T) {
+	secret := []byte("test-secret-please-do-not-use-in-prod")
+	v := NewMemoryOAuthValidator("https://issuer.test", "entdb-test")
+	v.AddKey("kid-1", JWKKey{Alg: "HS256", HS256Secret: secret})
+
+	tok, err := SignHS256ForTest(secret, "kid-1", map[string]any{
+		"sub": "alice",
+		"iss": "https://issuer.test",
+		"aud": "entdb-test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	claims, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims["sub"] != "alice" {
+		t.Errorf("sub = %v, want alice", claims["sub"])
+	}
+}
+
+func TestMemoryOAuthValidator_RS256_Valid(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	v := NewMemoryOAuthValidator("https://issuer.test", "entdb-test")
+	v.AddKey("kid-rsa", JWKKey{Alg: "RS256", RS256Public: &priv.PublicKey})
+
+	tok, err := SignRS256ForTest(priv, "kid-rsa", map[string]any{
+		"sub": "bob",
+		"iss": "https://issuer.test",
+		"aud": "entdb-test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	claims, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims["sub"] != "bob" {
+		t.Errorf("sub = %v, want bob", claims["sub"])
+	}
+}
+
+func TestMemoryOAuthValidator_RejectsExpired(t *testing.T) {
+	secret := []byte("s")
+	v := NewMemoryOAuthValidator("iss", "aud")
+	v.AddKey("k", JWKKey{Alg: "HS256", HS256Secret: secret})
+	tok, _ := SignHS256ForTest(secret, "k", map[string]any{
+		"sub": "alice",
+		"iss": "iss",
+		"aud": "aud",
+		"exp": time.Now().Add(-time.Minute).Unix(),
+	})
+	_, err := v.Validate(context.Background(), tok)
+	if err == nil {
+		t.Fatal("expected expired-token error")
+	}
+	if errs.Code(err) != codes.Unauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", errs.Code(err))
+	}
+}
+
+func TestMemoryOAuthValidator_RejectsBadSig(t *testing.T) {
+	v := NewMemoryOAuthValidator("iss", "aud")
+	v.AddKey("k", JWKKey{Alg: "HS256", HS256Secret: []byte("right")})
+	tok, _ := SignHS256ForTest([]byte("wrong"), "k", map[string]any{
+		"sub": "alice",
+		"iss": "iss",
+		"aud": "aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	_, err := v.Validate(context.Background(), tok)
+	if err == nil || errs.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected UNAUTHENTICATED, got err=%v code=%v", err, errs.Code(err))
+	}
+}
+
+func TestMemoryOAuthValidator_RejectsUnknownKid(t *testing.T) {
+	v := NewMemoryOAuthValidator("iss", "aud")
+	tok, _ := SignHS256ForTest([]byte("s"), "missing", map[string]any{
+		"sub": "alice",
+		"iss": "iss",
+		"aud": "aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	_, err := v.Validate(context.Background(), tok)
+	if err == nil || errs.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected UNAUTHENTICATED for unknown kid, got %v", err)
+	}
+}
+
+func TestMemoryOAuthValidator_RejectsAlgConfusion(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	v := NewMemoryOAuthValidator("iss", "aud")
+	// Key registered as RS256, but token claims HS256 -> reject.
+	v.AddKey("k", JWKKey{Alg: "RS256", RS256Public: &priv.PublicKey})
+	tok, _ := SignHS256ForTest([]byte("anything"), "k", map[string]any{
+		"sub": "alice",
+		"iss": "iss",
+		"aud": "aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), tok); err == nil {
+		t.Fatal("expected algorithm-confusion rejection")
+	}
+}
+
+func TestMemoryOAuthValidator_RejectsBadIssuerOrAudience(t *testing.T) {
+	secret := []byte("s")
+	v := NewMemoryOAuthValidator("https://right.test", "right-aud")
+	v.AddKey("k", JWKKey{Alg: "HS256", HS256Secret: secret})
+	tok, _ := SignHS256ForTest(secret, "k", map[string]any{
+		"sub": "alice",
+		"iss": "https://wrong.test",
+		"aud": "right-aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), tok); err == nil {
+		t.Errorf("expected issuer rejection")
+	}
+	tok, _ = SignHS256ForTest(secret, "k", map[string]any{
+		"sub": "alice",
+		"iss": "https://right.test",
+		"aud": "wrong-aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), tok); err == nil {
+		t.Errorf("expected audience rejection")
+	}
+}
+
+func TestMemoryOAuthValidator_RejectsNoneAlg(t *testing.T) {
+	// Synthesise a "alg: none" token by signing with HS256 then
+	// rewriting the header. Easier: validator just refuses anything
+	// outside HS256/RS256.
+	v := NewMemoryOAuthValidator("iss", "aud")
+	v.AddKey("k", JWKKey{Alg: "HS256", HS256Secret: []byte("s")})
+	// Manually crafted "none"-alg token (header: {"alg":"none","kid":"k"},
+	// payload: {}, sig: empty). Use base64 raw-url no padding.
+	tok := "eyJhbGciOiJub25lIiwia2lkIjoiayJ9.e30."
+	if _, err := v.Validate(context.Background(), tok); err == nil {
+		t.Errorf("expected rejection of alg=none")
+	}
+}

--- a/server/go/internal/auth/session.go
+++ b/server/go/internal/auth/session.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// SessionManager validates an opaque session token (the value of the
+// x-session-token header) and returns the associated user_id.
+type SessionManager interface {
+	Validate(ctx context.Context, token string) (SessionInfo, error)
+}
+
+// SessionInfo is the metadata surfaced for a successfully validated
+// session. UserID is what the interceptor uses as Identity.Subject.
+//
+// Mirrors the dict returned by SessionManager.validate_session in
+// server/python/entdb_server/auth/session_manager.py:110-138.
+type SessionInfo struct {
+	UserID    string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	Metadata  map[string]any
+}
+
+// MemorySessionManager is the in-memory SessionManager used by tests
+// and the no-auth dev server. It enforces a TTL per session and
+// supports revocation. It does NOT implement the per-user max-sessions
+// cap from the Python implementation -- that's not needed for unit
+// tests or the W1.5 contract pin and is easy to add later.
+//
+// For production behind a load balancer this needs to become Redis or
+// stateless signed tokens; flagged in
+// docs/go-port/shared/auth-interceptor.md "Open questions / risks".
+type MemorySessionManager struct {
+	defaultTTL time.Duration
+
+	mu       sync.RWMutex
+	sessions map[string]*sessionEntry
+
+	// Now lets tests pin a synthetic clock. nil -> time.Now.
+	Now func() time.Time
+}
+
+type sessionEntry struct {
+	userID    string
+	createdAt time.Time
+	expiresAt time.Time
+	metadata  map[string]any
+	revoked   bool
+}
+
+// NewMemorySessionManager returns a new in-memory session manager. ttl
+// is the default lifetime for sessions created via Create; pass 0 to
+// require an explicit ExpiresAt on every CreateWithExpiry call.
+func NewMemorySessionManager(ttl time.Duration) *MemorySessionManager {
+	return &MemorySessionManager{
+		defaultTTL: ttl,
+		sessions:   make(map[string]*sessionEntry),
+	}
+}
+
+func (m *MemorySessionManager) now() time.Time {
+	if m.Now != nil {
+		return m.Now()
+	}
+	return time.Now()
+}
+
+// Create issues a new session for userID with the manager's default
+// TTL. Returns the opaque token the client should put in the
+// x-session-token header.
+func (m *MemorySessionManager) Create(userID string, metadata map[string]any) (string, error) {
+	return m.CreateWithExpiry(userID, metadata, m.now().Add(m.defaultTTL))
+}
+
+// CreateWithExpiry issues a session with an explicit absolute expiry.
+// Used by tests that need to mint already-expired tokens.
+func (m *MemorySessionManager) CreateWithExpiry(userID string, metadata map[string]any, expiresAt time.Time) (string, error) {
+	tok, err := randomToken(32)
+	if err != nil {
+		return "", err
+	}
+	now := m.now()
+	entry := &sessionEntry{
+		userID:    userID,
+		createdAt: now,
+		expiresAt: expiresAt,
+		metadata:  metadata,
+	}
+	m.mu.Lock()
+	m.sessions[tok] = entry
+	m.mu.Unlock()
+	return tok, nil
+}
+
+// Revoke marks a session as revoked. Subsequent Validate calls return
+// an UNAUTHENTICATED error.
+func (m *MemorySessionManager) Revoke(token string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.sessions[token]; ok {
+		e.revoked = true
+	}
+}
+
+// Validate looks up the token, checks revocation and expiry, and
+// returns the session info.
+func (m *MemorySessionManager) Validate(_ context.Context, token string) (SessionInfo, error) {
+	if token == "" {
+		return SessionInfo{}, unauthenticatedf("missing session token")
+	}
+	m.mu.RLock()
+	entry, ok := m.sessions[token]
+	m.mu.RUnlock()
+	if !ok || entry == nil {
+		return SessionInfo{}, unauthenticatedf("invalid session token")
+	}
+	if entry.revoked {
+		return SessionInfo{}, unauthenticatedf("session has been revoked")
+	}
+	if !entry.expiresAt.IsZero() && !m.now().Before(entry.expiresAt) {
+		// Lazy-evict so the map doesn't grow unboundedly under churn.
+		m.mu.Lock()
+		delete(m.sessions, token)
+		m.mu.Unlock()
+		return SessionInfo{}, unauthenticatedf("session has expired")
+	}
+	// Defensive copy of metadata so callers can't poison the store.
+	var md map[string]any
+	if entry.metadata != nil {
+		md = make(map[string]any, len(entry.metadata))
+		for k, v := range entry.metadata {
+			md[k] = v
+		}
+	}
+	return SessionInfo{
+		UserID:    entry.userID,
+		CreatedAt: entry.createdAt,
+		ExpiresAt: entry.expiresAt,
+		Metadata:  md,
+	}, nil
+}
+
+func randomToken(nBytes int) (string, error) {
+	buf := make([]byte, nBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/server/go/internal/auth/session_test.go
+++ b/server/go/internal/auth/session_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+func TestMemorySessionManager_RoundTrip(t *testing.T) {
+	m := NewMemorySessionManager(time.Hour)
+	tok, err := m.Create("user:alice", map[string]any{"ip": "127.0.0.1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	info, err := m.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if info.UserID != "user:alice" {
+		t.Errorf("UserID = %q", info.UserID)
+	}
+	if info.Metadata["ip"] != "127.0.0.1" {
+		t.Errorf("Metadata = %v", info.Metadata)
+	}
+}
+
+func TestMemorySessionManager_RejectsUnknown(t *testing.T) {
+	m := NewMemorySessionManager(time.Hour)
+	_, err := m.Validate(context.Background(), "nope")
+	if err == nil || errs.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want UNAUTHENTICATED, got %v", err)
+	}
+}
+
+func TestMemorySessionManager_Revoke(t *testing.T) {
+	m := NewMemorySessionManager(time.Hour)
+	tok, _ := m.Create("u", nil)
+	m.Revoke(tok)
+	if _, err := m.Validate(context.Background(), tok); err == nil {
+		t.Fatal("expected revoked session to fail")
+	}
+}
+
+func TestMemorySessionManager_Expired(t *testing.T) {
+	m := NewMemorySessionManager(time.Hour)
+	tok, err := m.CreateWithExpiry("u", nil, time.Now().Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("CreateWithExpiry: %v", err)
+	}
+	if _, err := m.Validate(context.Background(), tok); err == nil {
+		t.Fatal("expected expired session to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- Port `server/python/entdb_server/auth/` to `server/go/internal/auth/`: `Interceptor` (unary + stream), `Actor` with `Kind` predicates and `User`/`System`/`Admin`/`Group` constructors, `Identity` context plumbing, and the `Authoritative(ctx, claimed)` trusted-actor chokepoint that enforces the CLAUDE.md invariant — `request.actor` on the wire is UNTRUSTED.
- In-memory `OAuthValidator` (HS256/RS256, no network), `APIKeyManager`, and `SessionManager`. Health and `grpc.health.v1.Health/Check` bypass auth via the spec's allow-list. Production JWKS rotation, OIDC discovery, and Redis-backed sessions stay deferred to Phase 2.
- Refs #407. Spec: `docs/go-port/shared/auth-interceptor.md` (34-case privilege-escalation pin in `tests/python/integration/test_privilege_escalation.py`).

## Test plan
- [x] `cd server/go && go vet ./... && go test ./...` — all green.
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` — clean.
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed.
- [x] Per-credential happy-path round-trips (OAuth/API-key/session) install `Identity` on the request context.
- [x] Invalid credentials per method surface `codes.Unauthenticated`.
- [x] `Authoritative` returns the trusted actor when the interceptor ran and falls back to `claimed` when it didn't (no-auth dev / unit-test path).
- [x] Health bypass allow-list lets through without identity for both unary and stream paths.
- [x] Bearer-vs-API-key priority + non-JWT bearer fall-through pinned.