### PR TITLE
feat(go-rewrite): GetReceiptStatus RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_receipt_status.go
+++ b/server/go/internal/api/get_receipt_status.go
@@ -1,0 +1,96 @@
+// W2.03 — GetReceiptStatus RPC (Python -> Go server port, EPIC #407).
+//
+// Spec: docs/go-port/rpcs/GetReceiptStatus.md. The handler is a pure
+// read of the per-tenant applied_events table indexed by
+// (tenant_id, idempotency_key). It is intentionally minimal:
+//
+//   - No auth / permission check (parity with
+//     api/grpc_server.py:946-971: actor in RequestContext is untrusted
+//     and ignored).
+//   - tenant.CheckTenant is the only ingress gate; on
+//     UNAVAILABLE / FAILED_PRECONDITION / NotFound it returns a gRPC
+//     error directly (the SDK relies on the redirect trailer being set
+//     before the status closes).
+//   - Any other error — including a panic inside CheckIdempotency —
+//     collapses to status=UNKNOWN, error=err.Error(), and the RPC
+//     returns OK. This mirrors the Python bare `except Exception` at
+//     grpc_server.py:966 and is required by the contract tests
+//     pinning (see spec, "Contract tests" section).
+//   - PENDING is returned both for "key issued but applier hasn't
+//     caught up" and "key never issued" — the two are wire-level
+//     indistinguishable; see spec, "Open questions" PENDING ambiguity.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// grpcMethodGetReceiptStatus is the metric label. Mirrors the Python
+// `record_grpc_request("GetReceiptStatus", ...)` calls in
+// api/grpc_server.py:964,967.
+const grpcMethodGetReceiptStatus = "GetReceiptStatus"
+
+// GetReceiptStatus implements entdb.v1.EntDBService/GetReceiptStatus.
+func (s *Server) GetReceiptStatus(ctx context.Context, req *pb.GetReceiptStatusRequest) (resp *pb.GetReceiptStatusResponse, err error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(grpcMethodGetReceiptStatus, outcome, time.Since(start))
+	}()
+
+	// Panic safety: Python's bare `except Exception` (grpc_server.py:966)
+	// collapses every runtime fault — including programmer errors — to
+	// status=UNKNOWN + error=<str(exc)>, with the RPC still returning
+	// OK. Go's default is a goroutine crash; recover here so contract
+	// tests under fault injection see the same shape.
+	defer func() {
+		if p := recover(); p != nil {
+			outcome = "error"
+			resp = &pb.GetReceiptStatusResponse{
+				Status: pb.ReceiptStatus_RECEIPT_STATUS_UNKNOWN,
+				Error:  fmt.Sprintf("panic: %v", p),
+			}
+			err = nil
+		}
+	}()
+
+	tenantID := req.GetContext().GetTenantId()
+
+	// Ingress gate — sharding ownership, tenant existence, region
+	// pinning. This is the ONLY place we may return a gRPC error code
+	// (UNAVAILABLE / FAILED_PRECONDITION / NotFound / InvalidArgument).
+	// Match Python parity: api/grpc_server.py:946-971 calls
+	// `_check_tenant` first and lets its grpc.aio.AbortError propagate.
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		outcome = "error"
+		return nil, err
+	}
+
+	// `req.context.actor` is read off the wire but deliberately NOT
+	// used for authorization or logging — see spec, "Auth" section
+	// (trusted-actor invariant).
+
+	applied, ierr := s.store.CheckIdempotency(ctx, tenantID, req.GetIdempotencyKey())
+	if ierr != nil {
+		// Application-level fault. Python collapses this to UNKNOWN +
+		// error (grpc_server.py:966); do NOT upgrade to codes.Internal
+		// — contract tests assert OK + UNKNOWN body.
+		outcome = "error"
+		return &pb.GetReceiptStatusResponse{
+			Status: pb.ReceiptStatus_RECEIPT_STATUS_UNKNOWN,
+			Error:  ierr.Error(),
+		}, nil
+	}
+
+	status := pb.ReceiptStatus_RECEIPT_STATUS_PENDING
+	if applied {
+		status = pb.ReceiptStatus_RECEIPT_STATUS_APPLIED
+	}
+	return &pb.GetReceiptStatusResponse{Status: status}, nil
+}

--- a/server/go/internal/api/get_receipt_status_test.go
+++ b/server/go/internal/api/get_receipt_status_test.go
@@ -1,0 +1,129 @@
+// Tests for the GetReceiptStatus RPC (W2.03 — EPIC #407).
+//
+// Pinning these three cases mirrors the Python contract tests at
+// tests/python/integration/test_grpc_contract.py:313-326 (APPLIED for
+// a recorded key, PENDING for an unknown key) and the spec error
+// contract at docs/go-port/rpcs/GetReceiptStatus.md (any store fault
+// collapses to status=UNKNOWN + error, with the RPC returning OK).
+
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// newTestStore returns a tmpdir-backed CanonicalStore with WAL on. The
+// store is closed automatically on test teardown.
+func newTestStore(t *testing.T) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// receiptReq is a small builder so each test case reads as the actual
+// wire payload it exercises.
+func receiptReq(tenantID, key string) *pb.GetReceiptStatusRequest {
+	return &pb.GetReceiptStatusRequest{
+		Context:        &pb.RequestContext{TenantId: tenantID},
+		IdempotencyKey: key,
+	}
+}
+
+// Case 1: receipt for a key that the applier has recorded returns
+// APPLIED + empty error. Pinned by spec "Error contract" row 6.
+func TestGetReceiptStatus_AppliedKeyReturnsApplied(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cs := newTestStore(t)
+	const tenantID = "tenant-a"
+	const key = "req-applied-1"
+
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if err := cs.RecordIdempotency(ctx, tenantID, key, "wal-topic:0:42"); err != nil {
+		t.Fatalf("RecordIdempotency: %v", err)
+	}
+
+	srv := New(WithStore(cs))
+	resp, err := srv.GetReceiptStatus(ctx, receiptReq(tenantID, key))
+	if err != nil {
+		t.Fatalf("GetReceiptStatus: unexpected gRPC error: %v", err)
+	}
+	if resp.GetStatus() != pb.ReceiptStatus_RECEIPT_STATUS_APPLIED {
+		t.Fatalf("status: got %v, want APPLIED", resp.GetStatus())
+	}
+	if resp.GetError() != "" {
+		t.Fatalf("error: got %q, want empty (mutually exclusive with non-UNKNOWN status)", resp.GetError())
+	}
+}
+
+// Case 2: receipt for a key never recorded returns PENDING + empty
+// error. Pinned by spec "Error contract" row 5 and the Python contract
+// test's "never-issued" assertion (test_grpc_contract.py:325-326).
+func TestGetReceiptStatus_UnknownKeyReturnsPending(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cs := newTestStore(t)
+	const tenantID = "tenant-b"
+
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	srv := New(WithStore(cs))
+	resp, err := srv.GetReceiptStatus(ctx, receiptReq(tenantID, "never-issued"))
+	if err != nil {
+		t.Fatalf("GetReceiptStatus: unexpected gRPC error: %v", err)
+	}
+	if resp.GetStatus() != pb.ReceiptStatus_RECEIPT_STATUS_PENDING {
+		t.Fatalf("status: got %v, want PENDING", resp.GetStatus())
+	}
+	if resp.GetError() != "" {
+		t.Fatalf("error: got %q, want empty", resp.GetError())
+	}
+}
+
+// Case 3: a store-internal error (here: the tenant DB has never been
+// opened, so the read-side pool lookup returns ErrTenantNotOpen) must
+// surface as status=UNKNOWN + error=<msg> with NO gRPC error. This is
+// the Python `except Exception` -> UNKNOWN collapse documented in the
+// spec "Error contract" row 4.
+func TestGetReceiptStatus_StoreErrorReturnsUnknownNotGRPC(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cs := newTestStore(t)
+	const tenantID = "tenant-c"
+
+	// Deliberately skip OpenTenant — CheckIdempotency will fail with
+	// ErrTenantNotOpen and the handler must collapse that to UNKNOWN.
+	srv := New(WithStore(cs))
+	resp, err := srv.GetReceiptStatus(ctx, receiptReq(tenantID, "any-key"))
+	if err != nil {
+		t.Fatalf("GetReceiptStatus: must return OK + UNKNOWN body, not gRPC error %v", err)
+	}
+	if resp.GetStatus() != pb.ReceiptStatus_RECEIPT_STATUS_UNKNOWN {
+		t.Fatalf("status: got %v, want UNKNOWN", resp.GetStatus())
+	}
+	if resp.GetError() == "" {
+		t.Fatalf("error: got empty, want non-empty (Python populates `error` on UNKNOWN)")
+	}
+	// Sanity-check that the error message refers to the underlying
+	// fault rather than being a generic placeholder. We don't pin the
+	// exact string — the Python contract is just "non-empty".
+	if !strings.Contains(resp.GetError(), tenantID) && !strings.Contains(resp.GetError(), "tenant") {
+		t.Logf("error message: %q (no tenant context; allowed but worth noting)", resp.GetError())
+	}
+}


### PR DESCRIPTION
## Summary

Implements `entdb.v1.EntDBService/GetReceiptStatus` on the Go server (W2.03, EPIC #407). It is a pure, side-effect-free read of per-tenant `applied_events` keyed by `idempotency_key`.

- `tenant.CheckTenant` is the only ingress gate (sharding ownership, region pinning, tenant existence).
- **No auth / permission check** — parity with `api/grpc_server.py:946-971`; `RequestContext.actor` is untrusted and ignored.
- Application-level errors and panics inside `CheckIdempotency` collapse to `status=UNKNOWN`, `error=<msg>`, with the RPC returning OK. Mirrors the Python bare `except Exception` at `grpc_server.py:966`. **No `codes.Internal`** — that would be a contract widening the Python server doesn't observe.
- `PENDING` is returned both for "key issued, applier behind" and "key never issued" (wire-level indistinguishable — see spec, "Open questions / PENDING ambiguity").
- `RECEIPT_STATUS_FAILED` is intentionally **not produced** (matches Python; out-of-scope per spec "Open questions").

## Wiring change

Adds `WithSharding(*tenant.Sharding)` and `WithServedRegion(string)` options on `api.Server` so the gate has the registry it needs. Zero values are single-node defaults (always-mine, no region pinning), so `main.go` stays unchanged.

## Tests

Three new Go unit tests in `server/go/internal/api/get_receipt_status_test.go`:

- APPLIED: key recorded via `RecordIdempotency` returns `RECEIPT_STATUS_APPLIED` + empty `error`.
- PENDING: unknown key on an opened tenant returns `RECEIPT_STATUS_PENDING` + empty `error`. Mirrors the Python contract test's `"never-issued"` assertion (`test_grpc_contract.py:325-326`).
- UNKNOWN: store-internal fault (`ErrTenantNotOpen`) returns OK + `status=UNKNOWN` + non-empty `error`, **not** a gRPC error. Pins the Python `except Exception` collapse.

## TODOs

- `tests/python/integration/_go_parity.py` does not exist yet — when the parity harness lands, `GetReceiptStatus` should be added to its `GO_IMPLEMENTED` set.

## Refs

- Issue: #407
- Spec: `docs/go-port/rpcs/GetReceiptStatus.md`

## Test plan

- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...` (all packages pass; new tests in `internal/api`)
- [x] `uvx ruff@0.15.7 check .`
- [x] `uvx ruff@0.15.7 format --check .`