### PR TITLE
feat(go-rewrite): WaitForOffset RPC — Wave 2

### DIFF
--- a/server/go/internal/api/wait_for_offset.go
+++ b/server/go/internal/api/wait_for_offset.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// WaitForOffset blocks until the applier on this node has materialized at
+// least the requested WAL stream position into the per-tenant SQLite
+// view, or the per-RPC deadline elapses, or the context is cancelled.
+//
+// Spec: docs/go-port/rpcs/WaitForOffset.md (EPIC #407, Wave 2). The Go
+// port uses the store-level sync.Cond watcher implemented in W1.8
+// (store/offset.go) so the handler parks on a single select and does not
+// burn a goroutine on a busy-loop.
+//
+// Differences from the Python handler:
+//   - Python swallows all internal errors and returns OK + reached=false.
+//     The Go port honours ctx cancellation as a real gRPC status
+//     (DEADLINE_EXCEEDED) — this matches grpc-go idiom and is the
+//     contract pinned by the W2 task spec.
+//   - Topic/partition prefix in stream_position is ignored (parity with
+//     canonical_store.py:_parse_stream_offset: split on last `:`, parse
+//     trailing int; non-numeric → 0).
+func (s *Server) WaitForOffset(ctx context.Context, req *pb.WaitForOffsetRequest) (*pb.WaitForOffsetResponse, error) {
+	tenantID := req.GetContext().GetTenantId()
+	if tenantID == "" {
+		return nil, errs.Errorf(codes.InvalidArgument, "WaitForOffset: tenant_id is required")
+	}
+	if s.store == nil {
+		return nil, errs.Errorf(codes.Unimplemented, "WaitForOffset: store not wired")
+	}
+
+	target := parseStreamOffset(req.GetStreamPosition())
+
+	// Honour an explicit request-side timeout_ms by wrapping ctx; the
+	// outer per-RPC deadline (if any) still applies. If timeout_ms is
+	// zero, use ctx as-is — the parent deadline is the only bound.
+	waitCtx := ctx
+	if ms := req.GetTimeoutMs(); ms > 0 {
+		var cancel context.CancelFunc
+		waitCtx, cancel = context.WithTimeout(ctx, time.Duration(ms)*time.Millisecond)
+		defer cancel()
+	}
+
+	err := s.store.WaitForOffset(waitCtx, tenantID, target)
+	if err != nil {
+		// Distinguish ctx cancel / deadline (return DEADLINE_EXCEEDED per
+		// task spec) from internal store errors (propagate via the errs
+		// mapping; status.Code already returns Unknown for naked errors,
+		// which the chokepoint upgrades to a real status if needed).
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return nil, errs.Errorf(codes.DeadlineExceeded, "WaitForOffset: %v", err)
+		}
+		return nil, errs.Errorf(errs.Code(err), "WaitForOffset: %v", err)
+	}
+
+	// Read the latest applied offset (after the wait succeeded) and
+	// rebuild a "topic:partition:offset"-shaped string so the response
+	// shape matches the client's view of the WAL. Matches Python at
+	// grpc_server.py:986 (`current_position = get_applied_offset(...) or
+	// ""`).
+	cur := s.currentAppliedPosition(ctx, tenantID, req.GetStreamPosition())
+
+	return &pb.WaitForOffsetResponse{
+		Reached:         true,
+		CurrentPosition: cur,
+	}, nil
+}
+
+// parseStreamOffset mirrors canonical_store.py:_parse_stream_offset (90):
+// split on the last `:` and parse the trailing integer. Inputs that do
+// not parse cleanly produce 0 — matching Python's `int(...) except 0`
+// behaviour. An empty string is therefore "offset 0", which is
+// "already reached" once anything has been applied for the tenant.
+func parseStreamOffset(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	tail := s
+	if i := strings.LastIndex(s, ":"); i >= 0 {
+		tail = s[i+1:]
+	}
+	n, err := strconv.ParseInt(tail, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// currentAppliedPosition queries the per-tenant applied offset and
+// rebuilds the "topic:partition:offset" string the client expects. The
+// (topic, partition) pair is parsed from the request's stream_position;
+// if absent we fall back to ("", 0). On any read error or
+// not-yet-applied tenant we return "" — matching grpc_server.py:986
+// (`current_position = get_applied_offset(...) or ""`).
+func (s *Server) currentAppliedPosition(ctx context.Context, tenantID, requested string) string {
+	topic, partition := parseStreamTopicPartition(requested)
+	off, err := s.store.GetAppliedOffset(ctx, tenantID, topic, partition)
+	if err != nil || off == 0 {
+		// 0 here means either no row, or applier genuinely at offset 0.
+		// Python collapses the latter to "" via `or ""` truthiness; we
+		// mirror that to keep contract tests deterministic.
+		return ""
+	}
+	if topic == "" {
+		return fmt.Sprintf("%d", off)
+	}
+	return fmt.Sprintf("%s:%d:%d", topic, partition, off)
+}
+
+// parseStreamTopicPartition splits "topic:partition:offset" into
+// (topic, partition). The partition is parsed as int32; non-numeric or
+// missing → 0. Mirror of canonical_store.py:_parse_stream_offset shape
+// awareness (90-109).
+func parseStreamTopicPartition(s string) (string, int32) {
+	if s == "" {
+		return "", 0
+	}
+	last := strings.LastIndex(s, ":")
+	if last < 0 {
+		return "", 0
+	}
+	head := s[:last]
+	mid := strings.LastIndex(head, ":")
+	if mid < 0 {
+		return "", 0
+	}
+	topic := head[:mid]
+	p, err := strconv.ParseInt(head[mid+1:], 10, 32)
+	if err != nil {
+		return topic, 0
+	}
+	return topic, int32(p)
+}

--- a/server/go/internal/api/wait_for_offset_test.go
+++ b/server/go/internal/api/wait_for_offset_test.go
@@ -1,0 +1,215 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// newStoreForTest builds a CanonicalStore rooted at t.TempDir() and
+// pre-opens a single tenant. Returned cleanup must run via t.Cleanup.
+func newStoreForTest(t *testing.T, tenant string) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(context.Background(), tenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	return cs
+}
+
+// TestWaitForOffset_AlreadyReached: the applier has already crossed the
+// requested offset, so the handler returns OK + reached=true without
+// blocking.
+func TestWaitForOffset_AlreadyReached(t *testing.T) {
+	t.Parallel()
+	cs := newStoreForTest(t, "t1")
+	if err := cs.UpdateAppliedOffset(context.Background(), "t1", "entdb-wal", 0, 42); err != nil {
+		t.Fatalf("UpdateAppliedOffset: %v", err)
+	}
+	srv := New(WithStore(cs))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := srv.WaitForOffset(ctx, &pb.WaitForOffsetRequest{
+		Context:        &pb.RequestContext{TenantId: "t1"},
+		StreamPosition: "entdb-wal:0:10",
+	})
+	if err != nil {
+		t.Fatalf("WaitForOffset: %v", err)
+	}
+	if !resp.GetReached() {
+		t.Fatalf("Reached: got false, want true")
+	}
+	if got, want := resp.GetCurrentPosition(), "entdb-wal:0:42"; got != want {
+		t.Fatalf("CurrentPosition: got %q, want %q", got, want)
+	}
+}
+
+// TestWaitForOffset_ConcurrentUpdateUnblocks: the handler blocks on a
+// target the applier has not yet reached, then a concurrent
+// UpdateAppliedOffset crosses the target and the handler returns OK.
+func TestWaitForOffset_ConcurrentUpdateUnblocks(t *testing.T) {
+	t.Parallel()
+	cs := newStoreForTest(t, "t1")
+	srv := New(WithStore(cs))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Fire the update from a goroutine after a short delay so the
+	// handler is parked inside sync.Cond.Wait when we cross the target.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		_ = cs.UpdateAppliedOffset(context.Background(), "t1", "entdb-wal", 0, 7)
+	}()
+
+	resp, err := srv.WaitForOffset(ctx, &pb.WaitForOffsetRequest{
+		Context:        &pb.RequestContext{TenantId: "t1"},
+		StreamPosition: "entdb-wal:0:7",
+	})
+	if err != nil {
+		t.Fatalf("WaitForOffset: %v", err)
+	}
+	if !resp.GetReached() {
+		t.Fatalf("Reached: got false, want true")
+	}
+	if got, want := resp.GetCurrentPosition(), "entdb-wal:0:7"; got != want {
+		t.Fatalf("CurrentPosition: got %q, want %q", got, want)
+	}
+}
+
+// TestWaitForOffset_DeadlineExceeded: the applier never reaches the
+// requested offset; the per-RPC ctx deadline fires and the handler
+// returns codes.DeadlineExceeded.
+func TestWaitForOffset_DeadlineExceeded(t *testing.T) {
+	t.Parallel()
+	cs := newStoreForTest(t, "t1")
+	srv := New(WithStore(cs))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := srv.WaitForOffset(ctx, &pb.WaitForOffsetRequest{
+		Context:        &pb.RequestContext{TenantId: "t1"},
+		StreamPosition: "entdb-wal:0:999",
+	})
+	if err == nil {
+		t.Fatalf("WaitForOffset: expected error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("WaitForOffset: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.DeadlineExceeded {
+		t.Fatalf("WaitForOffset: got code %v, want DeadlineExceeded", st.Code())
+	}
+}
+
+// TestWaitForOffset_TimeoutMsRequestField: when the request carries an
+// explicit timeout_ms shorter than the outer ctx deadline, that timeout
+// drives the cancel (still surfaced as DEADLINE_EXCEEDED per spec).
+func TestWaitForOffset_TimeoutMsRequestField(t *testing.T) {
+	t.Parallel()
+	cs := newStoreForTest(t, "t1")
+	srv := New(WithStore(cs))
+
+	// Outer ctx has plenty of headroom; timeout_ms=50 is the limit.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	_, err := srv.WaitForOffset(ctx, &pb.WaitForOffsetRequest{
+		Context:        &pb.RequestContext{TenantId: "t1"},
+		StreamPosition: "entdb-wal:0:999",
+		TimeoutMs:      50,
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("WaitForOffset: expected error, got nil")
+	}
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("WaitForOffset: got code %v, want DeadlineExceeded", status.Code(err))
+	}
+	if elapsed > time.Second {
+		t.Fatalf("WaitForOffset: took %v, expected <1s (timeout_ms should bound the wait)", elapsed)
+	}
+}
+
+// TestWaitForOffset_MissingTenant: tenant_id is required by the handler.
+func TestWaitForOffset_MissingTenant(t *testing.T) {
+	t.Parallel()
+	cs := newStoreForTest(t, "t1")
+	srv := New(WithStore(cs))
+
+	_, err := srv.WaitForOffset(context.Background(), &pb.WaitForOffsetRequest{
+		Context: &pb.RequestContext{TenantId: ""},
+	})
+	if err == nil {
+		t.Fatalf("expected InvalidArgument, got nil")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("got %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+// TestParseStreamOffset pins the partner of canonical_store.py
+// :_parse_stream_offset (90-109): split on last `:`, parse trailing int,
+// non-numeric → 0.
+func TestParseStreamOffset(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"", 0},
+		{"42", 42},
+		{"entdb-wal:0:42", 42},
+		{"0:42", 42},
+		{"entdb-wal:0:not-a-number", 0},
+		{"entdb-wal:0:", 0},
+	}
+	for _, tc := range cases {
+		got := parseStreamOffset(tc.in)
+		if got != tc.want {
+			t.Errorf("parseStreamOffset(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Sanity: an error from the handler should be a gRPC status, not a
+// naked Go error — protects the chokepoint contract documented in
+// internal/errs.
+func TestWaitForOffset_ErrorsAreStatuses(t *testing.T) {
+	t.Parallel()
+	cs := newStoreForTest(t, "t1")
+	srv := New(WithStore(cs))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := srv.WaitForOffset(ctx, &pb.WaitForOffsetRequest{
+		Context:        &pb.RequestContext{TenantId: "t1"},
+		StreamPosition: "entdb-wal:0:9999",
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, ok := status.FromError(err); !ok {
+		t.Fatalf("error is not a grpc status: %v", err)
+	}
+	// And not a raw context.DeadlineExceeded.
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error must be wrapped in a status, not a raw context.DeadlineExceeded")
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `entdb.v1.EntDBService/WaitForOffset` on the Go server (EPIC #407, sub-issue **W2.04**).
- Handler parks on the W1.8 store-level `sync.Cond` watcher (`internal/store/offset.go`); no busy loop, no leaked goroutines on cancel.
- Honours both the per-RPC `ctx` deadline and the request-side `timeout_ms`. Cancel / deadline surface as `codes.DeadlineExceeded` per the W2 task spec.

## Behaviour pinned by [docs/go-port/rpcs/WaitForOffset.md](../blob/main/docs/go-port/rpcs/WaitForOffset.md)
- `reached=true` once the applier has materialised `>= target` for the tenant.
- `stream_position` parsed via `_parse_stream_offset` semantics — split on last `:`, parse trailing int, non-numeric → 0.
- `current_position` rebuilt from `store.GetAppliedOffset(topic, partition)`; empty if no applier update.
- Empty `tenant_id` → `INVALID_ARGUMENT`.
- All handler errors go through `internal/errs` so contract tests see real gRPC statuses (never naked Go errors).

## Test plan
- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...`
- [x] `cd server/go && go test -race ./internal/api/...`
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- New tests (all pass):
  - `TestWaitForOffset_AlreadyReached` — returns immediately when offset already crossed.
  - `TestWaitForOffset_ConcurrentUpdateUnblocks` — handler wakes from `UpdateAppliedOffset` from another goroutine.
  - `TestWaitForOffset_DeadlineExceeded` — ctx deadline → `DEADLINE_EXCEEDED`.
  - `TestWaitForOffset_TimeoutMsRequestField` — request `timeout_ms` bounds the wait inside a longer ctx.
  - `TestWaitForOffset_MissingTenant` — empty tenant → `INVALID_ARGUMENT`.
  - `TestWaitForOffset_ErrorsAreStatuses` — handler errors are wrapped gRPC statuses.
  - `TestParseStreamOffset` — pins `_parse_stream_offset` edge cases.

## Follow-ups
- `tests/python/integration/_go_parity.py` does not yet exist; once the parity harness lands, add `WaitForOffset` to `GO_IMPLEMENTED`.
- Topic/partition awareness in `store.appliedOffsets` is keyed by tenant only (W1.8); response `current_position` echoes the requested `topic:partition` prefix.

Refs #407.