### PR TITLE
feat(go-rewrite): SearchMailbox stub — Wave 2

### DIFF
--- a/server/go/internal/api/search_mailbox.go
+++ b/server/go/internal/api/search_mailbox.go
@@ -1,0 +1,39 @@
+// SearchMailbox — Wave 2 deprecated stub. Mirrors the Python handler at
+// server/python/entdb_server/api/grpc_server.py:1456-1476 byte-for-byte:
+// run the tenant gate, then return SearchMailboxResponse{Results: nil,
+// HasMore: false}. The legacy per-user mailbox SQLite store was removed
+// upstream; fanout writes now land in the per-tenant `notifications`
+// table and a future FTS5-backed implementation will land behind this
+// same RPC.
+//
+// Spec: docs/go-port/rpcs/SearchMailbox.md (EPIC #407).
+//
+// Error contract today (pinned by tests/python/integration/test_grpc_
+// contract.py:267-273):
+//   - Tenant not owned by this node -> codes.Unavailable +
+//     `entdb-redirect-node` trailer.
+//   - Tenant region-pinned elsewhere -> codes.FailedPrecondition.
+//   - Tenant missing from globalstore -> codes.NotFound.
+//   - Happy path -> empty response, nil error.
+//
+// Out of scope for this PR: FTS5 index, mailbox table reads, authz
+// (trusted-actor check). Those land with the real implementation in a
+// follow-up. Keeping the stub at byte-for-byte parity preserves the
+// cross-implementation contract test.
+
+package api
+
+import (
+	"context"
+
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// SearchMailbox implements entdb.v1.EntDBService/SearchMailbox. It is
+// intentionally a stub — see file header for the deprecation rationale.
+func (s *Server) SearchMailbox(ctx context.Context, req *pb.SearchMailboxRequest) (*pb.SearchMailboxResponse, error) {
+	if err := s.checkTenant(ctx, req.GetContext().GetTenantId()); err != nil {
+		return nil, err
+	}
+	return &pb.SearchMailboxResponse{}, nil
+}

--- a/server/go/internal/api/search_mailbox_test.go
+++ b/server/go/internal/api/search_mailbox_test.go
@@ -1,0 +1,97 @@
+// Tests for the SearchMailbox stub handler. Two cases pin the contract
+// for Wave 2:
+//
+//  1. Happy path: known tenant -> empty SearchMailboxResponse, nil error.
+//     Mirrors tests/python/integration/test_grpc_contract.py:267-273.
+//
+//  2. Unknown tenant: globalstore returns no row -> codes.NotFound. This
+//     comes straight from tenant.CheckTenant; the handler just propagates
+//     the gate's error.
+//
+// A real FTS5 implementation is deferred (see
+// docs/go-port/rpcs/SearchMailbox.md). When it lands the empty-response
+// assertion will be expanded to cover the hit shape.
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
+)
+
+func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
+	t.Helper()
+	gs, err := globalstore.New(globalstore.Options{DataDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+	return gs
+}
+
+// TestSearchMailbox_HappyPath: existing tenant, sharding owns it,
+// region matches => stub returns SearchMailboxResponse{} with no error.
+func TestSearchMailbox_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := New(
+		WithGlobalStore(gs),
+		WithSharding(&tenant.Sharding{NodeID: "n1"}),
+		WithRegion("us-east-1"),
+	)
+
+	req := &pb.SearchMailboxRequest{
+		Context: &pb.RequestContext{TenantId: "acme"},
+		UserId:  "alice",
+		Query:   "hi",
+	}
+	resp, err := srv.SearchMailbox(ctx, req)
+	if err != nil {
+		t.Fatalf("SearchMailbox: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("SearchMailbox: nil response")
+	}
+	if len(resp.GetResults()) != 0 {
+		t.Fatalf("SearchMailbox: expected empty Results, got %d", len(resp.GetResults()))
+	}
+	if resp.GetHasMore() {
+		t.Fatalf("SearchMailbox: expected HasMore=false")
+	}
+}
+
+// TestSearchMailbox_UnknownTenant: tenant not in globalstore => the
+// tenant gate returns codes.NotFound and the handler propagates it.
+func TestSearchMailbox_UnknownTenant(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := New(
+		WithGlobalStore(gs),
+		WithSharding(&tenant.Sharding{NodeID: "n1"}),
+	)
+
+	req := &pb.SearchMailboxRequest{
+		Context: &pb.RequestContext{TenantId: "ghost"},
+		UserId:  "alice",
+		Query:   "hi",
+	}
+	resp, err := srv.SearchMailbox(context.Background(), req)
+	if err == nil {
+		t.Fatalf("SearchMailbox: expected error, got resp=%v", resp)
+	}
+	if got := errs.Code(err); got != codes.NotFound {
+		t.Fatalf("SearchMailbox: expected NotFound, got %v (err=%v)", got, err)
+	}
+}

--- a/server/go/internal/api/server.go
+++ b/server/go/internal/api/server.go
@@ -6,9 +6,12 @@
 package api
 
 import (
+	"context"
+
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
 
@@ -28,6 +31,8 @@ type Server struct {
 	store    *store.CanonicalStore
 	global   *globalstore.GlobalStore
 	producer wal.Producer
+	sharding *tenant.Sharding
+	region   string
 }
 
 // Option is a functional-options configurator for New.
@@ -50,6 +55,19 @@ func WithWALProducer(p wal.Producer) Option {
 	return func(srv *Server) { srv.producer = p }
 }
 
+// WithSharding wires the per-node tenant-ownership/redirect config the
+// tenant gate consults on every RPC. A nil value is the single-node
+// default — every tenant is owned by this node (see tenant.Sharding).
+func WithSharding(sh *tenant.Sharding) Option {
+	return func(srv *Server) { srv.sharding = sh }
+}
+
+// WithRegion wires the region this node is configured to serve. Empty
+// disables region pinning (tenant.Options{}.ServedRegion == "").
+func WithRegion(region string) Option {
+	return func(srv *Server) { srv.region = region }
+}
+
 // New constructs a Server. All RPCs return Unimplemented in Wave 1;
 // dependencies wired via opts are stored for use by Wave-2 handlers as
 // they land.
@@ -59,4 +77,14 @@ func New(opts ...Option) *Server {
 		o(s)
 	}
 	return s
+}
+
+// checkTenant is the per-handler tenant gate wrapper. It exists so
+// Wave-2 RPCs can write a single line at the top of their handler
+// instead of repeating the dependency-passing dance, and so the gate
+// has exactly one call shape across the server (mirrors the Python
+// `await self._check_tenant(...)` convention at
+// api/grpc_server.py:362).
+func (s *Server) checkTenant(ctx context.Context, tenantID string) error {
+	return tenant.CheckTenant(ctx, tenantID, s.global, s.sharding, tenant.Options{ServedRegion: s.region})
 }


### PR DESCRIPTION
## Summary

- Port the deprecated `SearchMailbox` RPC from the Python server (`api/grpc_server.py:1456-1476`) to the Go server as a byte-for-byte stub: run the tenant gate via `tenant.CheckTenant`, then return `SearchMailboxResponse{Results: nil, HasMore: false}`. The real FTS5-backed implementation is deferred to a follow-up — Wave 2 only needs behavioral parity.
- Wire `WithSharding` / `WithRegion` options on `api.Server` and add a small `checkTenant` helper so subsequent Wave-2 RPCs collapse the gate to a single line.
- Add Go unit tests pinning two cases: happy path returns an empty response with no error, and an unknown tenant propagates `codes.NotFound` from the gate.

Refs #407.
Spec: `docs/go-port/rpcs/SearchMailbox.md`.

This is a deprecated stub for byte-for-byte parity with the Python handler. No FTS5, no mailbox table reads, no auth changes — those land with the real implementation.

## Test plan

- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...`
- [x] `uvx ruff@0.15.7 check .`
- [x] `uvx ruff@0.15.7 format --check .`
- [x] New unit tests cover the happy path (matches `tests/python/integration/test_grpc_contract.py:267-273`) and the unknown-tenant NOT_FOUND path.