### PR TITLE
feat(go-rewrite): acl Go package — Wave 1

### DIFF
--- a/server/go/internal/acl/actor.go
+++ b/server/go/internal/acl/actor.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl
+
+import "strings"
+
+// ActorKind enumerates the principal categories valid as ACL grant
+// subjects. Mirrors Principal.parse at
+// server/python/entdb_server/apply/acl.py:80-106 plus the cross-tenant
+// "tenant:" addition from docs/decisions/acl.md (2026-04-13).
+//
+// Note this is a wider set than auth.Kind: the auth interceptor accepts
+// only user/system/admin as caller identities, while ACL grant subjects
+// also include group/role/tenant/service (the latter three never
+// authenticate, but they ARE valid grantees).
+type ActorKind uint8
+
+const (
+	// ActorKindUnknown is the zero value — a parse failure or the empty
+	// actor. Treat as untrusted.
+	ActorKindUnknown ActorKind = iota
+	// ActorKindUser — user:<id>. A specific user.
+	ActorKindUser
+	// ActorKindGroup — group:<id>. Resolved at check time via group_users.
+	ActorKindGroup
+	// ActorKindService — service:<id>. A service account.
+	ActorKindService
+	// ActorKindRole — role:<name>. Reserved; matches() does not expand it.
+	ActorKindRole
+	// ActorKindTenant — tenant:<id> grantee. <id> may be "*" (every
+	// authenticated user in the current tenant) or a specific tenant id
+	// (every authenticated user in tenant <id>; cross-tenant per
+	// docs/decisions/acl.md 2026-04-13).
+	ActorKindTenant
+	// ActorKindSystem — system:<svc>. Bypasses capability checks.
+	ActorKindSystem
+)
+
+// String returns the canonical prefix without the trailing colon.
+// Mirrors the prefix strings used by the Python Principal type.
+func (k ActorKind) String() string {
+	switch k {
+	case ActorKindUser:
+		return "user"
+	case ActorKindGroup:
+		return "group"
+	case ActorKindService:
+		return "service"
+	case ActorKindRole:
+		return "role"
+	case ActorKindTenant:
+		return "tenant"
+	case ActorKindSystem:
+		return "system"
+	default:
+		return "unknown"
+	}
+}
+
+// Actor is a value-typed ACL principal. It is intentionally narrower
+// than auth.Actor — that type is for caller identities the auth
+// interceptor admits, while this type is for grant subjects (which
+// includes group/role/service).
+//
+// The String form is "kind:id", matching the format stored in
+// node_access.actor_id and the ACLEntry.grantee proto field.
+type Actor struct {
+	Kind ActorKind
+	ID   string
+}
+
+// User returns a user:<id> actor.
+func User(id string) Actor { return Actor{Kind: ActorKindUser, ID: id} }
+
+// Group returns a group:<id> actor.
+func Group(id string) Actor { return Actor{Kind: ActorKindGroup, ID: id} }
+
+// Service returns a service:<id> actor.
+func Service(id string) Actor { return Actor{Kind: ActorKindService, ID: id} }
+
+// Role returns a role:<name> actor. Role expansion is a future concern;
+// the current Resolver returns it unchanged.
+func Role(name string) Actor { return Actor{Kind: ActorKindRole, ID: name} }
+
+// Tenant returns a tenant:<id> actor. Use TenantWildcard for the
+// current-tenant wildcard.
+func Tenant(id string) Actor { return Actor{Kind: ActorKindTenant, ID: id} }
+
+// TenantWildcard returns the tenant:* actor — every authenticated user
+// in the current tenant. Matches the wildcard handled at
+// canonical_store.py:2887 and acl.py:127-129.
+func TenantWildcard() Actor { return Actor{Kind: ActorKindTenant, ID: "*"} }
+
+// System returns a system:<svc> actor.
+func System(svc string) Actor { return Actor{Kind: ActorKindSystem, ID: svc} }
+
+// IsZero reports whether a is the zero value.
+func (a Actor) IsZero() bool { return a.Kind == ActorKindUnknown && a.ID == "" }
+
+// IsUser reports whether the actor is a user:<id>.
+func (a Actor) IsUser() bool { return a.Kind == ActorKindUser }
+
+// IsGroup reports whether the actor is a group:<id>.
+func (a Actor) IsGroup() bool { return a.Kind == ActorKindGroup }
+
+// IsTenantWildcard reports whether the actor is tenant:*.
+func (a Actor) IsTenantWildcard() bool {
+	return a.Kind == ActorKindTenant && a.ID == "*"
+}
+
+// IsSystem reports whether the actor is a system:<svc>. System actors
+// bypass capability checks (mirrors canonical_store.py:2883-2884).
+func (a Actor) IsSystem() bool { return a.Kind == ActorKindSystem }
+
+// String renders the actor as "kind:id". For the zero value returns "".
+func (a Actor) String() string {
+	if a.IsZero() {
+		return ""
+	}
+	if a.Kind == ActorKindUnknown {
+		return a.ID
+	}
+	return a.Kind.String() + ":" + a.ID
+}
+
+// ParseActor parses a "kind:id" string. Empty input returns the zero
+// Actor. An unknown prefix yields ActorKindUnknown with the raw string
+// preserved as ID.
+func ParseActor(s string) Actor {
+	if s == "" {
+		return Actor{}
+	}
+	idx := strings.IndexByte(s, ':')
+	if idx <= 0 || idx == len(s)-1 {
+		return Actor{Kind: ActorKindUnknown, ID: s}
+	}
+	prefix, id := s[:idx], s[idx+1:]
+	switch prefix {
+	case "user":
+		return Actor{Kind: ActorKindUser, ID: id}
+	case "group":
+		return Actor{Kind: ActorKindGroup, ID: id}
+	case "service":
+		return Actor{Kind: ActorKindService, ID: id}
+	case "role":
+		return Actor{Kind: ActorKindRole, ID: id}
+	case "tenant":
+		return Actor{Kind: ActorKindTenant, ID: id}
+	case "system":
+		return Actor{Kind: ActorKindSystem, ID: id}
+	default:
+		return Actor{Kind: ActorKindUnknown, ID: s}
+	}
+}

--- a/server/go/internal/acl/actor_test.go
+++ b/server/go/internal/acl/actor_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+)
+
+func TestActorString(t *testing.T) {
+	cases := []struct {
+		a    acl.Actor
+		want string
+	}{
+		{acl.User("alice"), "user:alice"},
+		{acl.Group("eng"), "group:eng"},
+		{acl.Service("svc1"), "service:svc1"},
+		{acl.Role("admin"), "role:admin"},
+		{acl.Tenant("acme"), "tenant:acme"},
+		{acl.TenantWildcard(), "tenant:*"},
+		{acl.System("applier"), "system:applier"},
+		{acl.Actor{}, ""},
+	}
+	for _, c := range cases {
+		if got := c.a.String(); got != c.want {
+			t.Fatalf("String(%+v) = %q, want %q", c.a, got, c.want)
+		}
+	}
+}
+
+func TestParseActor(t *testing.T) {
+	cases := []struct {
+		in   string
+		want acl.Actor
+	}{
+		{"", acl.Actor{}},
+		{"user:alice", acl.User("alice")},
+		{"group:eng", acl.Group("eng")},
+		{"tenant:*", acl.TenantWildcard()},
+		{"tenant:acme", acl.Tenant("acme")},
+		{"system:applier", acl.System("applier")},
+		{"service:svc1", acl.Service("svc1")},
+		{"role:admin", acl.Role("admin")},
+	}
+	for _, c := range cases {
+		got := acl.ParseActor(c.in)
+		if got != c.want {
+			t.Fatalf("ParseActor(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+	}
+	// Malformed inputs preserve the raw string.
+	got := acl.ParseActor("garbage")
+	if got.Kind != acl.ActorKindUnknown || got.ID != "garbage" {
+		t.Fatalf("ParseActor(garbage) = %+v, want unknown/garbage", got)
+	}
+	// Trailing colon = malformed.
+	got = acl.ParseActor("user:")
+	if got.Kind != acl.ActorKindUnknown {
+		t.Fatalf("ParseActor(user:) classified as %v, want Unknown", got.Kind)
+	}
+	// Unknown prefix.
+	got = acl.ParseActor("alien:42")
+	if got.Kind != acl.ActorKindUnknown {
+		t.Fatalf("ParseActor(alien:42) classified as %v, want Unknown", got.Kind)
+	}
+}
+
+func TestActorPredicates(t *testing.T) {
+	if !acl.User("a").IsUser() {
+		t.Fatalf("User.IsUser")
+	}
+	if !acl.Group("g").IsGroup() {
+		t.Fatalf("Group.IsGroup")
+	}
+	if !acl.System("s").IsSystem() {
+		t.Fatalf("System.IsSystem")
+	}
+	if !acl.TenantWildcard().IsTenantWildcard() {
+		t.Fatalf("TenantWildcard.IsTenantWildcard")
+	}
+	if acl.Tenant("acme").IsTenantWildcard() {
+		t.Fatalf("tenant:acme should not be tenant wildcard")
+	}
+	if !(acl.Actor{}).IsZero() {
+		t.Fatalf("zero Actor should IsZero()")
+	}
+}

--- a/server/go/internal/acl/capability.go
+++ b/server/go/internal/acl/capability.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl
+
+// CoreCapability is the typed-capability enum frozen in
+// docs/decisions/acl.md (2026-04-13). Wire-stable: integer values MUST
+// match entdb.v1.CoreCapability and the Python CoreCapability IntEnum
+// at server/python/entdb_server/auth/capability_registry.py:42-55.
+type CoreCapability uint8
+
+const (
+	// CoreCapUnspecified is the zero value. Treated as "no requirement"
+	// by Registry.RequiredForOp and "no grant" by CheckGrant.
+	CoreCapUnspecified CoreCapability = 0
+	// CoreCapRead — can see the node.
+	CoreCapRead CoreCapability = 1
+	// CoreCapComment — can create child Comment nodes. Implies READ.
+	CoreCapComment CoreCapability = 2
+	// CoreCapEdit — can update node fields. Implies READ, COMMENT.
+	CoreCapEdit CoreCapability = 3
+	// CoreCapDelete — can delete the node.
+	CoreCapDelete CoreCapability = 4
+	// CoreCapAdmin — can manage ACL + everything else. Supremum.
+	CoreCapAdmin CoreCapability = 5
+)
+
+// String returns the wire-stable name for a CoreCapability. Mirrors
+// the Python enum value names.
+func (c CoreCapability) String() string {
+	switch c {
+	case CoreCapUnspecified:
+		return "CORE_CAP_UNSPECIFIED"
+	case CoreCapRead:
+		return "CORE_CAP_READ"
+	case CoreCapComment:
+		return "CORE_CAP_COMMENT"
+	case CoreCapEdit:
+		return "CORE_CAP_EDIT"
+	case CoreCapDelete:
+		return "CORE_CAP_DELETE"
+	case CoreCapAdmin:
+		return "CORE_CAP_ADMIN"
+	default:
+		return "CORE_CAP_UNKNOWN"
+	}
+}
+
+// ExtCapID is an opaque per-type extension capability identifier. Its
+// meaning is type-scoped — see docs/decisions/acl.md "Layer 2".
+type ExtCapID int32
+
+// CoreImplications is the built-in core implication hierarchy, mirroring
+// CORE_IMPLICATIONS at capability_registry.py:80-94. Used by the
+// per-type closure builder; consumers go through Registry instead.
+var CoreImplications = map[CoreCapability][]CoreCapability{
+	CoreCapAdmin: {
+		CoreCapRead,
+		CoreCapComment,
+		CoreCapEdit,
+		CoreCapDelete,
+	},
+	CoreCapEdit: {
+		CoreCapRead,
+		CoreCapComment,
+	},
+	CoreCapComment: {
+		CoreCapRead,
+	},
+}
+
+// LegacyToCoreCaps maps a legacy Permission to the typed CoreCapability
+// list a grant of that permission implies. Mirrors
+// CapabilityRegistry.legacy_permission_to_core_caps at
+// capability_registry.py:357-389.
+//
+// Used by the wire compatibility shim on ShareNode and the
+// _migrate_permissions_to_capabilities back-fill at
+// canonical_store.py:3054.
+//
+//   - PermDeny → [] (deny grants no positive caps; the deny row itself
+//     is recognised by the ACL query path).
+//   - PermRead → [READ]
+//   - PermComment → [READ, COMMENT]
+//   - PermWrite → [READ, COMMENT, EDIT]
+//   - PermShare → [ADMIN] (collapses; SHARE is not a CoreCapability)
+//   - PermDelete → [READ, COMMENT, EDIT, DELETE]
+//   - PermAdmin → [ADMIN]
+func LegacyToCoreCaps(p Permission) []CoreCapability {
+	switch p {
+	case PermDeny:
+		return nil
+	case PermRead:
+		return []CoreCapability{CoreCapRead}
+	case PermComment:
+		return []CoreCapability{CoreCapRead, CoreCapComment}
+	case PermWrite:
+		return []CoreCapability{CoreCapRead, CoreCapComment, CoreCapEdit}
+	case PermShare:
+		return []CoreCapability{CoreCapAdmin}
+	case PermDelete:
+		return []CoreCapability{
+			CoreCapRead, CoreCapComment, CoreCapEdit, CoreCapDelete,
+		}
+	case PermAdmin:
+		return []CoreCapability{CoreCapAdmin}
+	default:
+		return nil
+	}
+}

--- a/server/go/internal/acl/checker.go
+++ b/server/go/internal/acl/checker.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// NodeMeta is the minimal node metadata the Checker needs to evaluate
+// a same-tenant grant: owner + type id. Returned by NodeMetaReader.
+type NodeMeta struct {
+	OwnerActor string // canonical "kind:id" form, e.g. "user:alice"
+	TypeID     int32
+}
+
+// NodeMetaReader resolves a (tenant, node) to its owner + type id. The
+// production binding wraps store.CanonicalStore.GetNode; tests provide
+// an in-memory shim. NotFound is signalled by returning errs.ErrNotFound.
+type NodeMetaReader interface {
+	NodeMeta(ctx context.Context, tenantID, nodeID string) (NodeMeta, error)
+}
+
+// GrantReader returns the grants on a single node. It MUST include
+// expired rows (the Checker drops them) so a future migration can
+// surface "expired but not yet swept" rows as a metric. Cross-tenant
+// callers can supply a CrossTenantGrantReader in addition.
+type GrantReader interface {
+	GrantsForNode(ctx context.Context, tenantID, nodeID string) ([]Grant, error)
+}
+
+// CrossTenantGrantReader is the cross-tenant slice. It is consulted
+// only when the same-tenant Checker.Check fails AND the actor is
+// foreign (different tenant than nodeTenant). Mirrors the
+// global_store.shared_index lookup at grpc_server.py:338,1892-1933.
+//
+// Returns the typed permission for (foreignActor, sourceTenant, nodeID)
+// or (PermDeny, false) when the row is absent. The Checker treats a
+// hit as "allow READ"; richer cross-tenant typed-cap grants are a
+// future concern (decision doc 2026-04-13).
+type CrossTenantGrantReader interface {
+	CrossTenantGrant(ctx context.Context, sourceTenant, nodeID, foreignActor string) (Permission, bool, error)
+}
+
+// Checker answers single-node authorization questions. Mirrors the
+// per-handler _check_capability call site at
+// server/python/entdb_server/api/grpc_server.py:299-360 plus the
+// _sync_can_access core at canonical_store.py:2867-2946.
+//
+// A Checker is built once per server and shared across handlers; it
+// holds no per-request state. All accessors are concurrency-safe to
+// the extent that the underlying readers are.
+type Checker struct {
+	registry *Registry
+	resolver *Resolver
+	nodes    NodeMetaReader
+	grants   GrantReader
+	xt       CrossTenantGrantReader
+
+	nowFn func() int64
+}
+
+// CheckerOptions configures a Checker. All non-nil readers are
+// required for production wiring; tests can omit cross-tenant by
+// leaving XT nil.
+type CheckerOptions struct {
+	Registry    *Registry
+	Resolver    *Resolver
+	Nodes       NodeMetaReader
+	Grants      GrantReader
+	CrossTenant CrossTenantGrantReader // optional
+	NowFn       func() int64           // optional, defaults to nil (no expiry filtering)
+}
+
+// NewChecker constructs a Checker. Required: Registry, Resolver,
+// Nodes, Grants. Returns an error if any required reader is nil.
+func NewChecker(opts CheckerOptions) (*Checker, error) {
+	if opts.Registry == nil {
+		return nil, fmt.Errorf("acl: NewChecker: Registry is required")
+	}
+	if opts.Resolver == nil {
+		return nil, fmt.Errorf("acl: NewChecker: Resolver is required")
+	}
+	if opts.Nodes == nil {
+		return nil, fmt.Errorf("acl: NewChecker: Nodes reader is required")
+	}
+	if opts.Grants == nil {
+		return nil, fmt.Errorf("acl: NewChecker: Grants reader is required")
+	}
+	return &Checker{
+		registry: opts.Registry,
+		resolver: opts.Resolver,
+		nodes:    opts.Nodes,
+		grants:   opts.Grants,
+		xt:       opts.CrossTenant,
+		nowFn:    opts.NowFn,
+	}, nil
+}
+
+// CheckRequest is the input to Checker.Check. TenantID is the tenant
+// the node lives in (the OWNER tenant, not necessarily the caller's).
+// ActorTenantID is the caller's tenant — used to determine same-tenant
+// vs cross-tenant. When equal to TenantID, only the same-tenant path
+// runs; otherwise the cross-tenant fallback is consulted.
+type CheckRequest struct {
+	TenantID      string
+	ActorTenantID string
+	Actor         Actor
+	NodeID        string
+	OpName        string
+	Field         string
+	FieldValue    string
+	ChildType     string
+}
+
+// Check returns nil if Actor has the capability required by OpName on
+// NodeID, or errs.ErrPermission otherwise. NotFound from the underlying
+// node lookup propagates unchanged.
+//
+// Algorithm (mirrors _check_capability + _sync_can_access):
+//
+//  1. System actors short-circuit allow.
+//  2. Resolve the node's type_id and owner. Owner is always allowed.
+//  3. Resolve the actor's group memberships (depth-bounded).
+//  4. Look up RequiredForOp(typeID, op, ...). No requirement → allow.
+//  5. Walk node grants:
+//     a. If any DENY row matches the resolved actor set → deny.
+//     b. If any allow row's typed caps satisfy the requirement → allow.
+//  6. Same-tenant fall-through is a deny.
+//  7. Cross-tenant: if ActorTenantID != TenantID and a CrossTenantGrantReader
+//     is configured, ask it for an allow row keyed on the caller's
+//     Actor (string form). A hit with READ-implying perm satisfies
+//     CoreCapRead requirements only; ADMIN cross-tenant grants
+//     satisfy everything via LegacyToCoreCaps + CheckGrant.
+func (c *Checker) Check(ctx context.Context, req CheckRequest) error {
+	if req.Actor.IsSystem() {
+		return nil
+	}
+	if req.Actor.IsZero() || req.NodeID == "" {
+		return errs.Errorf(codes.InvalidArgument, "acl: Check: actor and node_id required")
+	}
+	meta, err := c.nodes.NodeMeta(ctx, req.TenantID, req.NodeID)
+	if err != nil {
+		return err
+	}
+
+	// Resolve actor + groups, but only for same-tenant. Cross-tenant
+	// callers don't (yet) get group-membership lookups against the
+	// owner tenant.
+	var resolved []Actor
+	sameTenant := req.ActorTenantID == "" || req.ActorTenantID == req.TenantID
+	if sameTenant {
+		resolved, err = c.resolver.Expand(ctx, req.TenantID, req.Actor)
+		if err != nil {
+			return err
+		}
+	} else {
+		resolved = []Actor{req.Actor, TenantWildcardForTenant(req.ActorTenantID)}
+	}
+
+	// Owner short-circuit (canonical_store.py:2920) — owner_actor in
+	// the resolved set means allow. Compare via canonical string form.
+	if meta.OwnerActor != "" {
+		for _, a := range resolved {
+			if a.String() == meta.OwnerActor {
+				return nil
+			}
+		}
+	}
+
+	requiredCore, requiredExt := c.registry.RequiredForOp(meta.TypeID, req.OpName, OpQuery{
+		Field:      req.Field,
+		FieldValue: req.FieldValue,
+		ChildType:  req.ChildType,
+	})
+	if requiredCore == CoreCapUnspecified && requiredExt == 0 {
+		// No requirement registered — allow. This matches the Python
+		// (None, None) → allow contract at capability_registry.py:267.
+		return nil
+	}
+
+	grants, err := c.grants.GrantsForNode(ctx, req.TenantID, req.NodeID)
+	if err != nil {
+		return err
+	}
+
+	resolvedSet := map[string]struct{}{}
+	for _, a := range resolved {
+		resolvedSet[a.String()] = struct{}{}
+	}
+	// tenant:* matches any same-tenant caller (acl.py:127-129).
+	if sameTenant {
+		resolvedSet[TenantWildcard().String()] = struct{}{}
+	}
+
+	now := c.now()
+	// First pass: explicit DENY wins (acl.py:243-264, canonical_store.py:2893).
+	for _, g := range grants {
+		if !g.IsDeny() {
+			continue
+		}
+		if _, ok := resolvedSet[g.Subject.String()]; !ok {
+			continue
+		}
+		if g.IsExpired(now) {
+			continue
+		}
+		return errs.Errorf(codes.PermissionDenied,
+			"acl: actor %s denied on node %s/%s by explicit DENY",
+			req.Actor, req.TenantID, req.NodeID)
+	}
+	// Second pass: any matching grant whose typed caps satisfy req → allow.
+	for _, g := range grants {
+		if g.IsDeny() {
+			continue
+		}
+		if g.IsExpired(now) {
+			continue
+		}
+		if _, ok := resolvedSet[g.Subject.String()]; !ok {
+			continue
+		}
+		grantCore := g.EffectiveCoreCaps()
+		grantTypeID := g.TypeID
+		if grantTypeID == 0 {
+			grantTypeID = meta.TypeID
+		}
+		if c.registry.CheckGrant(grantCore, g.ExtCapIDs, requiredCore, requiredExt, grantTypeID) {
+			return nil
+		}
+	}
+
+	// Cross-tenant fallback.
+	if !sameTenant && c.xt != nil {
+		perm, ok, err := c.xt.CrossTenantGrant(ctx, req.TenantID, req.NodeID, req.Actor.String())
+		if err != nil {
+			return err
+		}
+		if ok {
+			grantCore := LegacyToCoreCaps(perm)
+			if c.registry.CheckGrant(grantCore, nil, requiredCore, requiredExt, meta.TypeID) {
+				return nil
+			}
+		}
+	}
+
+	return errs.Errorf(codes.PermissionDenied,
+		"acl: actor %s lacks %s on node %s/%s",
+		req.Actor, capabilityLabel(requiredCore, requiredExt),
+		req.TenantID, req.NodeID)
+}
+
+// TenantWildcardForTenant returns the cross-tenant grantee for a given
+// tenant id. Per docs/decisions/acl.md (2026-04-13): a grant to
+// tenant:<id> matches any authenticated caller from tenant <id>.
+func TenantWildcardForTenant(tenantID string) Actor {
+	return Actor{Kind: ActorKindTenant, ID: tenantID}
+}
+
+func capabilityLabel(core CoreCapability, ext ExtCapID) string {
+	if core != CoreCapUnspecified {
+		return core.String()
+	}
+	if ext != 0 {
+		return fmt.Sprintf("ext:%d", ext)
+	}
+	return "ANY"
+}
+
+func (c *Checker) now() int64 {
+	if c.nowFn == nil {
+		return 0
+	}
+	return c.nowFn()
+}

--- a/server/go/internal/acl/checker_test.go
+++ b/server/go/internal/acl/checker_test.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// fakeNodes is an in-memory NodeMetaReader.
+type fakeNodes struct {
+	meta map[string]acl.NodeMeta // key = "tenant/node"
+}
+
+func (f *fakeNodes) NodeMeta(_ context.Context, tenant, node string) (acl.NodeMeta, error) {
+	m, ok := f.meta[tenant+"/"+node]
+	if !ok {
+		return acl.NodeMeta{}, errs.Errorf(codes.NotFound,
+			"acl_test: node %s/%s not found", tenant, node)
+	}
+	return m, nil
+}
+
+// fakeGrants is an in-memory GrantReader.
+type fakeGrants struct {
+	rows map[string][]acl.Grant // key = "tenant/node"
+}
+
+func (f *fakeGrants) GrantsForNode(_ context.Context, tenant, node string) ([]acl.Grant, error) {
+	return f.rows[tenant+"/"+node], nil
+}
+
+// fakeXT is an in-memory CrossTenantGrantReader.
+type fakeXT struct {
+	rows map[string]acl.Permission // key = "tenant/node/actor"
+}
+
+func (f *fakeXT) CrossTenantGrant(_ context.Context, tenant, node, actor string) (acl.Permission, bool, error) {
+	p, ok := f.rows[tenant+"/"+node+"/"+actor]
+	return p, ok, nil
+}
+
+// newCheckerWithFixtures builds a Checker with empty fakes; callers
+// populate them.
+func newCheckerWithFixtures(t *testing.T, groups *fakeGroups, nodes *fakeNodes, grants *fakeGrants, xt *fakeXT, nowFn func() int64) *acl.Checker {
+	t.Helper()
+	r := acl.NewRegistry()
+	res := acl.NewResolver(groups)
+	c, err := acl.NewChecker(acl.CheckerOptions{
+		Registry:    r,
+		Resolver:    res,
+		Nodes:       nodes,
+		Grants:      grants,
+		CrossTenant: xt,
+		NowFn:       nowFn,
+	})
+	if err != nil {
+		t.Fatalf("NewChecker: %v", err)
+	}
+	return c
+}
+
+func TestCheckerSystemBypass(t *testing.T) {
+	c := newCheckerWithFixtures(t, &fakeGroups{}, &fakeNodes{}, &fakeGrants{}, nil, nil)
+	// System actor returns nil even without any setup.
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.System("applier"), NodeID: "n1", OpName: "DeleteNode",
+	})
+	if err != nil {
+		t.Fatalf("system bypass: %v", err)
+	}
+}
+
+func TestCheckerOwnerAlwaysAllowed(t *testing.T) {
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	c := newCheckerWithFixtures(t, &fakeGroups{}, nodes, &fakeGrants{}, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("alice"), NodeID: "n1", OpName: "DeleteNode",
+	})
+	if err != nil {
+		t.Fatalf("owner check: %v", err)
+	}
+}
+
+func TestCheckerNonOwnerNoGrantsDenied(t *testing.T) {
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	c := newCheckerWithFixtures(t, &fakeGroups{}, nodes, &fakeGrants{}, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("bob"), NodeID: "n1", OpName: "GetNode",
+	})
+	if err == nil {
+		t.Fatalf("non-owner with no grants should be denied")
+	}
+	if !errors.Is(err, errs.ErrPermission) {
+		t.Fatalf("err = %v, want errs.ErrPermission", err)
+	}
+}
+
+func TestCheckerDirectGrantAllows(t *testing.T) {
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	grants := &fakeGrants{rows: map[string][]acl.Grant{
+		"t1/n1": {
+			{Subject: acl.User("bob"), NodeID: "n1", Permission: acl.PermRead},
+		},
+	}}
+	c := newCheckerWithFixtures(t, &fakeGroups{}, nodes, grants, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("bob"), NodeID: "n1", OpName: "GetNode",
+	})
+	if err != nil {
+		t.Fatalf("direct READ grant: %v", err)
+	}
+	// Same READ grant should NOT permit DeleteNode (DELETE).
+	err = c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("bob"), NodeID: "n1", OpName: "DeleteNode",
+	})
+	if err == nil {
+		t.Fatalf("READ grant should not satisfy DELETE")
+	}
+	if !errors.Is(err, errs.ErrPermission) {
+		t.Fatalf("err = %v, want errs.ErrPermission", err)
+	}
+}
+
+func TestCheckerExplicitDenyOverrides(t *testing.T) {
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	grants := &fakeGrants{rows: map[string][]acl.Grant{
+		"t1/n1": {
+			// Allow grant first.
+			{Subject: acl.User("bob"), Permission: acl.PermAdmin},
+			// Explicit deny — wins regardless of position.
+			{Subject: acl.User("bob"), Permission: acl.PermDeny},
+		},
+	}}
+	c := newCheckerWithFixtures(t, &fakeGroups{}, nodes, grants, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("bob"), NodeID: "n1", OpName: "GetNode",
+	})
+	if !errors.Is(err, errs.ErrPermission) {
+		t.Fatalf("DENY should win, got %v", err)
+	}
+}
+
+func TestCheckerGroupGrantInherited(t *testing.T) {
+	// Grant on group:eng. user:bob ∈ eng.
+	groups := &fakeGroups{parents: map[string][]string{
+		"user:bob": {"eng"},
+	}}
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	grants := &fakeGrants{rows: map[string][]acl.Grant{
+		"t1/n1": {
+			{Subject: acl.Group("eng"), Permission: acl.PermRead},
+		},
+	}}
+	c := newCheckerWithFixtures(t, groups, nodes, grants, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("bob"), NodeID: "n1", OpName: "GetNode",
+	})
+	if err != nil {
+		t.Fatalf("group-inherited grant: %v", err)
+	}
+	// alice (not in eng) is also denied (she's the owner — owner short-circuit).
+	// Use carol who is unrelated.
+	err = c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("carol"), NodeID: "n1", OpName: "GetNode",
+	})
+	if !errors.Is(err, errs.ErrPermission) {
+		t.Fatalf("non-member should be denied, got %v", err)
+	}
+}
+
+func TestCheckerExpiredGrantIgnored(t *testing.T) {
+	pastMs := int64(1000)
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	grants := &fakeGrants{rows: map[string][]acl.Grant{
+		"t1/n1": {
+			{Subject: acl.User("bob"), Permission: acl.PermAdmin, ExpiresAt: &pastMs},
+		},
+	}}
+	c := newCheckerWithFixtures(t, &fakeGroups{}, nodes, grants, nil, func() int64 { return 9999 })
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("bob"), NodeID: "n1", OpName: "GetNode",
+	})
+	if !errors.Is(err, errs.ErrPermission) {
+		t.Fatalf("expired grant should not allow, got %v", err)
+	}
+}
+
+func TestCheckerTenantWildcardGrant(t *testing.T) {
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	grants := &fakeGrants{rows: map[string][]acl.Grant{
+		"t1/n1": {
+			{Subject: acl.TenantWildcard(), Permission: acl.PermRead},
+		},
+	}}
+	c := newCheckerWithFixtures(t, &fakeGroups{}, nodes, grants, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("bob"), NodeID: "n1", OpName: "GetNode",
+	})
+	if err != nil {
+		t.Fatalf("tenant:* should grant READ to any same-tenant user: %v", err)
+	}
+}
+
+func TestCheckerCrossTenantGrant(t *testing.T) {
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"acme/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	grants := &fakeGrants{rows: map[string][]acl.Grant{}}
+	xt := &fakeXT{rows: map[string]acl.Permission{
+		"acme/n1/user:carol": acl.PermRead,
+	}}
+	c := newCheckerWithFixtures(t, &fakeGroups{}, nodes, grants, xt, nil)
+	// carol is in tenant "beta" reading from "acme".
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID:      "acme",
+		ActorTenantID: "beta",
+		Actor:         acl.User("carol"),
+		NodeID:        "n1",
+		OpName:        "GetNode",
+	})
+	if err != nil {
+		t.Fatalf("cross-tenant READ: %v", err)
+	}
+	// But cross-tenant READ does not allow DELETE.
+	err = c.Check(context.Background(), acl.CheckRequest{
+		TenantID:      "acme",
+		ActorTenantID: "beta",
+		Actor:         acl.User("carol"),
+		NodeID:        "n1",
+		OpName:        "DeleteNode",
+	})
+	if !errors.Is(err, errs.ErrPermission) {
+		t.Fatalf("cross-tenant READ should not satisfy DELETE, got %v", err)
+	}
+}
+
+func TestCheckerOpWithoutDefaultAllows(t *testing.T) {
+	// CreateNode is intentionally absent from DefaultOpRequirements —
+	// no per-node check applies (capability_registry.py:60-61).
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	c := newCheckerWithFixtures(t, &fakeGroups{}, nodes, &fakeGrants{}, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("carol"), NodeID: "n1", OpName: "CreateNode",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode (no requirement) should allow: %v", err)
+	}
+}
+
+func TestCheckerEmptyActorRejected(t *testing.T) {
+	c := newCheckerWithFixtures(t, &fakeGroups{}, &fakeNodes{}, &fakeGrants{}, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", NodeID: "n1", OpName: "GetNode",
+	})
+	if !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("empty actor should err InvalidArgument, got %v", err)
+	}
+}
+
+func TestCheckerNodeNotFoundPropagates(t *testing.T) {
+	c := newCheckerWithFixtures(t, &fakeGroups{}, &fakeNodes{meta: map[string]acl.NodeMeta{}}, &fakeGrants{}, nil, nil)
+	err := c.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("alice"), NodeID: "missing", OpName: "GetNode",
+	})
+	if !errors.Is(err, errs.ErrNotFound) {
+		t.Fatalf("missing node should propagate NotFound, got %v", err)
+	}
+}
+
+func TestNewCheckerValidatesArgs(t *testing.T) {
+	r := acl.NewRegistry()
+	res := acl.NewResolver(nil)
+	for _, tc := range []struct {
+		name string
+		opts acl.CheckerOptions
+	}{
+		{"missing registry", acl.CheckerOptions{Resolver: res, Nodes: &fakeNodes{}, Grants: &fakeGrants{}}},
+		{"missing resolver", acl.CheckerOptions{Registry: r, Nodes: &fakeNodes{}, Grants: &fakeGrants{}}},
+		{"missing nodes", acl.CheckerOptions{Registry: r, Resolver: res, Grants: &fakeGrants{}}},
+		{"missing grants", acl.CheckerOptions{Registry: r, Resolver: res, Nodes: &fakeNodes{}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := acl.NewChecker(tc.opts); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/server/go/internal/acl/enforcer.go
+++ b/server/go/internal/acl/enforcer.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl
+
+import (
+	"context"
+	"fmt"
+)
+
+// Enforcer is the top-level ACL facade. One Enforcer per server; it
+// owns the Registry, Resolver, Checker and Filter. Mirrors the role
+// of AclManager + CapabilityRegistry + canonical_store ACL helpers in
+// the Python server.
+//
+// Handlers in server/go/internal/api do not call Resolver / Checker /
+// Filter directly — they go through Enforcer so the (registry,
+// resolver, readers) wiring stays in one place and is exchangable in
+// tests.
+type Enforcer struct {
+	registry *Registry
+	resolver *Resolver
+	checker  *Checker
+	filter   *Filter
+}
+
+// EnforcerOptions wires an Enforcer. Registry, Resolver, Checker and
+// Filter are all required. Any nil field returns an error.
+type EnforcerOptions struct {
+	Registry *Registry
+	Resolver *Resolver
+	Checker  *Checker
+	Filter   *Filter
+}
+
+// NewEnforcer constructs an Enforcer.
+func NewEnforcer(opts EnforcerOptions) (*Enforcer, error) {
+	if opts.Registry == nil {
+		return nil, fmt.Errorf("acl: NewEnforcer: Registry required")
+	}
+	if opts.Resolver == nil {
+		return nil, fmt.Errorf("acl: NewEnforcer: Resolver required")
+	}
+	if opts.Checker == nil {
+		return nil, fmt.Errorf("acl: NewEnforcer: Checker required")
+	}
+	if opts.Filter == nil {
+		return nil, fmt.Errorf("acl: NewEnforcer: Filter required")
+	}
+	return &Enforcer{
+		registry: opts.Registry,
+		resolver: opts.Resolver,
+		checker:  opts.Checker,
+		filter:   opts.Filter,
+	}, nil
+}
+
+// Registry returns the registry the Enforcer was built with.
+func (e *Enforcer) Registry() *Registry { return e.registry }
+
+// Resolver returns the resolver the Enforcer was built with.
+func (e *Enforcer) Resolver() *Resolver { return e.resolver }
+
+// Check delegates to the Checker. See CheckRequest for the input shape.
+func (e *Enforcer) Check(ctx context.Context, req CheckRequest) error {
+	return e.checker.Check(ctx, req)
+}
+
+// FilterReadable delegates to the Filter.
+func (e *Enforcer) FilterReadable(ctx context.Context, tenantID string, a Actor, nodeIDs []string) ([]string, error) {
+	return e.filter.FilterReadable(ctx, tenantID, a, nodeIDs)
+}
+
+// Expand delegates to the Resolver.
+func (e *Enforcer) Expand(ctx context.Context, tenantID string, a Actor) ([]Actor, error) {
+	return e.resolver.Expand(ctx, tenantID, a)
+}
+
+// RequiredForOp delegates to the Registry.
+func (e *Enforcer) RequiredForOp(typeID int32, op string, q OpQuery) (CoreCapability, ExtCapID) {
+	return e.registry.RequiredForOp(typeID, op, q)
+}
+
+// LegacyToCoreCaps delegates to the package-level helper.
+func (e *Enforcer) LegacyToCoreCaps(p Permission) []CoreCapability {
+	return LegacyToCoreCaps(p)
+}

--- a/server/go/internal/acl/enforcer_test.go
+++ b/server/go/internal/acl/enforcer_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+)
+
+func TestEnforcerWiring(t *testing.T) {
+	r := acl.NewRegistry()
+	res := acl.NewResolver(nil)
+	nodes := &fakeNodes{meta: map[string]acl.NodeMeta{
+		"t1/n1": {OwnerActor: "user:alice", TypeID: 0},
+	}}
+	c, err := acl.NewChecker(acl.CheckerOptions{
+		Registry: r, Resolver: res, Nodes: nodes, Grants: &fakeGrants{},
+	})
+	if err != nil {
+		t.Fatalf("NewChecker: %v", err)
+	}
+	f := acl.NewFilter(res, &fakeVis{
+		owners: map[string]string{"n1": "user:alice"},
+	})
+	enf, err := acl.NewEnforcer(acl.EnforcerOptions{
+		Registry: r, Resolver: res, Checker: c, Filter: f,
+	})
+	if err != nil {
+		t.Fatalf("NewEnforcer: %v", err)
+	}
+	// Check delegation.
+	if err := enf.Check(context.Background(), acl.CheckRequest{
+		TenantID: "t1", Actor: acl.User("alice"), NodeID: "n1", OpName: "DeleteNode",
+	}); err != nil {
+		t.Fatalf("Enforcer.Check: %v", err)
+	}
+	// FilterReadable delegation.
+	got, err := enf.FilterReadable(context.Background(), "t1", acl.User("alice"), []string{"n1"})
+	if err != nil || len(got) != 1 {
+		t.Fatalf("Enforcer.FilterReadable = %v err=%v", got, err)
+	}
+	// Expand delegation.
+	exp, err := enf.Expand(context.Background(), "t1", acl.User("alice"))
+	if err != nil || len(exp) != 1 {
+		t.Fatalf("Enforcer.Expand = %v err=%v", exp, err)
+	}
+	// RequiredForOp delegation.
+	core, ext := enf.RequiredForOp(0, "GetNode", acl.OpQuery{})
+	if core != acl.CoreCapRead || ext != 0 {
+		t.Fatalf("Enforcer.RequiredForOp = (%v,%v), want (READ,0)", core, ext)
+	}
+	// LegacyToCoreCaps delegation.
+	caps := enf.LegacyToCoreCaps(acl.PermAdmin)
+	if len(caps) != 1 || caps[0] != acl.CoreCapAdmin {
+		t.Fatalf("Enforcer.LegacyToCoreCaps(ADMIN) = %v", caps)
+	}
+}
+
+func TestNewEnforcerValidates(t *testing.T) {
+	r := acl.NewRegistry()
+	res := acl.NewResolver(nil)
+	c, _ := acl.NewChecker(acl.CheckerOptions{
+		Registry: r, Resolver: res, Nodes: &fakeNodes{}, Grants: &fakeGrants{},
+	})
+	f := acl.NewFilter(res, &fakeVis{})
+	cases := []struct {
+		name string
+		opts acl.EnforcerOptions
+	}{
+		{"missing registry", acl.EnforcerOptions{Resolver: res, Checker: c, Filter: f}},
+		{"missing resolver", acl.EnforcerOptions{Registry: r, Checker: c, Filter: f}},
+		{"missing checker", acl.EnforcerOptions{Registry: r, Resolver: res, Filter: f}},
+		{"missing filter", acl.EnforcerOptions{Registry: r, Resolver: res, Checker: c}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := acl.NewEnforcer(tc.opts); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/server/go/internal/acl/filter.go
+++ b/server/go/internal/acl/filter.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl
+
+import (
+	"context"
+)
+
+// VisibilityReader is the bulk read-path predicate. Mirrors the SQL
+// JOIN against node_visibility at canonical_store.py:2728 + the
+// post-filter pattern documented in docs/go-port/shared/acl.md "Post-
+// read filtering / SQL JOIN".
+//
+// store.CanonicalStore.GetVisibleNodeIDs already implements exactly
+// this contract for the same-tenant case. The interface lets tests
+// inject an in-memory map without spinning up SQLite.
+type VisibilityReader interface {
+	// VisibleNodeIDs returns the subset of nodeIDs that the actor set
+	// (already group-resolved) can see by owner_actor or
+	// node_visibility (including the tenant:* wildcard). Implementations
+	// MUST handle the tenant:* expansion themselves — callers don't
+	// pre-add it.
+	VisibleNodeIDs(ctx context.Context, tenantID string, actorIDs []string, nodeIDs []string) (map[string]struct{}, error)
+}
+
+// Filter is the bulk-read variant of Checker. It returns the subset of
+// nodeIDs the actor can READ — used by every multi-node read RPC
+// (GetNodes, QueryNodes, GetConnectedNodes) to post-filter results
+// before egress.
+//
+// The Filter does NOT enforce typed-capability requirements beyond
+// READ; richer per-row checks (capability_mappings on field reads)
+// belong on the Checker single-node path. The Python server uses the
+// same split: SQL JOIN for read filtering, _check_capability for
+// per-row authorization.
+type Filter struct {
+	resolver *Resolver
+	vis      VisibilityReader
+}
+
+// NewFilter constructs a Filter. Both readers are required.
+func NewFilter(resolver *Resolver, vis VisibilityReader) *Filter {
+	return &Filter{resolver: resolver, vis: vis}
+}
+
+// FilterReadable returns the subset of nodeIDs the actor can read.
+// Order is unspecified (callers should not rely on it).
+//
+// Special cases:
+//   - System actor → returns nodeIDs unchanged (system bypass at
+//     canonical_store.py:2883-2884).
+//   - Empty nodeIDs → returns nil.
+//   - Empty actor → returns nil (zero-trust default).
+func (f *Filter) FilterReadable(ctx context.Context, tenantID string, a Actor, nodeIDs []string) ([]string, error) {
+	if len(nodeIDs) == 0 {
+		return nil, nil
+	}
+	if a.IsZero() {
+		return nil, nil
+	}
+	if a.IsSystem() {
+		out := make([]string, len(nodeIDs))
+		copy(out, nodeIDs)
+		return out, nil
+	}
+	resolved, err := f.resolver.Expand(ctx, tenantID, a)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(resolved))
+	for i, x := range resolved {
+		ids[i] = x.String()
+	}
+	visible, err := f.vis.VisibleNodeIDs(ctx, tenantID, ids, nodeIDs)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(visible))
+	for _, id := range nodeIDs {
+		if _, ok := visible[id]; ok {
+			out = append(out, id)
+		}
+	}
+	return out, nil
+}

--- a/server/go/internal/acl/filter_test.go
+++ b/server/go/internal/acl/filter_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+)
+
+// fakeVis is an in-memory VisibilityReader. It treats actorIDs union
+// {"tenant:*"} as the principal set and reports any node it has been
+// pre-told the actor can see.
+type fakeVis struct {
+	// owners maps node_id -> owner principal.
+	owners map[string]string
+	// vis maps node_id -> set of principals (canonical "kind:id" strings).
+	vis map[string]map[string]struct{}
+}
+
+func (f *fakeVis) VisibleNodeIDs(_ context.Context, _ string, actorIDs []string, nodeIDs []string) (map[string]struct{}, error) {
+	out := map[string]struct{}{}
+	allowed := map[string]struct{}{}
+	for _, a := range actorIDs {
+		allowed[a] = struct{}{}
+	}
+	allowed["tenant:*"] = struct{}{} // wildcard matches every authenticated user.
+	for _, id := range nodeIDs {
+		if _, ok := allowed[f.owners[id]]; ok {
+			out[id] = struct{}{}
+			continue
+		}
+		for p := range f.vis[id] {
+			if _, ok := allowed[p]; ok {
+				out[id] = struct{}{}
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func TestFilterReadableEmptyInputs(t *testing.T) {
+	r := acl.NewResolver(nil)
+	f := acl.NewFilter(r, &fakeVis{})
+	got, err := f.FilterReadable(context.Background(), "t1", acl.User("a"), nil)
+	if err != nil || got != nil {
+		t.Fatalf("empty nodeIDs = %v, err=%v", got, err)
+	}
+	got, err = f.FilterReadable(context.Background(), "t1", acl.Actor{}, []string{"n1"})
+	if err != nil || got != nil {
+		t.Fatalf("empty actor = %v, err=%v", got, err)
+	}
+}
+
+func TestFilterReadableSubset(t *testing.T) {
+	vis := &fakeVis{
+		owners: map[string]string{"n1": "user:alice", "n2": "user:bob", "n3": "user:carol"},
+		vis: map[string]map[string]struct{}{
+			"n1": {"user:alice": {}},
+			"n2": {"user:bob": {}, "user:alice": {}}, // alice was shared n2.
+			"n3": {"user:carol": {}},
+		},
+	}
+	r := acl.NewResolver(nil)
+	f := acl.NewFilter(r, vis)
+	got, err := f.FilterReadable(context.Background(), "t1", acl.User("alice"),
+		[]string{"n1", "n2", "n3"})
+	if err != nil {
+		t.Fatalf("FilterReadable: %v", err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "n1" || got[1] != "n2" {
+		t.Fatalf("FilterReadable = %v, want [n1 n2]", got)
+	}
+}
+
+func TestFilterReadableSystemBypass(t *testing.T) {
+	vis := &fakeVis{} // empty — would deny everything for normal user.
+	r := acl.NewResolver(nil)
+	f := acl.NewFilter(r, vis)
+	got, err := f.FilterReadable(context.Background(), "t1", acl.System("applier"),
+		[]string{"n1", "n2"})
+	if err != nil {
+		t.Fatalf("FilterReadable: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("system bypass should return all nodes, got %v", got)
+	}
+}
+
+func TestFilterReadableTenantWildcardSeesAll(t *testing.T) {
+	vis := &fakeVis{
+		owners: map[string]string{"n1": "user:alice", "n2": "user:bob"},
+		vis: map[string]map[string]struct{}{
+			"n1": {"tenant:*": {}}, // all tenant readable.
+			"n2": {"user:bob": {}},
+		},
+	}
+	r := acl.NewResolver(nil)
+	f := acl.NewFilter(r, vis)
+	got, err := f.FilterReadable(context.Background(), "t1", acl.User("carol"), []string{"n1", "n2"})
+	if err != nil {
+		t.Fatalf("FilterReadable: %v", err)
+	}
+	if len(got) != 1 || got[0] != "n1" {
+		t.Fatalf("FilterReadable carol = %v, want [n1]", got)
+	}
+}
+
+func TestFilterReadableGroupExpansion(t *testing.T) {
+	groups := &fakeGroups{parents: map[string][]string{
+		"user:bob": {"eng"},
+	}}
+	vis := &fakeVis{
+		owners: map[string]string{"n1": "user:alice"},
+		vis: map[string]map[string]struct{}{
+			"n1": {"group:eng": {}}, // shared with eng.
+		},
+	}
+	r := acl.NewResolver(groups)
+	f := acl.NewFilter(r, vis)
+	got, err := f.FilterReadable(context.Background(), "t1", acl.User("bob"), []string{"n1"})
+	if err != nil {
+		t.Fatalf("FilterReadable: %v", err)
+	}
+	if len(got) != 1 || got[0] != "n1" {
+		t.Fatalf("group-shared filter = %v, want [n1]", got)
+	}
+}

--- a/server/go/internal/acl/grant.go
+++ b/server/go/internal/acl/grant.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl
+
+// Grant is the in-Go representation of one row of node_access — an ACL
+// grant for (NodeID, SubjectActor). Mirrors the Python row at
+// canonical_store.py:1103-1115 and 1211-1222 (typed-cap columns).
+//
+// Both the legacy Permission field and the typed Capability fields are
+// kept; on read the canonical store returns whichever the row has.
+// LegacyToCoreCaps fills the typed fields when the row is legacy-only
+// (mirrors the lazy back-fill at canonical_store.py:3054).
+type Grant struct {
+	// Subject is the grantee — who the grant applies to.
+	Subject Actor
+	// NodeID is the node the grant applies to.
+	NodeID string
+	// TypeID is the node's type id at grant time. Used by Registry to
+	// scope ExtCapID interpretation. 0 == "core only / type-agnostic".
+	TypeID int32
+	// Permission is the legacy enum (still on the wire).
+	Permission Permission
+	// CoreCaps is the typed core-capability set this grant carries.
+	// Empty when the row is legacy-only — call LegacyToCoreCaps to
+	// derive.
+	CoreCaps []CoreCapability
+	// ExtCapIDs is the typed extension-capability set, scoped to TypeID.
+	ExtCapIDs []ExtCapID
+	// GrantedBy is the actor that authored the grant. Used for audit
+	// and for the "delegating actor must already hold the cap" check
+	// (W1.10 applier territory; this package does not enforce it).
+	GrantedBy Actor
+	// GrantedAt is the unix-millis timestamp the grant was authored.
+	GrantedAt int64
+	// ExpiresAt is the unix-millis expiry; nil means "never expires".
+	// Mirrors node_access.expires_at NULLABLE.
+	ExpiresAt *int64
+}
+
+// IsExpired reports whether the grant has expired relative to now (a
+// unix-millis clock reading). A nil ExpiresAt means "never".
+func (g Grant) IsExpired(nowMs int64) bool {
+	if g.ExpiresAt == nil {
+		return false
+	}
+	return *g.ExpiresAt <= nowMs
+}
+
+// IsDeny reports whether this grant is the explicit-negative DENY row.
+// DENY rows carry no positive caps; the deny semantics is enforced by
+// the Checker two-pass.
+func (g Grant) IsDeny() bool { return g.Permission == PermDeny }
+
+// EffectiveCoreCaps returns the typed core-cap set this grant satisfies,
+// preferring the explicit CoreCaps field when present and falling back
+// to LegacyToCoreCaps(g.Permission) for legacy-only rows.
+func (g Grant) EffectiveCoreCaps() []CoreCapability {
+	if len(g.CoreCaps) > 0 {
+		return g.CoreCaps
+	}
+	return LegacyToCoreCaps(g.Permission)
+}
+

--- a/server/go/internal/acl/integration_test.go
+++ b/server/go/internal/acl/integration_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Integration tests that exercise the acl package against a real
+// store.CanonicalStore + globalstore.GlobalStore. The acl package
+// itself does not depend on store/globalstore — these tests prove the
+// production wiring shape works.
+//
+// Production binding pattern: a thin adapter in the api package wraps
+// store.CanonicalStore and exposes NodeMetaReader / GrantReader /
+// VisibilityReader / GroupMembershipReader on top of the existing
+// public methods (GetNode, ListSharedWithMe, GetVisibleNodeIDs,
+// AddGroupMember). The adapter is intentionally NOT in this package —
+// W1.10 will land it alongside the applier.
+
+package acl_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+func newRealStores(t *testing.T) (*store.CanonicalStore, *globalstore.GlobalStore) {
+	t.Helper()
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	gs, err := globalstore.New(globalstore.Options{DataDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+	return cs, gs
+}
+
+// storeVisibilityAdapter wraps store.CanonicalStore.GetVisibleNodeIDs
+// to satisfy acl.VisibilityReader.
+type storeVisibilityAdapter struct {
+	s *store.CanonicalStore
+}
+
+func (a *storeVisibilityAdapter) VisibleNodeIDs(ctx context.Context, tenant string, actorIDs []string, nodeIDs []string) (map[string]struct{}, error) {
+	return a.s.GetVisibleNodeIDs(ctx, tenant, actorIDs, nodeIDs)
+}
+
+// xtAdapter wraps globalstore.GlobalStore.ListSharedFromNode for the
+// (small, single-node) cross-tenant lookup used by the Checker.
+type xtAdapter struct {
+	g *globalstore.GlobalStore
+}
+
+func (x *xtAdapter) CrossTenantGrant(ctx context.Context, tenant, node, actor string) (acl.Permission, bool, error) {
+	rows, err := x.g.ListSharedFromNode(ctx, tenant, node)
+	if err != nil {
+		return acl.PermDeny, false, err
+	}
+	for _, r := range rows {
+		if "user:"+r.UserID == actor {
+			p, ok := acl.ParsePermission(r.Permission)
+			if !ok {
+				continue
+			}
+			return p, true, nil
+		}
+	}
+	return acl.PermDeny, false, nil
+}
+
+func TestFilterReadableRealStore(t *testing.T) {
+	cs, _ := newRealStores(t)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	// alice owns n1, bob owns n2, carol owns n3.
+	mustCreate(t, cs, "t1", "n1", "user:alice")
+	mustCreate(t, cs, "t1", "n2", "user:bob")
+	mustCreate(t, cs, "t1", "n3", "user:carol")
+	// Share n2 with bob (a no-op since bob already owns it) and n1 with bob.
+	if err := cs.AddVisibility(ctx, "t1", "n1", "user:bob"); err != nil {
+		t.Fatalf("AddVisibility: %v", err)
+	}
+
+	// Use the resolver with a no-op group reader (no groups seeded).
+	r := acl.NewResolver(nil)
+	f := acl.NewFilter(r, &storeVisibilityAdapter{s: cs})
+
+	got, err := f.FilterReadable(ctx, "t1", acl.User("bob"), []string{"n1", "n2", "n3"})
+	if err != nil {
+		t.Fatalf("FilterReadable: %v", err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "n1" || got[1] != "n2" {
+		t.Fatalf("FilterReadable bob = %v, want [n1 n2]", got)
+	}
+}
+
+func TestCrossTenantGrantRealStore(t *testing.T) {
+	_, gs := newRealStores(t)
+	ctx := context.Background()
+	// Seed the globalstore shared_index with a cross-tenant grant.
+	if err := gs.AddShared(ctx, "carol", "acme", "n1", "read"); err != nil {
+		t.Fatalf("AddShared: %v", err)
+	}
+	xt := &xtAdapter{g: gs}
+	perm, ok, err := xt.CrossTenantGrant(ctx, "acme", "n1", "user:carol")
+	if err != nil {
+		t.Fatalf("CrossTenantGrant: %v", err)
+	}
+	if !ok {
+		t.Fatalf("CrossTenantGrant: row should exist")
+	}
+	if perm != acl.PermRead {
+		t.Fatalf("CrossTenantGrant perm = %v, want PermRead", perm)
+	}
+	// Absent row.
+	_, ok, _ = xt.CrossTenantGrant(ctx, "acme", "n1", "user:dan")
+	if ok {
+		t.Fatalf("CrossTenantGrant absent row should not exist")
+	}
+}
+
+func mustCreate(t *testing.T, cs *store.CanonicalStore, tenant, node, owner string) {
+	t.Helper()
+	_, err := cs.CreateNodeRaw(context.Background(), tenant, store.NodeInput{
+		NodeID:     node,
+		TypeID:     1,
+		OwnerActor: owner,
+	})
+	if err != nil {
+		t.Fatalf("CreateNodeRaw %s: %v", node, err)
+	}
+}

--- a/server/go/internal/acl/permission.go
+++ b/server/go/internal/acl/permission.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package acl is the Go port of server/python/entdb_server/apply/acl.py
+// plus server/python/entdb_server/auth/capability_registry.py.
+//
+// Two parallel models live here:
+//
+//   - Permission: the legacy 7-value enum still on the wire
+//     (READ/COMMENT/WRITE/SHARE/DELETE/ADMIN/DENY). Source of truth:
+//     server/python/entdb_server/apply/acl.py:32-42 and the
+//     PERMISSION_HIERARCHY table at acl.py:190-210.
+//   - CoreCapability + ExtCapID: the typed capability model frozen in
+//     docs/decisions/acl.md (2026-04-13). New writes carry typed caps;
+//     legacy strings are mechanically derived for old grants.
+//
+// Spec: docs/go-port/shared/acl.md.
+package acl
+
+// Permission is the legacy coarse enum. Wire-stable: integer values
+// MUST not be reordered. Used by ACLEntry.permission strings on the
+// wire and by store.node_access.permission rows.
+type Permission uint8
+
+const (
+	// PermDeny is the explicit-negative override. Matches Python
+	// Permission.DENY (acl.py:41). Stored as the literal "deny" in
+	// node_access.permission. The zero value is DENY, NOT "unspecified",
+	// to mirror the Python set("") -> {} behaviour of an unset grant.
+	PermDeny Permission = iota
+	// PermRead — implies READ. Python "read".
+	PermRead
+	// PermComment — implies READ, COMMENT. Python "comment".
+	PermComment
+	// PermWrite — implies READ, COMMENT, WRITE. Python "write".
+	PermWrite
+	// PermShare — implies READ, COMMENT, WRITE, SHARE. Python "share".
+	PermShare
+	// PermDelete — implies READ, COMMENT, WRITE, DELETE (NOT SHARE).
+	// Python "delete".
+	PermDelete
+	// PermAdmin — implies every positive permission. Python "admin".
+	PermAdmin
+)
+
+// String returns the canonical lowercase form stored in
+// node_access.permission. Mirrors Permission.value in the Python enum.
+func (p Permission) String() string {
+	switch p {
+	case PermDeny:
+		return "deny"
+	case PermRead:
+		return "read"
+	case PermComment:
+		return "comment"
+	case PermWrite:
+		return "write"
+	case PermShare:
+		return "share"
+	case PermDelete:
+		return "delete"
+	case PermAdmin:
+		return "admin"
+	default:
+		return "unknown"
+	}
+}
+
+// ParsePermission parses the wire string form into a Permission. Unknown
+// inputs return (PermDeny, false) — callers must check the bool, since
+// PermDeny is a real value (not "unspecified").
+func ParsePermission(s string) (Permission, bool) {
+	switch s {
+	case "deny":
+		return PermDeny, true
+	case "read":
+		return PermRead, true
+	case "comment":
+		return PermComment, true
+	case "write":
+		return PermWrite, true
+	case "share":
+		return PermShare, true
+	case "delete":
+		return PermDelete, true
+	case "admin":
+		return PermAdmin, true
+	default:
+		return PermDeny, false
+	}
+}
+
+// permissionHierarchy mirrors AclManager.PERMISSION_HIERARCHY at
+// server/python/entdb_server/apply/acl.py:190-210. A grant of perm P
+// satisfies a request for required Q iff Q in permissionHierarchy[P].
+//
+// PermDeny grants nothing — the table is intentionally empty for it,
+// and the AclManager.check_permission two-pass treats DENY specially
+// (acl.py:243-264).
+var permissionHierarchy = map[Permission]map[Permission]struct{}{
+	PermRead: {
+		PermRead: {},
+	},
+	PermComment: {
+		PermRead:    {},
+		PermComment: {},
+	},
+	PermWrite: {
+		PermRead:    {},
+		PermComment: {},
+		PermWrite:   {},
+	},
+	PermShare: {
+		PermRead:    {},
+		PermComment: {},
+		PermWrite:   {},
+		PermShare:   {},
+	},
+	PermDelete: {
+		PermRead:    {},
+		PermComment: {},
+		PermWrite:   {},
+		PermDelete:  {},
+	},
+	PermAdmin: {
+		PermRead:    {},
+		PermComment: {},
+		PermWrite:   {},
+		PermShare:   {},
+		PermDelete:  {},
+		PermAdmin:   {},
+	},
+}
+
+// Implies reports whether holding p satisfies a request for required.
+// PermDeny implies nothing. Mirrors the lookup at acl.py:256-258.
+func (p Permission) Implies(required Permission) bool {
+	if p == PermDeny {
+		return false
+	}
+	_, ok := permissionHierarchy[p][required]
+	return ok
+}

--- a/server/go/internal/acl/permission_test.go
+++ b/server/go/internal/acl/permission_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+)
+
+func TestPermissionString(t *testing.T) {
+	cases := []struct {
+		p    acl.Permission
+		want string
+	}{
+		{acl.PermDeny, "deny"},
+		{acl.PermRead, "read"},
+		{acl.PermComment, "comment"},
+		{acl.PermWrite, "write"},
+		{acl.PermShare, "share"},
+		{acl.PermDelete, "delete"},
+		{acl.PermAdmin, "admin"},
+	}
+	for _, c := range cases {
+		if got := c.p.String(); got != c.want {
+			t.Fatalf("String(%v) = %q, want %q", c.p, got, c.want)
+		}
+	}
+}
+
+func TestParsePermission(t *testing.T) {
+	for _, s := range []string{"deny", "read", "comment", "write", "share", "delete", "admin"} {
+		p, ok := acl.ParsePermission(s)
+		if !ok {
+			t.Fatalf("ParsePermission(%q) failed", s)
+		}
+		if p.String() != s {
+			t.Fatalf("round-trip %q -> %v -> %q", s, p, p.String())
+		}
+	}
+	if _, ok := acl.ParsePermission("garbage"); ok {
+		t.Fatalf("ParsePermission(garbage) should fail")
+	}
+	if _, ok := acl.ParsePermission(""); ok {
+		t.Fatalf("ParsePermission empty should fail")
+	}
+}
+
+// TestPermissionImplies pins the hierarchy table at acl.py:190-210.
+func TestPermissionImplies(t *testing.T) {
+	cases := []struct {
+		grant, need acl.Permission
+		want        bool
+	}{
+		// Read implies only Read.
+		{acl.PermRead, acl.PermRead, true},
+		{acl.PermRead, acl.PermComment, false},
+		{acl.PermRead, acl.PermWrite, false},
+		// Comment implies Read+Comment.
+		{acl.PermComment, acl.PermRead, true},
+		{acl.PermComment, acl.PermComment, true},
+		{acl.PermComment, acl.PermWrite, false},
+		// Write implies Read, Comment, Write — NOT Share/Delete.
+		{acl.PermWrite, acl.PermRead, true},
+		{acl.PermWrite, acl.PermComment, true},
+		{acl.PermWrite, acl.PermWrite, true},
+		{acl.PermWrite, acl.PermShare, false},
+		{acl.PermWrite, acl.PermDelete, false},
+		// Share implies Read/Comment/Write/Share — NOT Delete.
+		{acl.PermShare, acl.PermShare, true},
+		{acl.PermShare, acl.PermDelete, false},
+		// Delete implies Read/Comment/Write/Delete — NOT Share.
+		{acl.PermDelete, acl.PermDelete, true},
+		{acl.PermDelete, acl.PermShare, false},
+		// Admin implies everything positive.
+		{acl.PermAdmin, acl.PermRead, true},
+		{acl.PermAdmin, acl.PermComment, true},
+		{acl.PermAdmin, acl.PermWrite, true},
+		{acl.PermAdmin, acl.PermShare, true},
+		{acl.PermAdmin, acl.PermDelete, true},
+		{acl.PermAdmin, acl.PermAdmin, true},
+		// Deny implies nothing.
+		{acl.PermDeny, acl.PermRead, false},
+		{acl.PermDeny, acl.PermAdmin, false},
+	}
+	for _, c := range cases {
+		if got := c.grant.Implies(c.need); got != c.want {
+			t.Fatalf("Implies(%v→%v) = %v, want %v", c.grant, c.need, got, c.want)
+		}
+	}
+}
+
+// TestLegacyToCoreCaps pins the migration table in
+// docs/decisions/acl.md:138 and capability_registry.py:357-389.
+func TestLegacyToCoreCaps(t *testing.T) {
+	cases := []struct {
+		in   acl.Permission
+		want []acl.CoreCapability
+	}{
+		{acl.PermDeny, nil},
+		{acl.PermRead, []acl.CoreCapability{acl.CoreCapRead}},
+		{acl.PermComment, []acl.CoreCapability{acl.CoreCapRead, acl.CoreCapComment}},
+		{acl.PermWrite, []acl.CoreCapability{acl.CoreCapRead, acl.CoreCapComment, acl.CoreCapEdit}},
+		{acl.PermShare, []acl.CoreCapability{acl.CoreCapAdmin}},
+		{acl.PermDelete, []acl.CoreCapability{acl.CoreCapRead, acl.CoreCapComment, acl.CoreCapEdit, acl.CoreCapDelete}},
+		{acl.PermAdmin, []acl.CoreCapability{acl.CoreCapAdmin}},
+	}
+	for _, c := range cases {
+		got := acl.LegacyToCoreCaps(c.in)
+		if len(got) != len(c.want) {
+			t.Fatalf("LegacyToCoreCaps(%v) = %v (len=%d), want %v", c.in, got, len(got), c.want)
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Fatalf("LegacyToCoreCaps(%v)[%d] = %v, want %v", c.in, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+func TestCoreCapabilityString(t *testing.T) {
+	cases := []struct {
+		c    acl.CoreCapability
+		want string
+	}{
+		{acl.CoreCapUnspecified, "CORE_CAP_UNSPECIFIED"},
+		{acl.CoreCapRead, "CORE_CAP_READ"},
+		{acl.CoreCapComment, "CORE_CAP_COMMENT"},
+		{acl.CoreCapEdit, "CORE_CAP_EDIT"},
+		{acl.CoreCapDelete, "CORE_CAP_DELETE"},
+		{acl.CoreCapAdmin, "CORE_CAP_ADMIN"},
+	}
+	for _, c := range cases {
+		if got := c.c.String(); got != c.want {
+			t.Fatalf("CoreCapability(%v).String = %q, want %q", c.c, got, c.want)
+		}
+	}
+}

--- a/server/go/internal/acl/registry.go
+++ b/server/go/internal/acl/registry.go
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Registry holds the proto-derived capability mappings and implication
+// closures. Built once at server startup; immutable thereafter.
+//
+// Mirrors server/python/entdb_server/auth/capability_registry.py
+// CapabilityRegistry. Wave 1 accepts JSON input mirroring
+// SchemaRegistry.to_json (the Python side already serialises this);
+// Wave 2 will wire it directly off proto descriptors.
+type Registry struct {
+	types       map[int32]*TypeCapabilities
+	defaultType *TypeCapabilities
+}
+
+// TypeCapabilities is per-type capability metadata after build. Mirrors
+// the Python TypeCapabilities dataclass at capability_registry.py:137-151.
+type TypeCapabilities struct {
+	TypeID            int32
+	ExtensionEnumName string
+	ExtCapNames       map[ExtCapID]string
+	Mappings          []CapabilityMapping
+	Implications      []CapabilityImplication
+
+	// Precomputed transitive closures, including built-in core rules.
+	implicationClosureCore map[CoreCapability]map[CoreCapability]struct{}
+	implicationClosureExt  map[ExtCapID]map[ExtCapID]struct{}
+	extImpliesCore         map[ExtCapID]map[CoreCapability]struct{}
+}
+
+// CapabilityMapping is one row of a type's op → capability table. Exactly
+// one of RequiredCore / RequiredExt is non-zero.
+type CapabilityMapping struct {
+	Op           string
+	RequiredCore CoreCapability // CoreCapUnspecified == not set
+	RequiredExt  ExtCapID       // 0 == not set
+	Field        string         // "" == any
+	FieldValue   string         // "" == any
+	ChildType    string         // "" == any
+}
+
+// Specificity returns a score used to pick the best matching mapping.
+// Higher is more specific. Mirrors CapabilityMapping.specificity at
+// capability_registry.py:113-119.
+func (m CapabilityMapping) Specificity() int {
+	score := 0
+	if m.Field != "" {
+		score++
+	}
+	if m.FieldValue != "" {
+		score++
+	}
+	if m.ChildType != "" {
+		score++
+	}
+	return score
+}
+
+// CapabilityImplication is a single implication rule for a type. Either
+// Core or Ext is set (exclusive). The implied set may mix core and ext.
+type CapabilityImplication struct {
+	Core        CoreCapability // CoreCapUnspecified == not the source
+	Ext         ExtCapID       // 0 == not the source
+	ImpliesCore []CoreCapability
+	ImpliesExt  []ExtCapID
+}
+
+// DefaultOpRequirements is the built-in op → core-cap table applied
+// when a type has no explicit override. Mirrors DEFAULT_OP_REQUIREMENTS
+// at capability_registry.py:61-76. CreateNode is intentionally absent —
+// that is a tenant-level check, not per-node.
+var DefaultOpRequirements = map[string]CoreCapability{
+	"GetNode":           CoreCapRead,
+	"GetNodes":          CoreCapRead,
+	"GetNodeByKey":      CoreCapRead,
+	"QueryNodes":        CoreCapRead,
+	"GetEdgesFrom":      CoreCapRead,
+	"GetEdgesTo":        CoreCapRead,
+	"GetConnectedNodes": CoreCapRead,
+	"UpdateNode":        CoreCapEdit,
+	"DeleteNode":        CoreCapDelete,
+	"CreateEdge":        CoreCapEdit,
+	"DeleteEdge":        CoreCapEdit,
+	"ShareNode":         CoreCapAdmin,
+	"RevokeAccess":      CoreCapAdmin,
+	"TransferOwnership": CoreCapAdmin,
+}
+
+// NewRegistry returns an empty registry whose only known type is the
+// implicit "type 0" — used for callers that haven't registered an
+// explicit type. Built-in core implications are applied to type 0 too.
+func NewRegistry() *Registry {
+	r := &Registry{
+		types:       map[int32]*TypeCapabilities{},
+		defaultType: &TypeCapabilities{TypeID: 0},
+	}
+	buildClosures(r.defaultType)
+	return r
+}
+
+// RegisterType installs a TypeCapabilities for typeID. Idempotent: a
+// second call replaces the previous registration for the same id.
+// Closures are recomputed from CoreImplications + the per-type
+// implications list.
+func (r *Registry) RegisterType(tc *TypeCapabilities) {
+	if tc == nil {
+		return
+	}
+	if tc.ExtCapNames == nil {
+		tc.ExtCapNames = map[ExtCapID]string{}
+	}
+	buildClosures(tc)
+	r.types[tc.TypeID] = tc
+}
+
+// GetType returns the TypeCapabilities for typeID, or the implicit
+// type-0 default when the id is unknown. Mirrors get_type at
+// capability_registry.py:244.
+func (r *Registry) GetType(typeID int32) *TypeCapabilities {
+	if tc, ok := r.types[typeID]; ok {
+		return tc
+	}
+	return r.defaultType
+}
+
+// KnownTypeIDs returns the registered type ids in ascending order. The
+// implicit type-0 default is NOT included unless it has been registered
+// explicitly via RegisterType.
+func (r *Registry) KnownTypeIDs() []int32 {
+	ids := make([]int32, 0, len(r.types))
+	for id := range r.types {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// OpQuery is the optional set of selectors that narrow a RequiredForOp
+// lookup. Empty fields mean "any".
+type OpQuery struct {
+	Field      string
+	FieldValue string
+	ChildType  string
+}
+
+// RequiredForOp returns the (core, ext) requirement for an op on a
+// node of the given type. Exactly one of the returned values is
+// non-zero, or both are zero meaning "no requirement — allow".
+//
+// Mirrors required_for_op at capability_registry.py:250-289. Lookup
+// order:
+//
+//  1. Most-specific type-level mapping matching op + selectors.
+//  2. Default op requirement baked into DefaultOpRequirements.
+//  3. (CoreCapUnspecified, 0) meaning no requirement.
+func (r *Registry) RequiredForOp(typeID int32, op string, q OpQuery) (CoreCapability, ExtCapID) {
+	tc := r.GetType(typeID)
+	var best *CapabilityMapping
+	bestScore := -1
+	for i := range tc.Mappings {
+		m := &tc.Mappings[i]
+		if m.Op != op {
+			continue
+		}
+		if m.Field != "" && m.Field != q.Field {
+			continue
+		}
+		if m.FieldValue != "" && m.FieldValue != q.FieldValue {
+			continue
+		}
+		if m.ChildType != "" && m.ChildType != q.ChildType {
+			continue
+		}
+		score := m.Specificity()
+		if score > bestScore {
+			best = m
+			bestScore = score
+		}
+	}
+	if best != nil {
+		return best.RequiredCore, best.RequiredExt
+	}
+	if def, ok := DefaultOpRequirements[op]; ok {
+		return def, 0
+	}
+	return CoreCapUnspecified, 0
+}
+
+// CheckGrant reports whether (grantedCore, grantedExt) satisfies the
+// (requiredCore, requiredExt) requirement, honouring implications.
+//
+// typeID selects which type's extension-capability space to use for
+// requiredExt and the type's ext → core closure. grantedExt is always
+// interpreted in the scope of the SAME typeID — cross-type extension
+// grants never satisfy a check (by construction of the registry).
+//
+// Mirrors check_grant at capability_registry.py:291-350.
+func (r *Registry) CheckGrant(grantedCore []CoreCapability, grantedExt []ExtCapID, requiredCore CoreCapability, requiredExt ExtCapID, typeID int32) bool {
+	if requiredCore == CoreCapUnspecified && requiredExt == 0 {
+		return true
+	}
+	tc := r.GetType(typeID)
+
+	grantCore := map[CoreCapability]struct{}{}
+	for _, c := range grantedCore {
+		if c == CoreCapUnspecified {
+			continue
+		}
+		grantCore[c] = struct{}{}
+	}
+	grantExt := map[ExtCapID]struct{}{}
+	for _, e := range grantedExt {
+		if e == 0 {
+			continue
+		}
+		grantExt[e] = struct{}{}
+	}
+
+	// Expand grant exts via per-type ext closure AND pull in core caps
+	// each ext implies (e.g. PR_EXT_CAP_MERGE → CORE_CAP_EDIT).
+	expandedExt := map[ExtCapID]struct{}{}
+	for e := range grantExt {
+		expandedExt[e] = struct{}{}
+		for t := range tc.implicationClosureExt[e] {
+			expandedExt[t] = struct{}{}
+		}
+	}
+	promotedCore := map[CoreCapability]struct{}{}
+	for e := range expandedExt {
+		for c := range tc.extImpliesCore[e] {
+			promotedCore[c] = struct{}{}
+		}
+	}
+
+	// Expand grant cores AFTER folding in promoted-from-ext cores so
+	// "ext → EDIT → {READ, COMMENT}" fires correctly.
+	expandedCore := map[CoreCapability]struct{}{}
+	for c := range grantCore {
+		expandedCore[c] = struct{}{}
+	}
+	for c := range promotedCore {
+		expandedCore[c] = struct{}{}
+	}
+	// Fixed-point would be needed for general DAGs; the closure is
+	// already transitive so one pass suffices.
+	for c := range expandedCore {
+		for t := range tc.implicationClosureCore[c] {
+			expandedCore[t] = struct{}{}
+		}
+	}
+
+	if requiredCore != CoreCapUnspecified {
+		_, ok := expandedCore[requiredCore]
+		return ok
+	}
+	if requiredExt != 0 {
+		_, ok := expandedExt[requiredExt]
+		return ok
+	}
+	return false
+}
+
+// LegacyToCoreCaps is a thin method alias for the package-level helper,
+// exposed on Registry for parity with the Python static method
+// CapabilityRegistry.legacy_permission_to_core_caps.
+func (r *Registry) LegacyToCoreCaps(p Permission) []CoreCapability {
+	return LegacyToCoreCaps(p)
+}
+
+// buildClosures populates implicationClosureCore / implicationClosureExt
+// / extImpliesCore on tc. Mirrors _build_closures at
+// capability_registry.py:392-449.
+func buildClosures(tc *TypeCapabilities) {
+	coreGraph := map[CoreCapability]map[CoreCapability]struct{}{}
+	for src, dsts := range CoreImplications {
+		s := map[CoreCapability]struct{}{}
+		for _, d := range dsts {
+			s[d] = struct{}{}
+		}
+		coreGraph[src] = s
+	}
+	extGraph := map[ExtCapID]map[ExtCapID]struct{}{}
+	extToCore := map[ExtCapID]map[CoreCapability]struct{}{}
+
+	for _, imp := range tc.Implications {
+		if imp.Core != CoreCapUnspecified {
+			set, ok := coreGraph[imp.Core]
+			if !ok {
+				set = map[CoreCapability]struct{}{}
+				coreGraph[imp.Core] = set
+			}
+			for _, c := range imp.ImpliesCore {
+				set[c] = struct{}{}
+			}
+			// Implies-ext on a core source is rare and intentionally
+			// not modelled: anyone holding imp.Core matches before exts
+			// are consulted (capability_registry.py:412-418).
+		} else if imp.Ext != 0 {
+			set, ok := extGraph[imp.Ext]
+			if !ok {
+				set = map[ExtCapID]struct{}{}
+				extGraph[imp.Ext] = set
+			}
+			for _, e := range imp.ImpliesExt {
+				set[e] = struct{}{}
+			}
+			if len(imp.ImpliesCore) > 0 {
+				cset, ok := extToCore[imp.Ext]
+				if !ok {
+					cset = map[CoreCapability]struct{}{}
+					extToCore[imp.Ext] = cset
+				}
+				for _, c := range imp.ImpliesCore {
+					cset[c] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// Fixed-point transitive closure over coreGraph.
+	for {
+		changed := false
+		for src, targets := range coreGraph {
+			for t := range targets {
+				for tt := range coreGraph[t] {
+					if _, ok := targets[tt]; !ok {
+						targets[tt] = struct{}{}
+						changed = true
+					}
+				}
+			}
+			coreGraph[src] = targets
+		}
+		if !changed {
+			break
+		}
+	}
+
+	// Fixed-point transitive closure over extGraph.
+	for {
+		changed := false
+		for src, targets := range extGraph {
+			for t := range targets {
+				for tt := range extGraph[t] {
+					if _, ok := targets[tt]; !ok {
+						targets[tt] = struct{}{}
+						changed = true
+					}
+				}
+			}
+			extGraph[src] = targets
+		}
+		if !changed {
+			break
+		}
+	}
+
+	tc.implicationClosureCore = coreGraph
+	tc.implicationClosureExt = extGraph
+	tc.extImpliesCore = extToCore
+}
+
+// RegistryJSON is the JSON wire shape consumed by LoadJSON. Mirrors the
+// SchemaRegistry.to_json output for the capability subset.
+type RegistryJSON struct {
+	Types []TypeJSON `json:"types"`
+}
+
+// TypeJSON is the per-type slice of RegistryJSON.
+type TypeJSON struct {
+	TypeID            int32             `json:"type_id"`
+	ExtensionEnumName string            `json:"extension_enum_name,omitempty"`
+	ExtCapNames       map[string]string `json:"ext_cap_names,omitempty"` // string keys for JSON
+	Mappings          []MappingJSON     `json:"mappings,omitempty"`
+	Implications      []ImplicationJSON `json:"implications,omitempty"`
+}
+
+// MappingJSON is one CapabilityMapping in JSON form.
+type MappingJSON struct {
+	Op           string `json:"op"`
+	RequiredCore int    `json:"required_core,omitempty"`
+	RequiredExt  int    `json:"required_ext,omitempty"`
+	Field        string `json:"field,omitempty"`
+	FieldValue   string `json:"field_value,omitempty"`
+	ChildType    string `json:"child_type,omitempty"`
+}
+
+// ImplicationJSON is one CapabilityImplication in JSON form.
+type ImplicationJSON struct {
+	Core        int   `json:"core,omitempty"`
+	Ext         int   `json:"ext,omitempty"`
+	ImpliesCore []int `json:"implies_core,omitempty"`
+	ImpliesExt  []int `json:"implies_ext,omitempty"`
+}
+
+// LoadJSON parses a RegistryJSON blob and registers each TypeJSON as a
+// TypeCapabilities. Used at startup once the schema package has emitted
+// its proto-derived capability metadata.
+func (r *Registry) LoadJSON(data []byte) error {
+	var rj RegistryJSON
+	if err := json.Unmarshal(data, &rj); err != nil {
+		return fmt.Errorf("acl: parse registry json: %w", err)
+	}
+	for _, tj := range rj.Types {
+		tc := &TypeCapabilities{
+			TypeID:            tj.TypeID,
+			ExtensionEnumName: tj.ExtensionEnumName,
+			ExtCapNames:       map[ExtCapID]string{},
+		}
+		for k, v := range tj.ExtCapNames {
+			var id int32
+			_, err := fmt.Sscanf(k, "%d", &id)
+			if err != nil {
+				return fmt.Errorf("acl: ext_cap_names key %q not an int: %w", k, err)
+			}
+			tc.ExtCapNames[ExtCapID(id)] = v
+		}
+		for _, m := range tj.Mappings {
+			tc.Mappings = append(tc.Mappings, CapabilityMapping{
+				Op:           m.Op,
+				RequiredCore: CoreCapability(m.RequiredCore),
+				RequiredExt:  ExtCapID(m.RequiredExt),
+				Field:        m.Field,
+				FieldValue:   m.FieldValue,
+				ChildType:    m.ChildType,
+			})
+		}
+		for _, imp := range tj.Implications {
+			ci := CapabilityImplication{
+				Core: CoreCapability(imp.Core),
+				Ext:  ExtCapID(imp.Ext),
+			}
+			for _, c := range imp.ImpliesCore {
+				ci.ImpliesCore = append(ci.ImpliesCore, CoreCapability(c))
+			}
+			for _, e := range imp.ImpliesExt {
+				ci.ImpliesExt = append(ci.ImpliesExt, ExtCapID(e))
+			}
+			tc.Implications = append(tc.Implications, ci)
+		}
+		r.RegisterType(tc)
+	}
+	return nil
+}

--- a/server/go/internal/acl/registry_test.go
+++ b/server/go/internal/acl/registry_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+)
+
+// TestRequiredForOpDefaults pins the DEFAULT_OP_REQUIREMENTS table at
+// capability_registry.py:61-76.
+func TestRequiredForOpDefaults(t *testing.T) {
+	r := acl.NewRegistry()
+	cases := []struct {
+		op   string
+		want acl.CoreCapability
+	}{
+		{"GetNode", acl.CoreCapRead},
+		{"GetNodes", acl.CoreCapRead},
+		{"QueryNodes", acl.CoreCapRead},
+		{"GetEdgesFrom", acl.CoreCapRead},
+		{"GetConnectedNodes", acl.CoreCapRead},
+		{"UpdateNode", acl.CoreCapEdit},
+		{"DeleteNode", acl.CoreCapDelete},
+		{"CreateEdge", acl.CoreCapEdit},
+		{"DeleteEdge", acl.CoreCapEdit},
+		{"ShareNode", acl.CoreCapAdmin},
+		{"RevokeAccess", acl.CoreCapAdmin},
+		{"TransferOwnership", acl.CoreCapAdmin},
+	}
+	for _, c := range cases {
+		core, ext := r.RequiredForOp(0, c.op, acl.OpQuery{})
+		if core != c.want || ext != 0 {
+			t.Fatalf("RequiredForOp(%q) = (%v, %v), want (%v, 0)", c.op, core, ext, c.want)
+		}
+	}
+}
+
+func TestRequiredForOpUnknownReturnsZero(t *testing.T) {
+	r := acl.NewRegistry()
+	core, ext := r.RequiredForOp(0, "UnknownOp", acl.OpQuery{})
+	if core != acl.CoreCapUnspecified || ext != 0 {
+		t.Fatalf("unknown op = (%v, %v), want (Unspecified, 0)", core, ext)
+	}
+}
+
+// TestRequiredForOpFieldOverride covers field-level gating per
+// docs/decisions/acl.md "Field-level permission gating" example.
+func TestRequiredForOpFieldOverride(t *testing.T) {
+	r := acl.NewRegistry()
+	r.RegisterType(&acl.TypeCapabilities{
+		TypeID: 7,
+		Mappings: []acl.CapabilityMapping{
+			// Override: UpdateNode on field "status" requires ext-cap 11.
+			{Op: "UpdateNode", Field: "status", RequiredExt: 11},
+			// Even more specific: status="merged" requires ext 22.
+			{Op: "UpdateNode", Field: "status", FieldValue: "merged", RequiredExt: 22},
+		},
+	})
+	// No-field fall-through to default EDIT.
+	core, ext := r.RequiredForOp(7, "UpdateNode", acl.OpQuery{})
+	if core != acl.CoreCapEdit || ext != 0 {
+		t.Fatalf("UpdateNode no field = (%v, %v), want (Edit, 0)", core, ext)
+	}
+	// Field=status -> ext 11.
+	core, ext = r.RequiredForOp(7, "UpdateNode", acl.OpQuery{Field: "status"})
+	if ext != 11 {
+		t.Fatalf("UpdateNode field=status = (%v, %v), want (_, 11)", core, ext)
+	}
+	// Field=status, value=merged -> ext 22 (more specific wins).
+	core, ext = r.RequiredForOp(7, "UpdateNode", acl.OpQuery{Field: "status", FieldValue: "merged"})
+	if ext != 22 {
+		t.Fatalf("UpdateNode status=merged = (%v, %v), want (_, 22)", core, ext)
+	}
+}
+
+func TestCheckGrantUnspecifiedRequirementAllows(t *testing.T) {
+	r := acl.NewRegistry()
+	if !r.CheckGrant(nil, nil, acl.CoreCapUnspecified, 0, 0) {
+		t.Fatalf("CheckGrant with no requirement should allow")
+	}
+}
+
+func TestCheckGrantCoreImplications(t *testing.T) {
+	r := acl.NewRegistry()
+	// Holding ADMIN should satisfy READ, COMMENT, EDIT, DELETE.
+	for _, need := range []acl.CoreCapability{acl.CoreCapRead, acl.CoreCapComment, acl.CoreCapEdit, acl.CoreCapDelete, acl.CoreCapAdmin} {
+		if !r.CheckGrant([]acl.CoreCapability{acl.CoreCapAdmin}, nil, need, 0, 0) {
+			t.Fatalf("ADMIN should imply %v", need)
+		}
+	}
+	// Holding READ should satisfy READ only.
+	if !r.CheckGrant([]acl.CoreCapability{acl.CoreCapRead}, nil, acl.CoreCapRead, 0, 0) {
+		t.Fatalf("READ implies READ")
+	}
+	if r.CheckGrant([]acl.CoreCapability{acl.CoreCapRead}, nil, acl.CoreCapComment, 0, 0) {
+		t.Fatalf("READ should not imply COMMENT")
+	}
+	if r.CheckGrant([]acl.CoreCapability{acl.CoreCapRead}, nil, acl.CoreCapEdit, 0, 0) {
+		t.Fatalf("READ should not imply EDIT")
+	}
+	// COMMENT implies READ.
+	if !r.CheckGrant([]acl.CoreCapability{acl.CoreCapComment}, nil, acl.CoreCapRead, 0, 0) {
+		t.Fatalf("COMMENT implies READ")
+	}
+	// EDIT implies READ + COMMENT.
+	if !r.CheckGrant([]acl.CoreCapability{acl.CoreCapEdit}, nil, acl.CoreCapComment, 0, 0) {
+		t.Fatalf("EDIT implies COMMENT")
+	}
+}
+
+func TestCheckGrantExtImpliesCore(t *testing.T) {
+	r := acl.NewRegistry()
+	r.RegisterType(&acl.TypeCapabilities{
+		TypeID: 301,
+		Implications: []acl.CapabilityImplication{
+			// PR_EXT_CAP_MERGE (1) implies CORE_CAP_EDIT.
+			{Ext: 1, ImpliesCore: []acl.CoreCapability{acl.CoreCapEdit}},
+		},
+	})
+	// Holding ext=1 should satisfy CORE_CAP_EDIT (and READ, COMMENT via core closure).
+	if !r.CheckGrant(nil, []acl.ExtCapID{1}, acl.CoreCapEdit, 0, 301) {
+		t.Fatalf("ext=1 should imply EDIT")
+	}
+	if !r.CheckGrant(nil, []acl.ExtCapID{1}, acl.CoreCapRead, 0, 301) {
+		t.Fatalf("ext=1 -> EDIT -> READ")
+	}
+	// Cross-type ext does NOT satisfy.
+	if r.CheckGrant(nil, []acl.ExtCapID{1}, acl.CoreCapEdit, 0, 999) {
+		t.Fatalf("ext=1 in type=999 should not satisfy EDIT (type-scoped)")
+	}
+}
+
+func TestCheckGrantExtRequiredMatch(t *testing.T) {
+	r := acl.NewRegistry()
+	r.RegisterType(&acl.TypeCapabilities{TypeID: 1})
+	if !r.CheckGrant(nil, []acl.ExtCapID{42}, acl.CoreCapUnspecified, 42, 1) {
+		t.Fatalf("ext=42 should match required ext=42")
+	}
+	if r.CheckGrant(nil, []acl.ExtCapID{1}, acl.CoreCapUnspecified, 42, 1) {
+		t.Fatalf("ext=1 should NOT match required ext=42")
+	}
+}
+
+func TestRegistryLoadJSON(t *testing.T) {
+	const blob = `{
+        "types": [
+            {
+                "type_id": 7,
+                "extension_enum_name": "TaskExt",
+                "ext_cap_names": {"1": "ASSIGN", "2": "CHANGE_STATUS"},
+                "mappings": [
+                    {"op": "UpdateNode", "field": "assignee_id", "required_ext": 1}
+                ],
+                "implications": [
+                    {"ext": 2, "implies_core": [3]}
+                ]
+            }
+        ]
+    }`
+	r := acl.NewRegistry()
+	if err := r.LoadJSON([]byte(blob)); err != nil {
+		t.Fatalf("LoadJSON: %v", err)
+	}
+	core, ext := r.RequiredForOp(7, "UpdateNode", acl.OpQuery{Field: "assignee_id"})
+	if ext != 1 || core != 0 {
+		t.Fatalf("RequiredForOp(7,UpdateNode,assignee_id) = (%v,%v), want (_,1)", core, ext)
+	}
+	// ext=2 (CHANGE_STATUS) implies core EDIT per the JSON.
+	if !r.CheckGrant(nil, []acl.ExtCapID{2}, acl.CoreCapEdit, 0, 7) {
+		t.Fatalf("CHANGE_STATUS should imply EDIT")
+	}
+}
+
+func TestKnownTypeIDs(t *testing.T) {
+	r := acl.NewRegistry()
+	r.RegisterType(&acl.TypeCapabilities{TypeID: 5})
+	r.RegisterType(&acl.TypeCapabilities{TypeID: 1})
+	r.RegisterType(&acl.TypeCapabilities{TypeID: 3})
+	got := r.KnownTypeIDs()
+	if len(got) != 3 || got[0] != 1 || got[1] != 3 || got[2] != 5 {
+		t.Fatalf("KnownTypeIDs = %v, want [1 3 5]", got)
+	}
+}

--- a/server/go/internal/acl/resolver.go
+++ b/server/go/internal/acl/resolver.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// MaxGroupResolutionDepth bounds recursive group-membership expansion.
+// Mirrors canonical_store.py:_ACL_MAX_DEPTH = 10. Exceeding it yields
+// errs.ErrInvalidArgument (the Python WITH RECURSIVE … WHERE depth < 10
+// just stops expanding; we surface it as an explicit error so a
+// pathological group cycle isn't silently truncated).
+const MaxGroupResolutionDepth = 10
+
+// GroupMembershipReader is the data source for parent-group expansion.
+// For an actor (user/group), it returns the set of groups that
+// directly contain it. The Resolver walks these recursively up to
+// MaxGroupResolutionDepth.
+//
+// Implementations must be safe for concurrent use. The contract is
+// intentionally minimal so that the production binding in W1.10 can
+// adapt either store.CanonicalStore.group_users or an applier-side
+// in-memory mirror.
+type GroupMembershipReader interface {
+	// GroupsContaining returns the group_ids (no "group:" prefix; just
+	// the bare id) that have memberActorID as a direct member. The
+	// memberActorID is passed in canonical "kind:id" form (e.g.
+	// "user:alice" or "group:eng").
+	GroupsContaining(ctx context.Context, tenantID, memberActorID string) ([]string, error)
+}
+
+// Resolver expands group principals to a flat actor list. Mirrors the
+// Python resolve_actor_groups (canonical_store.py:2828-2865).
+//
+// Behaviour:
+//
+//   - For a user / service / role / system actor: returns [actor].
+//   - For a group actor: returns [group, ...recursive parent groups].
+//     Cycle-safe via a visited set.
+//   - Depth-bounded: walking past MaxGroupResolutionDepth from any
+//     starting actor yields errs.ErrInvalidArgument.
+type Resolver struct {
+	reader GroupMembershipReader
+}
+
+// NewResolver returns a Resolver backed by reader. reader may be nil
+// for callers (and tests) that only need the trivial single-actor
+// expansion path; calls that would require group lookup will return
+// errs.ErrInternal in that case.
+func NewResolver(reader GroupMembershipReader) *Resolver {
+	return &Resolver{reader: reader}
+}
+
+// Expand returns the flat actor list — the input actor plus every
+// group it transitively belongs to. Order is stable: input first,
+// breadth-first afterwards.
+//
+// The returned slice is always non-empty when err == nil (it contains
+// at least the input actor).
+func (r *Resolver) Expand(ctx context.Context, tenantID string, a Actor) ([]Actor, error) {
+	if a.IsZero() {
+		return nil, errs.Errorf(codes.InvalidArgument,
+			"acl: Resolver.Expand: empty actor")
+	}
+	out := []Actor{a}
+	// Only group / user actors meaningfully participate in group_users
+	// lookups. tenant: / role: / system: actors expand to themselves.
+	if a.Kind != ActorKindUser && a.Kind != ActorKindGroup {
+		return out, nil
+	}
+	if r.reader == nil {
+		// Trivial expansion: no upstream groups available. This is the
+		// degenerate path tests use when they don't seed groups.
+		return out, nil
+	}
+	visited := map[string]struct{}{a.String(): {}}
+	type qItem struct {
+		actor Actor
+		depth int
+	}
+	queue := []qItem{{actor: a, depth: 0}}
+	for len(queue) > 0 {
+		head := queue[0]
+		queue = queue[1:]
+		if head.depth >= MaxGroupResolutionDepth {
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"acl: group resolution depth exceeds %d for %s",
+				MaxGroupResolutionDepth, a)
+		}
+		gids, err := r.reader.GroupsContaining(ctx, tenantID, head.actor.String())
+		if err != nil {
+			return nil, err
+		}
+		for _, gid := range gids {
+			parent := Group(gid)
+			if _, ok := visited[parent.String()]; ok {
+				continue
+			}
+			visited[parent.String()] = struct{}{}
+			out = append(out, parent)
+			queue = append(queue, qItem{actor: parent, depth: head.depth + 1})
+		}
+	}
+	return out, nil
+}
+
+// ExpandIDs is a convenience wrapper that returns the canonical
+// "kind:id" string form. Useful for IN (?, ?, …) lookups against
+// node_access.actor_id and node_visibility.principal.
+func (r *Resolver) ExpandIDs(ctx context.Context, tenantID string, a Actor) ([]string, error) {
+	actors, err := r.Expand(ctx, tenantID, a)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, len(actors))
+	for i, x := range actors {
+		out[i] = x.String()
+	}
+	return out, nil
+}

--- a/server/go/internal/acl/resolver_test.go
+++ b/server/go/internal/acl/resolver_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// fakeGroups is a tiny in-memory GroupMembershipReader. The map key is
+// the canonical "kind:id" form of the member (e.g. "user:alice"); the
+// value is the list of bare group ids that contain it.
+type fakeGroups struct {
+	parents map[string][]string
+}
+
+func (f *fakeGroups) GroupsContaining(_ context.Context, _, member string) ([]string, error) {
+	return f.parents[member], nil
+}
+
+func TestResolverUserNoGroups(t *testing.T) {
+	r := acl.NewResolver(&fakeGroups{})
+	out, err := r.Expand(context.Background(), "t1", acl.User("alice"))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if len(out) != 1 || out[0] != acl.User("alice") {
+		t.Fatalf("Expand returned %+v", out)
+	}
+}
+
+func TestResolverNonGroupActorPassthrough(t *testing.T) {
+	r := acl.NewResolver(&fakeGroups{})
+	for _, a := range []acl.Actor{
+		acl.Service("svc"), acl.Role("admin"), acl.Tenant("acme"), acl.System("applier"),
+	} {
+		out, err := r.Expand(context.Background(), "t1", a)
+		if err != nil {
+			t.Fatalf("Expand(%v): %v", a, err)
+		}
+		if len(out) != 1 || out[0] != a {
+			t.Fatalf("Expand(%v) = %+v, want [%v]", a, out, a)
+		}
+	}
+}
+
+func TestResolverNilReaderTrivial(t *testing.T) {
+	r := acl.NewResolver(nil)
+	out, err := r.Expand(context.Background(), "t1", acl.User("alice"))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("nil reader expansion = %+v, want [user:alice]", out)
+	}
+}
+
+func TestResolverGroupRecursive(t *testing.T) {
+	// alice ∈ eng, eng ∈ all-employees, bob ∈ eng (not used here).
+	groups := &fakeGroups{parents: map[string][]string{
+		"user:alice": {"eng"},
+		"group:eng":  {"all-employees"},
+		"user:bob":   {"eng"},
+	}}
+	r := acl.NewResolver(groups)
+	out, err := r.Expand(context.Background(), "t1", acl.User("alice"))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	got := actorStrings(out)
+	want := map[string]struct{}{
+		"user:alice":          {},
+		"group:eng":           {},
+		"group:all-employees": {},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Expand alice = %v, want %v", got, want)
+	}
+	for _, s := range got {
+		if _, ok := want[s]; !ok {
+			t.Fatalf("unexpected %s in expansion %v", s, got)
+		}
+	}
+	// Input first.
+	if out[0] != acl.User("alice") {
+		t.Fatalf("first element should be input actor, got %v", out[0])
+	}
+}
+
+func TestResolverCycleSafe(t *testing.T) {
+	// group:a ∈ b, group:b ∈ a (cycle). Should not loop.
+	groups := &fakeGroups{parents: map[string][]string{
+		"group:a": {"b"},
+		"group:b": {"a"},
+	}}
+	r := acl.NewResolver(groups)
+	out, err := r.Expand(context.Background(), "t1", acl.Group("a"))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	// Should contain a and b, exactly once each.
+	if len(out) != 2 {
+		t.Fatalf("cycle expansion = %v, want 2 unique groups", out)
+	}
+}
+
+func TestResolverDepthExceeded(t *testing.T) {
+	// Build a chain longer than MaxGroupResolutionDepth (10).
+	parents := map[string][]string{}
+	parents["user:alice"] = []string{"g0"}
+	for i := 0; i < acl.MaxGroupResolutionDepth+5; i++ {
+		parents["group:g"+itoa(i)] = []string{"g" + itoa(i+1)}
+	}
+	r := acl.NewResolver(&fakeGroups{parents: parents})
+	_, err := r.Expand(context.Background(), "t1", acl.User("alice"))
+	if err == nil {
+		t.Fatalf("Expand should have errored on depth")
+	}
+	if !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("err = %v, want errs.ErrInvalidArgument", err)
+	}
+	if !strings.Contains(err.Error(), "depth") {
+		t.Fatalf("err = %v, expected depth message", err)
+	}
+}
+
+func TestResolverEmptyActor(t *testing.T) {
+	r := acl.NewResolver(nil)
+	_, err := r.Expand(context.Background(), "t1", acl.Actor{})
+	if !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("empty actor expansion err = %v, want ErrInvalidArgument", err)
+	}
+}
+
+func TestResolverExpandIDs(t *testing.T) {
+	groups := &fakeGroups{parents: map[string][]string{
+		"user:alice": {"eng"},
+	}}
+	r := acl.NewResolver(groups)
+	ids, err := r.ExpandIDs(context.Background(), "t1", acl.User("alice"))
+	if err != nil {
+		t.Fatalf("ExpandIDs: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("ExpandIDs = %v, want 2", ids)
+	}
+}
+
+func actorStrings(actors []acl.Actor) []string {
+	out := make([]string, len(actors))
+	for i, a := range actors {
+		out[i] = a.String()
+	}
+	return out
+}
+
+// tiny itoa to avoid importing strconv just for tests.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	var buf [20]byte
+	n := len(buf)
+	for i > 0 {
+		n--
+		buf[n] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		n--
+		buf[n] = '-'
+	}
+	return string(buf[n:])
+}


### PR DESCRIPTION
## Summary
- Ports the Python ACL engine to Go under `server/go/internal/acl/`: legacy 7-value `Permission` enum + the typed `CoreCapability` / per-type `ExtCapID` model frozen in `docs/decisions/acl.md`.
- `Resolver` walks `group_users` recursively, depth-bounded to 10 (Python `_ACL_MAX_DEPTH` parity) and cycle-safe via a visited set; over-depth returns `errs.ErrInvalidArgument`.
- `Registry` mirrors `CapabilityRegistry`: per-type implication closures, `RequiredForOp` with field/field_value/child_type selectors, `CheckGrant` honouring core + type-scoped ext caps, and a JSON loader for Wave-1 schema feed.
- `Checker` does owner short-circuit, DENY-first / allow-second, tenant:* wildcard, expiry, and the cross-tenant `tenant:<id>` grantee path.
- `Filter` provides the bulk read post-filter via a `VisibilityReader` interface satisfied by the existing `store.GetVisibleNodeIDs`.
- `Enforcer` ties Registry/Resolver/Checker/Filter together for handler use.

## Specs
- `docs/go-port/shared/acl.md`
- `docs/decisions/acl.md` (2026-04-13 typed-capability + cross-tenant decisions)

## Test plan
- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...`
- [x] `cd server/go && go test -race ./internal/acl/...`
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .`
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` (2529 passed)

Refs #407.