### PR TITLE
feat(go-rewrite): GetSchema RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_schema.go
+++ b/server/go/internal/api/get_schema.go
@@ -1,0 +1,210 @@
+// GetSchema RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/GetSchema.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:79 (rpc), :590-596 (request),
+// :598-607 (response). Reference Python:
+// server/python/entdb_server/api/grpc_server.py:1619-1689.
+//
+// Semantics (preserved byte-for-byte from the Python handler):
+//
+//   - Read-only. No WAL append, no global_store touch.
+//   - No Permission check; auth interceptor handles credentials.
+//   - Swallow all errors as OK. The Python handler catches every
+//     exception path and returns &GetSchemaResponse{Fingerprint: ""}
+//     with grpc.OK. The sole contract pin
+//     (tests/python/integration/test_grpc_contract.py:208) only
+//     asserts `fingerprint != "" || HasField("schema")`, so the
+//     empty-but-OK response is the documented degraded path.
+//   - Optional req.TenantId drives a data-driven fallback when the
+//     registry is empty: we synthesise placeholder type entries from
+//     distinct type_ids observed in that tenant's SQLite. Wave-2 stub:
+//     the canonicalstore Go port doesn't expose GetDistinctTypeIDs
+//     yet, so the fallback is a no-op here and surfaces as the same
+//     empty-Struct response Python returns when its SQLite query
+//     errors (`:1665-1666`). This matches the contract pin and is
+//     flagged in the EPIC for the canonicalstore Wave-2 follow-up.
+//
+// Known latent bug (preserved for parity, NOT fixed here): the Python
+// handler reads req.TenantId without cross-checking the caller's
+// authenticated tenant binding, leaking distinct type_ids across
+// tenants. See spec "Open questions / risks" — flagged as follow-up.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const getSchemaMethod = "GetSchema"
+
+// GetSchema returns the in-memory schema registry as a typed
+// google.protobuf.Struct plus its post-freeze fingerprint. See file
+// header for the swallow-all-errors-as-OK contract.
+func (s *Server) GetSchema(_ context.Context, req *pb.GetSchemaRequest) (resp *pb.GetSchemaResponse, err error) {
+	start := time.Now()
+	status := "ok"
+	defer func() {
+		// Single emission point: emit metric whether we exited
+		// normally or via recover. status is mutated on the
+		// degraded path below.
+		metrics.RecordGRPCRequest(getSchemaMethod, status, time.Since(start))
+	}()
+
+	defer func() {
+		if r := recover(); r != nil {
+			// Match Python's outer except (`:1686-1689`): degrade to
+			// empty fingerprint with OK status. resp/err are named
+			// returns so the deferred closure can overwrite them.
+			status = "error"
+			resp = &pb.GetSchemaResponse{Fingerprint: ""}
+			err = nil
+			_ = r
+		}
+	}()
+
+	// Snapshot fingerprint up front so a marshal failure later still
+	// returns it (matches Python's `self.schema_registry.fingerprint
+	// or ""` at `:1684` — fingerprint is computed at freeze, not at
+	// serialise time).
+	var fingerprint string
+	if s.registry != nil {
+		fingerprint = s.registry.Fingerprint()
+	}
+
+	schemaMap, ierr := s.snapshotSchemaMap()
+	if ierr != nil {
+		// Marshal of an in-memory registry should never fail (it's
+		// strongly typed Go), but if it does, Python's outer except
+		// kicks in. Return empty fingerprint to match `:1684`'s `or ""`
+		// fallback when registry is unfrozen.
+		status = "error"
+		return &pb.GetSchemaResponse{Fingerprint: ""}, nil
+	}
+
+	// Data-driven fallback when the registry is empty and the caller
+	// provided a tenant_id (`:1645-1664`). The Go canonicalstore port
+	// does not yet expose GetDistinctTypeIDs; until it does, this path
+	// degrades to the same empty-Struct result Python returns when its
+	// SQLite query errors at `:1665-1666` — well within the contract
+	// pin (fingerprint or schema field present; an empty Struct still
+	// counts as "schema field present"). Flagged in the EPIC for the
+	// canonicalstore Wave-2 follow-up.
+	_ = mapHasTypes(schemaMap)
+	_ = req.GetTenantId()
+
+	// type_id filter (`:1668-1679`). Applied after the fallback so the
+	// node_types/edge_types maps reflect either registry contents or
+	// the fallback synthesis (today: just registry contents).
+	if req.GetTypeId() != 0 {
+		schemaMap = filterByTypeID(schemaMap, req.GetTypeId())
+	}
+
+	structVal, ierr := structpb.NewStruct(schemaMap)
+	if ierr != nil {
+		// Numeric values are emitted as float64 via the JSON round-trip
+		// in snapshotSchemaMap, so this should not fire in practice.
+		// If it does, degrade per Python's outer except (`:1686-1689`).
+		status = "error"
+		return &pb.GetSchemaResponse{Fingerprint: ""}, nil
+	}
+
+	return &pb.GetSchemaResponse{
+		Schema:      structVal,
+		Fingerprint: fingerprint,
+	}, nil
+}
+
+// snapshotSchemaMap lowers the registry into the Python `to_dict()`
+// shape: {"node_types": [...], "edge_types": [...]}. We piggyback on
+// schema.Registry.MarshalJSON (which already sorts by id and normalises
+// nil slices to []) and unmarshal back into a map[string]any so
+// structpb.NewStruct can consume it. JSON-round-trip is the same
+// canonical form the fingerprint canonicaliser uses, so the wire bytes
+// stay aligned with Python's `_dict_to_struct` (`:154-159`).
+//
+// Returns an empty map for a nil registry — matches Python returning
+// empty `node_types: []` / `edge_types: []` for an empty SchemaRegistry.
+func (s *Server) snapshotSchemaMap() (map[string]any, error) {
+	if s.registry == nil {
+		return map[string]any{
+			"node_types": []any{},
+			"edge_types": []any{},
+		}, nil
+	}
+	raw, err := json.Marshal(s.registry)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	// MarshalJSON guarantees the top-level keys, but defensively
+	// normalise so structpb conversion never sees nil.
+	if _, ok := m["node_types"]; !ok {
+		m["node_types"] = []any{}
+	}
+	if _, ok := m["edge_types"]; !ok {
+		m["edge_types"] = []any{}
+	}
+	return m, nil
+}
+
+// mapHasTypes reports whether the snapshot contains any node or edge
+// type entries. Mirrors the truthy check at `:1644` that decides
+// whether to fall back to the per-tenant SQLite distinct-type read.
+func mapHasTypes(m map[string]any) bool {
+	if nt, ok := m["node_types"].([]any); ok && len(nt) > 0 {
+		return true
+	}
+	if et, ok := m["edge_types"].([]any); ok && len(et) > 0 {
+		return true
+	}
+	return false
+}
+
+// filterByTypeID applies the optional req.type_id filter (`:1668-1679`).
+// Keeps node entries with matching type_id and edge entries that touch
+// it via from_type_id or to_type_id.
+//
+// NOTE: the JSON round-trip in snapshotSchemaMap lands every number as
+// float64, so we compare against float64(wanted).
+func filterByTypeID(m map[string]any, wanted int32) map[string]any {
+	wantedF := float64(wanted)
+	if nodes, ok := m["node_types"].([]any); ok {
+		kept := make([]any, 0, len(nodes))
+		for _, e := range nodes {
+			obj, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			if id, ok := obj["type_id"].(float64); ok && id == wantedF {
+				kept = append(kept, obj)
+			}
+		}
+		m["node_types"] = kept
+	}
+	if edges, ok := m["edge_types"].([]any); ok {
+		kept := make([]any, 0, len(edges))
+		for _, e := range edges {
+			obj, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			from, _ := obj["from_type_id"].(float64)
+			to, _ := obj["to_type_id"].(float64)
+			if from == wantedF || to == wantedF {
+				kept = append(kept, obj)
+			}
+		}
+		m["edge_types"] = kept
+	}
+	return m
+}

--- a/server/go/internal/api/get_schema_test.go
+++ b/server/go/internal/api/get_schema_test.go
@@ -1,0 +1,273 @@
+// Tests for the GetSchema RPC. Spec: docs/go-port/rpcs/GetSchema.md.
+//
+// The sole contract pin from the Python test suite
+// (tests/python/integration/test_grpc_contract.py:208) requires either
+// fingerprint != "" or HasField("schema"). The cases below cover both
+// the empty-registry path (Struct populated, fingerprint empty) and the
+// frozen-registry path (Struct populated AND fingerprint set), plus the
+// optional type_id filter and the degraded swallow-errors path.
+
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+)
+
+// TestGetSchema_NoRegistry covers Server constructed without
+// WithSchemaRegistry — should return OK with an empty Struct and empty
+// fingerprint, matching Python's behaviour when SchemaRegistry is empty
+// and tenant_id is also empty.
+func TestGetSchema_NoRegistry(t *testing.T) {
+	t.Parallel()
+	srv := New()
+
+	resp, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetSchema returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetSchema returned nil response")
+	}
+	if resp.GetFingerprint() != "" {
+		t.Errorf("Fingerprint: want \"\", got %q", resp.GetFingerprint())
+	}
+	if resp.GetSchema() == nil {
+		t.Fatalf("Schema struct: want non-nil, got nil")
+	}
+	fields := resp.GetSchema().GetFields()
+	nodeTypes, ok := fields["node_types"]
+	if !ok {
+		t.Errorf("Schema struct missing key node_types; keys=%v", keysOf(fields))
+	} else if lv := nodeTypes.GetListValue(); lv == nil {
+		t.Errorf("node_types: want list value, got %v", nodeTypes)
+	} else if n := len(lv.GetValues()); n != 0 {
+		t.Errorf("node_types: want 0 entries, got %d", n)
+	}
+	if _, ok := fields["edge_types"]; !ok {
+		t.Errorf("Schema struct missing key edge_types; keys=%v", keysOf(fields))
+	}
+}
+
+// TestGetSchema_EmptyRegistry covers Server with an explicit empty
+// (but possibly frozen) Registry. Both an unfrozen-empty and a
+// frozen-empty registry must round-trip an empty schema. The frozen
+// case sets fingerprint to a non-empty sha256:... string.
+func TestGetSchema_EmptyRegistry(t *testing.T) {
+	t.Parallel()
+	reg := schema.NewRegistry()
+	srv := New(WithSchemaRegistry(reg))
+
+	resp, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetSchema returned error: %v", err)
+	}
+	if got := resp.GetFingerprint(); got != "" {
+		t.Errorf("Fingerprint (unfrozen): want \"\", got %q", got)
+	}
+	if s := resp.GetSchema(); s == nil {
+		t.Fatalf("Schema struct: want non-nil, got nil")
+	} else {
+		if lv, ok := s.GetFields()["node_types"]; !ok || lv.GetListValue() == nil ||
+			len(lv.GetListValue().GetValues()) != 0 {
+			t.Errorf("node_types: want empty list, got %v", lv)
+		}
+		if lv, ok := s.GetFields()["edge_types"]; !ok || lv.GetListValue() == nil ||
+			len(lv.GetListValue().GetValues()) != 0 {
+			t.Errorf("edge_types: want empty list, got %v", lv)
+		}
+	}
+
+	// Freeze and re-run: fingerprint must populate.
+	fp, ferr := reg.Freeze()
+	if ferr != nil {
+		t.Fatalf("Freeze: %v", ferr)
+	}
+	if !strings.HasPrefix(fp, "sha256:") {
+		t.Errorf("Freeze fingerprint: want sha256: prefix, got %q", fp)
+	}
+	resp2, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetSchema after Freeze returned error: %v", err)
+	}
+	if resp2.GetFingerprint() != fp {
+		t.Errorf("Fingerprint (frozen): want %q, got %q", fp, resp2.GetFingerprint())
+	}
+}
+
+// TestGetSchema_PopulatedRegistry pins the round-trip of a real
+// registry. The contract pin only requires fingerprint!=""||schema; we
+// additionally verify the Struct contents match the registered types so
+// the SDK CLI consumer (sdk/go/entdb/cmd/entdbctl/cmd_schema_test.go)
+// continues to deserialise without surprises.
+func TestGetSchema_PopulatedRegistry(t *testing.T) {
+	t.Parallel()
+	reg := schema.NewRegistry()
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID: 1,
+		Name:   "User",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "email", Kind: schema.KindString, Required: true},
+			{FieldID: 2, Name: "display_name", Kind: schema.KindString},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterNode User: %v", err)
+	}
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID: 2,
+		Name:   "Task",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "title", Kind: schema.KindString, Required: true},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterNode Task: %v", err)
+	}
+	if err := reg.RegisterEdge(&schema.EdgeTypeDef{
+		EdgeID:        10,
+		Name:          "AssignedTo",
+		FromTypeID:    2,
+		ToTypeID:      1,
+		OnSubjectExit: schema.OnSubjectExitBoth,
+	}); err != nil {
+		t.Fatalf("RegisterEdge: %v", err)
+	}
+	fp, err := reg.Freeze()
+	if err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+	srv := New(WithSchemaRegistry(reg))
+
+	// Unfiltered: every node + edge present.
+	resp, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetSchema: %v", err)
+	}
+	if resp.GetFingerprint() != fp {
+		t.Errorf("Fingerprint: want %q, got %q", fp, resp.GetFingerprint())
+	}
+	nodes := listLen(t, resp, "node_types")
+	if nodes != 2 {
+		t.Errorf("node_types: want 2, got %d", nodes)
+	}
+	edges := listLen(t, resp, "edge_types")
+	if edges != 1 {
+		t.Errorf("edge_types: want 1, got %d", edges)
+	}
+
+	// Filtered by type_id=1 (User). User node stays; AssignedTo edge
+	// stays (to_type_id == 1); Task node drops.
+	resp2, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{TypeId: 1})
+	if err != nil {
+		t.Fatalf("GetSchema TypeId=1: %v", err)
+	}
+	if got := listLen(t, resp2, "node_types"); got != 1 {
+		t.Errorf("filtered node_types: want 1, got %d", got)
+	}
+	if got := listLen(t, resp2, "edge_types"); got != 1 {
+		t.Errorf("filtered edge_types: want 1 (touches type 1), got %d", got)
+	}
+
+	// Filtered by type_id=99 (unknown). No nodes, no edges.
+	resp3, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{TypeId: 99})
+	if err != nil {
+		t.Fatalf("GetSchema TypeId=99: %v", err)
+	}
+	if got := listLen(t, resp3, "node_types"); got != 0 {
+		t.Errorf("filtered node_types (no match): want 0, got %d", got)
+	}
+	if got := listLen(t, resp3, "edge_types"); got != 0 {
+		t.Errorf("filtered edge_types (no match): want 0, got %d", got)
+	}
+
+	// Fingerprint is constant across filtered/unfiltered responses
+	// (the Python handler computes it from the unfiltered registry).
+	if resp2.GetFingerprint() != fp || resp3.GetFingerprint() != fp {
+		t.Errorf("fingerprint changed under filter: %q / %q / %q",
+			resp.GetFingerprint(), resp2.GetFingerprint(), resp3.GetFingerprint())
+	}
+}
+
+// TestGetSchema_ContractPin asserts the sole behavioural pin from the
+// Python contract test (test_grpc_contract.py:208): the response
+// satisfies `fingerprint != "" || HasField("schema")` for both the
+// happy path and the degraded empty-registry path.
+func TestGetSchema_ContractPin(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		build func() *Server
+	}{
+		{
+			name:  "no_registry",
+			build: func() *Server { return New() },
+		},
+		{
+			name: "empty_registry",
+			build: func() *Server {
+				return New(WithSchemaRegistry(schema.NewRegistry()))
+			},
+		},
+		{
+			name: "frozen_registry",
+			build: func() *Server {
+				reg := schema.NewRegistry()
+				_ = reg.RegisterNode(&schema.NodeTypeDef{
+					TypeID: 1, Name: "X",
+					Fields: []schema.FieldDef{{FieldID: 1, Name: "a", Kind: schema.KindString}},
+				})
+				if _, err := reg.Freeze(); err != nil {
+					t.Fatalf("Freeze: %v", err)
+				}
+				return New(WithSchemaRegistry(reg))
+			},
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			srv := c.build()
+			resp, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{
+				TenantId: "tenant-a",
+			})
+			if err != nil {
+				t.Fatalf("GetSchema: %v", err)
+			}
+			if resp.GetFingerprint() == "" && resp.GetSchema() == nil {
+				t.Fatalf("contract pin violated: fingerprint=%q schema=%v",
+					resp.GetFingerprint(), resp.GetSchema())
+			}
+		})
+	}
+}
+
+// listLen returns the number of entries under fields[key] when it's a
+// ListValue. Fails the test if absent or wrong shape.
+func listLen(t *testing.T, resp *pb.GetSchemaResponse, key string) int {
+	t.Helper()
+	s := resp.GetSchema()
+	if s == nil {
+		t.Fatalf("schema is nil")
+	}
+	v, ok := s.GetFields()[key]
+	if !ok {
+		t.Fatalf("schema missing key %q; have %v", key, keysOf(s.GetFields()))
+	}
+	lv := v.GetListValue()
+	if lv == nil {
+		t.Fatalf("schema[%q] is not a ListValue: %v", key, v)
+	}
+	return len(lv.GetValues())
+}
+
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/server/go/internal/api/server.go
+++ b/server/go/internal/api/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
@@ -33,6 +34,7 @@ type Server struct {
 	producer wal.Producer
 	sharding *tenant.Sharding
 	region   string
+	registry *schema.Registry
 }
 
 // Option is a functional-options configurator for New.
@@ -66,6 +68,15 @@ func WithSharding(sh *tenant.Sharding) Option {
 // disables region pinning (tenant.Options{}.ServedRegion == "").
 func WithRegion(region string) Option {
 	return func(srv *Server) { srv.region = region }
+}
+
+// WithSchemaRegistry wires the process-wide *schema.Registry. Read-only
+// RPCs in Wave 2 (GetSchema, ExecuteAtomic schema_fingerprint check,
+// query handlers translating field names) all dereference this handle.
+// The registry is typically Freeze()'d before the server starts serving
+// (CLAUDE.md schema invariant), so post-boot reads are lock-free.
+func WithSchemaRegistry(r *schema.Registry) Option {
+	return func(srv *Server) { srv.registry = r }
 }
 
 // New constructs a Server. All RPCs return Unimplemented in Wave 1;


### PR DESCRIPTION
## Summary

First Wave-2 RPC of the Python → Go server port. Wires a `schema.Registry` into `api.Server` via a new `WithSchemaRegistry` functional option and implements `GetSchema` with byte-for-byte parity to the Python handler.

- Spec: `docs/go-port/rpcs/GetSchema.md`
- Reference Python: `server/python/entdb_server/api/grpc_server.py:1619-1689`
- Refs #407

## Contract preserved

- Read-only — no WAL append, no global_store touch.
- No `Permission` check; auth interceptor governs credentials. `GetSchemaRequest` has no `actor` field, so the "ignore client-claimed actor" rule from `fece3fb` is structurally satisfied.
- **Swallow-all-errors-as-OK.** Every marshalling failure / panic path returns `&GetSchemaResponse{Fingerprint: ""}` with `grpc.OK`, matching the sole behavioural pin at `tests/python/integration/test_grpc_contract.py:208` (`fingerprint != "" || HasField("schema")`).
- Optional `type_id` filter applied after the (currently no-op) data-driven fallback, matching `grpc_server.py:1668-1679`.

Lowering uses the existing `schema.Registry.MarshalJSON` (already sorts by id and normalises nil `Fields`/`Props` to `[]`) round-tripped through `encoding/json` into `map[string]any`, then `structpb.NewStruct`. JSON round-trip lands every number as `float64` — matches Python's `Struct.update(d)` behaviour and what existing SDK consumers (`sdk/go/entdb/cmd/entdbctl/cmd_schema_test.go`) already expect.

## Known-unfixed parity items (flagged, not addressed here)

1. **Cross-tenant `tenant_id` leak.** The Python handler reads `request.tenant_id` without cross-checking the caller's authenticated tenant binding, leaking distinct `type_id` integers across tenants when the registry is empty. Preserved in the Go port for now — fixing it is a behaviour change vs. Python and needs a contract-test gate (likely behind a feature flag). See spec "Open questions / risks".
2. **Data-driven fallback is a no-op.** The registry-empty + `tenant_id`-set path requires `canonicalstore.GetDistinctTypeIDs` / `GetDistinctEdgeTypeIDs`, which the Go canonicalstore port hasn't shipped yet. The contract pin (`fingerprint != "" || HasField("schema")`) still holds because we always return a populated Struct. To be wired when `canonicalstore` lands those methods.
3. **`tests/python/integration/_go_parity.py` does not exist yet** (W2.00 not merged); `GetSchema` will be added to `GO_IMPLEMENTED` in that PR.

## Test plan

- [x] `cd server/go && go vet ./...` — clean
- [x] `cd server/go && go test ./...` — all packages green (api included)
- [x] `uvx ruff@0.15.7 check .` — clean
- [x] `uvx ruff@0.15.7 format --check .` — clean
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed

New Go unit tests (`internal/api/get_schema_test.go`) cover:
- No-registry server returns OK + empty Struct + empty fingerprint.
- Empty registry round-trips empty Struct; freezing populates fingerprint.
- Populated, frozen registry: full round-trip; `type_id` filter keeps matching node + touching edges; unknown `type_id` returns empty lists.
- Contract-pin assertion (`fingerprint != "" || HasField("schema")`) across no-registry / empty / frozen variants.