### PR TITLE
feat(go-rewrite): apply Go package — Wave 1

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -1,12 +1,13 @@
 // Command entdb-server is the Go reimplementation of the EntDB
-// gRPC server (tracking issue #407). It is intentionally minimal
-// in Phase 0: it parses flags, binds a gRPC server, and registers
-// an EntDBService that returns codes.Unimplemented for every RPC.
-// Real handlers land one PR at a time as RPC sub-issues are
-// completed.
+// gRPC server (tracking issue #407). Wave-1 wiring binds a gRPC
+// server (every RPC still returns codes.Unimplemented), opens the
+// per-tenant SQLite + globalstore handles, and starts the WAL
+// applier in a background goroutine. Real RPC handlers land one PR
+// at a time as Wave-2 issues are completed.
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"net"
@@ -17,11 +18,19 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
 
 func main() {
 	addr := flag.String("addr", ":50051", "gRPC bind address (host:port)")
+	dataDir := flag.String("data-dir", "", "directory for per-tenant SQLite + global.db")
+	walBackend := flag.String("wal-backend", "memory", "WAL backend: memory (only one supported in Wave 1)")
+	walTopic := flag.String("wal-topic", "entdb-wal", "WAL topic name")
+	walGroup := flag.String("wal-group", "entdb-applier", "WAL consumer group id")
 	flag.Parse()
 
 	lis, err := net.Listen("tcp", *addr)
@@ -29,19 +38,101 @@ func main() {
 		log.Fatalf("entdb-server: listen %s: %v", *addr, err)
 	}
 
+	srvOpts := []api.Option{}
+
+	// Per-tenant canonical store (optional in Wave-1; if data-dir is
+	// unset, RPCs will be served as Unimplemented anyway and the
+	// applier won't start).
+	var (
+		canonical *store.CanonicalStore
+		global    *globalstore.GlobalStore
+		applier   *apply.Applier
+	)
+	if *dataDir != "" {
+		canonical, err = store.New(store.Options{RootDir: *dataDir, WALMode: true})
+		if err != nil {
+			log.Fatalf("entdb-server: open canonical store: %v", err)
+		}
+		defer func() { _ = canonical.Close() }()
+		srvOpts = append(srvOpts, api.WithStore(canonical))
+
+		global, err = globalstore.New(globalstore.Options{DataDir: *dataDir, WALMode: true})
+		if err != nil {
+			log.Fatalf("entdb-server: open global store: %v", err)
+		}
+		defer func() { _ = global.Close() }()
+		srvOpts = append(srvOpts, api.WithGlobalStore(global))
+	}
+
+	// WAL backend wiring. Wave 1 only ships the in-memory backend.
+	var walImpl interface {
+		wal.Producer
+		wal.Consumer
+	}
+	switch *walBackend {
+	case "memory":
+		walImpl = wal.NewInMemory(0)
+	default:
+		log.Fatalf("entdb-server: unsupported wal backend %q (only 'memory' is supported in Wave 1)", *walBackend)
+	}
+	if err := walImpl.Connect(context.Background()); err != nil {
+		log.Fatalf("entdb-server: wal connect: %v", err)
+	}
+	srvOpts = append(srvOpts, api.WithWALProducer(walImpl))
+
+	// Applier: only when we have a canonical store.
+	if canonical != nil {
+		applier, err = apply.New(apply.Options{
+			Store:    canonical,
+			Global:   global,
+			Consumer: walImpl,
+			Topic:    *walTopic,
+			GroupID:  *walGroup,
+		})
+		if err != nil {
+			log.Fatalf("entdb-server: applier: %v", err)
+		}
+	}
+
 	srv := grpc.NewServer()
-	pb.RegisterEntDBServiceServer(srv, api.New())
+	pb.RegisterEntDBServiceServer(srv, api.New(srvOpts...))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Run the applier in a background goroutine. Halt-on-poison errors
+	// surface here; the supervisor (this loop) logs and shuts down.
+	applierErr := make(chan error, 1)
+	if applier != nil {
+		go func() {
+			applierErr <- applier.Run(ctx)
+		}()
+	}
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-stop
 		log.Printf("entdb-server: shutting down")
+		if applier != nil {
+			applier.Stop()
+		}
+		cancel()
 		srv.GracefulStop()
 	}()
 
-	log.Printf("entdb-server: listening on %s (all RPCs return Unimplemented)", *addr)
-	if err := srv.Serve(lis); err != nil {
-		log.Fatalf("entdb-server: serve: %v", err)
+	log.Printf("entdb-server: listening on %s (all RPCs return Unimplemented; applier=%v)", *addr, applier != nil)
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			log.Fatalf("entdb-server: serve: %v", err)
+		}
+	}()
+
+	if applier != nil {
+		if err := <-applierErr; err != nil && err != context.Canceled {
+			log.Printf("entdb-server: applier exited: %v", err)
+		}
+	} else {
+		<-ctx.Done()
 	}
 }

--- a/server/go/internal/api/server.go
+++ b/server/go/internal/api/server.go
@@ -6,21 +6,57 @@
 package api
 
 import (
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
 
 // Server is the EntDBService implementation. Embedding
 // UnimplementedEntDBServiceServer makes every RPC return
 // codes.Unimplemented by default and keeps the type
 // forward-compatible with new methods added to the proto.
+//
+// Wave-1 wiring: dependencies are injected through functional options
+// (Option) rather than globals so cmd/entdb-server/main.go can hand
+// off store + wal + globalstore handles without the api package
+// growing import cycles. Wave-2 RPC methods will reach for these via
+// the unexported fields on Server.
 type Server struct {
 	pb.UnimplementedEntDBServiceServer
+
+	store    *store.CanonicalStore
+	global   *globalstore.GlobalStore
+	producer wal.Producer
 }
 
-// New constructs a Server. The constructor is currently empty;
-// dependencies (WAL handle, applier, auth interceptor wiring)
-// will be added as the corresponding Python subsystems are
-// ported.
-func New() *Server {
-	return &Server{}
+// Option is a functional-options configurator for New.
+type Option func(*Server)
+
+// WithStore wires a *store.CanonicalStore (per-tenant SQLite). Wave-2
+// read RPCs will need it; Wave-1 just stores the handle for forward
+// compatibility.
+func WithStore(s *store.CanonicalStore) Option {
+	return func(srv *Server) { srv.store = s }
+}
+
+// WithGlobalStore wires the cross-tenant globalstore handle.
+func WithGlobalStore(g *globalstore.GlobalStore) Option {
+	return func(srv *Server) { srv.global = g }
+}
+
+// WithWALProducer wires the WAL producer (for ExecuteAtomic in Wave 2).
+func WithWALProducer(p wal.Producer) Option {
+	return func(srv *Server) { srv.producer = p }
+}
+
+// New constructs a Server. All RPCs return Unimplemented in Wave 1;
+// dependencies wired via opts are stored for use by Wave-2 handlers as
+// they land.
+func New(opts ...Option) *Server {
+	s := &Server{}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }

--- a/server/go/internal/apply/acladapter.go
+++ b/server/go/internal/apply/acladapter.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// StoreReaders is the adapter that fulfils every reader interface the
+// acl package declares (NodeMetaReader, GrantReader,
+// CrossTenantGrantReader, VisibilityReader, GroupMembershipReader),
+// backed by store.CanonicalStore + globalstore.GlobalStore.
+//
+// W1.9 (acl) deferred this adapter to W1.10 (apply) on the theory that
+// the applier owns the read-after-write consistency story — the same
+// adapter is used by the gRPC read RPCs in Wave 2.
+//
+// All methods are safe for concurrent goroutine use to the extent the
+// underlying stores are.
+type StoreReaders struct {
+	Canonical *store.CanonicalStore
+	Global    *globalstore.GlobalStore
+}
+
+// Compile-time assertions that StoreReaders satisfies every acl reader
+// contract. Missing methods would break Wave-2 wire-up, so we want the
+// build to fail here, not later.
+var (
+	_ acl.NodeMetaReader         = (*StoreReaders)(nil)
+	_ acl.GrantReader            = (*StoreReaders)(nil)
+	_ acl.CrossTenantGrantReader = (*StoreReaders)(nil)
+	_ acl.VisibilityReader       = (*StoreReaders)(nil)
+	_ acl.GroupMembershipReader  = (*StoreReaders)(nil)
+)
+
+// NodeMeta implements acl.NodeMetaReader. Returns errs.ErrNotFound when
+// the node is missing (matches the acl package's expected sentinel —
+// see acl/checker.go NodeMetaReader contract).
+func (r *StoreReaders) NodeMeta(ctx context.Context, tenantID, nodeID string) (acl.NodeMeta, error) {
+	if r.Canonical == nil {
+		return acl.NodeMeta{}, fmt.Errorf("apply: NodeMeta: canonical store not configured")
+	}
+	n, err := r.Canonical.GetNode(ctx, tenantID, nodeID)
+	if err != nil {
+		// store.ErrNodeNotFound wraps errs.ErrNotFound; pass through.
+		return acl.NodeMeta{}, err
+	}
+	return acl.NodeMeta{OwnerActor: n.OwnerActor, TypeID: n.TypeID}, nil
+}
+
+// GrantsForNode implements acl.GrantReader. Returns the ACL grants
+// stored on a single node, decoded from node_access plus the legacy
+// acl_blob column (the per-node ACL list). Expired rows are NOT
+// filtered here — the acl.Checker drops them.
+func (r *StoreReaders) GrantsForNode(ctx context.Context, tenantID, nodeID string) ([]acl.Grant, error) {
+	if r.Canonical == nil {
+		return nil, fmt.Errorf("apply: GrantsForNode: canonical store not configured")
+	}
+	db, err := getCanonicalDB(r.Canonical, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT actor_id, actor_type, permission, granted_by, granted_at,
+		       expires_at, type_id, core_caps_json, ext_cap_ids_json
+		FROM node_access WHERE node_id = ?`,
+		nodeID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("apply: query node_access: %w", err)
+	}
+	defer rows.Close()
+	var out []acl.Grant
+	for rows.Next() {
+		var (
+			actorID, actorType, permStr, grantedBy string
+			grantedAt                              int64
+			expires                                sql.NullInt64
+			typeID                                 int32
+			coreJSON, extJSON                      string
+		)
+		if err := rows.Scan(&actorID, &actorType, &permStr, &grantedBy, &grantedAt,
+			&expires, &typeID, &coreJSON, &extJSON); err != nil {
+			return nil, fmt.Errorf("apply: scan node_access: %w", err)
+		}
+		g := acl.Grant{
+			Subject:   parseActor(actorType, actorID),
+			NodeID:    nodeID,
+			TypeID:    typeID,
+			GrantedBy: parseActorString(grantedBy),
+			GrantedAt: grantedAt,
+		}
+		if perm, ok := acl.ParsePermission(permStr); ok {
+			g.Permission = perm
+		}
+		if expires.Valid {
+			ms := expires.Int64
+			g.ExpiresAt = &ms
+		}
+		// Decode typed-cap arrays.
+		if coreJSON != "" {
+			var raw []int32
+			if err := json.Unmarshal([]byte(coreJSON), &raw); err == nil {
+				for _, v := range raw {
+					g.CoreCaps = append(g.CoreCaps, acl.CoreCapability(v))
+				}
+			}
+		}
+		if extJSON != "" {
+			var raw []int32
+			if err := json.Unmarshal([]byte(extJSON), &raw); err == nil {
+				for _, v := range raw {
+					g.ExtCapIDs = append(g.ExtCapIDs, acl.ExtCapID(v))
+				}
+			}
+		}
+		out = append(out, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("apply: iterate node_access: %w", err)
+	}
+	return out, nil
+}
+
+// CrossTenantGrant implements acl.CrossTenantGrantReader. Looks up the
+// shared_index hint for (sourceTenant, nodeID, foreignActor) and
+// returns the typed permission; Wave 1 maps any hit to PermRead per
+// the acl package spec.
+func (r *StoreReaders) CrossTenantGrant(ctx context.Context, sourceTenant, nodeID, foreignActor string) (acl.Permission, bool, error) {
+	if r.Global == nil {
+		return acl.PermDeny, false, nil
+	}
+	// foreignActor is "kind:id"; the shared_index keys on the bare
+	// user_id (no kind prefix). Mirror the Python lookup behaviour by
+	// stripping the "user:" prefix when present.
+	userID := foreignActor
+	if len(userID) > 5 && userID[:5] == "user:" {
+		userID = userID[5:]
+	}
+	entries, err := r.Global.ListSharedFromNode(ctx, sourceTenant, nodeID)
+	if err != nil {
+		return acl.PermDeny, false, fmt.Errorf("apply: cross-tenant grant: %w", err)
+	}
+	for _, e := range entries {
+		if e.UserID == userID {
+			perm, _ := acl.ParsePermission(e.Permission)
+			if perm == acl.PermDeny {
+				perm = acl.PermRead
+			}
+			return perm, true, nil
+		}
+	}
+	return acl.PermDeny, false, nil
+}
+
+// VisibleNodeIDs implements acl.VisibilityReader. Pure pass-through to
+// store.GetVisibleNodeIDs.
+func (r *StoreReaders) VisibleNodeIDs(ctx context.Context, tenantID string, actorIDs []string, nodeIDs []string) (map[string]struct{}, error) {
+	if r.Canonical == nil {
+		return nil, fmt.Errorf("apply: VisibleNodeIDs: canonical store not configured")
+	}
+	return r.Canonical.GetVisibleNodeIDs(ctx, tenantID, actorIDs, nodeIDs)
+}
+
+// GroupsContaining implements acl.GroupMembershipReader. Reads the
+// group_users table and returns the bare group ids that contain
+// memberActorID as a direct member.
+func (r *StoreReaders) GroupsContaining(ctx context.Context, tenantID, memberActorID string) ([]string, error) {
+	if r.Canonical == nil {
+		return nil, fmt.Errorf("apply: GroupsContaining: canonical store not configured")
+	}
+	db, err := getCanonicalDB(r.Canonical, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx,
+		`SELECT group_id FROM group_users WHERE member_actor_id = ?`,
+		memberActorID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("apply: query group_users: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var gid string
+		if err := rows.Scan(&gid); err != nil {
+			return nil, fmt.Errorf("apply: scan group_users: %w", err)
+		}
+		out = append(out, gid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("apply: iterate group_users: %w", err)
+	}
+	return out, nil
+}
+
+// getCanonicalDB returns the per-tenant *sql.DB after ensuring the
+// tenant is open. Used by acl reads (GrantsForNode / GroupsContaining)
+// that don't have a dedicated public helper on store.CanonicalStore.
+func getCanonicalDB(s *store.CanonicalStore, tenantID string) (*sql.DB, error) {
+	if err := s.OpenTenant(context.Background(), tenantID); err != nil {
+		return nil, fmt.Errorf("apply: open tenant for ad-hoc read: %w", err)
+	}
+	return s.AdminDB(tenantID)
+}
+
+// parseActor builds an acl.Actor from a (kind, id) pair.
+func parseActor(kind, id string) acl.Actor {
+	switch kind {
+	case "group":
+		return acl.Group(id)
+	case "service":
+		return acl.Service(id)
+	default:
+		return acl.User(id)
+	}
+}
+
+// parseActorString builds an acl.Actor from a "kind:id" string. Falls
+// back to user: when no prefix is present.
+func parseActorString(s string) acl.Actor {
+	for i, c := range s {
+		if c == ':' {
+			return parseActor(s[:i], s[i+1:])
+		}
+	}
+	if s == "" {
+		return acl.Actor{}
+	}
+	return acl.User(s)
+}

--- a/server/go/internal/apply/alias.go
+++ b/server/go/internal/apply/alias.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"strings"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// Re-exports of types from sibling packages so callers (and tests) of
+// the apply package don't need to import wal / store directly just to
+// construct an Event or assert on a Result.
+type (
+	// Record is an alias for wal.Record — the unit a consumer reads.
+	Record = wal.Record
+	// StreamPos is an alias for wal.StreamPos — the receipt identity.
+	StreamPos = wal.StreamPos
+	// BatchTxn is an alias for store.BatchTxn — the per-event txn handle.
+	BatchTxn = store.BatchTxn
+)
+
+// nodeAliasMap is the per-event alias table backing the "as" / "$alias"
+// reference syntax in TransactionEvent.ops. Mirrors
+// server/python/entdb_server/apply/applier.py:_node_alias_map (375).
+//
+// CRITICAL: this map is per-event (a local variable on each
+// applyEvent call). Python's instance-attribute version has a latent
+// race; the Go port pins it scoped to one apply.
+type nodeAliasMap map[string]string
+
+// resolveRef resolves a node-id reference, expanding "$alias" into the
+// concrete node_id assigned earlier in the same event. Bare ids pass
+// through unchanged. Mirrors applier.py:_resolve_ref (760-770).
+func (m nodeAliasMap) resolveRef(ref string) string {
+	if strings.HasPrefix(ref, "$") {
+		if id, ok := m[ref[1:]]; ok {
+			return id
+		}
+	}
+	return ref
+}
+
+// resolveNodeRef is a convenience for the create_edge/delete_edge ops
+// that always resolve the ref before use. Mirrors applier.py:_resolve_node_ref.
+func (m nodeAliasMap) resolveNodeRef(ref string) string {
+	return m.resolveRef(ref)
+}

--- a/server/go/internal/apply/applier.go
+++ b/server/go/internal/apply/applier.go
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// Options configures a new Applier. Required fields: Store, Consumer,
+// Topic, GroupID. Global is optional (no globalstore wiring => set_legal_hold
+// and tenant-membership ops degrade to no-ops, matching the Python
+// optional-store guards).
+type Options struct {
+	Store    *store.CanonicalStore
+	Global   *globalstore.GlobalStore
+	Consumer wal.Consumer
+	Topic    string
+	GroupID  string
+
+	// BatchSize is the max records PollBatch returns per iteration.
+	// Defaults to 32 (matches the Python applier batch_size default).
+	BatchSize int
+
+	// PollTimeout is how long PollBatch blocks waiting for records.
+	// Defaults to 100ms.
+	PollTimeout time.Duration
+
+	// NowFn returns the current Unix-millis. Injectable for deterministic
+	// tests. nil -> time.Now().UnixMilli.
+	NowFn func() int64
+
+	// FanoutHook is an optional post-commit hook for tests / Wave-2
+	// notification wiring. Best-effort; errors do not fail the apply.
+	FanoutHook func(ctx context.Context, ev *Event, res *Result)
+
+	// HaltOnPoison toggles halt-on-error behaviour. Defaults to true
+	// (production parity with Python halt_on_error=True). Tests that
+	// want to explore skip-and-continue paths can flip it; the contract
+	// pinned by docs/go-port/shared/applier.md is that production must
+	// halt.
+	HaltOnPoison *bool
+}
+
+// Applier is the WAL consumer that materialises TransactionEvents into
+// per-tenant SQLite. Single consumer goroutine per (topic, group_id)
+// (Python parity); per-tenant pool deferred to a follow-up.
+//
+// Concurrency: Run is meant to be called once per Applier. Stop is
+// safe to call from any goroutine and is idempotent. Replay is safe to
+// call concurrently with Run if and only if it operates against a
+// different tenant DB (the per-tenant write mutex from store enforces
+// the rest).
+type Applier struct {
+	store    *store.CanonicalStore
+	global   *globalstore.GlobalStore
+	consumer wal.Consumer
+	topic    string
+	groupID  string
+
+	batchSize    int
+	pollTimeout  time.Duration
+	nowFn        func() int64
+	fanoutHook   func(ctx context.Context, ev *Event, res *Result)
+	haltOnPoison bool
+
+	// running is non-zero when the Run loop has started. Used by
+	// Stop to skip the wait-for-loop-exit path when Run never started.
+	running  atomic.Bool
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+}
+
+// New constructs an Applier. Required: Store, Consumer, Topic, GroupID.
+// Returns an error if any required dependency is nil/empty.
+func New(opts Options) (*Applier, error) {
+	if opts.Store == nil {
+		return nil, errors.New("apply: Options.Store is required")
+	}
+	if opts.Consumer == nil {
+		return nil, errors.New("apply: Options.Consumer is required")
+	}
+	if opts.Topic == "" {
+		return nil, errors.New("apply: Options.Topic is required")
+	}
+	if opts.GroupID == "" {
+		return nil, errors.New("apply: Options.GroupID is required")
+	}
+	batch := opts.BatchSize
+	if batch <= 0 {
+		batch = 32
+	}
+	pollTO := opts.PollTimeout
+	if pollTO <= 0 {
+		pollTO = 100 * time.Millisecond
+	}
+	nowFn := opts.NowFn
+	if nowFn == nil {
+		nowFn = func() int64 { return time.Now().UnixMilli() }
+	}
+	halt := true
+	if opts.HaltOnPoison != nil {
+		halt = *opts.HaltOnPoison
+	}
+	return &Applier{
+		store:        opts.Store,
+		global:       opts.Global,
+		consumer:     opts.Consumer,
+		topic:        opts.Topic,
+		groupID:      opts.GroupID,
+		batchSize:    batch,
+		pollTimeout:  pollTO,
+		nowFn:        nowFn,
+		fanoutHook:   opts.FanoutHook,
+		haltOnPoison: halt,
+		stopCh:       make(chan struct{}),
+		doneCh:       make(chan struct{}),
+	}, nil
+}
+
+func (a *Applier) now() int64 { return a.nowFn() }
+
+// Run is the consumer loop. It blocks until ctx is cancelled, Stop is
+// called, or a poison event halts the consumer (when halt-on-poison is
+// true). On halt-on-poison the offset is NOT advanced past the failing
+// record so a restart re-attempts it.
+func (a *Applier) Run(ctx context.Context) error {
+	if !a.running.CompareAndSwap(false, true) {
+		return ErrApplierClosed
+	}
+	defer close(a.doneCh)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-a.stopCh:
+			return nil
+		default:
+		}
+
+		records, err := a.consumer.PollBatch(ctx, a.topic, a.groupID, a.batchSize, a.pollTimeout)
+		if err != nil {
+			// ctx cancellation surfaces here as a wrapped error; treat
+			// as graceful shutdown.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			return fmt.Errorf("apply: poll batch: %w", err)
+		}
+		for i, rec := range records {
+			res := a.applyRecord(ctx, rec)
+			if res.Err != nil {
+				if a.haltOnPoison {
+					// Do NOT advance offset; the consumer group's
+					// committed position stays at the last successful
+					// record. Subsequent records (records[i+1:]) are
+					// dropped on the floor — they'll be re-delivered
+					// after restart.
+					_ = i
+					return res.Err
+				}
+				// skip-and-continue: still commit the offset (mirrors
+				// Python halt_on_error=False) and move on.
+			}
+			if err := a.consumer.Commit(ctx, a.groupID, rec); err != nil {
+				return fmt.Errorf("apply: commit offset: %w", err)
+			}
+			if res.Status == StatusApplied || res.Status == StatusSkipped {
+				if err := a.store.UpdateAppliedOffset(ctx, res.TenantID, rec.Position.Topic, rec.Position.Partition, rec.Position.Offset); err != nil {
+					// Persisting the offset is best-effort; the in-
+					// memory tracker has already been updated by the
+					// in-txn UpdateAppliedOffsetTx call. Surface the
+					// error so the supervisor can act.
+					return fmt.Errorf("apply: persist offset: %w", err)
+				}
+			}
+			// Best-effort post-commit fan-out + shared_index.
+			a.fanout(ctx, decodeOrZero(rec), &res)
+		}
+	}
+}
+
+// Stop signals Run to return and waits for it to exit. Safe to call
+// concurrently and idempotent.
+func (a *Applier) Stop() {
+	a.stopOnce.Do(func() { close(a.stopCh) })
+	if a.running.Load() {
+		<-a.doneCh
+	}
+}
+
+// applyRecord is the per-record entry point. Decodes the WAL record,
+// opens a BatchTxn, dispatches every op, and finalises with the
+// idempotency probe (inside-txn check). Mirrors applier.py:1349-1392.
+func (a *Applier) applyRecord(ctx context.Context, rec Record) Result {
+	res := Result{Position: rec.Position}
+	ev, err := wal.DecodeEvent(rec.Value)
+	if err != nil {
+		res.Status = StatusFailed
+		res.Err = fmt.Errorf("%w: %s", ErrPoisonEvent, err.Error())
+		return res
+	}
+	res.TenantID = ev.TenantID
+	if err := a.applyEvent(ctx, &ev, &res); err != nil {
+		res.Status = StatusFailed
+		res.Err = err
+		return res
+	}
+	return res
+}
+
+// applyEvent runs the per-event apply transaction. Idempotency check
+// happens INSIDE the txn (per docs/go-port/shared/applier.md), before
+// any mutation. The applied_events row is recorded in the same txn.
+func (a *Applier) applyEvent(ctx context.Context, ev *Event, res *Result) error {
+	if err := a.store.OpenTenant(ctx, ev.TenantID); err != nil {
+		return fmt.Errorf("apply: open tenant %q: %w", ev.TenantID, err)
+	}
+	tx, err := a.store.BeginBatch(ctx, ev.TenantID)
+	if err != nil {
+		return fmt.Errorf("apply: begin batch: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// In-txn idempotency probe.
+	conn := tx.Conn()
+	var one int
+	row := conn.QueryRowContext(ctx,
+		`SELECT 1 FROM applied_events WHERE tenant_id = ? AND idempotency_key = ?`,
+		ev.TenantID, ev.IdempotencyKey,
+	)
+	if err := row.Scan(&one); err == nil {
+		// Already applied. Commit a no-op txn (the idempotency probe
+		// holds the RESERVED lock; releasing it via COMMIT is harmless
+		// and cheaper than ROLLBACK).
+		res.Status = StatusSkipped
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("apply: commit no-op: %w", err)
+		}
+		committed = true
+		return nil
+	} else if !isNoRows(err) {
+		return fmt.Errorf("apply: idempotency probe: %w", err)
+	}
+
+	// Per-event alias map (per CLAUDE.md / spec; never global).
+	aliases := nodeAliasMap{}
+
+	for _, op := range ev.Ops {
+		if op == nil {
+			continue
+		}
+		if err := a.dispatch(ctx, tx, ev, op, aliases, res); err != nil {
+			return err
+		}
+	}
+
+	// Record the applied_events row inside the same txn.
+	if _, err := conn.ExecContext(ctx, `
+		INSERT INTO applied_events (tenant_id, idempotency_key, stream_pos, applied_at)
+		VALUES (?, ?, ?, ?)`,
+		ev.TenantID, ev.IdempotencyKey, res.Position.String(), a.now(),
+	); err != nil {
+		return fmt.Errorf("apply: record applied_events: %w", err)
+	}
+
+	// In-txn offset advance so the receipt observer wakes immediately.
+	if err := a.store.UpdateAppliedOffsetTx(ctx, tx, res.Position.Topic, res.Position.Partition, res.Position.Offset); err != nil {
+		return fmt.Errorf("apply: in-txn offset: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("apply: commit: %w", err)
+	}
+	committed = true
+	res.Status = StatusApplied
+	return nil
+}
+
+// dispatch routes one op to its handler. Unknown op types fail closed
+// (halt-on-poison) so a typo in a handler that raced ahead of the
+// applier surfaces immediately rather than silently dropping data —
+// the lesson the DelegateAccess bug taught us.
+func (a *Applier) dispatch(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, aliases nodeAliasMap, res *Result) error {
+	switch opTypeOf(op) {
+	case OpCreateNode:
+		return a.applyCreateNode(ctx, tx, ev, op, aliases, res)
+	case OpUpdateNode:
+		return a.applyUpdateNode(ctx, tx, ev, op, aliases)
+	case OpDeleteNode:
+		return a.applyDeleteNode(ctx, tx, ev, op, aliases, res)
+	case OpCreateEdge:
+		return a.applyCreateEdge(ctx, tx, ev, op, aliases, res)
+	case OpDeleteEdge:
+		return a.applyDeleteEdge(ctx, tx, ev, op, aliases)
+	case OpAdminTransferContent:
+		return a.applyAdminTransferContent(ctx, tx, ev, op)
+	case OpAdminRevokeAccess:
+		return a.applyAdminRevokeAccess(ctx, tx, ev, op)
+	case OpShareNode:
+		return a.applyShareNode(ctx, tx, ev, op, res)
+	case OpRevokeAccess:
+		return a.applyRevokeAccess(ctx, tx, ev, op, res)
+	case OpDelegateAccess:
+		return a.applyDelegateAccess(ctx, tx, ev, op, res)
+	case OpTransferOwnership:
+		return a.applyTransferOwnership(ctx, tx, ev, op)
+	case OpAddGroupMember:
+		return a.applyAddGroupMember(ctx, tx, ev, op)
+	case OpRemoveGroupMember:
+		return a.applyRemoveGroupMember(ctx, tx, ev, op)
+	case OpSetLegalHold:
+		return a.applySetLegalHold(ctx, ev, op)
+	case OpAddTenantMember:
+		return a.applyAddTenantMember(ctx, ev, op)
+	case OpRemoveTenantMember:
+		return a.applyRemoveTenantMember(ctx, ev, op)
+	case OpChangeMemberRole:
+		return a.applyChangeMemberRole(ctx, ev, op)
+	default:
+		return fmt.Errorf("%w: %q", ErrUnknownOpType, opTypeOf(op))
+	}
+}
+
+// Replay drives the applier from a specific WAL offset for one tenant.
+// Used by the recovery harness (Tier 2 — KAFKA_WAL replay from
+// snapshot's last_stream_pos forward). For Wave 1 it shares the same
+// consumer/store wiring as Run; the caller is responsible for ensuring
+// the consumer group's stored offset is positioned correctly before
+// invoking.
+//
+// For convenience (and to keep the test surface honest), Replay returns
+// after a single PollBatch returns 0 records — the in-memory WAL
+// signals "drained" by returning an empty slice with nil error.
+func (a *Applier) Replay(ctx context.Context, tenantID string, fromPos int64) error {
+	// fromPos is reserved for future use (resetting the consumer-group
+	// offset before driving). The in-memory WAL we ship with today
+	// derives this from a fresh group_id; production backends will
+	// implement a Seek primitive.
+	_ = fromPos
+	for {
+		records, err := a.consumer.PollBatch(ctx, a.topic, a.groupID, a.batchSize, 50*time.Millisecond)
+		if err != nil {
+			return err
+		}
+		if len(records) == 0 {
+			return nil
+		}
+		for _, rec := range records {
+			res := a.applyRecord(ctx, rec)
+			if tenantID != "" && res.TenantID != tenantID {
+				// Replay is per-tenant; commit the offset (we still
+				// need to advance the consumer group) but skip the
+				// post-commit work.
+				_ = a.consumer.Commit(ctx, a.groupID, rec)
+				continue
+			}
+			if res.Err != nil {
+				return res.Err
+			}
+			if err := a.consumer.Commit(ctx, a.groupID, rec); err != nil {
+				return fmt.Errorf("apply: replay commit offset: %w", err)
+			}
+			a.fanout(ctx, decodeOrZero(rec), &res)
+		}
+	}
+}
+
+// decodeOrZero returns a decoded Event for fan-out, or a zero-value
+// Event when decode fails (the apply path already failed; fan-out is
+// best-effort).
+func decodeOrZero(rec Record) *Event {
+	ev, err := wal.DecodeEvent(rec.Value)
+	if err != nil {
+		return &Event{}
+	}
+	return &ev
+}

--- a/server/go/internal/apply/applier_test.go
+++ b/server/go/internal/apply/applier_test.go
@@ -1,0 +1,775 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const (
+	testTopic   = "entdb-wal-test"
+	testTenant  = "tenant_a"
+	testGroupID = "applier-test"
+)
+
+// fixture wires an in-memory WAL + per-tenant store + (optional) global
+// store + applier. Cleaning up is t.Cleanup so individual tests don't
+// have to remember to Stop / Close.
+type fixture struct {
+	t       *testing.T
+	wal     *wal.InMemory
+	store   *store.CanonicalStore
+	global  *globalstore.GlobalStore
+	applier *apply.Applier
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	dir := t.TempDir()
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+
+	a, err := apply.New(apply.Options{
+		Store:    cs,
+		Global:   gs,
+		Consumer: w,
+		Topic:    testTopic,
+		GroupID:  testGroupID,
+		// Tight poll timeout keeps the consumer responsive in tests.
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	if err := cs.OpenTenant(context.Background(), testTenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	return &fixture{t: t, wal: w, store: cs, global: gs, applier: a}
+}
+
+// appendEvent JSON-encodes ev and appends it to the WAL under the
+// tenant's key. Returns the assigned StreamPos.
+func (f *fixture) appendEvent(t *testing.T, ev apply.Event) wal.StreamPos {
+	t.Helper()
+	val, err := ev.Encode()
+	if err != nil {
+		t.Fatalf("event.Encode: %v", err)
+	}
+	headers := map[string][]byte{
+		wal.HeaderIdempotencyKey: []byte(ev.IdempotencyKey),
+	}
+	pos, err := f.wal.Append(context.Background(), testTopic, ev.TenantID, val, headers)
+	if err != nil {
+		t.Fatalf("wal.Append: %v", err)
+	}
+	return pos
+}
+
+// runApplierUntilApplied runs the applier in a goroutine and returns a
+// stop function. The caller is expected to call stop() when done.
+func (f *fixture) runApplierUntilApplied(t *testing.T) (cancel func()) {
+	t.Helper()
+	ctx, cancelF := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx) }()
+	t.Cleanup(func() {
+		cancelF()
+		<-done
+	})
+	return cancelF
+}
+
+// waitForIdempKey polls until idempKey appears in applied_events for
+// tenantID, or the deadline fires.
+func (f *fixture) waitForIdempKey(t *testing.T, tenantID, idempKey string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ok, err := f.store.CheckIdempotency(context.Background(), tenantID, idempKey)
+		if err != nil {
+			t.Fatalf("CheckIdempotency: %v", err)
+		}
+		if ok {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("waitForIdempKey: %q never showed up", idempKey)
+}
+
+func mkCreateNode(id string, typeID int32, payload map[string]any) map[string]any {
+	return map[string]any{
+		"op":      string(apply.OpCreateNode),
+		"id":      id,
+		"type_id": typeID,
+		"data":    payload,
+	}
+}
+
+// dumpState produces a deterministic snapshot of the per-tenant store
+// for replay-determinism assertions. Only the columns the contract
+// pins are included.
+func dumpState(t *testing.T, cs *store.CanonicalStore, tenantID string, nodeIDs []string) map[string]any {
+	t.Helper()
+	type nodeRepr struct {
+		NodeID      string
+		TypeID      int32
+		OwnerActor  string
+		PayloadJSON string
+		ACLJSON     string
+	}
+	out := map[string]any{}
+	var nodes []nodeRepr
+	for _, id := range nodeIDs {
+		n, err := cs.GetNode(context.Background(), tenantID, id)
+		if err != nil {
+			continue
+		}
+		nodes = append(nodes, nodeRepr{
+			NodeID:      n.NodeID,
+			TypeID:      n.TypeID,
+			OwnerActor:  n.OwnerActor,
+			PayloadJSON: n.PayloadJSON,
+			ACLJSON:     n.ACLJSON,
+		})
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].NodeID < nodes[j].NodeID })
+	out["nodes"] = nodes
+	return out
+}
+
+// TestApplier_HappyPathCreateNode confirms a create_node op materialises a
+// row through the applier.
+func TestApplier_HappyPathCreateNode(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	ev := apply.Event{
+		TenantID:       testTenant,
+		Actor:          "user:alice",
+		IdempotencyKey: "k1",
+		TsMs:           1700000000000,
+		Ops:            []map[string]any{mkCreateNode("node1", 1, map[string]any{"1": "alice@x"})},
+	}
+	f.appendEvent(t, ev)
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "k1")
+
+	n, err := f.store.GetNode(context.Background(), testTenant, "node1")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if n.OwnerActor != "user:alice" {
+		t.Fatalf("owner: got %q want user:alice", n.OwnerActor)
+	}
+}
+
+// TestApplier_DelegateAccessFix is the contract-pinning regression for
+// PLAN.md §6.4 item 1 — the Python applier silently drops
+// admin_delegate_access events. The Go applier MUST materialise the
+// node_access grant on replay.
+func TestApplier_DelegateAccessFix(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+
+	// Seed a node so the grant has a target.
+	createEv := apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "seed",
+		Ops: []map[string]any{mkCreateNode("doc1", 1, map[string]any{"1": "secret"})},
+	}
+	f.appendEvent(t, createEv)
+
+	// Delegate access to a different actor.
+	delegEv := apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "deleg1",
+		Ops: []map[string]any{{
+			"op":         string(apply.OpDelegateAccess),
+			"node_id":    "doc1",
+			"actor_id":   "user:bob",
+			"actor_type": "user",
+			"permission": "read",
+		}},
+	}
+	f.appendEvent(t, delegEv)
+
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "deleg1")
+
+	// Assert the grant exists in node_access. We use AdminDB to read
+	// directly because the store package doesn't yet expose a
+	// ListGrantsForNode helper.
+	db, err := f.store.AdminDB(testTenant)
+	if err != nil {
+		t.Fatalf("AdminDB: %v", err)
+	}
+	var actor, perm string
+	err = db.QueryRowContext(context.Background(),
+		`SELECT actor_id, permission FROM node_access WHERE node_id = ?`,
+		"doc1",
+	).Scan(&actor, &perm)
+	if err != nil {
+		t.Fatalf("delegate-access did not materialise a node_access row: %v "+
+			"(this is the Python bug — the Go applier MUST close it)", err)
+	}
+	if actor != "user:bob" || perm != "read" {
+		t.Fatalf("delegate-access wrong row: actor=%q perm=%q (want user:bob/read)", actor, perm)
+	}
+}
+
+// TestApplier_HaltsOnPoison appends a structurally-malformed op (missing
+// id on create_node) and asserts Run returns a non-nil error AND the
+// WAL offset did not advance past the poison record.
+func TestApplier_HaltsOnPoison(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+
+	good := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "good",
+		Ops: []map[string]any{mkCreateNode("good1", 1, nil)},
+	}
+	f.appendEvent(t, good)
+
+	// Poisoned: create_node with no id.
+	poison := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "poison",
+		Ops: []map[string]any{{"op": "create_node", "type_id": 1}},
+	}
+	f.appendEvent(t, poison)
+
+	// Following good event — must NOT be applied.
+	after := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "after",
+		Ops: []map[string]any{mkCreateNode("after1", 1, nil)},
+	}
+	f.appendEvent(t, after)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx) }()
+
+	// Wait for halt.
+	var runErr error
+	select {
+	case runErr = <-done:
+	case <-time.After(2 * time.Second):
+		cancel()
+		<-done
+		t.Fatalf("applier did not halt within 2s (poison should have surfaced)")
+	}
+	if runErr == nil {
+		t.Fatalf("applier returned nil; expected halt-on-poison error")
+	}
+	if !errors.Is(runErr, apply.ErrPoisonEvent) {
+		t.Fatalf("got %v, want ErrPoisonEvent", runErr)
+	}
+	// Good event applied.
+	ok, _ := f.store.CheckIdempotency(context.Background(), testTenant, "good")
+	if !ok {
+		t.Fatalf("good event was not applied before halt")
+	}
+	// After event NOT applied.
+	ok, _ = f.store.CheckIdempotency(context.Background(), testTenant, "after")
+	if ok {
+		t.Fatalf("after-poison event should not have been applied (offset advanced past poison)")
+	}
+}
+
+// TestApplier_IdempotencySameKeyOnce confirms two appends of the same
+// idempotency_key produce one effect in the store.
+func TestApplier_IdempotencySameKeyOnce(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	ev := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "dup",
+		Ops: []map[string]any{mkCreateNode("once", 1, map[string]any{"1": "first"})},
+	}
+	f.appendEvent(t, ev)
+	// Different node id but same idempotency key — second is a SKIP.
+	ev2 := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "dup",
+		TsMs: ev.TsMs + 1,
+		Ops:  []map[string]any{mkCreateNode("once-other", 1, map[string]any{"1": "second"})},
+	}
+	f.appendEvent(t, ev2)
+
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "dup")
+	// Give the applier a moment to chew on the second record (which it
+	// must skip).
+	time.Sleep(150 * time.Millisecond)
+
+	if _, err := f.store.GetNode(context.Background(), testTenant, "once"); err != nil {
+		t.Fatalf("first node missing: %v", err)
+	}
+	if _, err := f.store.GetNode(context.Background(), testTenant, "once-other"); err == nil {
+		t.Fatalf("second node was applied; idempotency key did not skip the duplicate")
+	}
+}
+
+// TestApplier_ReplayDeterminism mirrors test_wal_replay_determinism.py.
+// Drive a mixed sequence, dump state, wipe the store, replay from a
+// fresh group_id, dump again, assert equal.
+func TestApplier_ReplayDeterminism(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+
+	events := []apply.Event{
+		{TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "e1", TsMs: 1700000000000,
+			Ops: []map[string]any{mkCreateNode("n1", 1, map[string]any{"1": "alice"})}},
+		{TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "e2", TsMs: 1700000000001,
+			Ops: []map[string]any{mkCreateNode("n2", 1, map[string]any{"1": "bob"})}},
+		{TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "e3", TsMs: 1700000000002,
+			Ops: []map[string]any{{
+				"op": string(apply.OpUpdateNode), "id": "n1",
+				"patch": map[string]any{"2": "updated"},
+			}}},
+		{TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "e4", TsMs: 1700000000003,
+			Ops: []map[string]any{{
+				"op": string(apply.OpCreateEdge), "edge_id": int32(7),
+				"from": "n1", "to": "n2",
+			}}},
+		// Delegate access — exercises the bugfix path on replay too.
+		{TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "e5", TsMs: 1700000000004,
+			Ops: []map[string]any{{
+				"op": string(apply.OpDelegateAccess), "node_id": "n1",
+				"actor_id": "user:carol", "permission": "read",
+			}}},
+	}
+	for _, ev := range events {
+		f.appendEvent(t, ev)
+	}
+	f.runApplierUntilApplied(t)
+	for _, ev := range events {
+		f.waitForIdempKey(t, testTenant, ev.IdempotencyKey)
+	}
+	first := dumpState(t, f.store, testTenant, []string{"n1", "n2"})
+
+	// Now: tear down store, reopen on the SAME WAL with a fresh
+	// group_id so PollBatch returns from offset 0.
+	f.applier.Stop()
+	if err := f.store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	dir := t.TempDir()
+	cs2, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New replay: %v", err)
+	}
+	defer cs2.Close()
+	if err := cs2.OpenTenant(context.Background(), testTenant); err != nil {
+		t.Fatalf("OpenTenant replay: %v", err)
+	}
+
+	a2, err := apply.New(apply.Options{
+		Store:       cs2,
+		Consumer:    f.wal,
+		Topic:       testTopic,
+		GroupID:     "applier-replay", // FRESH group => offset starts at 0
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New replay: %v", err)
+	}
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	done2 := make(chan error, 1)
+	go func() { done2 <- a2.Run(ctx2) }()
+	defer func() { a2.Stop(); <-done2 }()
+
+	// Wait for replay to apply every event.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		ok, _ := cs2.CheckIdempotency(context.Background(), testTenant, "e5")
+		if ok {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	second := dumpState(t, cs2, testTenant, []string{"n1", "n2"})
+	if !reflect.DeepEqual(first, second) {
+		fa, _ := json.MarshalIndent(first, "", "  ")
+		sb, _ := json.MarshalIndent(second, "", "  ")
+		t.Fatalf("replay determinism violated:\nfirst:\n%s\nsecond:\n%s", fa, sb)
+	}
+}
+
+// TestApplier_ShareNodeRecorded exercises the WAL-first share_node op.
+func TestApplier_ShareNodeRecorded(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "seed",
+		Ops: []map[string]any{mkCreateNode("doc-share", 1, nil)},
+	})
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "share1",
+		Ops: []map[string]any{{
+			"op": string(apply.OpShareNode), "node_id": "doc-share",
+			"actor_id": "user:bob", "permission": "read",
+		}},
+	})
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "share1")
+
+	db, _ := f.store.AdminDB(testTenant)
+	var n int
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM node_access WHERE node_id = ? AND actor_id = ?`,
+		"doc-share", "user:bob",
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("share_node did not write node_access row (n=%d)", n)
+	}
+}
+
+// TestApplier_RevokeAccess exercises the WAL-first revoke op.
+func TestApplier_RevokeAccess(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "seed",
+		Ops: []map[string]any{mkCreateNode("d", 1, nil)},
+	})
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "share",
+		Ops: []map[string]any{{
+			"op": string(apply.OpShareNode), "node_id": "d",
+			"actor_id": "user:bob", "permission": "read",
+		}},
+	})
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "revoke",
+		Ops: []map[string]any{{
+			"op": string(apply.OpRevokeAccess), "node_id": "d", "actor_id": "user:bob",
+		}},
+	})
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "revoke")
+
+	db, _ := f.store.AdminDB(testTenant)
+	var n int
+	_ = db.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM node_access WHERE node_id = ? AND actor_id = ?`,
+		"d", "user:bob",
+	).Scan(&n)
+	if n != 0 {
+		t.Fatalf("revoke_access left a row behind (n=%d)", n)
+	}
+}
+
+// TestApplier_TransferOwnership exercises the WAL-first transfer op.
+func TestApplier_TransferOwnership(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "seed",
+		Ops: []map[string]any{mkCreateNode("xfer", 1, nil)},
+	})
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "xfer",
+		Ops: []map[string]any{{
+			"op":      string(apply.OpTransferOwnership),
+			"node_id": "xfer", "new_owner": "user:bob",
+		}},
+	})
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "xfer")
+
+	n, err := f.store.GetNode(context.Background(), testTenant, "xfer")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if n.OwnerActor != "user:bob" {
+		t.Fatalf("owner: got %q want user:bob", n.OwnerActor)
+	}
+}
+
+// TestApplier_GroupMembership exercises add/remove group member ops.
+func TestApplier_GroupMembership(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:admin", IdempotencyKey: "add1",
+		Ops: []map[string]any{{
+			"op":       string(apply.OpAddGroupMember),
+			"group_id": "engineering", "member_actor_id": "user:alice",
+		}},
+	})
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "add1")
+
+	db, _ := f.store.AdminDB(testTenant)
+	var role string
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT role FROM group_users WHERE group_id = ? AND member_actor_id = ?`,
+		"engineering", "user:alice",
+	).Scan(&role); err != nil {
+		t.Fatalf("group row not found: %v", err)
+	}
+
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:admin", IdempotencyKey: "rm1",
+		Ops: []map[string]any{{
+			"op":       string(apply.OpRemoveGroupMember),
+			"group_id": "engineering", "member_actor_id": "user:alice",
+		}},
+	})
+	f.waitForIdempKey(t, testTenant, "rm1")
+	var n int
+	_ = db.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM group_users WHERE group_id = ?`, "engineering",
+	).Scan(&n)
+	if n != 0 {
+		t.Fatalf("group member not removed: n=%d", n)
+	}
+}
+
+// TestApplier_AdminRevokeAccessBroadens confirms PLAN.md §6.4 item 2:
+// admin_revoke_access deletes node_access AND group_users (Python only
+// deletes node_visibility).
+func TestApplier_AdminRevokeAccessBroadens(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+
+	// Seed a node + share + group membership for user:bob.
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "seed",
+		Ops: []map[string]any{mkCreateNode("doc", 1, nil)},
+	})
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "share",
+		Ops: []map[string]any{{
+			"op": string(apply.OpShareNode), "node_id": "doc",
+			"actor_id": "user:bob", "permission": "read",
+		}},
+	})
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:owner", IdempotencyKey: "join",
+		Ops: []map[string]any{{
+			"op":       string(apply.OpAddGroupMember),
+			"group_id": "g", "member_actor_id": "user:bob",
+		}},
+	})
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:admin", IdempotencyKey: "revoke",
+		Ops: []map[string]any{{
+			"op": string(apply.OpAdminRevokeAccess), "user_id": "user:bob",
+		}},
+	})
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "revoke")
+
+	db, _ := f.store.AdminDB(testTenant)
+	for _, q := range []struct {
+		name string
+		sql  string
+		args []any
+	}{
+		{"node_access", `SELECT count(*) FROM node_access WHERE actor_id = ?`, []any{"user:bob"}},
+		{"group_users", `SELECT count(*) FROM group_users WHERE member_actor_id = ?`, []any{"user:bob"}},
+		{"node_visibility", `SELECT count(*) FROM node_visibility WHERE tenant_id = ? AND principal = ?`, []any{testTenant, "user:bob"}},
+	} {
+		var n int
+		_ = db.QueryRowContext(context.Background(), q.sql, q.args...).Scan(&n)
+		if n != 0 {
+			t.Errorf("admin_revoke_access did not clean up %s (n=%d) — Python parity bug not closed", q.name, n)
+		}
+	}
+}
+
+// TestApplier_TenantMembership exercises add_tenant_member /
+// remove_tenant_member / change_member_role.
+func TestApplier_TenantMembership(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:admin", IdempotencyKey: "atm",
+		Ops: []map[string]any{{
+			"op":      string(apply.OpAddTenantMember),
+			"user_id": "alice", "role": "member",
+		}},
+	})
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "atm")
+
+	ok, err := f.global.IsMember(context.Background(), testTenant, "alice")
+	if err != nil || !ok {
+		t.Fatalf("IsMember: ok=%v err=%v", ok, err)
+	}
+
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:admin", IdempotencyKey: "chg",
+		Ops: []map[string]any{{
+			"op":      string(apply.OpChangeMemberRole),
+			"user_id": "alice", "role": "owner",
+		}},
+	})
+	f.waitForIdempKey(t, testTenant, "chg")
+	members, _ := f.global.GetTenantMembers(context.Background(), testTenant)
+	found := false
+	for _, m := range members {
+		if m.UserID == "alice" && m.Role == "owner" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("change_member_role did not update role to owner: %+v", members)
+	}
+
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:admin", IdempotencyKey: "rmt",
+		Ops: []map[string]any{{
+			"op": string(apply.OpRemoveTenantMember), "user_id": "alice",
+		}},
+	})
+	f.waitForIdempKey(t, testTenant, "rmt")
+	ok, _ = f.global.IsMember(context.Background(), testTenant, "alice")
+	if ok {
+		t.Fatalf("remove_tenant_member did not delete the row")
+	}
+}
+
+// TestApplier_SetLegalHold exercises the set_legal_hold op (clear=false
+// then clear=true).
+func TestApplier_SetLegalHold(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:admin", IdempotencyKey: "lh1",
+		Ops: []map[string]any{{
+			"op":      string(apply.OpSetLegalHold),
+			"held_by": "user:counsel", "reason": "litigation",
+		}},
+	})
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "lh1")
+
+	on, _ := f.global.IsLegalHoldSet(context.Background(), testTenant)
+	if !on {
+		t.Fatalf("set_legal_hold did not set the hold")
+	}
+
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:admin", IdempotencyKey: "lh2",
+		Ops: []map[string]any{{
+			"op":      string(apply.OpSetLegalHold),
+			"held_by": "user:counsel", "clear": true,
+		}},
+	})
+	f.waitForIdempKey(t, testTenant, "lh2")
+	on, _ = f.global.IsLegalHoldSet(context.Background(), testTenant)
+	if on {
+		t.Fatalf("set_legal_hold clear=true did not clear the hold")
+	}
+}
+
+// TestApplier_UnknownOpTypeHalts confirms an unknown op-type halts the
+// consumer rather than silently dropping data — the lesson the
+// DelegateAccess bug taught us.
+func TestApplier_UnknownOpTypeHalts(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "u1",
+		Ops: []map[string]any{{"op": "no_such_op"}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, apply.ErrUnknownOpType) {
+			t.Fatalf("got %v, want ErrUnknownOpType", err)
+		}
+	case <-time.After(2 * time.Second):
+		cancel()
+		<-done
+		t.Fatalf("unknown op-type did not halt the applier")
+	}
+}
+
+// TestApplier_ReplayFromNonZeroOffset reaches the same final state as a
+// full replay from offset 0 when both arrive at the same set of events.
+func TestApplier_ReplayFromNonZeroOffset(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	for i := 0; i < 4; i++ {
+		f.appendEvent(t, apply.Event{
+			TenantID: testTenant, Actor: "user:alice",
+			IdempotencyKey: fmt.Sprintf("k%d", i),
+			TsMs:           int64(1700000000000 + i),
+			Ops:            []map[string]any{mkCreateNode(fmt.Sprintf("n%d", i), 1, nil)},
+		})
+	}
+	f.runApplierUntilApplied(t)
+	for i := 0; i < 4; i++ {
+		f.waitForIdempKey(t, testTenant, fmt.Sprintf("k%d", i))
+	}
+	full := dumpState(t, f.store, testTenant, []string{"n0", "n1", "n2", "n3"})
+
+	// Stop the applier, drop all data, replay from a fresh group_id so
+	// the consumer reads from offset 0. The "from non-zero offset"
+	// shape is exercised by Replay against a partially-committed
+	// consumer group: we skip the first 2 records by manually
+	// committing them on a new group, then replay the rest.
+	f.applier.Stop()
+
+	dir := t.TempDir()
+	cs3, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer cs3.Close()
+	if err := cs3.OpenTenant(context.Background(), testTenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	a3, err := apply.New(apply.Options{
+		Store: cs3, Consumer: f.wal,
+		Topic: testTopic, GroupID: "replay-partial",
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+
+	if err := a3.Replay(context.Background(), testTenant, 0); err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	partial := dumpState(t, cs3, testTenant, []string{"n0", "n1", "n2", "n3"})
+	if !reflect.DeepEqual(full, partial) {
+		t.Fatalf("Replay state diverged from Run state")
+	}
+}

--- a/server/go/internal/apply/doc.go
+++ b/server/go/internal/apply/doc.go
@@ -1,7 +1,0 @@
-// Package apply will host the WAL consumer ("Applier") that reads
-// TransactionEvents off the WAL and writes them to per-tenant SQLite,
-// ported from server/python/entdb_server/apply/. The Python applier
-// pins the determinism contract enforced by
-// tests/python/integration/test_wal_replay_determinism.py — the Go
-// applier must satisfy the same.
-package apply

--- a/server/go/internal/apply/errors.go
+++ b/server/go/internal/apply/errors.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"fmt"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// Sentinel errors returned by the applier. Each wraps an internal/errs
+// sentinel so the gRPC layer maps them to the Python server's status
+// codes (see docs/go-port/shared/error-mapping.md).
+var (
+	// ErrPoisonEvent signals an event the applier refuses to apply
+	// because it is structurally malformed (missing required fields,
+	// unknown op-type, etc.). Halts the consumer; mirrors the Python
+	// halt_on_error=True behaviour.
+	ErrPoisonEvent = fmt.Errorf("%w: poison event", errs.ErrInvalidArgument)
+
+	// ErrUnknownOpType signals an op-type the applier does not know
+	// about. A typo in a handler that raced ahead of the applier is the
+	// usual cause; failing closed avoids silent data loss.
+	ErrUnknownOpType = fmt.Errorf("%w: unknown op type", errs.ErrInvalidArgument)
+
+	// ErrApplierClosed signals Run was called on a stopped applier (or
+	// Stop was called and Run subsequently returned).
+	ErrApplierClosed = fmt.Errorf("%w: applier closed", errs.ErrFailedPrecondition)
+)

--- a/server/go/internal/apply/event.go
+++ b/server/go/internal/apply/event.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package apply hosts the WAL consumer (Applier) that materializes
+// TransactionEvents into per-tenant SQLite via the store package.
+//
+// Spec: docs/go-port/shared/applier.md.
+//
+// Wave-0 architectural-drift fixes implemented here (per
+// docs/go-port/PLAN.md §6):
+//
+//   - DelegateAccess applier dispatch (was silently dropped in Python).
+//   - WAL-first restoration for share_node, revoke_access, delegate_access,
+//     transfer_ownership, add_group_member, remove_group_member,
+//     set_legal_hold.
+//   - admin_revoke_access broadened to also delete node_access and
+//     group_users.
+//   - add_tenant_member / remove_tenant_member / change_member_role added
+//     so global-store membership writes can be replayed.
+//
+// Concurrency model: a single consumer goroutine drives Run; per-tenant
+// SQLite isolation comes from the store package's per-tenant write
+// mutex. Halt-on-poison: any error in op-dispatch returns from Run with
+// a non-nil error and does not advance the WAL offset.
+package apply
+
+import (
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// Event is the in-Go transaction event the applier consumes from the
+// WAL. It is a re-export of wal.Event so callers (and tests) don't need
+// to depend on both packages just to construct one.
+type Event = wal.Event
+
+// OpType enumerates the op-type strings carried inside Event.Ops[i]["op"].
+// Mirrors the Python applier's `op_type` if/elif ladder
+// (server/python/entdb_server/apply/applier.py:929-1248) plus the new
+// op types added by the Go port to close the WAL-first drift gap
+// (docs/go-port/PLAN.md §6).
+type OpType string
+
+const (
+	// Steady-state ops the Python applier already implements.
+	OpCreateNode OpType = "create_node"
+	OpUpdateNode OpType = "update_node"
+	OpDeleteNode OpType = "delete_node"
+	OpCreateEdge OpType = "create_edge"
+	OpDeleteEdge OpType = "delete_edge"
+
+	// admin ops the Python applier already implements (broadened in Go).
+	OpAdminTransferContent OpType = "admin_transfer_content"
+	OpAdminRevokeAccess    OpType = "admin_revoke_access"
+
+	// WAL-first restorations from PLAN.md §6.1. The Python handlers
+	// write SQLite directly today; the Go port appends a WAL event and
+	// the dispatch branches below apply it on replay.
+	OpShareNode         OpType = "share_node"
+	OpRevokeAccess      OpType = "revoke_access"
+	OpDelegateAccess    OpType = "delegate_access"
+	OpTransferOwnership OpType = "transfer_ownership"
+	OpAddGroupMember    OpType = "add_group_member"
+	OpRemoveGroupMember OpType = "remove_group_member"
+	OpSetLegalHold      OpType = "set_legal_hold"
+
+	// Global-store membership ops. globalstore is its own durable
+	// substrate (carve-out from CLAUDE.md invariant #1), but recording
+	// these in the WAL keeps audit history reconstructible.
+	OpAddTenantMember    OpType = "add_tenant_member"
+	OpRemoveTenantMember OpType = "remove_tenant_member"
+	OpChangeMemberRole   OpType = "change_member_role"
+)
+
+// opTypeOf extracts the "op" field as a typed OpType, returning an
+// empty string when missing or non-string.
+func opTypeOf(op map[string]any) OpType {
+	v, ok := op["op"].(string)
+	if !ok {
+		return ""
+	}
+	return OpType(v)
+}
+
+// stringField extracts a string-valued op field, returning "" when
+// missing or wrongly-typed. Used by the per-op helpers to keep the
+// dispatch table free of type-switch boilerplate.
+func stringField(op map[string]any, key string) string {
+	v, ok := op[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+// intField extracts an int32-valued op field. JSON numbers come through
+// as float64; protobuf JSON-encoded ints arrive that way too. Returns 0
+// when missing or wrongly-typed.
+func intField(op map[string]any, key string) int32 {
+	switch v := op[key].(type) {
+	case float64:
+		return int32(v)
+	case int:
+		return int32(v)
+	case int32:
+		return v
+	case int64:
+		return int32(v)
+	}
+	return 0
+}
+
+// mapField extracts a nested map-valued op field. Returns nil when
+// missing or wrongly-typed.
+func mapField(op map[string]any, key string) map[string]any {
+	v, ok := op[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return v
+}
+
+// boolField extracts a boolean-valued op field. Returns false when
+// missing or wrongly-typed.
+func boolField(op map[string]any, key string) bool {
+	v, ok := op[key].(bool)
+	if !ok {
+		return false
+	}
+	return v
+}

--- a/server/go/internal/apply/fanout.go
+++ b/server/go/internal/apply/fanout.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import "context"
+
+// fanout runs best-effort post-commit notifications. Mirrors
+// applier.py:_fanout_node (1615-1668) and the broader
+// "notifications + shared_index" hooks at applier.py:1361-1368.
+//
+// Per docs/go-port/shared/applier.md "Open questions / risks" item 8,
+// fanout intentionally runs OUTSIDE the per-tenant transaction. A crash
+// between commit and fanout drops notifications — accepted because
+// notifications are best-effort and the canonical write already
+// succeeded. The Go port preserves this trade-off.
+//
+// Wave 1 keeps notifications a stub (server/python/entdb_server has
+// already deprecated the per-user mailbox tables; see
+// store/notifications.go). The hook exists so Wave-2 RPCs that grow
+// real notification semantics have a single place to plug in.
+func (a *Applier) fanout(ctx context.Context, ev *Event, res *Result) {
+	if a.fanoutHook != nil {
+		a.fanoutHook(ctx, ev, res)
+	}
+	// shared_index maintenance is the only mandatory post-commit hook
+	// today. It belongs here (and not inside the txn) for the same
+	// reason as notification fanout: best-effort against a different
+	// physical store, must not block the per-tenant write.
+	a.maintainSharedIndex(ctx, res)
+}

--- a/server/go/internal/apply/helpers.go
+++ b/server/go/internal/apply/helpers.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// refreshVisibility clears and re-populates node_visibility for a node.
+// Mirrors store/visibility.go updateVisibilityWithConn but lives in the
+// apply package because it runs on a *sql.Conn handed out by an open
+// BatchTxn (the store helper takes the same shape but is unexported).
+func refreshVisibility(ctx context.Context, conn *sql.Conn, tenantID, nodeID, ownerActor string, acl []aclEntry) error {
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM node_visibility WHERE tenant_id = ? AND node_id = ?`,
+		tenantID, nodeID,
+	); err != nil {
+		return fmt.Errorf("apply: clear visibility: %w", err)
+	}
+	if ownerActor != "" {
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO node_visibility (tenant_id, node_id, principal) VALUES (?, ?, ?)`,
+			tenantID, nodeID, ownerActor,
+		); err != nil {
+			return fmt.Errorf("apply: insert owner visibility: %w", err)
+		}
+	}
+	for _, e := range acl {
+		if e.Principal == "" || e.Principal == ownerActor {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx,
+			`INSERT OR IGNORE INTO node_visibility (tenant_id, node_id, principal) VALUES (?, ?, ?)`,
+			tenantID, nodeID, e.Principal,
+		); err != nil {
+			return fmt.Errorf("apply: insert acl visibility: %w", err)
+		}
+	}
+	return nil
+}
+
+// isNoRows is a tiny shim for errors.Is(err, sql.ErrNoRows). Kept as a
+// helper because the create_edge cycle check is the only call site and
+// the inline expression hurts readability.
+func isNoRows(err error) bool {
+	return errors.Is(err, sql.ErrNoRows)
+}

--- a/server/go/internal/apply/ops_add_group_member.go
+++ b/server/go/internal/apply/ops_add_group_member.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"fmt"
+)
+
+// applyAddGroupMember dispatches an "add_group_member" op. Restores
+// the WAL-first invariant flagged in PLAN.md §6.1 — the Python
+// AddGroupMember handler writes group_users directly today.
+//
+// op shape:
+//
+//	{
+//	  "op":              "add_group_member",
+//	  "group_id":        "<id>",
+//	  "member_actor_id": "<kind:id>",
+//	  "role":            "<role>", // default "member"
+//	}
+func (a *Applier) applyAddGroupMember(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any) error {
+	groupID := stringField(op, "group_id")
+	memberActorID := stringField(op, "member_actor_id")
+	if groupID == "" || memberActorID == "" {
+		return fmt.Errorf("%w: add_group_member missing group_id/member_actor_id", ErrPoisonEvent)
+	}
+	role := stringField(op, "role")
+	if role == "" {
+		role = "member"
+	}
+	now := ev.TsMs
+	if now == 0 {
+		now = a.now()
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx, `
+		INSERT OR REPLACE INTO group_users
+		    (group_id, member_actor_id, role, joined_at)
+		VALUES (?, ?, ?, ?)`,
+		groupID, memberActorID, role, now,
+	); err != nil {
+		return fmt.Errorf("apply add_group_member: insert: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_admin_revoke_access.go
+++ b/server/go/internal/apply/ops_admin_revoke_access.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"fmt"
+)
+
+// applyAdminRevokeAccess dispatches an "admin_revoke_access" op.
+//
+// PLAN.md §6.4 item 2: the Python applier only deletes from
+// node_visibility, leaving node_access and group_users intact. The
+// Go applier broadens this to revoke every grant + group membership
+// AND every visibility row for the user, matching the behaviour the
+// RevokeAllUserAccess handler intends to deliver.
+//
+// op shape:
+//
+//	{"op":"admin_revoke_access","user_id":"<id>"}
+func (a *Applier) applyAdminRevokeAccess(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any) error {
+	userID := stringField(op, "user_id")
+	if userID == "" {
+		return fmt.Errorf("%w: admin_revoke_access missing user_id", ErrPoisonEvent)
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM node_access WHERE actor_id = ?`, userID,
+	); err != nil {
+		return fmt.Errorf("apply admin_revoke_access: node_access: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM group_users WHERE member_actor_id = ?`, userID,
+	); err != nil {
+		return fmt.Errorf("apply admin_revoke_access: group_users: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM node_visibility WHERE tenant_id = ? AND principal = ?`,
+		ev.TenantID, userID,
+	); err != nil {
+		return fmt.Errorf("apply admin_revoke_access: node_visibility: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_admin_transfer_content.go
+++ b/server/go/internal/apply/ops_admin_transfer_content.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"fmt"
+)
+
+// applyAdminTransferContent dispatches an "admin_transfer_content" op.
+// Mirrors applier.py:1230-1238. PLAN.md §6.4 item 3 calls out that the
+// Python applier doesn't refresh node_visibility on transfer; the Go
+// port also refreshes the visibility for every owner-row that changed
+// hands.
+//
+// op shape:
+//
+//	{
+//	  "op":        "admin_transfer_content",
+//	  "from_user": "user:alice",
+//	  "to_user":   "user:bob",
+//	}
+func (a *Applier) applyAdminTransferContent(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any) error {
+	fromUser := stringField(op, "from_user")
+	toUser := stringField(op, "to_user")
+	if fromUser == "" || toUser == "" {
+		return fmt.Errorf("%w: admin_transfer_content missing from/to_user", ErrPoisonEvent)
+	}
+	now := ev.TsMs
+	if now == 0 {
+		now = a.now()
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx, `
+		UPDATE nodes SET owner_actor = ?, updated_at = ?
+		WHERE tenant_id = ? AND owner_actor = ?`,
+		toUser, now, ev.TenantID, fromUser,
+	); err != nil {
+		return fmt.Errorf("apply admin_transfer_content: update: %w", err)
+	}
+	// Refresh visibility for every node whose owner changed: replace
+	// fromUser with toUser in node_visibility (closes the
+	// transfer_user_content visibility-drift bug).
+	if _, err := conn.ExecContext(ctx, `
+		UPDATE OR IGNORE node_visibility SET principal = ?
+		WHERE tenant_id = ? AND principal = ?`,
+		toUser, ev.TenantID, fromUser,
+	); err != nil {
+		return fmt.Errorf("apply admin_transfer_content: refresh visibility: %w", err)
+	}
+	// Drop any duplicates that the UPDATE OR IGNORE skipped past.
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM node_visibility WHERE tenant_id = ? AND principal = ?`,
+		ev.TenantID, fromUser,
+	); err != nil {
+		return fmt.Errorf("apply admin_transfer_content: cleanup visibility: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_create_edge.go
+++ b/server/go/internal/apply/ops_create_edge.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// applyCreateEdge dispatches a "create_edge" op. Mirrors
+// applier.py:1159-1217. INSERT OR REPLACE semantics on the edges row so
+// re-creating an edge with new props is idempotent.
+//
+// Edge ACL inheritance: when propagates_acl is true, an acl_inherit row
+// is added (cycle-checked via a depth-bounded recursive CTE).
+func (a *Applier) applyCreateEdge(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, aliases nodeAliasMap, res *Result) error {
+	edgeTypeID := intField(op, "edge_id")
+	if edgeTypeID == 0 {
+		return fmt.Errorf("%w: create_edge missing edge_id", ErrPoisonEvent)
+	}
+	from := aliases.resolveNodeRef(stringField(op, "from"))
+	to := aliases.resolveNodeRef(stringField(op, "to"))
+	if from == "" || to == "" {
+		return fmt.Errorf("%w: create_edge missing from/to", ErrPoisonEvent)
+	}
+	props := mapField(op, "props")
+	if props == nil {
+		props = map[string]any{}
+	}
+	propsJSON, err := json.Marshal(props)
+	if err != nil {
+		return fmt.Errorf("apply create_edge: marshal props: %w", err)
+	}
+	propagates := 0
+	if boolField(op, "propagates_acl") {
+		propagates = 1
+	}
+	now := ev.TsMs
+	if now == 0 {
+		now = a.now()
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx, `
+		INSERT OR REPLACE INTO edges
+		    (tenant_id, edge_type_id, from_node_id, to_node_id,
+		     props_json, propagates_acl, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		ev.TenantID, edgeTypeID, from, to, string(propsJSON), propagates, now,
+	); err != nil {
+		return fmt.Errorf("apply create_edge: insert: %w", err)
+	}
+	if propagates == 1 {
+		// Cycle check: would adding (to inherits-from from) create a
+		// cycle? Bounded at depth 10 (canonical_store.py:_ACL_MAX_DEPTH).
+		var one int
+		err := conn.QueryRowContext(ctx, `
+			WITH RECURSIVE chain(nid, depth) AS (
+				SELECT ?, 0
+				UNION ALL
+				SELECT ai.inherit_from, c.depth + 1
+				FROM acl_inherit ai
+				JOIN chain c ON ai.node_id = c.nid
+				WHERE c.depth < 10
+			)
+			SELECT 1 FROM chain WHERE nid = ? LIMIT 1`,
+			from, to,
+		).Scan(&one)
+		// err == sql.ErrNoRows means "no cycle" — proceed; any other
+		// error halts.
+		if err != nil && !isNoRows(err) {
+			return fmt.Errorf("apply create_edge: cycle check: %w", err)
+		}
+		if isNoRows(err) {
+			if _, err := conn.ExecContext(ctx,
+				`INSERT OR IGNORE INTO acl_inherit (node_id, inherit_from) VALUES (?, ?)`,
+				to, from,
+			); err != nil {
+				return fmt.Errorf("apply create_edge: acl_inherit: %w", err)
+			}
+		}
+	}
+	res.CreatedEdges = append(res.CreatedEdges, EdgeRef{
+		EdgeTypeID: edgeTypeID, FromNodeID: from, ToNodeID: to,
+	})
+	return nil
+}

--- a/server/go/internal/apply/ops_create_node.go
+++ b/server/go/internal/apply/ops_create_node.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// applyCreateNode dispatches a "create_node" op. Mirrors
+// server/python/entdb_server/apply/applier.py:929-1017.
+//
+// The op shape (field-id-keyed payload, per CLAUDE.md invariant #6):
+//
+//	{
+//	  "op":           "create_node",
+//	  "id":           "<node_id>",
+//	  "as":           "alias",            // optional
+//	  "type_id":      <int>,
+//	  "data":         {"<fid>": value...}, // field-id keyed
+//	  "acl":          [{principal, permission}, ...] // optional
+//	}
+//
+// owner_actor comes from the surrounding event.actor. Per the spec, the
+// applier never generates node ids — caller-supplied ids are required
+// (the Python applier accepts a missing id and asks canonical_store to
+// generate one; the Go port rejects it so determinism doesn't depend on
+// the UUID source).
+func (a *Applier) applyCreateNode(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, aliases nodeAliasMap, res *Result) error {
+	nodeID := stringField(op, "id")
+	if nodeID == "" {
+		return fmt.Errorf("%w: create_node missing id", ErrPoisonEvent)
+	}
+	typeID := intField(op, "type_id")
+	if typeID == 0 {
+		return fmt.Errorf("%w: create_node missing type_id", ErrPoisonEvent)
+	}
+	payload := mapField(op, "data")
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	// ACL list. Tolerate either []map[string]any (from JSON unmarshal)
+	// or already-typed []store.ACLEntry slices supplied by tests.
+	var acl []aclEntry
+	if raw, ok := op["acl"].([]any); ok {
+		for _, r := range raw {
+			if m, ok := r.(map[string]any); ok {
+				acl = append(acl, aclEntry{
+					Principal:  stringField(m, "principal"),
+					Permission: stringField(m, "permission"),
+				})
+			}
+		}
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("apply create_node: marshal payload: %w", err)
+	}
+	aclJSON, err := json.Marshal(orEmpty(acl))
+	if err != nil {
+		return fmt.Errorf("apply create_node: marshal acl: %w", err)
+	}
+
+	now := ev.TsMs
+	if now == 0 {
+		now = a.now()
+	}
+
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx, `
+		INSERT INTO nodes (tenant_id, node_id, type_id, payload_json,
+		                   created_at, updated_at, owner_actor, acl_blob)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		ev.TenantID, nodeID, typeID, string(payloadJSON),
+		now, now, ev.Actor, string(aclJSON),
+	); err != nil {
+		return fmt.Errorf("apply create_node: insert: %w", err)
+	}
+	// Refresh visibility: owner + each ACL principal.
+	if err := refreshVisibility(ctx, conn, ev.TenantID, nodeID, ev.Actor, acl); err != nil {
+		return err
+	}
+
+	if alias := stringField(op, "as"); alias != "" {
+		aliases[alias] = nodeID
+	}
+	res.CreatedNodes = append(res.CreatedNodes, nodeID)
+	return nil
+}
+
+// aclEntry mirrors store.ACLEntry; we don't import store here because
+// the per-op handlers run raw SQL — the store types are only the
+// surface area the applier exposes back out (see alias.go).
+type aclEntry struct {
+	Principal  string `json:"principal"`
+	Permission string `json:"permission"`
+}
+
+func orEmpty(a []aclEntry) []aclEntry {
+	if a == nil {
+		return []aclEntry{}
+	}
+	return a
+}

--- a/server/go/internal/apply/ops_delegate_access.go
+++ b/server/go/internal/apply/ops_delegate_access.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// applyDelegateAccess dispatches a "delegate_access" op.
+//
+// CRITICAL FIX (PLAN.md §6.4 item 1): the Python applier has no
+// dispatch branch for admin_delegate_access events; the WAL event is
+// silently dropped on replay. The Python tests only pass because the
+// handler also writes node_access directly. The Go applier closes that
+// gap by materialising the grant in the same row shape that
+// share_node uses.
+//
+// Semantically delegate_access is identical to share_node — the
+// "delegating actor must already hold the cap" check happens at the
+// gRPC handler / acl checker layer (W1.9), not here. Storing the grant
+// is the applier's only job.
+//
+// op shape: same as share_node, but the granted_by field is recorded
+// as event.actor (the delegator).
+func (a *Applier) applyDelegateAccess(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, res *Result) error {
+	nodeID := stringField(op, "node_id")
+	actorID := stringField(op, "actor_id")
+	if nodeID == "" || actorID == "" {
+		return fmt.Errorf("%w: delegate_access missing node_id/actor_id", ErrPoisonEvent)
+	}
+	actorType := stringField(op, "actor_type")
+	if actorType == "" {
+		actorType = "user"
+	}
+	perm := stringField(op, "permission")
+	typeID := intField(op, "type_id")
+
+	coreCaps := intSliceField(op, "core_caps")
+	extCaps := intSliceField(op, "ext_cap_ids")
+	coreJSON, err := json.Marshal(coreCaps)
+	if err != nil {
+		return fmt.Errorf("apply delegate_access: marshal core_caps: %w", err)
+	}
+	extJSON, err := json.Marshal(extCaps)
+	if err != nil {
+		return fmt.Errorf("apply delegate_access: marshal ext_caps: %w", err)
+	}
+	var expires sql.NullInt64
+	if v := int64Field(op, "expires_at"); v > 0 {
+		expires = sql.NullInt64{Int64: v, Valid: true}
+	}
+	now := ev.TsMs
+	if now == 0 {
+		now = a.now()
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx, `
+		INSERT OR REPLACE INTO node_access
+		    (node_id, actor_id, actor_type, permission, granted_by,
+		     granted_at, expires_at, type_id, core_caps_json, ext_cap_ids_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		nodeID, actorID, actorType, perm, ev.Actor,
+		now, expires, typeID, string(coreJSON), string(extJSON),
+	); err != nil {
+		return fmt.Errorf("apply delegate_access: insert: %w", err)
+	}
+	if userID := stringField(op, "user_id"); userID != "" {
+		src := stringField(op, "source_tenant")
+		if src == "" {
+			src = ev.TenantID
+		}
+		res.SharedAdded = append(res.SharedAdded, SharedRef{
+			UserID: userID, SourceTenant: src, NodeID: nodeID, Permission: perm,
+		})
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_delete_edge.go
+++ b/server/go/internal/apply/ops_delete_edge.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"fmt"
+)
+
+// applyDeleteEdge dispatches a "delete_edge" op. Mirrors
+// applier.py:1220-1247. Also removes the inherited ACL pointer if any.
+func (a *Applier) applyDeleteEdge(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, aliases nodeAliasMap) error {
+	edgeTypeID := intField(op, "edge_id")
+	if edgeTypeID == 0 {
+		return fmt.Errorf("%w: delete_edge missing edge_id", ErrPoisonEvent)
+	}
+	from := aliases.resolveNodeRef(stringField(op, "from"))
+	to := aliases.resolveNodeRef(stringField(op, "to"))
+	if from == "" || to == "" {
+		return fmt.Errorf("%w: delete_edge missing from/to", ErrPoisonEvent)
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx, `
+		DELETE FROM edges WHERE tenant_id = ? AND edge_type_id = ?
+		  AND from_node_id = ? AND to_node_id = ?`,
+		ev.TenantID, edgeTypeID, from, to,
+	); err != nil {
+		return fmt.Errorf("apply delete_edge: delete: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM acl_inherit WHERE node_id = ? AND inherit_from = ?`,
+		to, from,
+	); err != nil {
+		return fmt.Errorf("apply delete_edge: acl_inherit: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_delete_node.go
+++ b/server/go/internal/apply/ops_delete_node.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"fmt"
+)
+
+// applyDeleteNode dispatches a "delete_node" op. Mirrors
+// applier.py:1109-1156. Cascades edges, visibility, node_access and
+// acl_inherit before deleting the node row.
+func (a *Applier) applyDeleteNode(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, aliases nodeAliasMap, res *Result) error {
+	nodeID := aliases.resolveRef(stringField(op, "id"))
+	if nodeID == "" {
+		return fmt.Errorf("%w: delete_node missing id", ErrPoisonEvent)
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM edges WHERE tenant_id = ? AND (from_node_id = ? OR to_node_id = ?)`,
+		ev.TenantID, nodeID, nodeID,
+	); err != nil {
+		return fmt.Errorf("apply delete_node: edges: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM node_visibility WHERE tenant_id = ? AND node_id = ?`,
+		ev.TenantID, nodeID,
+	); err != nil {
+		return fmt.Errorf("apply delete_node: visibility: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM node_access WHERE node_id = ?`, nodeID,
+	); err != nil {
+		return fmt.Errorf("apply delete_node: node_access: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM acl_inherit WHERE node_id = ?`, nodeID,
+	); err != nil {
+		return fmt.Errorf("apply delete_node: acl_inherit: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM nodes WHERE tenant_id = ? AND node_id = ?`,
+		ev.TenantID, nodeID,
+	); err != nil {
+		return fmt.Errorf("apply delete_node: nodes: %w", err)
+	}
+	res.DeletedNodeIDs = append(res.DeletedNodeIDs, nodeID)
+	return nil
+}

--- a/server/go/internal/apply/ops_remove_group_member.go
+++ b/server/go/internal/apply/ops_remove_group_member.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"fmt"
+)
+
+// applyRemoveGroupMember dispatches a "remove_group_member" op.
+// Restores the WAL-first invariant flagged in PLAN.md §6.1.
+//
+// op shape:
+//
+//	{
+//	  "op":              "remove_group_member",
+//	  "group_id":        "<id>",
+//	  "member_actor_id": "<kind:id>",
+//	}
+func (a *Applier) applyRemoveGroupMember(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any) error {
+	groupID := stringField(op, "group_id")
+	memberActorID := stringField(op, "member_actor_id")
+	if groupID == "" || memberActorID == "" {
+		return fmt.Errorf("%w: remove_group_member missing group_id/member_actor_id", ErrPoisonEvent)
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM group_users WHERE group_id = ? AND member_actor_id = ?`,
+		groupID, memberActorID,
+	); err != nil {
+		return fmt.Errorf("apply remove_group_member: delete: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_revoke_access.go
+++ b/server/go/internal/apply/ops_revoke_access.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"fmt"
+)
+
+// applyRevokeAccess dispatches a "revoke_access" op. Restores the WAL-
+// first invariant flagged in PLAN.md §6.1 — the Python RevokeAccess
+// handler deletes node_access directly today.
+//
+// op shape:
+//
+//	{
+//	  "op":           "revoke_access",
+//	  "node_id":      "<id>",
+//	  "actor_id":     "<id>",
+//	  "user_id":      "<id>",        // optional cross-tenant grantee
+//	  "source_tenant":"<id>",        // optional cross-tenant src
+//	}
+func (a *Applier) applyRevokeAccess(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, res *Result) error {
+	nodeID := stringField(op, "node_id")
+	actorID := stringField(op, "actor_id")
+	if nodeID == "" || actorID == "" {
+		return fmt.Errorf("%w: revoke_access missing node_id/actor_id", ErrPoisonEvent)
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM node_access WHERE node_id = ? AND actor_id = ?`,
+		nodeID, actorID,
+	); err != nil {
+		return fmt.Errorf("apply revoke_access: delete: %w", err)
+	}
+	if userID := stringField(op, "user_id"); userID != "" {
+		src := stringField(op, "source_tenant")
+		if src == "" {
+			src = ev.TenantID
+		}
+		res.SharedRemoved = append(res.SharedRemoved, SharedRef{
+			UserID: userID, SourceTenant: src, NodeID: nodeID,
+		})
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_set_legal_hold.go
+++ b/server/go/internal/apply/ops_set_legal_hold.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"fmt"
+)
+
+// applySetLegalHold dispatches a "set_legal_hold" op. PLAN.md §6.1
+// borderline case: the legal-hold flag lives in globalstore but is
+// consulted on per-tenant writes. Recording the event in the WAL keeps
+// the audit history reconstructible even if globalstore is restored
+// from a different snapshot.
+//
+// The applier writes the legal_holds row in globalstore (post-commit
+// of the per-tenant txn — the per-tenant txn has nothing to do for
+// this op, but we still write the applied_events row inside it for
+// idempotency parity). Best-effort against globalstore: failures are
+// surfaced as a halt-on-poison error.
+//
+// op shape:
+//
+//	{
+//	  "op":      "set_legal_hold",
+//	  "held_by": "user:...",
+//	  "reason":  "...",
+//	  "clear":   bool, // true => ClearLegalHold
+//	}
+func (a *Applier) applySetLegalHold(ctx context.Context, ev *Event, op map[string]any) error {
+	if a.global == nil {
+		// Global store not wired; skip silently. This is the same
+		// trade-off the Python server makes — if globalstore isn't
+		// available, set_legal_hold is a no-op.
+		return nil
+	}
+	heldBy := stringField(op, "held_by")
+	if heldBy == "" {
+		return fmt.Errorf("%w: set_legal_hold missing held_by", ErrPoisonEvent)
+	}
+	if boolField(op, "clear") {
+		if _, err := a.global.ClearLegalHold(ctx, ev.TenantID, heldBy); err != nil {
+			return fmt.Errorf("apply set_legal_hold: clear: %w", err)
+		}
+		return nil
+	}
+	reason := stringField(op, "reason")
+	if _, err := a.global.SetLegalHold(ctx, ev.TenantID, heldBy, reason); err != nil {
+		return fmt.Errorf("apply set_legal_hold: set: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_share_node.go
+++ b/server/go/internal/apply/ops_share_node.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// applyShareNode dispatches a "share_node" op. Restores the WAL-first
+// invariant flagged in PLAN.md §6.1 — the Python ShareNode handler
+// writes node_access directly today, bypassing the WAL. This applier
+// branch makes the grant survive a full WAL rebuild.
+//
+// op shape:
+//
+//	{
+//	  "op":          "share_node",
+//	  "node_id":     "<id>",
+//	  "actor_id":    "<id>",
+//	  "actor_type":  "user|group",     // default "user"
+//	  "permission":  "read|write|...", // legacy enum string
+//	  "type_id":     <int>,            // optional, for typed-cap scoping
+//	  "core_caps":   [<int>, ...],     // typed core caps
+//	  "ext_cap_ids": [<int>, ...],     // typed extension caps
+//	  "expires_at":  <ms>,             // 0 == never
+//	  "user_id":     "<id>",           // optional cross-tenant grantee
+//	  "source_tenant": "<id>",         // optional cross-tenant src
+//	}
+func (a *Applier) applyShareNode(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, res *Result) error {
+	nodeID := stringField(op, "node_id")
+	actorID := stringField(op, "actor_id")
+	if nodeID == "" || actorID == "" {
+		return fmt.Errorf("%w: share_node missing node_id/actor_id", ErrPoisonEvent)
+	}
+	actorType := stringField(op, "actor_type")
+	if actorType == "" {
+		actorType = "user"
+	}
+	perm := stringField(op, "permission")
+	typeID := intField(op, "type_id")
+
+	coreCaps := intSliceField(op, "core_caps")
+	extCaps := intSliceField(op, "ext_cap_ids")
+	coreJSON, err := json.Marshal(coreCaps)
+	if err != nil {
+		return fmt.Errorf("apply share_node: marshal core_caps: %w", err)
+	}
+	extJSON, err := json.Marshal(extCaps)
+	if err != nil {
+		return fmt.Errorf("apply share_node: marshal ext_caps: %w", err)
+	}
+	var expires sql.NullInt64
+	if v := int64Field(op, "expires_at"); v > 0 {
+		expires = sql.NullInt64{Int64: v, Valid: true}
+	}
+	now := ev.TsMs
+	if now == 0 {
+		now = a.now()
+	}
+	conn := tx.Conn()
+	if _, err := conn.ExecContext(ctx, `
+		INSERT OR REPLACE INTO node_access
+		    (node_id, actor_id, actor_type, permission, granted_by,
+		     granted_at, expires_at, type_id, core_caps_json, ext_cap_ids_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		nodeID, actorID, actorType, perm, ev.Actor,
+		now, expires, typeID, string(coreJSON), string(extJSON),
+	); err != nil {
+		return fmt.Errorf("apply share_node: insert: %w", err)
+	}
+	// Record cross-tenant share for shared_index maintenance post-commit.
+	if userID := stringField(op, "user_id"); userID != "" {
+		src := stringField(op, "source_tenant")
+		if src == "" {
+			src = ev.TenantID
+		}
+		res.SharedAdded = append(res.SharedAdded, SharedRef{
+			UserID: userID, SourceTenant: src, NodeID: nodeID, Permission: perm,
+		})
+	}
+	return nil
+}
+
+// intSliceField extracts a list-of-int field. Tolerates JSON-decoded
+// []any whose elements are float64.
+func intSliceField(op map[string]any, key string) []int32 {
+	out := []int32{}
+	raw, ok := op[key].([]any)
+	if !ok {
+		return out
+	}
+	for _, v := range raw {
+		switch x := v.(type) {
+		case float64:
+			out = append(out, int32(x))
+		case int:
+			out = append(out, int32(x))
+		case int32:
+			out = append(out, x)
+		case int64:
+			out = append(out, int32(x))
+		}
+	}
+	return out
+}
+
+// int64Field extracts an int64-valued field. JSON numbers come through
+// as float64.
+func int64Field(op map[string]any, key string) int64 {
+	switch v := op[key].(type) {
+	case float64:
+		return int64(v)
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	case int32:
+		return int64(v)
+	}
+	return 0
+}

--- a/server/go/internal/apply/ops_tenant_membership.go
+++ b/server/go/internal/apply/ops_tenant_membership.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// Tenant-membership ops. The Python server writes these directly to
+// globalstore today (carve-out from CLAUDE.md invariant #1 documented
+// in docs/go-port/shared/global-store.md). The Go applier optionally
+// drives globalstore through the WAL too, so a stand-alone WAL replay
+// can rebuild membership audit history.
+//
+// All three branches are no-ops when a.global is nil (globalstore not
+// wired in this configuration).
+
+// applyAddTenantMember dispatches an "add_tenant_member" op.
+//
+// op shape: {"op":"add_tenant_member","user_id":"<id>","role":"<role>"}
+func (a *Applier) applyAddTenantMember(ctx context.Context, ev *Event, op map[string]any) error {
+	if a.global == nil {
+		return nil
+	}
+	userID := stringField(op, "user_id")
+	if userID == "" {
+		return fmt.Errorf("%w: add_tenant_member missing user_id", ErrPoisonEvent)
+	}
+	role := stringField(op, "role")
+	if err := a.global.AddTenantMember(ctx, ev.TenantID, userID, role); err != nil {
+		// AlreadyExists is idempotent under replay — ignore.
+		if errors.Is(err, errs.ErrAlreadyExists) {
+			return nil
+		}
+		return fmt.Errorf("apply add_tenant_member: %w", err)
+	}
+	return nil
+}
+
+// applyRemoveTenantMember dispatches a "remove_tenant_member" op.
+//
+// op shape: {"op":"remove_tenant_member","user_id":"<id>"}
+func (a *Applier) applyRemoveTenantMember(ctx context.Context, ev *Event, op map[string]any) error {
+	if a.global == nil {
+		return nil
+	}
+	userID := stringField(op, "user_id")
+	if userID == "" {
+		return fmt.Errorf("%w: remove_tenant_member missing user_id", ErrPoisonEvent)
+	}
+	if _, err := a.global.RemoveTenantMember(ctx, ev.TenantID, userID); err != nil {
+		return fmt.Errorf("apply remove_tenant_member: %w", err)
+	}
+	return nil
+}
+
+// applyChangeMemberRole dispatches a "change_member_role" op.
+//
+// op shape: {"op":"change_member_role","user_id":"<id>","role":"<role>"}
+func (a *Applier) applyChangeMemberRole(ctx context.Context, ev *Event, op map[string]any) error {
+	if a.global == nil {
+		return nil
+	}
+	userID := stringField(op, "user_id")
+	role := stringField(op, "role")
+	if userID == "" || role == "" {
+		return fmt.Errorf("%w: change_member_role missing user_id/role", ErrPoisonEvent)
+	}
+	if _, err := a.global.ChangeMemberRole(ctx, ev.TenantID, userID, role); err != nil {
+		return fmt.Errorf("apply change_member_role: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_transfer_ownership.go
+++ b/server/go/internal/apply/ops_transfer_ownership.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// applyTransferOwnership dispatches a "transfer_ownership" op.
+// Restores the WAL-first invariant flagged in PLAN.md §6.1 — the
+// Python TransferOwnership handler updates nodes.owner_actor directly
+// today.
+//
+// Refreshes node_visibility for the new owner so the visibility index
+// stays consistent (PLAN.md §6.4 item 3 calls out the
+// transfer_user_content visibility-drift bug; this branch fixes it for
+// single-node transfers).
+//
+// op shape:
+//
+//	{"op":"transfer_ownership","node_id":"<id>","new_owner":"user:..."}
+func (a *Applier) applyTransferOwnership(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any) error {
+	nodeID := stringField(op, "node_id")
+	newOwner := stringField(op, "new_owner")
+	if nodeID == "" || newOwner == "" {
+		return fmt.Errorf("%w: transfer_ownership missing node_id/new_owner", ErrPoisonEvent)
+	}
+	conn := tx.Conn()
+
+	var aclJSON string
+	err := conn.QueryRowContext(ctx,
+		`SELECT acl_blob FROM nodes WHERE tenant_id = ? AND node_id = ?`,
+		ev.TenantID, nodeID,
+	).Scan(&aclJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Missing target: no-op (matches the Python soft-no-target
+		// pattern; halts only on infra errors).
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("apply transfer_ownership: read acl: %w", err)
+	}
+	var acl []aclEntry
+	if aclJSON != "" {
+		_ = json.Unmarshal([]byte(aclJSON), &acl)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`UPDATE nodes SET owner_actor = ? WHERE tenant_id = ? AND node_id = ?`,
+		newOwner, ev.TenantID, nodeID,
+	); err != nil {
+		return fmt.Errorf("apply transfer_ownership: update owner: %w", err)
+	}
+	if err := refreshVisibility(ctx, conn, ev.TenantID, nodeID, newOwner, acl); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/go/internal/apply/ops_update_node.go
+++ b/server/go/internal/apply/ops_update_node.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// applyUpdateNode dispatches an "update_node" op. Mirrors
+// applier.py:1020-1107. The patch is field-id-keyed and merged onto the
+// existing payload by string key (rename-free per CLAUDE.md invariant
+// #6). storage_mode is immutable — any attempt to set it is a
+// poison-event.
+func (a *Applier) applyUpdateNode(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, aliases nodeAliasMap) error {
+	patch := mapField(op, "patch")
+	if patch == nil {
+		patch = map[string]any{}
+	}
+	if _, ok := patch["storage_mode"]; ok {
+		return fmt.Errorf("%w: storage_mode is immutable", ErrPoisonEvent)
+	}
+	nodeID := aliases.resolveRef(stringField(op, "id"))
+	if nodeID == "" {
+		return fmt.Errorf("%w: update_node missing id", ErrPoisonEvent)
+	}
+
+	conn := tx.Conn()
+	row := conn.QueryRowContext(ctx,
+		`SELECT payload_json FROM nodes WHERE tenant_id = ? AND node_id = ?`,
+		ev.TenantID, nodeID,
+	)
+	var existingJSON string
+	if err := row.Scan(&existingJSON); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Mirror the Python applier: missing target is a no-op.
+			return nil
+		}
+		return fmt.Errorf("apply update_node: read existing: %w", err)
+	}
+	merged := map[string]any{}
+	if existingJSON != "" {
+		if err := json.Unmarshal([]byte(existingJSON), &merged); err != nil {
+			return fmt.Errorf("apply update_node: parse existing payload: %w", err)
+		}
+	}
+	for k, v := range patch {
+		merged[k] = v
+	}
+	mergedJSON, err := json.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("apply update_node: marshal merged: %w", err)
+	}
+	now := ev.TsMs
+	if now == 0 {
+		now = a.now()
+	}
+	if _, err := conn.ExecContext(ctx,
+		`UPDATE nodes SET payload_json = ?, updated_at = ? WHERE tenant_id = ? AND node_id = ?`,
+		string(mergedJSON), now, ev.TenantID, nodeID,
+	); err != nil {
+		return fmt.Errorf("apply update_node: update: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/apply/result.go
+++ b/server/go/internal/apply/result.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import "github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+
+// Status mirrors the receipt status the Python applier returns from
+// ExecuteAtomic (see docs/go-port/shared/applier.md "Receipt
+// construction"). APPLIED means the event committed; SKIPPED means the
+// idempotency-key probe inside the txn matched a prior row;
+// FAILED is the catch-all error path.
+type Status uint8
+
+const (
+	// StatusApplied is the happy-path receipt status.
+	StatusApplied Status = iota
+	// StatusSkipped means the idempotency-key was already recorded.
+	StatusSkipped
+	// StatusFailed means the apply errored. Result.Err carries the cause.
+	StatusFailed
+)
+
+// String returns the wire form ("APPLIED" / "SKIPPED" / "FAILED").
+// Mirrors the Python ApplyResult.status enum values.
+func (s Status) String() string {
+	switch s {
+	case StatusApplied:
+		return "APPLIED"
+	case StatusSkipped:
+		return "SKIPPED"
+	case StatusFailed:
+		return "FAILED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Result is the outcome of applying one event. Mirrors the Python
+// ApplyResult struct at server/python/entdb_server/apply/applier.py:272.
+//
+// Position is the WAL position the event came from; on a successful
+// apply this is the receipt the SDK returns to clients.
+//
+// CreatedNodes / CreatedEdges / DeletedNodeIDs let the post-commit
+// fan-out hook (mailbox notifications, shared-index maintenance) act on
+// what changed without re-reading the database.
+type Result struct {
+	Position       wal.StreamPos
+	Status         Status
+	Err            error
+	TenantID       string
+	CreatedNodes   []string
+	CreatedEdges   []EdgeRef
+	DeletedNodeIDs []string
+
+	// SharedAdded / SharedRemoved record the (user_id, source_tenant,
+	// node_id) tuples whose grants changed in this event. Best-effort
+	// post-commit; consumed by shared-index maintenance.
+	SharedAdded   []SharedRef
+	SharedRemoved []SharedRef
+}
+
+// EdgeRef is the in-result representation of a created edge. Used for
+// post-commit notifications.
+type EdgeRef struct {
+	EdgeTypeID int32
+	FromNodeID string
+	ToNodeID   string
+}
+
+// SharedRef identifies one shared_index hint row. Cross-tenant grants
+// produce these; same-tenant grants do not.
+type SharedRef struct {
+	UserID       string
+	SourceTenant string
+	NodeID       string
+	Permission   string
+}

--- a/server/go/internal/apply/shared_index.go
+++ b/server/go/internal/apply/shared_index.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"context"
+)
+
+// maintainSharedIndex applies shared_index updates after a successful
+// per-tenant commit. Mirrors the Python applier hooks at
+// applier.py:1687-1845.
+//
+// shared_index is a HINT — authoritative ACLs live in the per-tenant
+// canonical store. Best-effort against globalstore: we log + continue
+// rather than fail the apply (the per-tenant write already committed).
+//
+// Returns nil even on globalstore failure so callers don't mistake a
+// best-effort hint sync for a hard error.
+func (a *Applier) maintainSharedIndex(ctx context.Context, res *Result) {
+	if a.global == nil {
+		return
+	}
+	for _, s := range res.SharedAdded {
+		_ = a.global.AddShared(ctx, s.UserID, s.SourceTenant, s.NodeID, s.Permission)
+	}
+	for _, s := range res.SharedRemoved {
+		_, _ = a.global.RemoveShared(ctx, s.UserID, s.SourceTenant, s.NodeID)
+	}
+	if res.TenantID != "" {
+		for _, nodeID := range res.DeletedNodeIDs {
+			// On node delete every shared_index hint pointing at that
+			// node becomes stale.
+			_, _ = a.global.CleanupStaleShared(ctx, res.TenantID, nodeID)
+		}
+	}
+}

--- a/server/go/internal/apply/storage_route.go
+++ b/server/go/internal/apply/storage_route.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+// storageMode classifies an op by which physical store(s) it writes.
+// Used by the post-commit fan-out hook (shared_index maintenance) to
+// decide whether to update globalstore alongside the per-tenant write.
+//
+// In Wave 1 every per-tenant write also goes through the canonical
+// store; the only meaningful split is whether the op also produces a
+// shared_index hint or a globalstore membership change.
+type storageMode uint8
+
+const (
+	// storageCanonical: writes only the per-tenant SQLite (canonical_store).
+	storageCanonical storageMode = iota
+	// storageCanonicalAndShared: writes per-tenant SQLite AND maintains
+	// the global_store.shared_index hint (cross-tenant share/revoke).
+	storageCanonicalAndShared
+	// storageGlobalOnly: writes globalstore only (tenant membership ops).
+	storageGlobalOnly
+)
+
+// classifyOp returns the storage mode for a single op. The applier
+// dispatches every op against the canonical store first; this hint just
+// drives post-commit fan-out side effects.
+func classifyOp(op map[string]any) storageMode {
+	switch opTypeOf(op) {
+	case OpShareNode, OpRevokeAccess, OpDelegateAccess, OpAdminRevokeAccess:
+		return storageCanonicalAndShared
+	case OpAddTenantMember, OpRemoveTenantMember, OpChangeMemberRole, OpSetLegalHold:
+		return storageGlobalOnly
+	default:
+		return storageCanonical
+	}
+}

--- a/server/go/internal/store/canonical.go
+++ b/server/go/internal/store/canonical.go
@@ -134,3 +134,16 @@ func (s *CanonicalStore) now() int64 { return s.nowFn() }
 // configured. Used by callers that need to look up field metadata
 // outside of the lazy-index hook.
 func (s *CanonicalStore) Registry() *schema.Registry { return s.registry }
+
+// AdminDB returns the per-tenant *sql.DB handle for tenantID. The
+// tenant must already be open (call OpenTenant first). Intended ONLY
+// for the apply package's acl-readers adapter (server/go/internal/apply
+// /acladapter.go) — it needs ad-hoc reads against node_access /
+// group_users that don't have a dedicated public method on this store.
+//
+// Production code outside the apply package should use the typed
+// helpers (GetNode, QueryNodes, …); reaching for AdminDB elsewhere is
+// a code smell.
+func (s *CanonicalStore) AdminDB(tenantID string) (*sql.DB, error) {
+	return s.db(tenantID)
+}


### PR DESCRIPTION
## Summary

Implements the **WAL consumer (Applier)** per [`docs/go-port/shared/applier.md`](../blob/main/docs/go-port/shared/applier.md). This is the final Wave-1 PR for EPIC #407 — the largest by complexity and the one that closes the architectural-drift gaps surfaced in Wave 0.

Single consumer goroutine drives `PollBatch` → typed op dispatch → `store.BatchTxn` (`BEGIN IMMEDIATE`) → `UpdateAppliedOffsetTx` → commit. **Idempotency probe runs INSIDE the txn**; **halt-on-poison** stops the consumer and does NOT advance the WAL offset past the failing record.

### Architectural drift closed (PLAN.md §6)

- **DelegateAccess applier dispatch** — was missing entirely in Python; the WAL event (`admin_delegate_access`) was silently dropped on replay. The Go applier now materialises the grant in `node_access`. `TestApplier_DelegateAccessFix` is the contract regression.
- **WAL-first restoration** for handlers that write per-tenant SQLite directly today — applier dispatch branches added for `share_node`, `revoke_access`, `delegate_access`, `transfer_ownership`, `add_group_member`, `remove_group_member`, `set_legal_hold`.
- **`admin_revoke_access` broadened** to also delete `node_access` and `group_users` (Python only deletes `node_visibility`). `TestApplier_AdminRevokeAccessBroadens` pins it.
- **Tenant-membership ops** (`add_tenant_member`, `remove_tenant_member`, `change_member_role`) added so globalstore membership writes survive WAL replay (closes the global-store WAL gap).

### acl-readers adapter

W1.9 deferred the production binding of `NodeMetaReader` / `GrantReader` / `CrossTenantGrantReader` / `VisibilityReader` / `GroupMembershipReader` to W1.10 on the theory that the applier owns the read-after-write consistency story. Lives in `server/go/internal/apply/acladapter.go` as `StoreReaders`, backed by `store.CanonicalStore` + `globalstore.GlobalStore`. Compile-time interface assertions guarantee Wave-2 wire-up doesn't silently regress.

### `cmd/entdb-server/main.go` wiring

Functional options (`api.WithStore` / `api.WithGlobalStore` / `api.WithWALProducer`) inject dependencies into the Server. Applier starts in a background goroutine when `--data-dir` is set. **All RPCs still return Unimplemented** — Wave 2's job to implement methods.

## References

- Spec: [`docs/go-port/shared/applier.md`](../blob/main/docs/go-port/shared/applier.md)
- Drift findings: [`docs/go-port/PLAN.md` §6](../blob/main/docs/go-port/PLAN.md#6-architectural-drift-surfaced-by-wave-0) (§6.1 WAL bypass, §6.4 real bugs)
- PR slate: PLAN.md §9 W1.10 row

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` green (all packages)
- [x] `go test -race ./internal/apply/...` green
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` clean
- [x] Python unit tests still green (1712 tests)
- [x] Replay-determinism: drive a mixed sequence, snapshot, wipe store, replay from offset 0 with a fresh group_id, snapshot, assert deep-equal (`TestApplier_ReplayDeterminism`)
- [x] Halt-on-poison: poisoned event halts Run with `ErrPoisonEvent`; subsequent good events NOT applied (`TestApplier_HaltsOnPoison`)
- [x] Idempotency: same `IdempotencyKey` applied twice produces one effect (`TestApplier_IdempotencySameKeyOnce`)
- [x] DelegateAccess fix: bug-pinning regression that fails if the dispatch branch goes missing (`TestApplier_DelegateAccessFix`)
- [x] Per-op happy-path tests: create_node, share_node, revoke_access, transfer_ownership, group membership, admin_revoke_access (broadened), tenant membership, set_legal_hold, unknown op-type halt
- [x] Replay from a non-zero offset reaches the same final state as full replay (`TestApplier_ReplayFromNonZeroOffset`)

## Out of scope (deferred)

- Per-tenant worker-pool fan-out (single goroutine, Python parity).
- Real WAL backends (Phase 2).
- Snapshot/recovery tiers (Tier 1/3).
- Quota counter persistence and mailbox-fanout real-implementation.