### PR TITLE
feat(go-rewrite): CreateUser RPC — Wave 2

### DIFF
--- a/server/go/internal/api/create_user.go
+++ b/server/go/internal/api/create_user.go
@@ -1,0 +1,131 @@
+// CreateUser RPC — Wave 2 of the Python -> Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/CreateUser.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:112 (rpc), :802-814 (messages),
+// :792-800 (UserInfo). Reference Python:
+// server/python/entdb_server/api/grpc_server.py:2099-2147 and
+// server/python/entdb_server/global_store.py:336-369.
+//
+// Semantics (this is a deliberate carve-out from the CLAUDE.md "all
+// writes go through the WAL" invariant — user_registry is global_store
+// control-plane state, not per-tenant event-sourced data):
+//
+//   - Admin-only. Caller must resolve to a system:* / admin:* trusted
+//     actor via auth.Authoritative. The request.actor field is UNTRUSTED
+//     and is fed in only as the fallback when no interceptor ran (unit
+//     tests). Privilege-escalation pin:
+//     tests/python/integration/test_privilege_escalation.py:321-341.
+//
+//   - Single SQLite write to global_store.user_registry. No WAL append,
+//     no canonical-store touch, no audit hook. The Python handler calls
+//     global_store.create_user(...) directly; the Go port does the same
+//     via globalstore.CreateUser.
+//
+//   - user_id boundary: the wire / storage form is bare ("alice"); the
+//     "user:alice" tenant_principal form is added by ACL / membership
+//     code only. We pass req.UserId through verbatim.
+//
+// Error contract:
+//
+//	UNIMPLEMENTED       — global_store not configured.
+//	INVALID_ARGUMENT    — empty actor / user_id / email / name.
+//	PERMISSION_DENIED   — trusted actor is not system:* / admin:*.
+//	ALREADY_EXISTS      — duplicate user_id (PK) or duplicate email
+//	                      (UNIQUE). The Go port surfaces this as a
+//	                      proper gRPC status (the globalstore layer
+//	                      already returns errs.Errorf(AlreadyExists, …)
+//	                      via its sqlite-driver sentinel detection).
+//	INTERNAL            — any other store failure.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const createUserMethod = "CreateUser"
+
+// CreateUser implements entdb.v1.EntDBService/CreateUser. See file header
+// for the full semantics + error contract.
+func (s *Server) CreateUser(ctx context.Context, req *pb.CreateUserRequest) (*pb.CreateUserResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(createUserMethod, outcome, time.Since(start))
+	}()
+
+	if s.global == nil {
+		outcome = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "User registry not configured")
+	}
+
+	// Validate actor presence first (matches Python ordering at
+	// grpc_server.py:2113). We do this BEFORE the trusted-actor lookup so
+	// callers that forget to set the field get a precise INVALID_ARGUMENT
+	// instead of a confusing PERMISSION_DENIED.
+	if req.GetActor() == "" {
+		outcome = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+
+	// Trusted-actor chokepoint. The wire-claimed actor is fed in as the
+	// fallback for the no-interceptor path (unit tests); when a real
+	// AuthInterceptor populated ctx, that identity wins regardless of
+	// what req.Actor claims. See auth/authoritative.go for the full
+	// privilege-escalation argument.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	if !(trusted.IsAdmin() || trusted.IsSystem()) {
+		outcome = "error"
+		return nil, errs.Errorf(codes.PermissionDenied,
+			"CreateUser requires admin or system actor")
+	}
+
+	if req.GetUserId() == "" {
+		outcome = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "user_id is required")
+	}
+	if req.GetEmail() == "" {
+		outcome = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "email is required")
+	}
+	if req.GetName() == "" {
+		outcome = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "name is required")
+	}
+
+	user, err := s.global.CreateUser(ctx, req.GetUserId(), req.GetEmail(), req.GetName())
+	if err != nil {
+		outcome = "error"
+		// globalstore.CreateUser already wraps duplicate-key collisions
+		// as errs.Errorf(codes.AlreadyExists, …) using a typed sqlite
+		// driver sentinel — propagate that verbatim.
+		if errors.Is(err, errs.ErrAlreadyExists) {
+			return nil, err
+		}
+		// Anything else is an unexpected backend failure: surface it as
+		// INTERNAL rather than the Python OK+success=false swallow path.
+		// The spec flags this as a deliberate Go-port improvement.
+		return nil, errs.Errorf(codes.Internal, "create user: %v", err)
+	}
+
+	return &pb.CreateUserResponse{
+		Success: true,
+		User: &pb.UserInfo{
+			UserId:    user.UserID,
+			Email:     user.Email,
+			Name:      user.Name,
+			Status:    user.Status,
+			CreatedAt: user.CreatedAt,
+			UpdatedAt: user.UpdatedAt,
+		},
+	}, nil
+}

--- a/server/go/internal/api/create_user_test.go
+++ b/server/go/internal/api/create_user_test.go
@@ -1,0 +1,238 @@
+// Tests for the CreateUser RPC. Spec: docs/go-port/rpcs/CreateUser.md.
+//
+// Behavioural pins from the Python suite this port must satisfy:
+//
+//   - tests/python/unit/test_user_registry.py:68-97   — happy path with
+//     actor="system:admin".
+//   - tests/python/unit/test_user_registry.py:126-145 — non-admin caller
+//     returns PERMISSION_DENIED and the store is NOT touched.
+//   - tests/python/unit/test_user_registry.py:147-169 — duplicate user
+//     surfaces as a uniqueness collision.
+//   - tests/python/unit/test_user_registry.py:171-187 — empty required
+//     field aborts with INVALID_ARGUMENT.
+//
+// The Go port deliberately upgrades the duplicate-key path to
+// codes.AlreadyExists (the Python handler returns OK+success=false). The
+// spec calls this out as an acceptable parity break — the Python contract
+// test only inspects success=false, which is no longer reachable, but the
+// upgraded code is a strict superset of information.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestCreateUser_HappyPath_AdminActor pins the canonical success case:
+// an admin caller creates a user and the response carries the populated
+// UserInfo with status="active" plus non-zero timestamps.
+func TestCreateUser_HappyPath_AdminActor(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.CreateUser(context.Background(), &pb.CreateUserRequest{
+		Actor:  "admin:root",
+		UserId: "alice",
+		Email:  "alice@example.com",
+		Name:   "Alice",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("CreateUser: response is nil")
+	}
+	if !resp.GetSuccess() {
+		t.Errorf("Success: want true, got false (error=%q)", resp.GetError())
+	}
+	u := resp.GetUser()
+	if u == nil {
+		t.Fatalf("User: want non-nil UserInfo")
+	}
+	if u.GetUserId() != "alice" {
+		t.Errorf("UserId: want %q, got %q", "alice", u.GetUserId())
+	}
+	if u.GetEmail() != "alice@example.com" {
+		t.Errorf("Email: want %q, got %q", "alice@example.com", u.GetEmail())
+	}
+	if u.GetName() != "Alice" {
+		t.Errorf("Name: want %q, got %q", "Alice", u.GetName())
+	}
+	if u.GetStatus() != "active" {
+		t.Errorf("Status: want %q, got %q", "active", u.GetStatus())
+	}
+	if u.GetCreatedAt() == 0 {
+		t.Errorf("CreatedAt: want non-zero unix-seconds value")
+	}
+	if u.GetUpdatedAt() == 0 {
+		t.Errorf("UpdatedAt: want non-zero unix-seconds value")
+	}
+}
+
+// TestCreateUser_HappyPath_SystemActor pins parity with the Python case
+// at test_user_registry.py:99-124: system:* trusted actors are equally
+// privileged.
+func TestCreateUser_HappyPath_SystemActor(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.CreateUser(context.Background(), &pb.CreateUserRequest{
+		Actor:  "system:bootstrap",
+		UserId: "bob",
+		Email:  "bob@example.com",
+		Name:   "Bob",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: unexpected error: %v", err)
+	}
+	if !resp.GetSuccess() || resp.GetUser().GetUserId() != "bob" {
+		t.Fatalf("CreateUser: unexpected response: %+v", resp)
+	}
+}
+
+// TestCreateUser_DuplicateUserID pins the AlreadyExists path. The second
+// call collides on the user_id PRIMARY KEY; globalstore detects this via
+// the modernc.org/sqlite driver sentinel and surfaces an
+// errs.ErrAlreadyExists which the handler propagates verbatim.
+func TestCreateUser_DuplicateUserID(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+	ctx := context.Background()
+
+	if _, err := srv.CreateUser(ctx, &pb.CreateUserRequest{
+		Actor:  "admin:root",
+		UserId: "alice",
+		Email:  "alice@example.com",
+		Name:   "Alice",
+	}); err != nil {
+		t.Fatalf("CreateUser (first): unexpected error: %v", err)
+	}
+
+	_, err := srv.CreateUser(ctx, &pb.CreateUserRequest{
+		Actor:  "admin:root",
+		UserId: "alice",
+		Email:  "alice2@example.com",
+		Name:   "Alice the Second",
+	})
+	if err == nil {
+		t.Fatalf("CreateUser (duplicate): expected ALREADY_EXISTS, got nil")
+	}
+	if got := errs.Code(err); got != codes.AlreadyExists {
+		t.Fatalf("CreateUser (duplicate): code = %v, want AlreadyExists (err=%v)", got, err)
+	}
+}
+
+// TestCreateUser_NonAdminActor_PermissionDenied pins the privilege gate.
+// The Python regression test at test_privilege_escalation.py:321-341
+// covers the harder case where the wire claims admin but the trusted
+// identity is a regular user; here we cover the simpler path where the
+// wire itself does not claim admin (no interceptor on ctx, so claimed
+// passes through Authoritative unchanged).
+func TestCreateUser_NonAdminActor_PermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.CreateUser(context.Background(), &pb.CreateUserRequest{
+		Actor:  "user:eve",
+		UserId: "alice",
+		Email:  "alice@example.com",
+		Name:   "Alice",
+	})
+	if err == nil {
+		t.Fatalf("CreateUser: expected PERMISSION_DENIED, got nil")
+	}
+	if got := errs.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("CreateUser: code = %v, want PermissionDenied (err=%v)", got, err)
+	}
+
+	// And nothing was written to the store: the row does not exist.
+	got, gerr := gs.GetUser(context.Background(), "alice")
+	if gerr != nil {
+		t.Fatalf("GetUser: %v", gerr)
+	}
+	if got != nil {
+		t.Errorf("GetUser: unexpected row %+v — handler must not write on PERMISSION_DENIED", got)
+	}
+}
+
+// TestCreateUser_EmptyRequiredField pins validation. Each empty
+// non-optional field aborts with INVALID_ARGUMENT before the store is
+// touched. Mirrors the parametric Python test at
+// test_user_registry.py:171-187 over actor / user_id / email / name.
+func TestCreateUser_EmptyRequiredField(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		req  *pb.CreateUserRequest
+	}{
+		{
+			name: "empty_actor",
+			req:  &pb.CreateUserRequest{UserId: "alice", Email: "a@x", Name: "A"},
+		},
+		{
+			name: "empty_user_id",
+			req:  &pb.CreateUserRequest{Actor: "admin:root", Email: "a@x", Name: "A"},
+		},
+		{
+			name: "empty_email",
+			req:  &pb.CreateUserRequest{Actor: "admin:root", UserId: "alice", Name: "A"},
+		},
+		{
+			name: "empty_name",
+			req:  &pb.CreateUserRequest{Actor: "admin:root", UserId: "alice", Email: "a@x"},
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			gs := newGlobalStore(t)
+			srv := api.New(api.WithGlobalStore(gs))
+
+			_, err := srv.CreateUser(context.Background(), c.req)
+			if err == nil {
+				t.Fatalf("CreateUser: expected INVALID_ARGUMENT, got nil")
+			}
+			if got := errs.Code(err); got != codes.InvalidArgument {
+				t.Fatalf("CreateUser: code = %v, want InvalidArgument (err=%v)", got, err)
+			}
+		})
+	}
+}
+
+// TestCreateUser_NoGlobalStore pins the UNIMPLEMENTED guard. A Server
+// constructed without WithGlobalStore must reject CreateUser before
+// touching auth or validation.
+func TestCreateUser_NoGlobalStore(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New()
+	_, err := srv.CreateUser(context.Background(), &pb.CreateUserRequest{
+		Actor:  "admin:root",
+		UserId: "alice",
+		Email:  "alice@example.com",
+		Name:   "Alice",
+	})
+	if err == nil {
+		t.Fatalf("CreateUser: expected UNIMPLEMENTED, got nil")
+	}
+	if got := errs.Code(err); got != codes.Unimplemented {
+		t.Fatalf("CreateUser: code = %v, want Unimplemented (err=%v)", got, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `entdb.v1.EntDBService/CreateUser` in the Go port (EPIC #407, Wave 2). Spec: [`docs/go-port/rpcs/CreateUser.md`](../blob/main/docs/go-port/rpcs/CreateUser.md). Reference Python: `server/python/entdb_server/api/grpc_server.py:2099-2147` backed by `global_store.py:336-369`.
- Admin-only carve-out from the CLAUDE.md "all writes go through the WAL" invariant — `user_registry` lives in `global_store` control-plane state, not per-tenant event-sourced data, so the handler issues a single SQLite write via `globalstore.CreateUser` with no WAL append.
- Trusted-actor chokepoint via `auth.Authoritative`: the wire-claimed `actor` is fed in only as the no-interceptor fallback, matching the privilege-escalation pin at `tests/python/integration/test_privilege_escalation.py:321-341`.

## Error contract

| Trigger | gRPC code |
|---|---|
| `global_store` not configured | `UNIMPLEMENTED` |
| Empty `actor` / `user_id` / `email` / `name` | `INVALID_ARGUMENT` |
| Trusted actor not `system:*` / `admin:*` | `PERMISSION_DENIED` |
| Duplicate `user_id` (PK) or duplicate `email` (UNIQUE) | `ALREADY_EXISTS` |
| Other store failure | `INTERNAL` |

The Go port upgrades duplicate-key + generic-store-error paths from Python's `OK + success=false` swallow to typed `errs.Errorf(...)` sentinels, per the spec's "Open questions / risks" follow-up. `globalstore.CreateUser` already detects duplicate keys via the `modernc.org/sqlite` driver sentinel rather than string-matching.

## Scope

- No new options or fields on `Server` (shape is frozen by the orchestrator).
- Shared `newGlobalStore` helper at `helpers_external_test.go` is reused as-is.
- Drive-by: `server_test.go`'s `TestServer_UnimplementedRPC_Default` probed `GetSchema`, which landed in #427 and now returns OK; the probe rebinds to `GetUser` (still unported) so the suite stays green. Same minimal swap the Health PR did when Health landed.
- `tests/python/integration/_go_parity.py` deliberately untouched — Batch D consolidation lands separately.

Refs #407.

## Test plan

- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...` — every package passes (api suite includes 6 new CreateUser cases + 4 sub-tests for empty-field validation).
- [x] `uvx ruff@0.15.7 check .`
- [x] `uvx ruff@0.15.7 format --check .`
- [ ] CI green on the PR.