### PR TITLE
feat(go-rewrite): ListMailboxUsers stub — Wave 2

### DIFF
--- a/server/go/internal/api/list_mailbox_users.go
+++ b/server/go/internal/api/list_mailbox_users.go
@@ -1,0 +1,39 @@
+// ListMailboxUsers is a deprecated stub. The legacy per-user mailbox
+// SQLite store has been removed; this handler is retained for proto
+// compatibility and unconditionally returns an empty user_ids list.
+//
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:1605-1617.
+// Port spec: docs/go-port/rpcs/ListMailboxUsers.md.
+//
+// Contract pins (must not regress):
+//   - tests/python/integration/test_grpc_contract.py:281-287 — a valid
+//     tenant returns ListMailboxUsersResponse{user_ids: []}.
+//   - The handler MUST NOT touch the WAL, canonical SQLite, schema, ACL,
+//     audit, quota, or crypto — it is read-only and identity-independent.
+//   - An unknown tenant MUST surface NOT_FOUND via tenant.CheckTenant
+//     (mirrors the Python _check_tenant gate).
+
+package api
+
+import (
+	"context"
+
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// ListMailboxUsers implements entdb.v1.EntDBService/ListMailboxUsers as
+// a deprecated stub: tenant gate, then an empty response. Resurrecting
+// a real implementation is intentionally out of scope for EPIC #407 —
+// see the open-questions section of the port spec.
+func (s *Server) ListMailboxUsers(
+	ctx context.Context,
+	req *pb.ListMailboxUsersRequest,
+) (*pb.ListMailboxUsersResponse, error) {
+	if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
+		return nil, err
+	}
+	// UserIds is explicitly a zero-length, non-nil slice to mirror the
+	// Python `ListMailboxUsersResponse(user_ids=[])` pinned by
+	// test_grpc_contract.py:286.
+	return &pb.ListMailboxUsersResponse{UserIds: []string{}}, nil
+}

--- a/server/go/internal/api/list_mailbox_users_test.go
+++ b/server/go/internal/api/list_mailbox_users_test.go
@@ -1,0 +1,79 @@
+// Tests for the deprecated ListMailboxUsers stub. Behavioural parity
+// with Python is pinned by tests/python/integration/test_grpc_contract.py:281-287
+// (the cross-language contract suite); this file covers the two
+// branches the Python handler has after _check_tenant:
+//
+//  1. valid tenant -> OK with an empty user_ids list.
+//  2. unknown tenant -> NOT_FOUND from the tenant.CheckTenant gate.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
+	t.Helper()
+	gs, err := globalstore.New(globalstore.Options{DataDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+	return gs
+}
+
+// TestListMailboxUsers_EmptyForValidTenant pins the deprecated-stub
+// contract: a tenant that passes the gate returns an empty user_ids
+// list. The slice must be non-nil — matches Python's
+// `ListMailboxUsersResponse(user_ids=[])` repeated-field default.
+func TestListMailboxUsers_EmptyForValidTenant(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.ListMailboxUsers(ctx, &pb.ListMailboxUsersRequest{TenantId: "acme"})
+	if err != nil {
+		t.Fatalf("ListMailboxUsers: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("ListMailboxUsers: response is nil")
+	}
+	if resp.UserIds == nil {
+		t.Fatalf("ListMailboxUsers: UserIds is nil; want empty slice (contract pin)")
+	}
+	if len(resp.UserIds) != 0 {
+		t.Fatalf("ListMailboxUsers: UserIds = %v; want []", resp.UserIds)
+	}
+}
+
+// TestListMailboxUsers_UnknownTenantNotFound: when globalstore is wired
+// and the tenant row is absent, tenant.CheckTenant returns NOT_FOUND
+// and the handler must propagate it verbatim.
+func TestListMailboxUsers_UnknownTenantNotFound(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.ListMailboxUsers(context.Background(), &pb.ListMailboxUsersRequest{TenantId: "ghost"})
+	if err == nil {
+		t.Fatalf("ListMailboxUsers: expected NOT_FOUND, got nil")
+	}
+	if got := errs.Code(err); got != codes.NotFound {
+		t.Fatalf("ListMailboxUsers: code = %v, want NotFound (err=%v)", got, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Wave 2 of EPIC #407 (Python -> Go server port). Implements `entdb.v1.EntDBService/ListMailboxUsers` as a deprecated stub on the Go server, mirroring the Python handler at `server/python/entdb_server/api/grpc_server.py:1605-1617`.
- Adds `tenant.CheckTenant` wiring to `*api.Server` via `WithSharding` / `WithTenantOptions` options + an internal `checkTenant` helper, so this and future tenant-scoped RPCs can share the gate.
- New `ListMailboxUsers` handler runs the tenant gate and returns a non-nil, zero-length `user_ids` slice (preserves the `[]` repeated-field contract pinned by `test_grpc_contract.py:286`). No WAL, SQLite, schema, ACL, audit, quota or crypto access — read-only and identity-independent, per the port spec.

## Behaviour pinned by tests
- Valid tenant -> `OK` with `user_ids == []`.
- Unknown tenant -> `NOT_FOUND` (surfaced by `tenant.CheckTenant` -> `globalstore.GetTenant`).
- Spec: `docs/go-port/rpcs/ListMailboxUsers.md`.

## Test plan
- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...` — full Go server suite green.
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed.
- [x] `uvx ruff@0.15.7 check .` clean.
- [x] `uvx ruff@0.15.7 format --check .` clean.
- [x] `gofmt -l server/go/internal/api/` clean.

## Scope
- One RPC, stub-only. No edits to `docs/`, `.github/`, Python source, or other Go RPC files.
- Does not resurrect a real mailbox-user enumeration — explicitly out of scope per the port spec's open-questions section.