### PR TITLE
feat(go-rewrite): AddTenantMember RPC — Wave 2

### DIFF
--- a/server/go/internal/api/add_tenant_member.go
+++ b/server/go/internal/api/add_tenant_member.go
@@ -1,0 +1,182 @@
+// AddTenantMember implements entdb.v1.EntDBService/AddTenantMember.
+//
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:2442-2490.
+// Port spec: docs/go-port/rpcs/AddTenantMember.md.
+//
+// # WAL bypass — explicit carve-out from CLAUDE.md §1
+//
+// Tenant-membership writes go DIRECTLY to the cross-tenant globalstore
+// (the `tenant_members` table). They MUST NOT be appended to the
+// per-tenant Kafka/Kinesis WAL. This is a deliberate exception to the
+// "all writes go through the WAL" invariant: globalstore is a
+// non-event-sourced control-plane store (see
+// server/go/internal/globalstore/doc — package comment "Carve-out from
+// invariant #1"). Adding a WAL event for membership would change
+// rebuild semantics and break the cross-language contract suite. If
+// you are tempted to "fix" this by routing through the Applier, stop
+// and read the package doc on globalstore first.
+//
+// # Auth model — trusted-actor admin-only
+//
+// 1. Authentication is required (handler is NOT in
+//    AuthInterceptor.UNAUTHENTICATED_METHODS).
+// 2. The wire-claimed `actor` field is UNTRUSTED — the handler rebinds
+//    to the interceptor-attested identity via auth.Authoritative on
+//    entry. Every authorization branch consults the trusted actor,
+//    never req.GetActor(). Privilege-escalation regression pinned by
+//    commit fece3fb ("Fix privilege escalation: ignore client-claimed
+//    actor in gRPC handlers").
+// 3. Authorization succeeds iff EITHER:
+//      a. trusted actor is system: / admin: prefixed, OR
+//      b. trusted actor's role in tenant_members for tenant_id is
+//         "owner" or "admin".
+//
+// # Side effects (intentionally minimal)
+//
+//   - Direct INSERT into globalstore.tenant_members. UNIQUE constraint
+//     on (tenant_id, user_id).
+//   - NO mailbox / notification fanout. The added member is silent —
+//     discovery is via GetUserTenants. Matches Python parity.
+//   - NO FK validation on tenant_id / user_id. Both can refer to rows
+//     that were never created — preserved for parity (see the spec's
+//     "Open questions / risks" section; harden in a separate ticket).
+//
+// # Error contract
+//
+//	UNIMPLEMENTED       globalstore not configured.
+//	INVALID_ARGUMENT    actor / tenant_id / user_id empty.
+//	PERMISSION_DENIED   trusted actor is neither admin/system nor an
+//	                    owner/admin member of tenant_id.
+//	OK + success=false  duplicate (tenant_id, user_id) row — soft
+//	                    failure, NOT a gRPC error.
+//	OK + success=false  any other AddTenantMember error.
+//	OK + success=true   insert succeeded.
+//
+// Metrics: emits entdb_grpc_requests_total{method="AddTenantMember",
+// status="ok"|"error"} via the shared chokepoint.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// AddTenantMember inserts a (tenant_id, user_id, role) row into the
+// cross-tenant globalstore. See package-level doc for the WAL-bypass
+// carve-out and auth model.
+func (s *Server) AddTenantMember(
+	ctx context.Context,
+	req *pb.TenantMemberRequest,
+) (*pb.TenantMemberResponse, error) {
+	start := time.Now()
+	status := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest("AddTenantMember", status, time.Since(start))
+	}()
+
+	if s.global == nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
+	}
+
+	// Mirror grpc_server.py:2456-2461: required-arg validation BEFORE
+	// any identity work. Empty actor is INVALID_ARGUMENT even when the
+	// interceptor has attested a stronger identity on ctx — Python pins
+	// this in test_grpc_contract.py:519-523.
+	if req.GetActor() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+	if req.GetTenantId() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetUserId() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "user_id is required")
+	}
+
+	// Trusted-actor rebind. From this point on, req.GetActor() is
+	// strictly informational — every authorization branch consults
+	// `trusted`. Mirrors grpc_server.py:2466 self._trusted_actor(...)
+	// and the privilege-escalation regression fix in commit fece3fb.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	// Admin / system bypass: same predicate as
+	// grpc_server.py:2053-2069 _is_admin_or_system. group: actors are
+	// not valid callers and never reach this branch.
+	if !(trusted.IsAdmin() || trusted.IsSystem()) {
+		// Membership-based admin: caller must be owner or admin of
+		// the target tenant. Python uses _get_member_role
+		// (grpc_server.py:2290-2296) which is an O(N) scan over
+		// tenant_members; we mirror that with GetTenantMembers since
+		// the dataset is tiny per tenant. Filing a hardening ticket
+		// to expose a typed MemberRole helper in globalstore is
+		// tracked in the spec's "Implementation outline" notes.
+		role, err := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
+		if err != nil {
+			status = "error"
+			return nil, errs.Errorf(codes.Internal, "lookup member role: %v", err)
+		}
+		if role != "owner" && role != "admin" {
+			status = "error"
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"Only owner or admin can add members")
+		}
+	}
+
+	role := req.GetRole()
+	if role == "" {
+		role = "member"
+	}
+
+	if err := s.global.AddTenantMember(ctx, req.GetTenantId(), req.GetUserId(), role); err != nil {
+		// Soft-failure path: duplicate (tenant_id, user_id). Returns
+		// gRPC OK with success=false so SDK retries on transient
+		// network errors observe an idempotent-replay signal.
+		// Pinned by grpc_server.py:2484-2487.
+		if errors.Is(err, errs.ErrAlreadyExists) {
+			status = "error"
+			return &pb.TenantMemberResponse{
+				Success: false,
+				Error:   "Member already exists in this tenant",
+			}, nil
+		}
+		// Any other globalstore error: same swallow shape — gRPC OK
+		// with success=false. Mirrors grpc_server.py:2488-2490.
+		status = "error"
+		return &pb.TenantMemberResponse{
+			Success: false,
+			Error:   err.Error(),
+		}, nil
+	}
+
+	return &pb.TenantMemberResponse{Success: true}, nil
+}
+
+// lookupMemberRole returns the role string for (tenantID, userID), or
+// "" if no membership exists. O(N) in the tenant's member count to
+// stay in lock-step with the Python _get_member_role implementation
+// (grpc_server.py:2290-2296). A dedicated MemberRole helper in
+// globalstore is tracked as a follow-up in the port spec.
+func (s *Server) lookupMemberRole(ctx context.Context, tenantID, userID string) (string, error) {
+	members, err := s.global.GetTenantMembers(ctx, tenantID)
+	if err != nil {
+		return "", err
+	}
+	for _, m := range members {
+		if m.UserID == userID {
+			return m.Role, nil
+		}
+	}
+	return "", nil
+}

--- a/server/go/internal/api/add_tenant_member_test.go
+++ b/server/go/internal/api/add_tenant_member_test.go
@@ -1,0 +1,235 @@
+// Tests for AddTenantMember. Behavioural parity with the Python handler
+// (server/python/entdb_server/api/grpc_server.py:2442-2490) is pinned by
+// the cross-language contract suite at
+// tests/python/integration/test_grpc_contract.py:511-530 and the unit
+// tests at tests/python/unit/test_tenant_registry.py:404-449. This file
+// covers the four branches the spec calls out:
+//
+//   1. Admin happy path -> OK + success=true; row inserted.
+//   2. Non-admin caller -> PERMISSION_DENIED.
+//   3. Duplicate (tenant_id, user_id) -> OK + success=false, no gRPC error.
+//   4. Empty fields -> INVALID_ARGUMENT.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestAddTenantMember_AdminHappyPath: a trusted admin: actor adds a
+// new member; handler returns OK + success=true and the row lands in
+// globalstore.tenant_members.
+func TestAddTenantMember_AdminHappyPath(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Trusted admin identity attested by the (simulated) interceptor.
+	// Wire-claimed actor matches but, per the trusted-actor invariant,
+	// would be ignored if it didn't.
+	authedCtx := auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodAPIKey,
+		Subject: "admin:root",
+	})
+
+	resp, err := srv.AddTenantMember(authedCtx, &pb.TenantMemberRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+		UserId:   "charlie",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("AddTenantMember: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("AddTenantMember: nil response")
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("AddTenantMember: success=false, error=%q; want success=true", resp.GetError())
+	}
+
+	// Confirm the row landed.
+	members, err := gs.GetTenantMembers(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	var found *string
+	for _, m := range members {
+		if m.UserID == "charlie" {
+			r := m.Role
+			found = &r
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("GetTenantMembers: charlie row missing; got %+v", members)
+	}
+	if *found != "member" {
+		t.Fatalf("GetTenantMembers: charlie role = %q; want %q", *found, "member")
+	}
+}
+
+// TestAddTenantMember_NonAdminPermissionDenied: a regular user without
+// owner/admin role for the target tenant gets PERMISSION_DENIED. Pins
+// the membership-based admin check (grpc_server.py:2468-2474) and
+// implicitly the trusted-actor invariant — the wire actor claims
+// "system:admin" but the interceptor-attested identity wins.
+func TestAddTenantMember_NonAdminPermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	// Bob is a plain member — not owner, not admin.
+	if err := gs.AddTenantMember(ctx, "acme", "bob", "member"); err != nil {
+		t.Fatalf("seed AddTenantMember: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Privilege-escalation regression pin (commit fece3fb): bob's
+	// session is bound to user:bob, but the request claims
+	// actor=system:admin. The handler MUST ignore the wire claim and
+	// authorise as user:bob.
+	authedCtx := auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodSession,
+		Subject: "user:bob",
+	})
+
+	_, err := srv.AddTenantMember(authedCtx, &pb.TenantMemberRequest{
+		Actor:    "system:admin", // wire-claimed escalation attempt
+		TenantId: "acme",
+		UserId:   "charlie",
+		Role:     "member",
+	})
+	if err == nil {
+		t.Fatalf("AddTenantMember: expected PERMISSION_DENIED, got nil")
+	}
+	if got := errs.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("AddTenantMember: code = %v, want PermissionDenied (err=%v)", got, err)
+	}
+}
+
+// TestAddTenantMember_DuplicateSoftFailure: a second AddTenantMember
+// for the same (tenant_id, user_id) returns gRPC OK with
+// success=false and the canonical error string. Pinned by
+// grpc_server.py:2484-2487 and the SDK idempotent-replay contract.
+func TestAddTenantMember_DuplicateSoftFailure(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	authedCtx := auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodAPIKey,
+		Subject: "admin:root",
+	})
+
+	req := &pb.TenantMemberRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+		UserId:   "charlie",
+		Role:     "member",
+	}
+
+	// First call: lands the row.
+	resp1, err := srv.AddTenantMember(authedCtx, req)
+	if err != nil {
+		t.Fatalf("AddTenantMember (first): %v", err)
+	}
+	if !resp1.GetSuccess() {
+		t.Fatalf("AddTenantMember (first): success=false, error=%q", resp1.GetError())
+	}
+
+	// Second call: duplicate — soft failure.
+	resp2, err := srv.AddTenantMember(authedCtx, req)
+	if err != nil {
+		t.Fatalf("AddTenantMember (duplicate): expected nil error, got %v", err)
+	}
+	if resp2 == nil {
+		t.Fatalf("AddTenantMember (duplicate): nil response")
+	}
+	if resp2.GetSuccess() {
+		t.Fatalf("AddTenantMember (duplicate): success=true; want false")
+	}
+	const wantMsg = "Member already exists in this tenant"
+	if resp2.GetError() != wantMsg {
+		t.Fatalf("AddTenantMember (duplicate): error = %q; want %q", resp2.GetError(), wantMsg)
+	}
+}
+
+// TestAddTenantMember_EmptyFieldsInvalidArgument: each of actor /
+// tenant_id / user_id, when empty, surfaces INVALID_ARGUMENT BEFORE
+// any identity work. Pinned by test_grpc_contract.py:519-523 (empty
+// actor) and grpc_server.py:2456-2461.
+func TestAddTenantMember_EmptyFieldsInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodAPIKey,
+		Subject: "admin:root",
+	})
+
+	cases := []struct {
+		name string
+		req  *pb.TenantMemberRequest
+	}{
+		{
+			name: "empty actor",
+			req: &pb.TenantMemberRequest{
+				Actor:    "",
+				TenantId: "acme",
+				UserId:   "charlie",
+			},
+		},
+		{
+			name: "empty tenant_id",
+			req: &pb.TenantMemberRequest{
+				Actor:    "admin:root",
+				TenantId: "",
+				UserId:   "charlie",
+			},
+		},
+		{
+			name: "empty user_id",
+			req: &pb.TenantMemberRequest{
+				Actor:    "admin:root",
+				TenantId: "acme",
+				UserId:   "",
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := srv.AddTenantMember(ctx, tt.req)
+			if err == nil {
+				t.Fatalf("AddTenantMember: expected INVALID_ARGUMENT, got nil")
+			}
+			if got := errs.Code(err); got != codes.InvalidArgument {
+				t.Fatalf("AddTenantMember: code = %v, want InvalidArgument (err=%v)", got, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Ports `entdb.v1.EntDBService/AddTenantMember` from Python (`server/python/entdb_server/api/grpc_server.py:2442-2490`) to Go per `docs/go-port/rpcs/AddTenantMember.md`.
- Trusted-actor admin-only auth: wire actor rebound via `auth.Authoritative` on entry; `system:`/`admin:` bypass, otherwise caller must be owner/admin in `tenant_members` for the target tenant. Privilege-escalation regression pinned (commit `fece3fb`).
- **WAL bypass — explicit carve-out from CLAUDE.md §1**: tenant-membership writes go DIRECTLY to globalstore. globalstore is a non-event-sourced control-plane store; routing through the WAL would change rebuild semantics and break the cross-language contract suite. Handler doc-comment cites the carve-out so future readers don't "fix" it.
- Soft-failure on duplicate `(tenant_id, user_id)` → gRPC OK + `success=false` + `"Member already exists in this tenant"` (SDK idempotent-replay signal).
- No mailbox/notification fanout, no FK validation on `user_id`/`tenant_id` — preserved for parity (hardening tracked separately in the spec).

## Test plan

- [x] `TestAddTenantMember_AdminHappyPath` — `admin:root` adds `charlie`; row lands in `globalstore.tenant_members`.
- [x] `TestAddTenantMember_NonAdminPermissionDenied` — plain `user:bob` claims `actor=system:admin` on the wire; handler ignores wire claim, returns `PERMISSION_DENIED` (privilege-escalation pin).
- [x] `TestAddTenantMember_DuplicateSoftFailure` — second insert returns `success=false`, no gRPC error.
- [x] `TestAddTenantMember_EmptyFieldsInvalidArgument` — each of `actor`/`tenant_id`/`user_id` empty → `INVALID_ARGUMENT`.
- [x] `go vet ./...` clean.
- [x] `go test ./...` — only pre-existing failure (`TestServer_UnimplementedRPC_Default` probing `GetSchema`, which has since landed) is unrelated to this PR.
- [x] `uvx ruff@0.15.7 check .` and `format --check .` clean.