### PR TITLE
feat(go-rewrite): Health RPC — Wave 2

### DIFF
--- a/server/go/internal/api/health.go
+++ b/server/go/internal/api/health.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/version"
+)
+
+// walPinger is the optional probe contract a WAL Producer may implement.
+// Mirrors the Python `wal.is_connected()` shim at
+// server/python/entdb_server/api/grpc_server.py:1512 — handlers must NOT
+// round-trip to the broker inside Health, so implementations are expected
+// to return a cached connection flag rather than performing a live ping.
+//
+// Producers that do not implement walPinger are treated as healthy (matches
+// Python's hasattr() fall-through at grpc_server.py:1512-1515).
+type walPinger interface {
+	IsConnected() bool
+}
+
+// storagePinger is the optional probe contract a CanonicalStore may
+// implement. Today no Go store has a Health hook (Python doesn't probe
+// SQLite either, see docs/go-port/rpcs/Health.md "storage='healthy' is a
+// lie"), so this lives here only to keep the door open for a future
+// PRAGMA quick_check probe behind a flag.
+type storagePinger interface {
+	Health(ctx context.Context) error
+}
+
+// Health implements the entdb.v1.EntDBService/Health RPC. Spec:
+// docs/go-port/rpcs/Health.md.
+//
+// Contract pins:
+//   - No auth, no rate-limit, no actor — allow-listed by the auth and
+//     rate-limit interceptors. The handler MUST NOT consult ACLs.
+//   - No WAL append, no store write, no global_store read. Strictly
+//     read-only, in-memory introspection.
+//   - `healthy` is true iff components["wal"] == "healthy" AND
+//     components["storage"] == "healthy". The multi-node info keys
+//     (node_id, assigned_tenants) are informational and MUST NOT gate
+//     healthy. Pinned by tests/python/unit/test_cron_fixes.py:116-147.
+//   - Always returns OK; an internal panic is the only path to INTERNAL.
+func (s *Server) Health(ctx context.Context, _ *pb.HealthRequest) (*pb.HealthResponse, error) {
+	start := time.Now()
+	resultStatus := "ok"
+	defer func() {
+		if r := recover(); r != nil {
+			metrics.RecordGRPCRequest("Health", "error", time.Since(start))
+			panic(r)
+		}
+		metrics.RecordGRPCRequest("Health", resultStatus, time.Since(start))
+	}()
+
+	components := make(map[string]string, 4)
+
+	// WAL probe. Cheap, non-blocking; never round-trip to the broker —
+	// otherwise the Docker HEALTHCHECK starves. See spec "Open questions
+	// / risks: WAL IsConnected semantics differ across backends".
+	if s.producer == nil {
+		components["wal"] = "unknown"
+	} else {
+		components["wal"] = probeWAL(s.producer)
+	}
+
+	// Storage probe. Python never actually opens an SQLite cursor and
+	// returns "healthy" unconditionally; we preserve that contract but
+	// still report "unknown" when no store handle is wired so a
+	// misconfigured server doesn't silently report healthy. The nil
+	// check is on the concrete *store.CanonicalStore pointer to avoid
+	// the typed-nil-in-interface trap.
+	if s.store == nil {
+		components["storage"] = "unknown"
+	} else {
+		components["storage"] = probeStorage(ctx, s.store)
+	}
+
+	// Multi-node sharding info keys (node_id, assigned_tenants) are
+	// emitted by the Python handler when sharding is multi-node. Wave-1
+	// has no Go sharding package yet, so we skip them here. Crucially,
+	// when they DO land, they MUST be appended to `components` AFTER
+	// the `healthy` gate below — the info keys MUST NOT count against
+	// health. Regression pinned by
+	// tests/python/unit/test_cron_fixes.py:116-147 and the Go test
+	// TestHealth_MultiNodeInfoKeysDoNotGateHealth.
+
+	healthy := components["wal"] == "healthy" && components["storage"] == "healthy"
+
+	return &pb.HealthResponse{
+		Healthy:    healthy,
+		Version:    version.Version,
+		Components: components,
+	}, nil
+}
+
+// probeWAL returns the wal component string for HealthResponse.components.
+// Caller must guarantee p is non-nil (typed-nil-in-interface guard lives
+// in the Health handler so this helper can stay simple).
+// Contract:
+//   - producer w/o IsConnected() (e.g. in-memory)  -> "healthy"
+//     (matches Python hasattr() fall-through)
+//   - IsConnected() panics                         -> "unknown"
+//   - IsConnected() == true                        -> "healthy"
+//   - IsConnected() == false                       -> "unhealthy"
+func probeWAL(p any) (result string) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = "unknown"
+		}
+	}()
+	pinger, ok := p.(walPinger)
+	if !ok {
+		return "healthy"
+	}
+	if pinger.IsConnected() {
+		return "healthy"
+	}
+	return "unhealthy"
+}
+
+// probeStorage returns the storage component string. Caller must
+// guarantee st is non-nil. Today Wave-1 has no SQLite probe, so we
+// report "healthy" by default (mirrors Python's unconditional "healthy"
+// when a store is present). If the store ever grows a Health(ctx) hook,
+// it's consulted here.
+func probeStorage(ctx context.Context, st any) (result string) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = "unknown"
+		}
+	}()
+	if pinger, ok := st.(storagePinger); ok {
+		if err := pinger.Health(ctx); err != nil {
+			return "unhealthy"
+		}
+	}
+	return "healthy"
+}

--- a/server/go/internal/api/health_test.go
+++ b/server/go/internal/api/health_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/version"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// fakeProducerNoPing is a wal.Producer-shaped stub that does NOT
+// implement IsConnected. Mirrors the "backend lacks the method" branch
+// at docs/go-port/rpcs/Health.md step 2 — must be treated as healthy.
+type fakeProducerNoPing struct{}
+
+func (fakeProducerNoPing) Connect(_ context.Context) error { return nil }
+func (fakeProducerNoPing) Close(_ context.Context) error   { return nil }
+func (fakeProducerNoPing) Append(_ context.Context, _, _ string, _ []byte, _ map[string][]byte) (wal.StreamPos, error) {
+	return wal.StreamPos{}, nil
+}
+
+// fakeProducerConnected implements the optional IsConnected probe and
+// reports connected.
+type fakeProducerConnected struct{ fakeProducerNoPing }
+
+func (fakeProducerConnected) IsConnected() bool { return true }
+
+// fakeProducerDisconnected implements the optional IsConnected probe
+// and reports disconnected.
+type fakeProducerDisconnected struct{ fakeProducerNoPing }
+
+func (fakeProducerDisconnected) IsConnected() bool { return false }
+
+// fakeProducerPanic panics inside IsConnected. The handler MUST catch
+// and report "unknown" rather than crash the RPC (matches Python
+// grpc_server.py:1514-1515).
+type fakeProducerPanic struct{ fakeProducerNoPing }
+
+func (fakeProducerPanic) IsConnected() bool { panic("boom") }
+
+// newRealStore returns a tmpdir-backed CanonicalStore. Health never
+// calls into it; we only need a non-nil handle to flip the "is the dep
+// wired?" check.
+func newRealStore(t *testing.T) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// TestHealth_AllDepsWired pins the happy path: WAL + storage both
+// report healthy, version is the build-stamped Version (non-empty), and
+// the components map contains both keys.
+//
+// Mirrors tests/python/integration/test_grpc_contract.py:195-202.
+func TestHealth_AllDepsWired(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New(
+		api.WithStore(newRealStore(t)),
+		api.WithWALProducer(fakeProducerConnected{}),
+	)
+
+	resp, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: unexpected error: %v", err)
+	}
+	if !resp.Healthy {
+		t.Fatalf("Health: expected healthy=true, got false; components=%v", resp.Components)
+	}
+	if resp.Version == "" {
+		t.Fatalf("Health: expected non-empty version, got %q", resp.Version)
+	}
+	if resp.Version != version.Version {
+		t.Fatalf("Health: version mismatch: got %q want %q", resp.Version, version.Version)
+	}
+	if got := resp.Components["wal"]; got != "healthy" {
+		t.Fatalf("Health: components[wal]=%q, want healthy", got)
+	}
+	if got := resp.Components["storage"]; got != "healthy" {
+		t.Fatalf("Health: components[storage]=%q, want healthy", got)
+	}
+	// Multi-node info keys MUST NOT be present in the single-node base case.
+	if _, ok := resp.Components["node_id"]; ok {
+		t.Fatalf("Health: components[node_id] leaked into single-node response: %v", resp.Components)
+	}
+	if _, ok := resp.Components["assigned_tenants"]; ok {
+		t.Fatalf("Health: components[assigned_tenants] leaked into single-node response: %v", resp.Components)
+	}
+}
+
+// TestHealth_NoDepsWired pins the misconfig path: server booted without
+// store or wal handles reports components but is NOT healthy.
+func TestHealth_NoDepsWired(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New() // no options
+
+	resp, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: unexpected error: %v", err)
+	}
+	if resp.Healthy {
+		t.Fatalf("Health: expected healthy=false when deps absent, got true; components=%v", resp.Components)
+	}
+	if got := resp.Components["wal"]; got != "unknown" {
+		t.Fatalf("Health: components[wal]=%q, want unknown", got)
+	}
+	if got := resp.Components["storage"]; got != "unknown" {
+		t.Fatalf("Health: components[storage]=%q, want unknown", got)
+	}
+}
+
+// TestHealth_WALProducerWithoutIsConnected pins the in-memory-backend
+// branch: a Producer that doesn't implement the optional IsConnected
+// probe is treated as healthy. Mirrors Python's
+// `hasattr(self.wal, "is_connected")` shim returning False.
+func TestHealth_WALProducerWithoutIsConnected(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New(
+		api.WithStore(newRealStore(t)),
+		api.WithWALProducer(fakeProducerNoPing{}),
+	)
+
+	resp, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: unexpected error: %v", err)
+	}
+	if got := resp.Components["wal"]; got != "healthy" {
+		t.Fatalf("Health: producer w/o IsConnected: components[wal]=%q, want healthy", got)
+	}
+	if !resp.Healthy {
+		t.Fatalf("Health: expected healthy=true, got false")
+	}
+}
+
+// TestHealth_WALDisconnected pins the unhappy WAL path: IsConnected
+// reports false → components[wal]="unhealthy" → healthy=false.
+func TestHealth_WALDisconnected(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New(
+		api.WithStore(newRealStore(t)),
+		api.WithWALProducer(fakeProducerDisconnected{}),
+	)
+
+	resp, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: unexpected error: %v", err)
+	}
+	if got := resp.Components["wal"]; got != "unhealthy" {
+		t.Fatalf("Health: components[wal]=%q, want unhealthy", got)
+	}
+	if resp.Healthy {
+		t.Fatalf("Health: expected healthy=false when wal unhealthy, got true")
+	}
+}
+
+// TestHealth_WALProbePanicIsCaught pins the panic-recovery contract:
+// a panic inside IsConnected becomes "unknown", the RPC still returns
+// OK. Mirrors Python's bare-except at grpc_server.py:1514-1515.
+func TestHealth_WALProbePanicIsCaught(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New(
+		api.WithStore(newRealStore(t)),
+		api.WithWALProducer(fakeProducerPanic{}),
+	)
+
+	resp, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: unexpected error: %v", err)
+	}
+	if got := resp.Components["wal"]; got != "unknown" {
+		t.Fatalf("Health: components[wal]=%q, want unknown", got)
+	}
+	if resp.Healthy {
+		t.Fatalf("Health: expected healthy=false when wal probe panics, got true")
+	}
+}
+
+// TestHealth_MultiNodeInfoKeysDoNotGateHealth is the regression guard
+// pinned by tests/python/unit/test_cron_fixes.py:116-147. The
+// node_id / assigned_tenants info keys MUST NOT count against `healthy`.
+//
+// Wave-1 has no sharding handle on the Server struct yet, so today the
+// best we can do is post-process the response: stuff arbitrary info keys
+// in and re-derive healthy the way the handler does. The derived bool
+// MUST stay true even with extra keys present — i.e. the gating check
+// only consults wal+storage, never the whole map.
+func TestHealth_MultiNodeInfoKeysDoNotGateHealth(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New(
+		api.WithStore(newRealStore(t)),
+		api.WithWALProducer(fakeProducerConnected{}),
+	)
+
+	resp, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: unexpected error: %v", err)
+	}
+
+	// Simulate the multi-node branch by adding the info keys the
+	// handler will eventually emit when sharding is wired. Healthy is a
+	// function of wal + storage only — info keys MUST NOT drag it false.
+	resp.Components["node_id"] = "node-1"
+	resp.Components["assigned_tenants"] = "t1,t2,t3"
+
+	derived := resp.Components["wal"] == "healthy" && resp.Components["storage"] == "healthy"
+	if !derived {
+		t.Fatalf("Health: multi-node info keys leaked into health gate; components=%v", resp.Components)
+	}
+	if !resp.Healthy {
+		t.Fatalf("Health: expected healthy=true with info keys present, got false; components=%v", resp.Components)
+	}
+}
+
+// TestHealth_NoSideEffects pins the read-only contract: calling Health
+// twice yields fresh, equivalent component maps (no memoization, no
+// shared mutable state across calls). Mirrors the "Concurrency" risk
+// note in docs/go-port/rpcs/Health.md.
+func TestHealth_NoSideEffects(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New(
+		api.WithStore(newRealStore(t)),
+		api.WithWALProducer(fakeProducerConnected{}),
+	)
+
+	r1, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: unexpected error: %v", err)
+	}
+	r1.Components["wal"] = "tampered"
+
+	r2, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: unexpected error on second call: %v", err)
+	}
+	if got := r2.Components["wal"]; got != "healthy" {
+		t.Fatalf("Health: components map appears to be shared across calls: got wal=%q on second call after tampering with first", got)
+	}
+}

--- a/server/go/internal/api/server_test.go
+++ b/server/go/internal/api/server_test.go
@@ -10,23 +10,24 @@ import (
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
 
-// In Phase 0 every RPC must return codes.Unimplemented. This test
-// pins that contract for a representative method so the next PR
-// (which actually implements one) flips the assertion deliberately
-// rather than silently regressing other methods.
-func TestServer_HealthReturnsUnimplemented(t *testing.T) {
+// TestServer_UnimplementedRPC_Default pins the Wave-1 contract: any RPC
+// that hasn't been ported yet still returns codes.Unimplemented via the
+// embedded UnimplementedEntDBServiceServer. We probe a representative
+// not-yet-ported method (GetSchema) rather than Health because Health
+// has now landed (W2.01) and returns OK.
+func TestServer_UnimplementedRPC_Default(t *testing.T) {
 	t.Parallel()
 	srv := New()
 
-	_, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	_, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{})
 	if err == nil {
-		t.Fatalf("Health: expected error, got nil")
+		t.Fatalf("GetSchema: expected Unimplemented error, got nil")
 	}
 	st, ok := status.FromError(err)
 	if !ok {
-		t.Fatalf("Health: error is not a grpc status: %v", err)
+		t.Fatalf("GetSchema: error is not a grpc status: %v", err)
 	}
 	if st.Code() != codes.Unimplemented {
-		t.Fatalf("Health: expected code Unimplemented, got %v", st.Code())
+		t.Fatalf("GetSchema: expected code Unimplemented, got %v", st.Code())
 	}
 }


### PR DESCRIPTION
## Summary

Implements `entdb.v1.EntDBService/Health` in the Go server per `docs/go-port/rpcs/Health.md`. This is **W2.01** of EPIC #407 (Python → Go server port) and is the canary RPC that will gate the cross-implementation contract-test harness once it lands.

## Contract pins (mirroring Python `grpc_server.py:1500-1535`)

- **No auth, no rate-limit, no actor.** Health is in the auth interceptor allow-list; handler does not consult ACLs, WAL, global store, or canonical-store writes.
- **`healthy` is true iff `components["wal"]=="healthy"` AND `components["storage"]=="healthy"`.** The optional multi-node info keys (`node_id`, `assigned_tenants`) MUST NOT count against `healthy` — regression guard for the Python bug pinned by `tests/python/unit/test_cron_fixes.py:116-147`.
- **WAL probe is opt-in** via the `walPinger` interface (`IsConnected() bool`). Producers that don't implement it (e.g. the in-memory backend) are treated as healthy, matching Python's `hasattr` fall-through. The probe MUST stay cheap and non-blocking — never round-trip to the broker, or Docker `HEALTHCHECK` starves.
- **Storage probe is unconditionally "healthy"** when a store is wired (matches Python; future work is a real `PRAGMA quick_check` behind a flag). Misconfigured server (no store handle) reports `"unknown"`.
- **Version** comes from the build-stamped `version.Version` var (`-ldflags -X`), defaults to `"dev"` outside release builds.
- **Always returns `OK`**; only a panic escaping recovery yields `INTERNAL`. Metrics counter records `("Health","ok"|"error", elapsed)`.

## Tests

`server/go/internal/api/health_test.go` covers all seven contract scenarios from the spec:

1. `TestHealth_AllDepsWired` — happy path: store + WAL both wired → `healthy=true`, non-empty version, both component keys present, multi-node info keys absent in single-node case.
2. `TestHealth_NoDepsWired` — misconfig: server booted without store or wal → both components report `"unknown"`, `healthy=false`.
3. `TestHealth_WALProducerWithoutIsConnected` — in-memory backend branch: producer without `IsConnected()` → `"healthy"`.
4. `TestHealth_WALDisconnected` — `IsConnected()` returns false → `"unhealthy"` and `healthy=false`.
5. `TestHealth_WALProbePanicIsCaught` — `IsConnected()` panics → `"unknown"` (matches Python bare-except), RPC still returns `OK`.
6. `TestHealth_MultiNodeInfoKeysDoNotGateHealth` — regression guard: stuffing `node_id`/`assigned_tenants` keys into the response MUST NOT flip `healthy` false.
7. `TestHealth_NoSideEffects` — repeated calls return fresh component maps (no memoization, no shared mutable state).

The existing `server_test.go` Phase-0 "everything is `Unimplemented`" pin was updated to probe `GetSchema` (still unported) instead of `Health` (now ported).

## TODO

- `tests/python/integration/_go_parity.py` (the cross-impl harness `GO_IMPLEMENTED` set) does not exist yet — **W2.00 has not merged**. Once it lands, follow up to add `"Health"` to that set so the harness flips Health onto the Go server.

## Test plan

- [x] `cd server/go && go vet ./...` clean
- [x] `cd server/go && go test ./...` all green (api + every W1 package)
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed (no Python source touched; sanity that the existing handler still behaves)
- [ ] CI green on the PR

Refs #407 · Spec: `docs/go-port/rpcs/Health.md`