### PR TITLE
feat(go-rewrite): GetTenant RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_tenant.go
+++ b/server/go/internal/api/get_tenant.go
@@ -1,0 +1,135 @@
+// GetTenant RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/GetTenant.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:119 (rpc), :880-883
+// (request), :885-888 (response), :853-863 (TenantDetail). Reference
+// Python: server/python/entdb_server/api/grpc_server.py:2362-2395.
+//
+// Semantics (preserved byte-for-byte from the Python handler):
+//
+//   - Read-only on globalstore.tenant_registry. No WAL append, no
+//     per-tenant SQLite touch (CLAUDE.md invariants #1 / #4 satisfied
+//     trivially — the registry is the cross-tenant exception).
+//   - NO membership / admin gate. Python deliberately omits
+//     `_check_tenant` here (contrast `GetTenantQuota` at
+//     grpc_server.py:3130). Any authenticated caller can read any
+//     tenant's metadata. This is pinned by
+//     tests/python/integration/test_region_pinning.py:97-106 and
+//     tests/python/unit/test_tenant_registry.py:307-321 — preserving
+//     this cross-tenant metadata leak for parity is REQUIRED, not a
+//     bug we're free to fix here. Flagged as a follow-up in the spec
+//     "Open questions / risks" section.
+//   - Authoritative actor is still resolved via auth.Authoritative so
+//     the privilege-escalation fix (commit fece3fb) holds: a malicious
+//     caller cannot claim `actor: "system:admin"` and expect the
+//     handler to honour the body claim. The actor is then NOT consulted
+//     for any authorization decision — this matches Python's posture.
+//   - Argument validation (`actor == ""` / `tenant_id == ""`) returns
+//     `INVALID_ARGUMENT` cleanly via status.Error, BEFORE the recover
+//     block. This is strictly stricter than Python (where
+//     context.abort raises AbortError that the outer except may swallow
+//     to `found=false`); the contract test at
+//     test_grpc_contract.py:472-476 accepts either form. See spec
+//     "Error contract" wart at grpc_server.py:2392-2395.
+//   - All other unexpected errors / panics degrade to
+//     `&GetTenantResponse{Found: false}, nil` with metric label
+//     "error". Mirrors Python's catch-all at :2392-2395.
+//   - `s.global == nil` returns `UNIMPLEMENTED` (defensive — no test
+//     pins this path but it guards against partial deployments;
+//     mirrors :2370-2374).
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const getTenantMethod = "GetTenant"
+
+// GetTenant returns the tenant_registry row for `tenant_id`, or
+// `found=false` when the tenant does not exist. See file header for the
+// auth posture (intentionally-no-permission-check, cross-tenant
+// metadata reads allowed) and the swallow-errors-as-OK contract.
+func (s *Server) GetTenant(ctx context.Context, req *pb.GetTenantRequest) (resp *pb.GetTenantResponse, err error) {
+	start := time.Now()
+	status := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(getTenantMethod, status, time.Since(start))
+	}()
+
+	// Defensive: registry not configured. No test pins this path but it
+	// guards partial deployments. Emit BEFORE arg validation so the
+	// signal is useful in monitoring (a misconfigured node should not
+	// be masked by a bad request).
+	if s.global == nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "GetTenant: tenant registry not configured")
+	}
+
+	// Argument validation BEFORE the recover block so INVALID_ARGUMENT
+	// surfaces cleanly to the client (spec "Error contract" wart).
+	if req.GetActor() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "GetTenant: actor is required")
+	}
+	if req.GetTenantId() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "GetTenant: tenant_id is required")
+	}
+
+	// Resolve the trusted actor. The result is intentionally NOT used
+	// for any membership/admin check — Python posture is "any
+	// authenticated caller may read any tenant's row". We still call
+	// Authoritative so the call shape matches every other registry RPC
+	// (defence in depth: if a future hardening pass adds a gate here,
+	// it gets the trusted identity, not the wire claim).
+	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	// Defer recover AFTER input validation so a panic in the lookup
+	// degrades to `found=false` (Python parity, :2392-2395) without
+	// swallowing INVALID_ARGUMENT.
+	defer func() {
+		if r := recover(); r != nil {
+			status = "error"
+			resp = &pb.GetTenantResponse{Found: false}
+			err = nil
+			_ = r
+		}
+	}()
+
+	tenant, lookupErr := s.global.GetTenant(ctx, req.GetTenantId())
+	if lookupErr != nil {
+		// Python's outer except catches every SQLite / runtime error
+		// and returns found=false with OK status. Do NOT propagate as
+		// codes.Internal — that would break the contract test at
+		// test_grpc_contract.py:466-471 which only accepts
+		// `r.found is False` on the negative path.
+		status = "error"
+		return &pb.GetTenantResponse{Found: false}, nil
+	}
+	if tenant == nil {
+		// Genuine not-found. Python returns found=false with OK status
+		// (:2383-2385). Metric label stays "ok" — this is the success
+		// path for a well-formed lookup.
+		return &pb.GetTenantResponse{Found: false}, nil
+	}
+
+	return &pb.GetTenantResponse{
+		Found: true,
+		Tenant: &pb.TenantDetail{
+			TenantId:  tenant.TenantID,
+			Name:      tenant.Name,
+			Status:    tenant.Status,
+			CreatedAt: tenant.CreatedAt,
+			Region:    tenant.Region,
+		},
+	}, nil
+}

--- a/server/go/internal/api/get_tenant_test.go
+++ b/server/go/internal/api/get_tenant_test.go
@@ -1,0 +1,229 @@
+// Tests for the GetTenant RPC. Spec: docs/go-port/rpcs/GetTenant.md.
+//
+// Coverage matches the Python contract pins:
+//
+//   - test_grpc_contract.py:460-465 / test_tenant_registry.py:307-321
+//     happy path: existing tenant round-trips with tenant_id, name,
+//     status, created_at, region.
+//   - test_grpc_contract.py:466-471 / test_tenant_registry.py:323-334
+//     not-found: an unknown tenant_id yields `found=false` with OK
+//     status, NOT a NOT_FOUND gRPC error.
+//   - test_grpc_contract.py:472-476: empty actor / empty tenant_id
+//     yields INVALID_ARGUMENT. The Go port returns this cleanly
+//     (Python's wart at grpc_server.py:2392-2395 is fixed; the contract
+//     test accepts either form — see spec "Error contract").
+//   - test_region_pinning.py:97-106: cross-tenant metadata reads are
+//     allowed. Any authenticated caller can fetch any tenant's
+//     metadata; the region-pinning test pins this behaviour and we
+//     preserve it for parity.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestGetTenant_Roundtrip pins the happy path: a tenant created via
+// globalstore.CreateTenant round-trips through GetTenant with all
+// TenantDetail fields populated. Mirrors
+// tests/python/unit/test_tenant_registry.py:307-321 plus the SDK-side
+// region pin at :804-823.
+func TestGetTenant_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	created, err := gs.CreateTenant(ctx, "acme", "Acme Corp", "us-east-1")
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.GetTenant(ctx, &pb.GetTenantRequest{
+		Actor:    "user:alice",
+		TenantId: "acme",
+	})
+	if err != nil {
+		t.Fatalf("GetTenant: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetTenant: response is nil")
+	}
+	if !resp.GetFound() {
+		t.Fatalf("GetTenant: Found = false, want true")
+	}
+	td := resp.GetTenant()
+	if td == nil {
+		t.Fatalf("GetTenant: Tenant is nil; want populated TenantDetail")
+	}
+	if got, want := td.GetTenantId(), "acme"; got != want {
+		t.Errorf("TenantId = %q, want %q", got, want)
+	}
+	if got, want := td.GetName(), "Acme Corp"; got != want {
+		t.Errorf("Name = %q, want %q", got, want)
+	}
+	if got, want := td.GetStatus(), "active"; got != want {
+		t.Errorf("Status = %q, want %q", got, want)
+	}
+	if got, want := td.GetRegion(), "us-east-1"; got != want {
+		t.Errorf("Region = %q, want %q", got, want)
+	}
+	if got, want := td.GetCreatedAt(), created.CreatedAt; got != want {
+		t.Errorf("CreatedAt = %d, want %d", got, want)
+	}
+}
+
+// TestGetTenant_UnknownTenantInBandFalse pins the not-found contract:
+// an unknown tenant_id yields `found=false` with no gRPC error. The
+// handler MUST NOT return NOT_FOUND. Mirrors
+// tests/python/unit/test_tenant_registry.py:323-334.
+func TestGetTenant_UnknownTenantInBandFalse(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.GetTenant(context.Background(), &pb.GetTenantRequest{
+		Actor:    "user:alice",
+		TenantId: "ghost",
+	})
+	if err != nil {
+		t.Fatalf("GetTenant: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetTenant: response is nil")
+	}
+	if resp.GetFound() {
+		t.Errorf("GetTenant: Found = true, want false for unknown tenant")
+	}
+	if resp.GetTenant() != nil {
+		t.Errorf("GetTenant: Tenant = %v, want nil for unknown tenant", resp.GetTenant())
+	}
+}
+
+// TestGetTenant_EmptyTenantIDInvalidArgument pins
+// test_grpc_contract.py:472-476: an empty tenant_id yields
+// INVALID_ARGUMENT. The Go port returns this cleanly via status.Error
+// (Python's argument-validation-vs-catch-all wart is fixed here; spec
+// "Error contract").
+func TestGetTenant_EmptyTenantIDInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.GetTenant(context.Background(), &pb.GetTenantRequest{
+		Actor:    "user:alice",
+		TenantId: "",
+	})
+	if err == nil {
+		t.Fatalf("GetTenant: want INVALID_ARGUMENT, got nil")
+	}
+	if got := errs.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("GetTenant: code = %v, want InvalidArgument (err=%v)", got, err)
+	}
+}
+
+// TestGetTenant_EmptyActorInvalidArgument pins the same wart from the
+// other side: empty `actor` -> INVALID_ARGUMENT. Python validates
+// actor before tenant_id (grpc_server.py:2376-2379) and so do we.
+func TestGetTenant_EmptyActorInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.GetTenant(context.Background(), &pb.GetTenantRequest{
+		Actor:    "",
+		TenantId: "acme",
+	})
+	if err == nil {
+		t.Fatalf("GetTenant: want INVALID_ARGUMENT, got nil")
+	}
+	if got := errs.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("GetTenant: code = %v, want InvalidArgument (err=%v)", got, err)
+	}
+}
+
+// TestGetTenant_CrossTenantMetadataLeak pins the region-pinning
+// behaviour at tests/python/integration/test_region_pinning.py:97-106:
+// any authenticated caller can read any tenant's metadata regardless
+// of membership. This is a known information leak preserved for parity
+// with Python (spec "Open questions / risks"). The trusted identity on
+// ctx is bob, but bob is not a member of t-us — the lookup MUST still
+// succeed. Flagging this with a dedicated test ensures a future
+// hardening pass cannot silently change behaviour without breaking
+// this pin.
+func TestGetTenant_CrossTenantMetadataLeak(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	// Create a US-pinned tenant; the caller (bob) is not associated
+	// with it in any way.
+	if _, err := gs.CreateTenant(ctx, "t-us", "US Tenant", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Trusted identity: bob (a user who is NOT a member of t-us).
+	authed := auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodSession,
+		Subject: "user:bob",
+	})
+
+	resp, err := srv.GetTenant(authed, &pb.GetTenantRequest{
+		Actor:    "user:bob",
+		TenantId: "t-us",
+	})
+	if err != nil {
+		t.Fatalf("GetTenant cross-tenant: unexpected error: %v", err)
+	}
+	if !resp.GetFound() {
+		t.Fatalf("GetTenant cross-tenant: Found = false; want true (parity with test_region_pinning.py:97-106)")
+	}
+	td := resp.GetTenant()
+	if td == nil {
+		t.Fatalf("GetTenant cross-tenant: Tenant is nil")
+	}
+	if got, want := td.GetTenantId(), "t-us"; got != want {
+		t.Errorf("TenantId = %q, want %q", got, want)
+	}
+	// Region leak is the specific bit the region-pinning test pins —
+	// non-members can observe data-residency choices.
+	if got, want := td.GetRegion(), "us-east-1"; got != want {
+		t.Errorf("Region = %q, want %q (region leak preserved for parity)", got, want)
+	}
+}
+
+// TestGetTenant_NoGlobalStoreUnimplemented pins the defensive
+// UNIMPLEMENTED path (grpc_server.py:2370-2374). No Python test pins
+// this — preserved per spec for partial-deployment safety.
+func TestGetTenant_NoGlobalStoreUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New() // no WithGlobalStore
+
+	_, err := srv.GetTenant(context.Background(), &pb.GetTenantRequest{
+		Actor:    "user:alice",
+		TenantId: "acme",
+	})
+	if err == nil {
+		t.Fatalf("GetTenant: want UNIMPLEMENTED, got nil")
+	}
+	if got := errs.Code(err); got != codes.Unimplemented {
+		t.Fatalf("GetTenant: code = %v, want Unimplemented (err=%v)", got, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `GetTenant` in `server/go/internal/api/get_tenant.go` against `globalstore.GetTenant`. Spec: `docs/go-port/rpcs/GetTenant.md`.
- Preserves Python's intentionally-no-permission-check auth posture: `auth.Authoritative` is invoked (so privilege-escalation via wire-claimed actor is blocked, per commit `fece3fb`) but the trusted actor is NOT consulted for any membership/admin gate. Cross-tenant metadata reads remain allowed.
- Emits `INVALID_ARGUMENT` cleanly on empty `actor` / empty `tenant_id`, fixing Python's argument-validation-vs-catch-all wart at `grpc_server.py:2392-2395`. The contract test at `test_grpc_contract.py:472-476` accepts either form.
- Unexpected lookup errors / panics degrade to `found=false` with OK status (Python parity, `:2392-2395`).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/api/... -run TestGetTenant` — 6/6 pass
- [x] `ruff check .` / `ruff format --check .` clean
- [x] Round-trip happy path (`tenant_id`, `name`, `status`, `created_at`, `region`)
- [x] Unknown tenant → in-band `found=false` (no NOT_FOUND)
- [x] Empty `tenant_id` / empty `actor` → `INVALID_ARGUMENT`
- [x] Cross-tenant metadata leak — region-pinning behaviour at `test_region_pinning.py:97-106` preserved
- [x] Missing globalstore → `UNIMPLEMENTED` (defensive)

Note: a pre-existing test in `server_test.go` (`TestServer_UnimplementedRPC_Default`) fails on `origin/main` because `GetSchema` was implemented in #427 without updating that probe. Not touched here per task scope ("DO NOT modify `server.go`").