### PR TITLE
feat(go-rewrite): GetMailbox stub — Wave 2

### DIFF
--- a/server/go/internal/api/get_mailbox.go
+++ b/server/go/internal/api/get_mailbox.go
@@ -1,0 +1,79 @@
+// GetMailbox is a deprecated stub. The legacy cross-tenant mailbox
+// SQLite store was removed; per-tenant fanout now lives in the
+// `notifications` table. The RPC is retained for proto compatibility
+// and contract pinning (see
+// docs/go-port/rpcs/GetMailbox.md and the Python source at
+// server/python/entdb_server/api/grpc_server.py:1478-1498).
+//
+// Behavior parity with the Python stub:
+//
+//  1. Run the tenant gate (CheckTenant): sharding + region. Errors
+//     from the gate (UNAVAILABLE with redirect trailer,
+//     FAILED_PRECONDITION on region mismatch, NOT_FOUND on missing
+//     tenant) propagate to the client unchanged.
+//  2. On success, return a well-formed empty response:
+//     items = [] (non-nil), unread_count = 0, has_more = false.
+//  3. Other exceptions inside the handler body are swallowed and the
+//     empty response is returned (matches grpc_server.py:1495-1498).
+//  4. No SQLite reads, no WAL append, no ACL check, no read of
+//     request.user_id / filters / pagination — all ignored on purpose.
+//
+// Metrics: emits entdb_grpc_requests_total{method="GetMailbox",
+// status="ok"|"error"} via the shared metrics chokepoint.
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// GetMailbox implements entdb.v1.EntDBService/GetMailbox.
+//
+// DEPRECATED STUB. Always returns an empty mailbox on the success
+// path. The only real work is the tenant gate.
+func (s *Server) GetMailbox(ctx context.Context, req *pb.GetMailboxRequest) (*pb.GetMailboxResponse, error) {
+	start := time.Now()
+
+	// Swallow-on-panic. Mirrors the Python try/except at
+	// grpc_server.py:1495 which logs and falls through to an empty
+	// response. A panic must NOT propagate as a gRPC error to the
+	// SDK.
+	var (
+		resp *pb.GetMailboxResponse
+		err  error
+	)
+	defer func() {
+		if r := recover(); r != nil {
+			metrics.RecordGRPCRequest("GetMailbox", "error", time.Since(start))
+			resp = emptyMailboxResponse()
+			err = nil
+		}
+	}()
+
+	tenantID := req.GetContext().GetTenantId()
+	if cerr := s.checkTenant(ctx, tenantID); cerr != nil {
+		metrics.RecordGRPCRequest("GetMailbox", "error", time.Since(start))
+		return nil, cerr
+	}
+
+	metrics.RecordGRPCRequest("GetMailbox", "ok", time.Since(start))
+	resp = emptyMailboxResponse()
+	return resp, err
+}
+
+// emptyMailboxResponse is the canned empty response. Items is a
+// non-nil empty slice for symmetry with grpc_server.py:1494
+// (`items=[]`); protobuf-go marshals nil and an empty slice
+// identically on the wire, but explicit `[]` keeps the Go source
+// readable.
+func emptyMailboxResponse() *pb.GetMailboxResponse {
+	return &pb.GetMailboxResponse{
+		Items:       []*pb.MailboxItem{},
+		UnreadCount: 0,
+		HasMore:     false,
+	}
+}

--- a/server/go/internal/api/get_mailbox_test.go
+++ b/server/go/internal/api/get_mailbox_test.go
@@ -1,0 +1,139 @@
+// Tests for the deprecated GetMailbox stub.
+//
+// The Python contract test at
+// tests/python/integration/test_grpc_contract.py:274-280 pins the
+// happy-path shape (`items == [] and unread_count == 0`). The Go
+// unit tests below pin the same shape plus the tenant-gate
+// NOT_FOUND branch which the contract test does not cover for this
+// RPC (see GetMailbox.md "Contract tests pinning behavior").
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
+)
+
+func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
+	t.Helper()
+	gs, err := globalstore.New(globalstore.Options{DataDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+	return gs
+}
+
+// TestGetMailbox_HappyPath: with a registered tenant, the stub
+// returns an empty, well-formed response — `items == []`,
+// `unread_count == 0`, `has_more == false`. Mirrors the Python
+// contract pin at test_grpc_contract.py:274-280.
+func TestGetMailbox_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithSharding(&tenant.Sharding{NodeID: "node-a"}),
+	)
+
+	resp, err := srv.GetMailbox(ctx, &pb.GetMailboxRequest{
+		Context: &pb.RequestContext{TenantId: "acme"},
+		UserId:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("GetMailbox: unexpected err: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetMailbox: nil response")
+	}
+	if len(resp.GetItems()) != 0 {
+		t.Fatalf("GetMailbox: items: got %d, want 0", len(resp.GetItems()))
+	}
+	if resp.GetUnreadCount() != 0 {
+		t.Fatalf("GetMailbox: unread_count: got %d, want 0", resp.GetUnreadCount())
+	}
+	if resp.GetHasMore() != false {
+		t.Fatalf("GetMailbox: has_more: got %v, want false", resp.GetHasMore())
+	}
+}
+
+// TestGetMailbox_HappyPath_SingleNode: with no globalstore and no
+// sharding wired, the gate degrades to single-node-default and the
+// stub still returns the empty response. This is the bring-up path
+// for the Go server before globalstore is connected.
+func TestGetMailbox_HappyPath_SingleNode(t *testing.T) {
+	t.Parallel()
+	srv := api.New()
+	resp, err := srv.GetMailbox(context.Background(), &pb.GetMailboxRequest{
+		Context: &pb.RequestContext{TenantId: "acme"},
+	})
+	if err != nil {
+		t.Fatalf("GetMailbox: %v", err)
+	}
+	if resp == nil || len(resp.GetItems()) != 0 || resp.GetUnreadCount() != 0 || resp.GetHasMore() {
+		t.Fatalf("GetMailbox: want empty response, got %+v", resp)
+	}
+}
+
+// TestGetMailbox_UnknownTenant: when globalstore is wired and the
+// tenant does not exist, the tenant gate produces NOT_FOUND and the
+// handler MUST propagate it (no swallow — the gate's status is the
+// signal the SDK needs).
+func TestGetMailbox_UnknownTenant(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithSharding(&tenant.Sharding{NodeID: "node-a"}),
+	)
+
+	resp, err := srv.GetMailbox(context.Background(), &pb.GetMailboxRequest{
+		Context: &pb.RequestContext{TenantId: "ghost"},
+	})
+	if err == nil {
+		t.Fatalf("GetMailbox: expected error for unknown tenant, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("GetMailbox: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Fatalf("GetMailbox: code: got %v, want NotFound", st.Code())
+	}
+}
+
+// TestGetMailbox_IgnoresFilters: the stub ignores user_id, filters,
+// and pagination. Setting wild values must not affect the response.
+func TestGetMailbox_IgnoresFilters(t *testing.T) {
+	t.Parallel()
+	srv := api.New()
+	resp, err := srv.GetMailbox(context.Background(), &pb.GetMailboxRequest{
+		Context:      &pb.RequestContext{TenantId: "acme"},
+		UserId:       "alice",
+		SourceTypeId: 42,
+		ThreadId:     "t-1",
+		UnreadOnly:   true,
+		Limit:        100,
+		Offset:       50,
+	})
+	if err != nil {
+		t.Fatalf("GetMailbox: %v", err)
+	}
+	if len(resp.GetItems()) != 0 || resp.GetUnreadCount() != 0 || resp.GetHasMore() {
+		t.Fatalf("GetMailbox: filters leaked into response: %+v", resp)
+	}
+}


### PR DESCRIPTION
## Summary

W2.43 — `GetMailbox` RPC for EPIC #407 (Python → Go server port). DEPRECATED STUB: mirrors `server/python/entdb_server/api/grpc_server.py:1478-1498` — runs the tenant gate and returns an empty, well-formed response.

- New handler `server/go/internal/api/get_mailbox.go`: runs `tenant.CheckTenant` (sharding + region + existence), returns `GetMailboxResponse{Items:[], UnreadCount:0, HasMore:false}` on success. Panics in the handler body are swallowed to match Python's `try/except` swallow-and-return-empty (see GetMailbox.md "Error contract").
- `request.user_id`, filters, and pagination are intentionally ignored — pinned by the Python stub and the contract test at `tests/python/integration/test_grpc_contract.py:274-280`.
- No SQLite reads, no WAL append, no ACL check (CLAUDE.md §1 + §4: the removed cross-tenant mailbox is NOT being restored).
- `server.go`: added `WithSharding` + `WithServedRegion` functional options so the gate can be wired from `cmd/entdb-server/main.go` as Wave-2 RPCs land. Nil sharding + empty region preserves single-node-default behavior.
- Spec: `docs/go-port/rpcs/GetMailbox.md`.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — full Go suite passes, including 4 new unit tests in `get_mailbox_test.go`:
  - happy path with registered tenant returns empty response
  - single-node default (no globalstore / no sharding) returns empty response
  - unknown tenant → `codes.NotFound` (covers the gate branch the Python contract test does not exercise for this RPC)
  - filters/pagination ignored (stub contract)
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [x] Full Python suite (`pytest tests/python/unit/ tests/python/integration/ -q`) — 2529 passed

## Policy notes

- One RPC, one PR.
- No edits to `docs/`, `.github/`, Python source, or other RPC files.
- `_go_parity.py` does not exist in the tree; step 5 of the task spec is a no-op.