### PR TITLE
feat(go-rewrite): payload Go package — Wave 1

### DIFF
--- a/server/go/internal/payload/translate.go
+++ b/server/go/internal/payload/translate.go
@@ -1,0 +1,412 @@
+// Package payload is the gRPC-boundary translator between name-keyed
+// google.protobuf.Struct payloads (the wire) and id-keyed map[uint32]any
+// payloads (storage / WAL events).
+//
+// Per CLAUDE.md invariant #6 ("field IDs, not field names, on disk")
+// translation happens at exactly two points: ingress in the gRPC handler
+// layer (StructToPayload, FilterNamesToIDs) and egress that converts a
+// stored id-keyed JSON blob back to names for SDKs that need it
+// (PayloadJSONToNames). The egress to *structpb.Struct (PayloadToStruct)
+// is a zero-translation wrap — the wire stays id-keyed and the SDK does
+// the id→name lookup on the client side.
+//
+// Spec: docs/go-port/shared/payload-translation.md.
+//
+// Source-of-truth Python:
+//   - server/python/entdb_server/schema/field_id_translation.py
+//   - tests/python/unit/test_grpc_wire_format.py
+package payload
+
+import (
+	"encoding/base64"
+	"strconv"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// StructToPayload translates a wire google.protobuf.Struct into the
+// id-keyed internal payload representation map[uint32]any. Used on the
+// ingress side of CreateNode / UpdateNode.
+//
+// Behavior (mirrors name_to_id_keys in the Python port):
+//
+//   - nil / empty s -> empty map (never nil) so downstream JSON
+//     marshalling stays deterministic.
+//   - reg == nil OR nodeTypeName == "" OR registry has no entry for
+//     nodeTypeName -> schema-less passthrough: keys are interpreted
+//     verbatim. Digit-only keys parse to uint32 ids; non-digit keys
+//     are dropped (silently) since the internal map is uint32-keyed.
+//   - Schema-aware path:
+//       - Digit-only key matching a known field_id is kept as-is.
+//       - String key matching a field name is translated to its id.
+//       - Unknown name keys are dropped silently (matches Python
+//         contract: ingress is permissive so legacy clients sending
+//         deprecated fields don't break writes).
+//   - Field-kind coercion (only when schema is known):
+//       - BYTES: structpb has no bytes type; the wire carries base64
+//         strings. Decode to []byte for storage.
+//       - TIMESTAMP / INTEGER: structpb represents numbers as float64.
+//         Coerce to int64 on ingress so disk values are integers.
+//       - JSON: top-level passthrough. Nested *structpb.Struct values
+//         are converted to map[string]any once at this layer; the
+//         translator never recurses into them.
+//
+// Order independence is a property of map iteration; do not rely on
+// Struct.Fields insertion order anywhere downstream.
+func StructToPayload(reg *schema.Registry, nodeTypeName string, s *structpb.Struct) (map[uint32]any, error) {
+	if s == nil || len(s.GetFields()) == 0 {
+		return map[uint32]any{}, nil
+	}
+
+	// Schema-less passthrough: the wire is treated as already id-keyed.
+	// Digit-only keys map to uint32; everything else is dropped.
+	nt := lookupNodeType(reg, nodeTypeName)
+	if nt == nil {
+		out := make(map[uint32]any, len(s.GetFields()))
+		for k, v := range s.GetFields() {
+			if id, ok := parseFieldID(k); ok {
+				out[id] = v.AsInterface()
+			}
+		}
+		return out, nil
+	}
+
+	// Build name->FieldDef and id->FieldDef indices once per call. The
+	// registry caches these post-Freeze for the hot path; we keep our
+	// own copy here so the kind-coercion lookup is O(1).
+	nameToField := make(map[string]*schema.FieldDef, len(nt.Fields))
+	idToField := make(map[uint32]*schema.FieldDef, len(nt.Fields))
+	for i := range nt.Fields {
+		f := &nt.Fields[i]
+		nameToField[f.Name] = f
+		idToField[f.FieldID] = f
+	}
+
+	out := make(map[uint32]any, len(s.GetFields()))
+	for key, value := range s.GetFields() {
+		// Pre-translated digit keys: a caller (e.g. typed Go SDK) may
+		// already have done id translation. If the digit matches a
+		// known field id, keep it; otherwise the key is unknown on
+		// this schema and is dropped.
+		if id, ok := parseFieldID(key); ok {
+			if f := idToField[id]; f != nil {
+				coerced, err := coerceForKind(f, value)
+				if err != nil {
+					return nil, err
+				}
+				out[id] = coerced
+				continue
+			}
+			// Digit but not a known id: drop silently (forward-compat
+			// scenarios are handled on egress, not ingress).
+			continue
+		}
+
+		f := nameToField[key]
+		if f == nil {
+			// Unknown name: drop silently. Matches Python
+			// name_to_id_keys (ingress is permissive).
+			continue
+		}
+		coerced, err := coerceForKind(f, value)
+		if err != nil {
+			return nil, err
+		}
+		out[f.FieldID] = coerced
+	}
+	return out, nil
+}
+
+// PayloadToStruct wraps an id-keyed payload for the wire.
+//
+// The wire stays id-keyed (per the spec's "zero-translation egress"
+// rule). nodeTypeName is consumed only for kind-aware coercion in the
+// reverse direction:
+//
+//   - BYTES: storage holds []byte (or pre-base64 string); structpb has
+//     no bytes type, so we encode to base64 string on the wire.
+//   - TIMESTAMP / INTEGER: storage holds int64; structpb represents
+//     numbers as float64.
+//
+// When nodeTypeName == "" or the registry has no entry, the egress is a
+// pure passthrough — values go through structpb.NewValue as-is.
+//
+// The returned Struct has stringified field_id keys ("1", "2", ...).
+func PayloadToStruct(reg *schema.Registry, nodeTypeName string, p map[uint32]any) (*structpb.Struct, error) {
+	out := &structpb.Struct{Fields: make(map[string]*structpb.Value, len(p))}
+	if len(p) == 0 {
+		return out, nil
+	}
+
+	nt := lookupNodeType(reg, nodeTypeName)
+
+	for id, raw := range p {
+		key := strconv.FormatUint(uint64(id), 10)
+
+		var v *structpb.Value
+		var err error
+		if nt != nil {
+			if f := nt.GetFieldByID(id); f != nil {
+				v, err = encodeForKind(f, raw)
+			} else {
+				// Unknown id on egress is preserved verbatim
+				// (forward-compat) — matches Python id_to_name_keys.
+				v, err = newValue(raw)
+			}
+		} else {
+			v, err = newValue(raw)
+		}
+		if err != nil {
+			return nil, err
+		}
+		out.Fields[key] = v
+	}
+	return out, nil
+}
+
+// FilterNamesToIDs translates a name-keyed filter dict (used by
+// QueryNodes) into the id-keyed form the canonical store expects.
+//
+// Differs from StructToPayload in two ways:
+//
+//   - The input is map[string]any, not *structpb.Struct (the gRPC layer
+//     unwraps a Struct before calling).
+//   - Unknown names are an error, not a silent drop. A QueryNodes
+//     filter mentioning a field that does not exist on the schema is a
+//     client bug and should surface as INVALID_ARGUMENT — silently
+//     dropping it would change the result set.
+//
+// Mirrors translate_filter_name_to_id in the Python port, with the
+// stricter unknown-key behavior the Go server enforces (see
+// docs/go-port/shared/payload-translation.md "QueryNodes filter").
+func FilterNamesToIDs(reg *schema.Registry, nodeTypeName string, filter map[string]any) (map[uint32]any, error) {
+	if len(filter) == 0 {
+		return map[uint32]any{}, nil
+	}
+
+	nt := lookupNodeType(reg, nodeTypeName)
+	if nt == nil {
+		// Schema-less: digit-only keys parse to uint32; non-digit keys
+		// are an error because we cannot resolve them without a schema.
+		out := make(map[uint32]any, len(filter))
+		for k, v := range filter {
+			id, ok := parseFieldID(k)
+			if !ok {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"payload: cannot translate filter key %q without a schema", k)
+			}
+			out[id] = v
+		}
+		return out, nil
+	}
+
+	out := make(map[uint32]any, len(filter))
+	for key, value := range filter {
+		if id, ok := parseFieldID(key); ok {
+			if nt.GetFieldByID(id) == nil {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"payload: filter references unknown field_id %d on type %q", id, nodeTypeName)
+			}
+			out[id] = value
+			continue
+		}
+		f := nt.GetField(key)
+		if f == nil {
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"payload: filter references unknown field %q on type %q", key, nodeTypeName)
+		}
+		out[f.FieldID] = value
+	}
+	return out, nil
+}
+
+// PayloadJSONToNames converts an id-keyed payload (e.g. as fetched from
+// the canonical store) to a name-keyed map[string]any suitable for
+// JSON-friendly egress paths (audit exports, the console JSON view).
+//
+// Unknown ids are preserved verbatim (as their decimal string) so a
+// row written by a future schema revision is not lossy on read.
+// Unknown ids preserved as decimal-string keys is identical to the
+// Python id_to_name_keys fallthrough.
+//
+// When reg / nodeTypeName resolves to no schema, every id is rendered
+// as its decimal string.
+func PayloadJSONToNames(reg *schema.Registry, nodeTypeName string, p map[uint32]any) (map[string]any, error) {
+	out := make(map[string]any, len(p))
+	if len(p) == 0 {
+		return out, nil
+	}
+
+	nt := lookupNodeType(reg, nodeTypeName)
+	for id, value := range p {
+		var key string
+		if nt != nil {
+			if f := nt.GetFieldByID(id); f != nil {
+				key = f.Name
+			} else {
+				key = strconv.FormatUint(uint64(id), 10)
+			}
+		} else {
+			key = strconv.FormatUint(uint64(id), 10)
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+// --- internal helpers ---------------------------------------------------
+
+// lookupNodeType is the single resolver this package uses. Empty
+// nodeTypeName or nil registry returns nil (schema-less).
+func lookupNodeType(reg *schema.Registry, nodeTypeName string) *schema.NodeTypeDef {
+	if reg == nil || nodeTypeName == "" {
+		return nil
+	}
+	return reg.NodeTypeByName(nodeTypeName)
+}
+
+// parseFieldID parses a digit-only string into a uint32 within the
+// FieldDef bound (1-65535). Returns false for empty / non-digit / 0 /
+// out-of-range. Mirrors the field_id invariant on FieldDef.Validate.
+func parseFieldID(s string) (uint32, bool) {
+	if s == "" {
+		return 0, false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil || n == 0 || n > 65535 {
+		return 0, false
+	}
+	return uint32(n), true
+}
+
+// coerceForKind converts a *structpb.Value into the canonical Go type
+// for a field's Kind. Returns the raw AsInterface() result for kinds
+// that need no coercion. Returns INVALID_ARGUMENT on a structurally
+// wrong wire value (e.g. BYTES field carrying a non-string).
+//
+// Nil or NullValue is preserved as nil so callers can distinguish "key
+// present, value null" from "key absent" — matches the Python contract
+// where FieldDef.validate_value treats None as "not provided" (and the
+// applier silently no-ops on it).
+func coerceForKind(f *schema.FieldDef, v *structpb.Value) (any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	if _, ok := v.Kind.(*structpb.Value_NullValue); ok {
+		return nil, nil
+	}
+	switch f.Kind {
+	case schema.KindBytes:
+		s, ok := v.Kind.(*structpb.Value_StringValue)
+		if !ok {
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"payload: field %q (bytes) requires base64 string, got %T",
+				f.Name, v.Kind)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(s.StringValue)
+		if err != nil {
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"payload: field %q (bytes) is not valid base64: %v", f.Name, err)
+		}
+		return decoded, nil
+	case schema.KindTimestamp, schema.KindInteger:
+		n, ok := v.Kind.(*structpb.Value_NumberValue)
+		if !ok {
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"payload: field %q (%s) requires a number, got %T",
+				f.Name, f.Kind, v.Kind)
+		}
+		// structpb numbers are float64. Reject values outside the
+		// safe-integer range (2^53) to keep replay deterministic.
+		if n.NumberValue > 1<<53 || n.NumberValue < -(1<<53) {
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"payload: field %q (%s) value %v exceeds safe integer range",
+				f.Name, f.Kind, n.NumberValue)
+		}
+		return int64(n.NumberValue), nil
+	case schema.KindJSON:
+		// Top-level passthrough. *structpb.Struct unwraps to
+		// map[string]any (recursively, but only at the value level —
+		// the translator never recurses into nested struct keys).
+		return v.AsInterface(), nil
+	case schema.KindEnum:
+		s, ok := v.Kind.(*structpb.Value_StringValue)
+		if !ok {
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"payload: field %q (enum) requires a string, got %T",
+				f.Name, v.Kind)
+		}
+		return s.StringValue, nil
+	default:
+		return v.AsInterface(), nil
+	}
+}
+
+// encodeForKind is the egress counterpart of coerceForKind. Storage
+// values for BYTES are []byte; structpb has no bytes type so we encode
+// to base64 string. TIMESTAMP / INTEGER values may be int64 on disk
+// but structpb represents numbers as float64; structpb.NewValue handles
+// numeric conversion.
+func encodeForKind(f *schema.FieldDef, raw any) (*structpb.Value, error) {
+	if raw == nil {
+		return structpb.NewNullValue(), nil
+	}
+	switch f.Kind {
+	case schema.KindBytes:
+		switch b := raw.(type) {
+		case []byte:
+			return structpb.NewStringValue(base64.StdEncoding.EncodeToString(b)), nil
+		case string:
+			// Already base64-encoded by an earlier write path; pass
+			// through verbatim.
+			return structpb.NewStringValue(b), nil
+		default:
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"payload: field %q (bytes) stored as %T, expected []byte or string",
+				f.Name, raw)
+		}
+	default:
+		return newValue(raw)
+	}
+}
+
+// newValue is a shim around structpb.NewValue that accepts the int64 /
+// uint32 / int / float forms the on-disk layer produces and returns a
+// gRPC-status-bearing error on failure (rather than the raw protobuf
+// error). Mirrors errs.* sentinels for the gRPC boundary.
+func newValue(raw any) (*structpb.Value, error) {
+	// structpb.NewValue is strict about input types — it does not
+	// accept int64 directly (only float64, int, bool, string, []byte
+	// without base64, []any, map[string]any, nil). Normalize the
+	// numeric forms storage might use.
+	switch n := raw.(type) {
+	case int64:
+		return structpb.NewNumberValue(float64(n)), nil
+	case int32:
+		return structpb.NewNumberValue(float64(n)), nil
+	case uint32:
+		return structpb.NewNumberValue(float64(n)), nil
+	case uint64:
+		return structpb.NewNumberValue(float64(n)), nil
+	case []byte:
+		// Schema-less egress: a raw []byte has no kind hint. Encode as
+		// base64 so the value is JSON-safe; the SDK that wrote it must
+		// know it's bytes.
+		return structpb.NewStringValue(base64.StdEncoding.EncodeToString(n)), nil
+	}
+	v, err := structpb.NewValue(raw)
+	if err != nil {
+		return nil, errs.Errorf(codes.InvalidArgument,
+			"payload: cannot encode value of type %T: %v", raw, err)
+	}
+	return v, nil
+}
+

--- a/server/go/internal/payload/translate_test.go
+++ b/server/go/internal/payload/translate_test.go
@@ -1,0 +1,594 @@
+// Tests for payload translation. Mirrors the asserted behavior in
+// tests/python/unit/test_grpc_wire_format.py — wire payload is
+// id-keyed, unknown names dropped, field order does not matter,
+// schema-less mode passes through.
+
+package payload
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// fixtureRegistry seeds a minimal frozen registry with a User-like type.
+// Field IDs are deliberately non-sequential so order independence and
+// id-vs-name correctness are observable in test output.
+func fixtureRegistry(t *testing.T) *schema.Registry {
+	t.Helper()
+	reg := schema.NewRegistry()
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID: 1,
+		Name:   "User",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "email", Kind: schema.KindString},
+			{FieldID: 2, Name: "name", Kind: schema.KindString},
+			{FieldID: 3, Name: "age", Kind: schema.KindInteger},
+			{FieldID: 4, Name: "active", Kind: schema.KindBoolean},
+			{FieldID: 5, Name: "avatar", Kind: schema.KindBytes},
+			{FieldID: 6, Name: "created_at", Kind: schema.KindTimestamp},
+			{FieldID: 7, Name: "metadata", Kind: schema.KindJSON},
+			{FieldID: 8, Name: "status", Kind: schema.KindEnum, EnumValues: []string{"active", "banned"}},
+		},
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("freeze: %v", err)
+	}
+	return reg
+}
+
+func mustStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+	return s
+}
+
+// TestStructToPayload_KeysAreFieldIDs is the central CLAUDE.md
+// invariant #6 test: marshal a Struct keyed by field NAMES and assert
+// the resulting map keys are field_ids (uint32), not names.
+func TestStructToPayload_KeysAreFieldIDs(t *testing.T) {
+	reg := fixtureRegistry(t)
+	s := mustStruct(t, map[string]any{
+		"email": "alice@example.com",
+		"name":  "Alice",
+	})
+	got, err := StructToPayload(reg, "User", s)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	if v, ok := got[1]; !ok || v != "alice@example.com" {
+		t.Fatalf("expected got[1]=email value, got %v (%T), full=%v", v, v, got)
+	}
+	if v, ok := got[2]; !ok || v != "Alice" {
+		t.Fatalf("expected got[2]=name value, got %v (%T), full=%v", v, v, got)
+	}
+	// No string keys leaked through (the map type forbids that, but
+	// also assert that the size is exactly 2 — no extras).
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries (id-keyed), got %d: %v", len(got), got)
+	}
+}
+
+func TestStructToPayload_DropsUnknownFields(t *testing.T) {
+	reg := fixtureRegistry(t)
+	s := mustStruct(t, map[string]any{
+		"email":       "drop@example.com",
+		"ghost_field": "should be dropped",
+	})
+	got, err := StructToPayload(reg, "User", s)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected only known field after drop, got %v", got)
+	}
+	if _, ok := got[1]; !ok {
+		t.Fatalf("expected email (id=1) in result, got %v", got)
+	}
+}
+
+func TestStructToPayload_EmptyStructIsEmptyMap(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := StructToPayload(reg, "User", &structpb.Struct{})
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil map for empty struct")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %v", got)
+	}
+	got2, err := StructToPayload(reg, "User", nil)
+	if err != nil {
+		t.Fatalf("StructToPayload(nil): %v", err)
+	}
+	if len(got2) != 0 {
+		t.Fatalf("expected empty map for nil struct, got %v", got2)
+	}
+}
+
+func TestStructToPayload_DigitKeyPassthrough(t *testing.T) {
+	reg := fixtureRegistry(t)
+	// Pre-translated digit keys: id 1 is known (email), id 99 is not.
+	s := mustStruct(t, map[string]any{
+		"1":  "via@digit.com",
+		"99": "unknown id, drop",
+	})
+	got, err := StructToPayload(reg, "User", s)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	if v, ok := got[1]; !ok || v != "via@digit.com" {
+		t.Fatalf("expected digit-key passthrough, got %v", got)
+	}
+	if _, ok := got[99]; ok {
+		t.Fatalf("unknown digit id should have been dropped, got %v", got)
+	}
+}
+
+func TestStructToPayload_BytesBase64Coercion(t *testing.T) {
+	reg := fixtureRegistry(t)
+	original := []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02}
+	encoded := base64.StdEncoding.EncodeToString(original)
+	s := mustStruct(t, map[string]any{"avatar": encoded})
+
+	got, err := StructToPayload(reg, "User", s)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	v, ok := got[5].([]byte)
+	if !ok {
+		t.Fatalf("expected []byte for avatar, got %T (%v)", got[5], got[5])
+	}
+	if !bytes.Equal(v, original) {
+		t.Fatalf("bytes round-trip mismatch: got %x want %x", v, original)
+	}
+}
+
+func TestStructToPayload_BytesInvalidBase64IsInvalidArgument(t *testing.T) {
+	reg := fixtureRegistry(t)
+	s := mustStruct(t, map[string]any{"avatar": "***not base64***"})
+	_, err := StructToPayload(reg, "User", s)
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+	if !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("expected INVALID_ARGUMENT, got %v", err)
+	}
+}
+
+func TestStructToPayload_TimestampAndIntegerCoerced(t *testing.T) {
+	reg := fixtureRegistry(t)
+	s := mustStruct(t, map[string]any{
+		"age":        42.0,
+		"created_at": 1715000000000.0,
+	})
+	got, err := StructToPayload(reg, "User", s)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	if v, ok := got[3].(int64); !ok || v != 42 {
+		t.Fatalf("expected age=int64(42), got %T(%v)", got[3], got[3])
+	}
+	if v, ok := got[6].(int64); !ok || v != 1715000000000 {
+		t.Fatalf("expected created_at=int64(...), got %T(%v)", got[6], got[6])
+	}
+}
+
+func TestStructToPayload_TimestampOutOfRange(t *testing.T) {
+	reg := fixtureRegistry(t)
+	// 2^54 — outside structpb safe integer range.
+	s := mustStruct(t, map[string]any{"created_at": float64(1) * (1 << 54)})
+	_, err := StructToPayload(reg, "User", s)
+	if err == nil || !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("expected INVALID_ARGUMENT for out-of-range timestamp, got %v", err)
+	}
+}
+
+func TestStructToPayload_JSONNestedMapPassthrough(t *testing.T) {
+	reg := fixtureRegistry(t)
+	s := mustStruct(t, map[string]any{
+		"metadata": map[string]any{
+			"key": "value",
+			"nested": map[string]any{
+				"deep": float64(1),
+			},
+		},
+	})
+	got, err := StructToPayload(reg, "User", s)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	m, ok := got[7].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any for metadata, got %T", got[7])
+	}
+	if m["key"] != "value" {
+		t.Fatalf("expected metadata.key=value, got %v", m["key"])
+	}
+	nested, ok := m["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested map, got %T", m["nested"])
+	}
+	if nested["deep"] != float64(1) {
+		t.Fatalf("nested.deep mismatch: %v", nested["deep"])
+	}
+}
+
+func TestStructToPayload_EnumStringPreserved(t *testing.T) {
+	reg := fixtureRegistry(t)
+	s := mustStruct(t, map[string]any{"status": "active"})
+	got, err := StructToPayload(reg, "User", s)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	if got[8] != "active" {
+		t.Fatalf("expected status=active, got %v", got[8])
+	}
+}
+
+func TestStructToPayload_FieldOrderIndependent(t *testing.T) {
+	reg := fixtureRegistry(t)
+	s1 := mustStruct(t, map[string]any{"email": "x@example.com", "name": "X"})
+	s2 := mustStruct(t, map[string]any{"name": "X", "email": "x@example.com"})
+
+	g1, err := StructToPayload(reg, "User", s1)
+	if err != nil {
+		t.Fatalf("s1: %v", err)
+	}
+	g2, err := StructToPayload(reg, "User", s2)
+	if err != nil {
+		t.Fatalf("s2: %v", err)
+	}
+	if g1[1] != g2[1] || g1[2] != g2[2] || len(g1) != len(g2) {
+		t.Fatalf("order should not matter; got %v vs %v", g1, g2)
+	}
+}
+
+// --- PayloadToStruct -----------------------------------------------------
+
+func TestPayloadToStruct_KeysAreStringifiedFieldIDs(t *testing.T) {
+	reg := fixtureRegistry(t)
+	in := map[uint32]any{
+		1: "alice@example.com",
+		2: "Alice",
+	}
+	got, err := PayloadToStruct(reg, "User", in)
+	if err != nil {
+		t.Fatalf("PayloadToStruct: %v", err)
+	}
+	keys := got.GetFields()
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys on the wire, got %d (%v)", len(keys), keys)
+	}
+	if v, ok := keys["1"]; !ok || v.GetStringValue() != "alice@example.com" {
+		t.Fatalf("expected keys[\"1\"]=email, got %v", keys)
+	}
+	if v, ok := keys["2"]; !ok || v.GetStringValue() != "Alice" {
+		t.Fatalf("expected keys[\"2\"]=name, got %v", keys)
+	}
+}
+
+func TestPayloadToStruct_BytesEncodedAsBase64(t *testing.T) {
+	reg := fixtureRegistry(t)
+	original := []byte{0xca, 0xfe, 0xba, 0xbe}
+	got, err := PayloadToStruct(reg, "User", map[uint32]any{5: original})
+	if err != nil {
+		t.Fatalf("PayloadToStruct: %v", err)
+	}
+	v := got.GetFields()["5"].GetStringValue()
+	if v != base64.StdEncoding.EncodeToString(original) {
+		t.Fatalf("expected base64 encoded bytes, got %q", v)
+	}
+}
+
+func TestPayloadToStruct_TimestampInt64IsNumberValue(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := PayloadToStruct(reg, "User", map[uint32]any{6: int64(1715000000000)})
+	if err != nil {
+		t.Fatalf("PayloadToStruct: %v", err)
+	}
+	v := got.GetFields()["6"].GetNumberValue()
+	if v != 1715000000000.0 {
+		t.Fatalf("expected number 1715000000000, got %v", v)
+	}
+}
+
+func TestPayloadToStruct_SchemaLessPassthrough(t *testing.T) {
+	// No registry, no type name — the wire still carries stringified
+	// field_id keys and primitive values pass through.
+	got, err := PayloadToStruct(nil, "", map[uint32]any{
+		1: "hello",
+		2: float64(3.14),
+		3: true,
+	})
+	if err != nil {
+		t.Fatalf("PayloadToStruct(schema-less): %v", err)
+	}
+	f := got.GetFields()
+	if f["1"].GetStringValue() != "hello" {
+		t.Fatalf("expected hello, got %v", f["1"])
+	}
+	if f["2"].GetNumberValue() != 3.14 {
+		t.Fatalf("expected 3.14, got %v", f["2"])
+	}
+	if !f["3"].GetBoolValue() {
+		t.Fatalf("expected true, got %v", f["3"])
+	}
+}
+
+func TestPayloadToStruct_UnknownFieldIDPreservedOnEgress(t *testing.T) {
+	reg := fixtureRegistry(t)
+	// Field ID 999 is not on the schema; egress must still emit it
+	// (forward-compat).
+	got, err := PayloadToStruct(reg, "User", map[uint32]any{
+		1:   "known",
+		999: "unknown but kept",
+	})
+	if err != nil {
+		t.Fatalf("PayloadToStruct: %v", err)
+	}
+	if got.GetFields()["999"].GetStringValue() != "unknown but kept" {
+		t.Fatalf("expected unknown id preserved, got %v", got.GetFields())
+	}
+}
+
+func TestPayloadToStruct_EmptyPayloadIsEmptyStruct(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := PayloadToStruct(reg, "User", map[uint32]any{})
+	if err != nil {
+		t.Fatalf("PayloadToStruct: %v", err)
+	}
+	if len(got.GetFields()) != 0 {
+		t.Fatalf("expected empty Struct, got %v", got)
+	}
+	got2, err := PayloadToStruct(reg, "User", nil)
+	if err != nil {
+		t.Fatalf("PayloadToStruct(nil): %v", err)
+	}
+	if got2 == nil || len(got2.GetFields()) != 0 {
+		t.Fatalf("expected empty Struct for nil map, got %v", got2)
+	}
+}
+
+// --- Round-trip ----------------------------------------------------------
+
+func TestRoundTrip_NameKeyedToIDKeyedToWire(t *testing.T) {
+	reg := fixtureRegistry(t)
+	in := mustStruct(t, map[string]any{
+		"email":  "rt@example.com",
+		"name":   "Round Trip",
+		"age":    42.0,
+		"active": true,
+	})
+	mid, err := StructToPayload(reg, "User", in)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	out, err := PayloadToStruct(reg, "User", mid)
+	if err != nil {
+		t.Fatalf("PayloadToStruct: %v", err)
+	}
+	// The wire should be id-keyed.
+	keys := out.GetFields()
+	wantKeys := []string{"1", "2", "3", "4"}
+	for _, k := range wantKeys {
+		if _, ok := keys[k]; !ok {
+			t.Fatalf("round-trip missing key %q (got %v)", k, keys)
+		}
+	}
+	if keys["1"].GetStringValue() != "rt@example.com" {
+		t.Fatalf("email round-trip mismatch")
+	}
+	if keys["3"].GetNumberValue() != 42.0 {
+		t.Fatalf("age round-trip mismatch")
+	}
+	if !keys["4"].GetBoolValue() {
+		t.Fatalf("active round-trip mismatch")
+	}
+}
+
+// --- FilterNamesToIDs ----------------------------------------------------
+
+func TestFilterNamesToIDs_TranslatesNames(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := FilterNamesToIDs(reg, "User", map[string]any{
+		"email": "alice@example.com",
+		"age":   42,
+	})
+	if err != nil {
+		t.Fatalf("FilterNamesToIDs: %v", err)
+	}
+	if got[1] != "alice@example.com" {
+		t.Fatalf("expected got[1]=email, got %v", got)
+	}
+	if got[3] != 42 {
+		t.Fatalf("expected got[3]=age, got %v", got)
+	}
+}
+
+func TestFilterNamesToIDs_DigitKeyPassthrough(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := FilterNamesToIDs(reg, "User", map[string]any{
+		"1": "via id",
+	})
+	if err != nil {
+		t.Fatalf("FilterNamesToIDs: %v", err)
+	}
+	if got[1] != "via id" {
+		t.Fatalf("expected got[1]=via id, got %v", got)
+	}
+}
+
+func TestFilterNamesToIDs_UnknownNameIsInvalidArgument(t *testing.T) {
+	reg := fixtureRegistry(t)
+	_, err := FilterNamesToIDs(reg, "User", map[string]any{
+		"ghost": "x",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown filter field")
+	}
+	if !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("expected INVALID_ARGUMENT, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("expected error to mention field name, got %v", err)
+	}
+}
+
+func TestFilterNamesToIDs_UnknownDigitIDIsInvalidArgument(t *testing.T) {
+	reg := fixtureRegistry(t)
+	_, err := FilterNamesToIDs(reg, "User", map[string]any{
+		"999": "x",
+	})
+	if err == nil || !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("expected INVALID_ARGUMENT for unknown digit id, got %v", err)
+	}
+}
+
+func TestFilterNamesToIDs_SchemaLessRequiresDigitKeys(t *testing.T) {
+	got, err := FilterNamesToIDs(nil, "", map[string]any{"1": "x"})
+	if err != nil {
+		t.Fatalf("FilterNamesToIDs(schema-less, digit): %v", err)
+	}
+	if got[1] != "x" {
+		t.Fatalf("expected schema-less digit passthrough, got %v", got)
+	}
+	_, err = FilterNamesToIDs(nil, "", map[string]any{"name": "x"})
+	if err == nil || !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("schema-less + name key should be INVALID_ARGUMENT, got %v", err)
+	}
+}
+
+// --- PayloadJSONToNames --------------------------------------------------
+
+func TestPayloadJSONToNames_TranslatesIDsToNames(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := PayloadJSONToNames(reg, "User", map[uint32]any{
+		1: "alice@example.com",
+		2: "Alice",
+	})
+	if err != nil {
+		t.Fatalf("PayloadJSONToNames: %v", err)
+	}
+	if got["email"] != "alice@example.com" {
+		t.Fatalf("expected email, got %v", got)
+	}
+	if got["name"] != "Alice" {
+		t.Fatalf("expected name, got %v", got)
+	}
+}
+
+func TestPayloadJSONToNames_UnknownIDPreservedAsString(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := PayloadJSONToNames(reg, "User", map[uint32]any{
+		1:   "known",
+		999: "future",
+	})
+	if err != nil {
+		t.Fatalf("PayloadJSONToNames: %v", err)
+	}
+	if got["email"] != "known" {
+		t.Fatalf("expected email=known, got %v", got)
+	}
+	if got["999"] != "future" {
+		t.Fatalf("expected unknown id preserved as decimal-string key, got %v", got)
+	}
+}
+
+func TestPayloadJSONToNames_SchemaLessUsesDecimalKeys(t *testing.T) {
+	got, err := PayloadJSONToNames(nil, "", map[uint32]any{
+		1: "v1",
+		2: "v2",
+	})
+	if err != nil {
+		t.Fatalf("PayloadJSONToNames(schema-less): %v", err)
+	}
+	if got["1"] != "v1" || got["2"] != "v2" {
+		t.Fatalf("expected decimal-keyed map, got %v", got)
+	}
+}
+
+func TestPayloadJSONToNames_EmptyInput(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := PayloadJSONToNames(reg, "User", map[uint32]any{})
+	if err != nil {
+		t.Fatalf("PayloadJSONToNames: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil empty map")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %v", got)
+	}
+}
+
+// PayloadJSONToNames is the inverse of StructToPayload for the
+// schema-aware case (modulo proto Value vs Go any boxing).
+func TestPayloadJSONToNames_InverseOfStructToPayload(t *testing.T) {
+	reg := fixtureRegistry(t)
+	in := mustStruct(t, map[string]any{
+		"email": "round@example.com",
+		"name":  "Round",
+	})
+	mid, err := StructToPayload(reg, "User", in)
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	out, err := PayloadJSONToNames(reg, "User", mid)
+	if err != nil {
+		t.Fatalf("PayloadJSONToNames: %v", err)
+	}
+	if out["email"] != "round@example.com" {
+		t.Fatalf("expected email round-trip, got %v", out)
+	}
+	if out["name"] != "Round" {
+		t.Fatalf("expected name round-trip, got %v", out)
+	}
+}
+
+// --- Schema-less ingress -------------------------------------------------
+
+func TestStructToPayload_SchemaLessDigitKeyPassthrough(t *testing.T) {
+	got, err := StructToPayload(nil, "", mustStruct(t, map[string]any{
+		"1":    "id-keyed",
+		"name": "name-keyed-but-no-schema",
+	}))
+	if err != nil {
+		t.Fatalf("StructToPayload(schema-less): %v", err)
+	}
+	if got[1] != "id-keyed" {
+		t.Fatalf("expected digit passthrough, got %v", got)
+	}
+	if _, ok := got[0]; ok {
+		t.Fatalf("schema-less: name keys should be dropped (no resolver), got %v", got)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d (%v)", len(got), got)
+	}
+}
+
+func TestStructToPayload_UnknownTypeNameSchemaLess(t *testing.T) {
+	reg := fixtureRegistry(t)
+	got, err := StructToPayload(reg, "DoesNotExist", mustStruct(t, map[string]any{
+		"1": "passthrough",
+	}))
+	if err != nil {
+		t.Fatalf("StructToPayload: %v", err)
+	}
+	if got[1] != "passthrough" {
+		t.Fatalf("expected schema-less passthrough for unknown type, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `server/go/internal/payload`, the gRPC-boundary translator between name-keyed `google.protobuf.Struct` payloads (the wire) and id-keyed `map[uint32]any` payloads (storage / WAL events).
- Implements `StructToPayload`, `PayloadToStruct`, `FilterNamesToIDs`, and `PayloadJSONToNames` with kind-aware coercion (bytes/base64, timestamp/integer safe-range, JSON passthrough, enum) plus schema-less fallback.
- Pins CLAUDE.md invariant #6 (field IDs, not field names, on disk): translation happens **only** at this boundary; storage and WAL packages will consume the id-keyed map directly.

Mirrors `server/python/entdb_server/schema/field_id_translation.py`. Test surface mirrors the wire-format invariants asserted by `tests/python/unit/test_grpc_wire_format.py` (id-keyed wire, unknown-name silent drop, field-order independence, empty payload tolerated).

Refs #407. Spec: `docs/go-port/shared/payload-translation.md`.

## Test plan

- [x] `cd server/go && go vet ./...` clean
- [x] `cd server/go && go test ./...` — all packages pass (payload tests cover round-trip, drop-unknown, kind coercion, schema-less, field-id correctness)
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [x] Full Python suite (`tests/python/unit/` + `tests/python/integration/`) — 2529 passed