### PR TITLE
feat(go-rewrite): ArchiveTenant RPC — Wave 2

### DIFF
--- a/server/go/internal/api/archive_tenant.go
+++ b/server/go/internal/api/archive_tenant.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// ArchiveTenant RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/ArchiveTenant.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:120 (rpc), :890-898 (messages).
+// Reference Python: server/python/entdb_server/api/grpc_server.py:2397-2440.
+//
+// Behavioural parity with Python is preserved deliberately, including the
+// known gap below. The handler:
+//
+//   - Returns UNIMPLEMENTED when global_store is not wired (parity with
+//     `grpc_server.py:2406-2409`).
+//   - Returns INVALID_ARGUMENT for empty actor / tenant_id (`:2411-2414`).
+//   - Resolves the trusted actor via auth.Authoritative (CLAUDE.md
+//     trusted-actor invariant — see docs/go-port/shared/auth-interceptor.md).
+//   - Wave-2 narrowing: only system: / admin: actors may archive. The
+//     Python handler additionally lets the tenant "owner" archive after a
+//     member-role lookup (`:2421-2427`); the Go port restricts this to
+//     admin-only for now. The owner branch will land alongside the WAL-
+//     first restoration (see "Known gaps" below).
+//   - Calls globalstore.SetTenantStatus(tenant_id, "archived") synchronously
+//     and returns success=true iff the row existed. Re-archiving an already-
+//     archived tenant is idempotent and returns success=true (the UPDATE
+//     still matches the row) — pinned by spec "Open questions" item 6.
+//   - Returns OK + success=false + error="Tenant not found" when the row is
+//     missing (`:2431-2433`). Asymmetric error contract preserved.
+//
+// Known gaps (preserved for parity, NOT fixed in this PR):
+//
+//  1. No WAL append. CLAUDE.md invariant #1 says every mutation flows
+//     through the WAL → Applier → SQLite. The Python handler does a direct
+//     globalstore SQLite UPDATE (a long-standing gap also called out in the
+//     spec). The WAL-first restoration for tenant-archive is in scope of a
+//     future PR — it requires a new applier op `archive_tenant` which the
+//     Wave-2 applier does not yet handle. See PLAN.md §6.
+//  2. No archiver / cold-storage handoff, no member or API-key revocation.
+//     Mirrors Python's no-op-after-flag behaviour.
+//  3. Legal-hold collision: `archived` and `legal_hold` share one status
+//     column. Spec "Open questions" item 1 flags this. We do not gate on
+//     current status here — Python doesn't either.
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const archiveTenantMethod = "ArchiveTenant"
+
+// ArchiveTenant flips tenant_registry.status to 'archived' for a given
+// tenant. See file header for the full contract.
+func (s *Server) ArchiveTenant(
+	ctx context.Context,
+	req *pb.ArchiveTenantRequest,
+) (*pb.ArchiveTenantResponse, error) {
+	start := time.Now()
+	status := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(archiveTenantMethod, status, time.Since(start))
+	}()
+
+	// Optional-store guard. Mirrors Python `:2406-2409` which aborts with
+	// UNIMPLEMENTED when the global_store dep is not configured.
+	if s.global == nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
+	}
+
+	// Required-arg validation. Empty actor / tenant_id surface as
+	// INVALID_ARGUMENT before any privilege decision (parity with
+	// `:2411-2414`). We MUST validate the wire actor non-empty even though
+	// the trusted actor below comes from the interceptor — this is a
+	// wire-contract pin (test_grpc_contract.py:690-693).
+	if req.GetActor() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+	if req.GetTenantId() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+
+	// Resolve the trusted actor. The wire `actor` field is UNTRUSTED — we
+	// rebind to the interceptor-bound identity before any authz decision.
+	// In no-auth deployments / unit tests with no Identity on ctx, the
+	// claimed actor is returned as-is (auth.Authoritative documented
+	// fallback) — matching the Python ContextVar fall-through.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	// Wave-2 narrowing: admin-only. The Python handler also allows the
+	// tenant owner via a member-role lookup; we defer that branch until
+	// the WAL-first restoration lands (see file header gap #1).
+	if !trusted.IsAdmin() && !trusted.IsSystem() {
+		status = "error"
+		return nil, errs.Errorf(codes.PermissionDenied,
+			"Only tenant owner can archive a tenant")
+	}
+
+	// Synchronous archive: direct global_store UPDATE. No WAL append today
+	// — see file header gap #1.
+	updated, err := s.global.SetTenantStatus(ctx, req.GetTenantId(), "archived")
+	if err != nil {
+		// Mirrors Python's broad except (`:2437-2440`): swallow as
+		// OK + success=false. Note: this leaks the Go error string to
+		// the wire. Spec "Open questions" item 5 flags this; matching
+		// Python parity for now.
+		return &pb.ArchiveTenantResponse{Success: false, Error: err.Error()}, nil
+	}
+	if !updated {
+		// Tenant id not found in registry. Asymmetric contract: OK +
+		// success=false rather than a NOT_FOUND status code (parity
+		// with `:2431-2433`).
+		return &pb.ArchiveTenantResponse{Success: false, Error: "Tenant not found"}, nil
+	}
+	return &pb.ArchiveTenantResponse{Success: true}, nil
+}

--- a/server/go/internal/api/archive_tenant_test.go
+++ b/server/go/internal/api/archive_tenant_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for the ArchiveTenant RPC. Spec: docs/go-port/rpcs/ArchiveTenant.md.
+//
+// Behavioural pins (mirror Python):
+//   - tests/python/integration/test_grpc_contract.py:683-693 — admin actor
+//     happy path returns success=true; empty actor returns INVALID_ARGUMENT.
+//   - tests/python/unit/test_tenant_registry.py:347-391 — admin succeeds
+//     without membership; non-admin / non-owner is PERMISSION_DENIED.
+//   - Spec "Open questions" item 6 — re-archiving is idempotent
+//     (UPDATE still matches the row → success=true).
+//   - Python `:2431-2433` — unknown tenant returns OK + success=false
+//     with error="Tenant not found"; this is an intentional asymmetry
+//     vs. validation/auth which abort with a status code.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestArchiveTenant_AdminHappyPath: admin-prefixed trusted actor archives
+// an existing tenant; response is success=true; status flips to "archived"
+// in the global store.
+func TestArchiveTenant_AdminHappyPath(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.ArchiveTenant(ctx, &pb.ArchiveTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+	})
+	if err != nil {
+		t.Fatalf("ArchiveTenant: unexpected error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("ArchiveTenant: success=false, error=%q; want success=true", resp.GetError())
+	}
+	if resp.GetError() != "" {
+		t.Errorf("ArchiveTenant: unexpected error message %q", resp.GetError())
+	}
+
+	// Confirm side effect: tenant_registry.status flipped to "archived".
+	tnt, gerr := gs.GetTenant(ctx, "acme")
+	if gerr != nil {
+		t.Fatalf("GetTenant after archive: %v", gerr)
+	}
+	if tnt == nil {
+		t.Fatalf("GetTenant after archive: tenant disappeared")
+	}
+	if tnt.Status != "archived" {
+		t.Errorf("post-archive status = %q; want %q", tnt.Status, "archived")
+	}
+}
+
+// TestArchiveTenant_SystemHappyPath: system: actor (e.g. internal control
+// plane caller) is treated the same as admin: by IsAdminOrSystem; pinned
+// here so we don't regress to admin-only.
+func TestArchiveTenant_SystemHappyPath(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.ArchiveTenant(ctx, &pb.ArchiveTenantRequest{
+		Actor:    "system:control-plane",
+		TenantId: "acme",
+	})
+	if err != nil {
+		t.Fatalf("ArchiveTenant: unexpected error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("ArchiveTenant (system): success=false, error=%q", resp.GetError())
+	}
+}
+
+// TestArchiveTenant_NonAdminPermissionDenied: a user: actor with no
+// member-role bypass MUST be rejected. Wave-2 is admin-only — the
+// owner-can-archive branch is deferred to the WAL-first restoration PR.
+func TestArchiveTenant_NonAdminPermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.ArchiveTenant(ctx, &pb.ArchiveTenantRequest{
+		Actor:    "user:bob",
+		TenantId: "acme",
+	})
+	if err == nil {
+		t.Fatalf("ArchiveTenant: expected PERMISSION_DENIED, got nil error")
+	}
+	if got := errs.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("ArchiveTenant: code = %v; want PermissionDenied (err=%v)", got, err)
+	}
+
+	// Side-effect probe: tenant must remain active.
+	tnt, gerr := gs.GetTenant(ctx, "acme")
+	if gerr != nil {
+		t.Fatalf("GetTenant: %v", gerr)
+	}
+	if tnt.Status != "active" {
+		t.Errorf("post-deny status = %q; want %q (no side effect on permission denial)",
+			tnt.Status, "active")
+	}
+}
+
+// TestArchiveTenant_UnknownTenant: an admin call against a tenant id that
+// is not in the registry returns OK + success=false + error="Tenant not
+// found". Python parity (`grpc_server.py:2431-2433`) — this is asymmetric
+// vs. validation/auth which abort with a status code.
+func TestArchiveTenant_UnknownTenant(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.ArchiveTenant(context.Background(), &pb.ArchiveTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "ghost",
+	})
+	if err != nil {
+		t.Fatalf("ArchiveTenant: unexpected error: %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Errorf("ArchiveTenant (ghost): success=true; want false")
+	}
+	if resp.GetError() != "Tenant not found" {
+		t.Errorf("ArchiveTenant (ghost): error=%q; want %q", resp.GetError(), "Tenant not found")
+	}
+}
+
+// TestArchiveTenant_AlreadyArchivedIsIdempotent: re-archiving an already-
+// archived tenant succeeds (the UPDATE still matches the row). Pinned by
+// spec "Open questions" item 6.
+func TestArchiveTenant_AlreadyArchivedIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	first, err := srv.ArchiveTenant(ctx, &pb.ArchiveTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+	})
+	if err != nil {
+		t.Fatalf("first ArchiveTenant: %v", err)
+	}
+	if !first.GetSuccess() {
+		t.Fatalf("first ArchiveTenant: success=false, error=%q", first.GetError())
+	}
+
+	second, err := srv.ArchiveTenant(ctx, &pb.ArchiveTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+	})
+	if err != nil {
+		t.Fatalf("second ArchiveTenant: %v", err)
+	}
+	if !second.GetSuccess() {
+		t.Errorf("second ArchiveTenant: success=false, error=%q; want success=true (idempotent)",
+			second.GetError())
+	}
+}
+
+// TestArchiveTenant_EmptyActorInvalidArgument: empty wire actor must
+// surface as INVALID_ARGUMENT before any auth decision. Pinned by
+// test_grpc_contract.py:690-693.
+func TestArchiveTenant_EmptyActorInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.ArchiveTenant(context.Background(), &pb.ArchiveTenantRequest{
+		Actor:    "",
+		TenantId: "acme",
+	})
+	if err == nil {
+		t.Fatalf("ArchiveTenant: expected INVALID_ARGUMENT, got nil")
+	}
+	if got := errs.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("ArchiveTenant: code = %v; want InvalidArgument (err=%v)", got, err)
+	}
+}
+
+// TestArchiveTenant_EmptyTenantIDInvalidArgument: empty tenant_id must
+// also surface INVALID_ARGUMENT. Pinned by Python `:2413-2414`.
+func TestArchiveTenant_EmptyTenantIDInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.ArchiveTenant(context.Background(), &pb.ArchiveTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "",
+	})
+	if err == nil {
+		t.Fatalf("ArchiveTenant: expected INVALID_ARGUMENT, got nil")
+	}
+	if got := errs.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("ArchiveTenant: code = %v; want InvalidArgument (err=%v)", got, err)
+	}
+}
+
+// TestArchiveTenant_GlobalStoreNotConfigured: when the optional global_store
+// dep is absent, the handler returns UNIMPLEMENTED. Pinned by Python
+// `:2406-2409`.
+func TestArchiveTenant_GlobalStoreNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New() // no WithGlobalStore
+
+	_, err := srv.ArchiveTenant(context.Background(), &pb.ArchiveTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+	})
+	if err == nil {
+		t.Fatalf("ArchiveTenant: expected UNIMPLEMENTED, got nil")
+	}
+	if got := errs.Code(err); got != codes.Unimplemented {
+		t.Fatalf("ArchiveTenant: code = %v; want Unimplemented (err=%v)", got, err)
+	}
+}


### PR DESCRIPTION
## Summary

Wave-2 port of `entdb.v1.EntDBService/ArchiveTenant` from Python to Go.
Source-of-truth: `server/python/entdb_server/api/grpc_server.py:2397-2440`.
Spec: `docs/go-port/rpcs/ArchiveTenant.md`.

- New handler at `server/go/internal/api/archive_tenant.go`. Optional-store guard, INVALID_ARGUMENT validation, trusted-actor resolution via `auth.Authoritative`, direct `globalstore.SetTenantStatus(..., "archived")`, asymmetric error contract preserved (unknown tenant -> OK + `success=false` + `error="Tenant not found"`).
- Tests at `server/go/internal/api/archive_tenant_test.go` (package `api_test`): admin happy path, system happy path, non-admin PERMISSION_DENIED, unknown tenant, idempotent re-archive, empty actor / tenant_id INVALID_ARGUMENT, missing global_store UNIMPLEMENTED.
- No changes to `server.go` or `_go_parity.py`.

## Deferred (intentionally out of scope; flagged in code + spec)

1. **WAL-first restoration.** CLAUDE.md invariant #1 requires every mutation flow `handler -> wal.append -> Applier -> SQLite`. The Python handler bypasses the WAL with a direct global_store SQLite UPDATE (long-standing gap also called out in the port spec, "Open questions" item 2). Routing ArchiveTenant through the WAL requires a new applier op `archive_tenant` that the Wave-2 applier does not yet handle. We preserve Python parity for this PR; the WAL-first restoration is in scope of a follow-up PR (PLAN.md §6).
2. **Owner-can-archive branch.** The Python handler additionally permits the tenant owner via a member-role lookup. The Go port narrows Wave-2 to admin: / system: actors only; the owner branch lands alongside the WAL-first restoration.
3. **Archiver / cold-storage handoff, member / API-key revocation.** Not done in Python today either; the spec proposes them as future work.
4. **Legal-hold collision.** `archived` and `legal_hold` share one column. Spec "Open questions" item 1 — out of scope here.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/api/... -run TestArchiveTenant` passes (8 cases)
- [x] `go test ./...` green except pre-existing `TestServer_UnimplementedRPC_Default` (unrelated; broken since GetSchema landed in #427 — that test still probes GetSchema for an Unimplemented status which it no longer returns)
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean