### PR TITLE
fix(go-rewrite): dedupe newGlobalStore test helper

### DIFF
--- a/server/go/internal/api/get_mailbox_test.go
+++ b/server/go/internal/api/get_mailbox_test.go
@@ -17,20 +17,9 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
 )
-
-func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
-	t.Helper()
-	gs, err := globalstore.New(globalstore.Options{DataDir: t.TempDir(), WALMode: true})
-	if err != nil {
-		t.Fatalf("globalstore.New: %v", err)
-	}
-	t.Cleanup(func() { _ = gs.Close() })
-	return gs
-}
 
 // TestGetMailbox_HappyPath: with a registered tenant, the stub
 // returns an empty, well-formed response — `items == []`,

--- a/server/go/internal/api/helpers_external_test.go
+++ b/server/go/internal/api/helpers_external_test.go
@@ -1,0 +1,19 @@
+// Shared external-test (package api_test) helpers for the api package.
+
+package api_test
+
+import (
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+)
+
+func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
+	t.Helper()
+	gs, err := globalstore.New(globalstore.Options{DataDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+	return gs
+}

--- a/server/go/internal/api/list_mailbox_users_test.go
+++ b/server/go/internal/api/list_mailbox_users_test.go
@@ -16,19 +16,8 @@ import (
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
-
-func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
-	t.Helper()
-	gs, err := globalstore.New(globalstore.Options{DataDir: t.TempDir(), WALMode: true})
-	if err != nil {
-		t.Fatalf("globalstore.New: %v", err)
-	}
-	t.Cleanup(func() { _ = gs.Close() })
-	return gs
-}
 
 // TestListMailboxUsers_EmptyForValidTenant pins the deprecated-stub
 // contract: a tenant that passes the gate returns an empty user_ids


### PR DESCRIPTION
## Summary

PRs #423 (ListMailboxUsers) and #425 (GetMailbox) each landed an identical `newGlobalStore` helper in `package api_test`, breaking the build on `origin/main` with `newGlobalStore redeclared`.

This PR moves the helper to a single shared `server/go/internal/api/helpers_external_test.go` and prunes the now-unused `globalstore` imports from the two test files.

Refs #407.

## Test plan

- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...`
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .`