### PR TITLE
feat(go-rewrite): GetUserTenants RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_user_tenants.go
+++ b/server/go/internal/api/get_user_tenants.go
@@ -1,0 +1,113 @@
+// W2 — GetUserTenants RPC (Python -> Go server port, EPIC #407).
+//
+// Spec: docs/go-port/rpcs/GetUserTenants.md.
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:2572-2599.
+//
+// Contract pins (must not regress):
+//
+//   - actor / user_id presence-checked. Empty actor or user_id ->
+//     INVALID_ARGUMENT (mirrors grpc_server.py:2586-2589). Validation
+//     order: actor first, then user_id, matching Python.
+//   - global_store == nil -> UNIMPLEMENTED with the exact message
+//     "Tenant registry not configured" (grpc_server.py:2580-2584).
+//   - The trusted-actor invariant is honoured: the wire-claimed actor
+//     is run through auth.Authoritative so the interceptor's identity
+//     wins over any payload-claimed identity. Per the Python parity
+//     contract today, the resolved actor is NOT used for an authz
+//     decision (any authenticated caller may read any user's
+//     memberships). The privilege-boundary gap is documented in the
+//     spec and tracked as a follow-up; do NOT plug it here without
+//     coordinated proto/contract-test changes (see spec "Auth"
+//     section).
+//   - Memberships are returned in joined_at ASC order, sourced from
+//     globalstore.GetUserTenants. Empty list when the user has no
+//     memberships.
+//   - Catch-all parity: any error from globalstore (or a panic inside
+//     the handler body after validation) collapses to OK with
+//     memberships=[]. We MUST NOT propagate codes.Internal — the
+//     contract test relies on the empty-OK degradation
+//     (grpc_server.py:2596-2599).
+//
+// Metrics: emits entdb_grpc_requests_total{method="GetUserTenants",
+// status="ok"|"error"} via the shared metrics chokepoint. Matching
+// Python, the validation and UNIMPLEMENTED short-circuits do NOT emit
+// metrics — only the post-validation success-or-degraded path does.
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// grpcMethodGetUserTenants is the metric label.
+const grpcMethodGetUserTenants = "GetUserTenants"
+
+// GetUserTenants implements entdb.v1.EntDBService/GetUserTenants.
+func (s *Server) GetUserTenants(
+	ctx context.Context,
+	req *pb.GetUserTenantsRequest,
+) (resp *pb.GetUserTenantsResponse, err error) {
+	// Pre-validation guards run BEFORE the metrics defer is armed,
+	// matching the Python handler which short-circuits before the
+	// record_grpc_request call site (grpc_server.py:2580-2589 vs :2594).
+	if s.global == nil {
+		return nil, status.Error(
+			codes.Unimplemented, "Tenant registry not configured")
+	}
+	if req.GetActor() == "" {
+		return nil, status.Error(codes.InvalidArgument, "actor is required")
+	}
+	if req.GetUserId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	start := time.Now()
+	outcome := "ok"
+	// Empty-OK degradation on panic: mirror Python's bare `except
+	// Exception` at grpc_server.py:2596-2599. The handler MUST NOT
+	// surface codes.Internal; contract tests pin the empty-OK shape.
+	defer func() {
+		if r := recover(); r != nil {
+			outcome = "error"
+			resp = &pb.GetUserTenantsResponse{
+				Memberships: []*pb.TenantMemberInfo{},
+			}
+			err = nil
+		}
+		metrics.RecordGRPCRequest(grpcMethodGetUserTenants, outcome, time.Since(start))
+	}()
+
+	// Trusted-actor resolution. The result is intentionally not used
+	// for an authz decision (Python parity); the call exists so the
+	// interceptor's identity always wins over any payload-claimed
+	// actor (defence in depth — see the spec's "privilege-boundary
+	// gap" note and the comment block above).
+	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	rows, qerr := s.global.GetUserTenants(ctx, req.GetUserId())
+	if qerr != nil {
+		// Python silently swallows and returns memberships=[] OK.
+		outcome = "error"
+		return &pb.GetUserTenantsResponse{
+			Memberships: []*pb.TenantMemberInfo{},
+		}, nil
+	}
+
+	memberships := make([]*pb.TenantMemberInfo, 0, len(rows))
+	for _, m := range rows {
+		memberships = append(memberships, &pb.TenantMemberInfo{
+			TenantId: m.TenantID,
+			UserId:   m.UserID,
+			Role:     m.Role,
+			JoinedAt: m.JoinedAt,
+		})
+	}
+	return &pb.GetUserTenantsResponse{Memberships: memberships}, nil
+}

--- a/server/go/internal/api/get_user_tenants_test.go
+++ b/server/go/internal/api/get_user_tenants_test.go
@@ -1,0 +1,218 @@
+// Tests for the GetUserTenants handler. Behavioural parity is
+// pinned by tests/python/integration/test_grpc_contract.py:500-510 and
+// tests/python/unit/test_tenant_registry.py:557-582; this file covers
+// every branch the Python handler has after the validation gate plus
+// the silent-swallow degradation path.
+
+package api_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestGetUserTenants_ZeroMemberships pins the empty-list happy path:
+// a known user with no memberships returns OK and an empty (but
+// non-nil) Memberships slice. Mirrors Python's
+// `global_store.get_user_tenants(...)` returning [] (global_store.py:622-628).
+func TestGetUserTenants_ZeroMemberships(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.GetUserTenants(context.Background(), &pb.GetUserTenantsRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+	})
+	if err != nil {
+		t.Fatalf("GetUserTenants: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetUserTenants: response is nil")
+	}
+	if resp.Memberships == nil {
+		t.Fatalf("GetUserTenants: Memberships is nil; want empty slice")
+	}
+	if len(resp.Memberships) != 0 {
+		t.Fatalf("GetUserTenants: Memberships = %v; want []", resp.Memberships)
+	}
+}
+
+// TestGetUserTenants_OneMembership pins the single-tenant happy path
+// from test_grpc_contract.py:500-505: the response carries one
+// TenantMemberInfo with the tenant_id, user_id, role, and joined_at
+// populated.
+func TestGetUserTenants_OneMembership(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	resp, err := srv.GetUserTenants(ctx, &pb.GetUserTenantsRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+	})
+	if err != nil {
+		t.Fatalf("GetUserTenants: unexpected error: %v", err)
+	}
+	if got := len(resp.GetMemberships()); got != 1 {
+		t.Fatalf("GetUserTenants: len(memberships) = %d; want 1 (resp=%v)", got, resp)
+	}
+	m := resp.GetMemberships()[0]
+	if m.GetTenantId() != "acme" {
+		t.Fatalf("TenantId = %q; want %q", m.GetTenantId(), "acme")
+	}
+	if m.GetUserId() != "alice" {
+		t.Fatalf("UserId = %q; want %q", m.GetUserId(), "alice")
+	}
+	if m.GetRole() != "owner" {
+		t.Fatalf("Role = %q; want %q", m.GetRole(), "owner")
+	}
+	if m.GetJoinedAt() <= 0 {
+		t.Fatalf("JoinedAt = %d; want > 0", m.GetJoinedAt())
+	}
+}
+
+// TestGetUserTenants_MultipleMemberships pins the multi-tenant case
+// from test_tenant_registry.py:557-582: alice in two tenants, both
+// must be returned.
+func TestGetUserTenants_MultipleMemberships(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	gs := newGlobalStore(t)
+	for _, tid := range []string{"t1", "t2"} {
+		if _, err := gs.CreateTenant(ctx, tid, tid, "us-east-1"); err != nil {
+			t.Fatalf("CreateTenant(%q): %v", tid, err)
+		}
+		if err := gs.AddTenantMember(ctx, tid, "alice", "member"); err != nil {
+			t.Fatalf("AddTenantMember(%q): %v", tid, err)
+		}
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	resp, err := srv.GetUserTenants(ctx, &pb.GetUserTenantsRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+	})
+	if err != nil {
+		t.Fatalf("GetUserTenants: unexpected error: %v", err)
+	}
+	got := make([]string, 0, len(resp.GetMemberships()))
+	for _, m := range resp.GetMemberships() {
+		got = append(got, m.GetTenantId())
+	}
+	sort.Strings(got)
+	want := []string{"t1", "t2"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("tenant_ids = %v; want %v", got, want)
+	}
+}
+
+// TestGetUserTenants_EmptyActor: empty actor string -> INVALID_ARGUMENT.
+// Mirrors grpc_server.py:2586-2587 and is the contract pin from
+// test_grpc_contract.py:506-510.
+func TestGetUserTenants_EmptyActor(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.GetUserTenants(context.Background(), &pb.GetUserTenantsRequest{
+		Actor:  "",
+		UserId: "alice",
+	})
+	if err == nil {
+		t.Fatalf("GetUserTenants: expected INVALID_ARGUMENT, got nil")
+	}
+	if got := errs.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("code = %v; want InvalidArgument (err=%v)", got, err)
+	}
+}
+
+// TestGetUserTenants_EmptyUserID: empty user_id -> INVALID_ARGUMENT.
+// Pinned by grpc_server.py:2588-2589. The Python contract suite does
+// not currently exercise this branch through gRPC; the spec calls out
+// the gap and instructs the Go port to lock it down.
+func TestGetUserTenants_EmptyUserID(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.GetUserTenants(context.Background(), &pb.GetUserTenantsRequest{
+		Actor:  "user:alice",
+		UserId: "",
+	})
+	if err == nil {
+		t.Fatalf("GetUserTenants: expected INVALID_ARGUMENT, got nil")
+	}
+	if got := errs.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("code = %v; want InvalidArgument (err=%v)", got, err)
+	}
+}
+
+// TestGetUserTenants_NoGlobalStore: when the server has no globalstore
+// wired, the handler returns UNIMPLEMENTED with the canonical message.
+// Mirrors grpc_server.py:2580-2584.
+func TestGetUserTenants_NoGlobalStore(t *testing.T) {
+	t.Parallel()
+	srv := api.New() // no WithGlobalStore
+
+	_, err := srv.GetUserTenants(context.Background(), &pb.GetUserTenantsRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+	})
+	if err == nil {
+		t.Fatalf("GetUserTenants: expected UNIMPLEMENTED, got nil")
+	}
+	if got := errs.Code(err); got != codes.Unimplemented {
+		t.Fatalf("code = %v; want Unimplemented (err=%v)", got, err)
+	}
+}
+
+// TestGetUserTenants_InternalErrorReturnsEmptyOK pins the unusual but
+// canonical degradation contract: any error from the global_store
+// query is caught, logged, and collapsed to OK + memberships=[]. We
+// trigger the error by closing the underlying SQLite handle out from
+// under the running query (a closed *sql.DB returns ErrConnDone).
+// Mirrors grpc_server.py:2596-2599.
+func TestGetUserTenants_InternalErrorReturnsEmptyOK(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Closing the store makes any subsequent QueryContext return
+	// sql.ErrConnDone -- the closest we get to "global_store is broken
+	// at runtime" without inventing a fault-injection driver.
+	if err := gs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	resp, err := srv.GetUserTenants(context.Background(), &pb.GetUserTenantsRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+	})
+	if err != nil {
+		t.Fatalf("GetUserTenants: expected OK degradation, got err=%v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetUserTenants: response is nil; want empty memberships")
+	}
+	if resp.Memberships == nil {
+		t.Fatalf("GetUserTenants: Memberships is nil; want empty slice")
+	}
+	if len(resp.Memberships) != 0 {
+		t.Fatalf("GetUserTenants: Memberships = %v; want [] (degradation pin)", resp.Memberships)
+	}
+}


### PR DESCRIPTION
## Summary

Ports `GetUserTenants` from `server/python/entdb_server/api/grpc_server.py:2572-2599` to the Go server (EPIC #407, Wave 2). The handler reads a user's cross-tenant memberships from `globalstore.GetUserTenants` (already implemented) and translates them to `[]*pb.TenantMemberInfo` ordered by `joined_at` ASC.

Behaviour parity with Python — see `docs/go-port/rpcs/GetUserTenants.md`:

- Empty `actor` or `user_id` -> `INVALID_ARGUMENT` (validation order matches Python: `actor` first).
- `global_store == nil` -> `UNIMPLEMENTED` with the canonical "Tenant registry not configured" message.
- Trusted-actor invariant: claimed actor runs through `auth.Authoritative` so the interceptor's identity wins. Per the spec, the resolved actor is intentionally NOT used for an authz decision today; the privilege-boundary gap (any authenticated caller can read any user's memberships) is flagged in the spec as a v2 follow-up to gate behind a config flag.
- Catch-all parity: a `globalstore` error or a panic inside the handler body collapses to `OK + memberships=[]`. `INTERNAL` is never surfaced — the contract test pins the empty-OK degradation.
- Metrics: `status="ok"` on success, `"error"` on the degraded path; validation and `UNIMPLEMENTED` short-circuits do NOT emit, matching Python.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/api/ -run GetUserTenants` — 7 cases pass (zero/one/multiple-membership round-trip, empty actor, empty user_id, no globalstore, closed-store -> empty-OK degradation)
- [x] `uvx ruff@0.15.7 check .` and `format --check .` clean
- [x] Go SDK `go vet ./... && go test ./...` clean
- [ ] Note: `TestServer_UnimplementedRPC_Default` was already failing on `origin/main` before this PR (it probes `GetSchema`, which landed in #427); not addressed here.