### PR TITLE
feat(go-rewrite): CreateTenant RPC — Wave 2

### DIFF
--- a/server/go/internal/api/create_tenant.go
+++ b/server/go/internal/api/create_tenant.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package api
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// CreateTenant implements the entdb.v1.EntDBService/CreateTenant RPC.
+// Spec: docs/go-port/rpcs/CreateTenant.md.
+//
+// Carve-out from CLAUDE.md invariant #1 (intentional, scoped to the
+// tenant-registry control plane): the write goes directly into the
+// globalstore SQLite without a WAL append. tenant_registry is a
+// non-WAL-backed control plane in this port; the per-tenant SQLite file
+// is created lazily on first data-plane use, NOT here. Wave 2 deliberately
+// keeps this carve-out so the bring-up path doesn't depend on the WAL
+// applier landing first; a follow-up may either (a) introduce a
+// TenantCreated WAL op or (b) document the control plane formally.
+//
+// Three-step shape (non-atomic, mirrors Python):
+//
+//  1. validate (admin gate, non-empty fields)
+//  2. globalstore.CreateTenant (registry row + region pin column)
+//  3. globalstore.AddTenantMember (creator → "owner")
+//
+// A crash between steps 2 and 3 leaves an orphan tenant with no owner.
+// This is the Python parity hazard flagged in the spec under "Open
+// questions / risks: Non-atomic three-step write" — preserved here on
+// purpose so the contract matches; do NOT wrap these in a single SQLite
+// transaction without updating the spec and Python source together.
+//
+// Auth contract:
+//   - Wire actor (req.Actor) is UNTRUSTED. The trusted principal is
+//     resolved via auth.Authoritative(ctx, claimed) — privilege-escalation
+//     remediation per commit fece3fb.
+//   - Admin-only: Wave-2 decision deviating from current Python (which
+//     has no admin gate today). Any caller whose trusted actor is not
+//     admin: or system: gets PERMISSION_DENIED. This closes the multi-
+//     tenant abuse vector flagged in the spec ("Admin gate" open
+//     question).
+func (s *Server) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) (*pb.CreateTenantResponse, error) {
+	start := time.Now()
+	resultStatus := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest("CreateTenant", resultStatus, time.Since(start))
+	}()
+
+	// Step 1a: globalstore must be wired. Mirrors Python's
+	// `if not self.global_store: abort(UNIMPLEMENTED, ...)`
+	// (grpc_server.py:2312-2316).
+	if s.global == nil {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
+	}
+
+	// Step 1b: required-field validation. Matches the three INVALID_ARGUMENT
+	// aborts in Python (grpc_server.py:2318-2323). The wire `actor` MUST be
+	// non-empty even though we ignore it for the auth decision — this keeps
+	// the wire contract identical so existing SDK callers don't break.
+	if req.GetActor() == "" {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+	if req.GetTenantId() == "" {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetName() == "" {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "name is required")
+	}
+
+	// Step 1c: trusted-actor + admin gate. Wire `actor` is rebound; the
+	// authoritative principal comes from the auth interceptor's per-RPC
+	// context. Anything that isn't admin: or system: is rejected.
+	claimed := auth.ParseActor(req.GetActor())
+	principal := auth.Authoritative(ctx, claimed)
+	if !(principal.IsAdmin() || principal.IsSystem()) {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.PermissionDenied,
+			"CreateTenant requires admin or system actor")
+	}
+
+	// Step 1d: resolve region. Empty → server's served region → final
+	// fallback "us-east-1" (globalstore.DefaultRegion). Mirrors Python's
+	// `request.region or self.served_region or "us-east-1"`
+	// (grpc_server.py:2334).
+	region := req.GetRegion()
+	if region == "" {
+		region = s.region
+	}
+
+	// Step 2: globalstore write. UNIQUE on tenant_registry.tenant_id
+	// surfaces as ALREADY_EXISTS; the handler maps that to a typed gRPC
+	// error (NOT the Python success=false channel — Wave-2 decision per
+	// task spec, gives SDKs a real status code to dispatch on).
+	tenant, err := s.global.CreateTenant(ctx, req.GetTenantId(), req.GetName(), region)
+	if err != nil {
+		resultStatus = "error"
+		if errors.Is(err, errs.ErrAlreadyExists) {
+			return nil, err
+		}
+		return nil, errs.Errorf(codes.Internal,
+			"create_tenant: %v", err)
+	}
+
+	// Step 3: record the creator as owner. Idempotent on retry — an
+	// already-existing membership is swallowed so a crash-then-retry
+	// after step 2 succeeds without surfacing a spurious error. The
+	// step is non-atomic with step 2 by design (see top-of-file note).
+	if err := s.global.AddTenantMember(ctx, tenant.TenantID, principal.ID(), "owner"); err != nil {
+		if !errors.Is(err, errs.ErrAlreadyExists) {
+			resultStatus = "error"
+			return nil, errs.Errorf(codes.Internal,
+				"add_tenant_member: %v", err)
+		}
+	}
+
+	return &pb.CreateTenantResponse{
+		Success: true,
+		Tenant: &pb.TenantDetail{
+			TenantId:  tenant.TenantID,
+			Name:      tenant.Name,
+			Status:    tenant.Status,
+			CreatedAt: tenant.CreatedAt,
+			Region:    tenant.Region,
+		},
+	}, nil
+}

--- a/server/go/internal/api/create_tenant_test.go
+++ b/server/go/internal/api/create_tenant_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for the CreateTenant RPC. Pins the Wave-2 contract:
+//
+//   - Admin happy path → Success=true, registry row + owner membership.
+//   - Non-admin trusted actor → PERMISSION_DENIED (Wave-2 admin gate).
+//   - Duplicate tenant_id → ALREADY_EXISTS.
+//   - Empty/invalid tenant_id (and other required fields) → INVALID_ARGUMENT.
+//
+// Spec: docs/go-port/rpcs/CreateTenant.md.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// adminCtx returns a context carrying a trusted admin Identity, the way
+// the auth interceptor would after authenticating an admin caller. Tests
+// that call the handler directly need to plumb this in themselves
+// because no interceptor runs in the unit-test path.
+func adminCtx() context.Context {
+	return auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodSession,
+		Subject: "admin:root",
+	})
+}
+
+// userCtx returns a context carrying a trusted *non-admin* Identity. The
+// admin gate must reject this even if the wire `actor` claims admin.
+func userCtx() context.Context {
+	return auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodSession,
+		Subject: "user:alice",
+	})
+}
+
+// TestCreateTenant_AdminHappyPath: admin caller, all required fields
+// populated, region pin applied. Verifies the response shape and the
+// side effects on globalstore (registry row + owner membership).
+func TestCreateTenant_AdminHappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs), api.WithRegion("eu-west-1"))
+
+	resp, err := srv.CreateTenant(adminCtx(), &pb.CreateTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+		Name:     "Acme Corp",
+		Region:   "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateTenant: unexpected err: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("CreateTenant: success=false, error=%q", resp.GetError())
+	}
+	if got := resp.GetTenant().GetTenantId(); got != "acme" {
+		t.Fatalf("tenant_id: got %q, want %q", got, "acme")
+	}
+	if got := resp.GetTenant().GetName(); got != "Acme Corp" {
+		t.Fatalf("name: got %q, want %q", got, "Acme Corp")
+	}
+	if got := resp.GetTenant().GetStatus(); got != "active" {
+		t.Fatalf("status: got %q, want %q", got, "active")
+	}
+	if got := resp.GetTenant().GetRegion(); got != "us-east-1" {
+		t.Fatalf("region: got %q, want %q", got, "us-east-1")
+	}
+	if resp.GetTenant().GetCreatedAt() <= 0 {
+		t.Fatalf("created_at: got %d, want >0", resp.GetTenant().GetCreatedAt())
+	}
+
+	// Side effects: registry row exists and creator was recorded as owner.
+	got, err := gs.GetTenant(context.Background(), "acme")
+	if err != nil || got == nil {
+		t.Fatalf("GetTenant: err=%v tenant=%v", err, got)
+	}
+	if got.Region != "us-east-1" {
+		t.Fatalf("registry region: got %q, want %q", got.Region, "us-east-1")
+	}
+	members, err := gs.GetTenantMembers(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("members: got %d, want 1 (%+v)", len(members), members)
+	}
+	// The admin's bare ID (without the "admin:" prefix) is what's stored
+	// as the user_id, mirroring _actor_user_id in the Python source.
+	if members[0].UserID != "root" {
+		t.Fatalf("owner user_id: got %q, want %q", members[0].UserID, "root")
+	}
+	if members[0].Role != "owner" {
+		t.Fatalf("owner role: got %q, want %q", members[0].Role, "owner")
+	}
+}
+
+// TestCreateTenant_RegionDefaultsToServedRegion: empty req.region falls
+// back to s.region. Pinned by the Python region-pin contract test at
+// tests/python/integration/test_region_pinning.py:81-106.
+func TestCreateTenant_RegionDefaultsToServedRegion(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs), api.WithRegion("eu-west-1"))
+
+	resp, err := srv.CreateTenant(adminCtx(), &pb.CreateTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+		Name:     "Acme Corp",
+	})
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if got := resp.GetTenant().GetRegion(); got != "eu-west-1" {
+		t.Fatalf("region: got %q, want %q (server's served region)", got, "eu-west-1")
+	}
+}
+
+// TestCreateTenant_NonAdminPermissionDenied: a trusted user: actor (the
+// auth interceptor authenticated them as user:alice) hits the admin gate
+// and gets PERMISSION_DENIED — even though the wire payload claims an
+// admin: actor. This is the privilege-escalation regression guard.
+func TestCreateTenant_NonAdminPermissionDenied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.CreateTenant(userCtx(), &pb.CreateTenantRequest{
+		Actor:    "admin:root", // wire claim is ignored; trusted actor wins
+		TenantId: "acme",
+		Name:     "Acme Corp",
+	})
+	if err == nil {
+		t.Fatalf("CreateTenant: expected error, got nil")
+	}
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("code: got %v, want PermissionDenied", got)
+	}
+
+	// Side-effect guarantee: no registry row should have been written.
+	got, err := gs.GetTenant(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("registry row leaked despite PERMISSION_DENIED: %+v", got)
+	}
+}
+
+// TestCreateTenant_DuplicateAlreadyExists: a second CreateTenant with the
+// same tenant_id surfaces as ALREADY_EXISTS. (Wave-2 deviates from
+// Python's success=false channel for typed-error ergonomics; spec note
+// in CreateTenant.md "Error contract" allows the deviation in the Go
+// port.)
+func TestCreateTenant_DuplicateAlreadyExists(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs), api.WithRegion("us-east-1"))
+
+	if _, err := srv.CreateTenant(adminCtx(), &pb.CreateTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+		Name:     "Acme Corp",
+	}); err != nil {
+		t.Fatalf("first CreateTenant: %v", err)
+	}
+
+	_, err := srv.CreateTenant(adminCtx(), &pb.CreateTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+		Name:     "Acme Corp v2",
+	})
+	if err == nil {
+		t.Fatalf("CreateTenant: expected ALREADY_EXISTS, got nil")
+	}
+	if got := status.Code(err); got != codes.AlreadyExists {
+		t.Fatalf("code: got %v, want AlreadyExists", got)
+	}
+}
+
+// TestCreateTenant_InvalidArgument: each of the three required wire
+// fields produces INVALID_ARGUMENT when empty. Mirrors the three
+// abort sites in Python at grpc_server.py:2318-2323.
+func TestCreateTenant_InvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		req  *pb.CreateTenantRequest
+	}{
+		{
+			name: "empty_actor",
+			req:  &pb.CreateTenantRequest{TenantId: "acme", Name: "Acme"},
+		},
+		{
+			name: "empty_tenant_id",
+			req:  &pb.CreateTenantRequest{Actor: "admin:root", Name: "Acme"},
+		},
+		{
+			name: "empty_name",
+			req:  &pb.CreateTenantRequest{Actor: "admin:root", TenantId: "acme"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			gs := newGlobalStore(t)
+			srv := api.New(api.WithGlobalStore(gs))
+			_, err := srv.CreateTenant(adminCtx(), c.req)
+			if err == nil {
+				t.Fatalf("CreateTenant: expected INVALID_ARGUMENT, got nil")
+			}
+			if got := status.Code(err); got != codes.InvalidArgument {
+				t.Fatalf("code: got %v, want InvalidArgument", got)
+			}
+		})
+	}
+}
+
+// TestCreateTenant_GlobalStoreUnconfigured: no globalstore wired →
+// UNIMPLEMENTED. Mirrors Python's `abort(UNIMPLEMENTED, "Tenant
+// registry not configured")` at grpc_server.py:2312-2316.
+func TestCreateTenant_GlobalStoreUnconfigured(t *testing.T) {
+	t.Parallel()
+	srv := api.New() // no globalstore
+
+	_, err := srv.CreateTenant(adminCtx(), &pb.CreateTenantRequest{
+		Actor:    "admin:root",
+		TenantId: "acme",
+		Name:     "Acme Corp",
+	})
+	if err == nil {
+		t.Fatalf("CreateTenant: expected UNIMPLEMENTED, got nil")
+	}
+	if got := status.Code(err); got != codes.Unimplemented {
+		t.Fatalf("code: got %v, want Unimplemented", got)
+	}
+}


### PR DESCRIPTION
## Summary

Ports `entdb.v1.EntDBService/CreateTenant` from the Python server (Wave 2, EPIC #407).

- Trusted-actor resolution via `auth.Authoritative` (privilege-escalation remediation per commit `fece3fb`).
- Admin-only gate (admin: or system: kinds). Wave-2 deviation from current Python parity that closes the multi-tenant abuse vector flagged in `docs/go-port/rpcs/CreateTenant.md` "Admin gate".
- Region resolution: `req.region → s.region → globalstore.DefaultRegion ("us-east-1")`.
- Three-step write into globalstore: validate → `CreateTenant` (registry row + region pin column) → `AddTenantMember` (owner). Non-atomic by design to mirror Python; the spec's "non-atomicity" hazard is preserved.

## WAL carve-out (intentional)

The handler bypasses the WAL. This is a scoped carve-out from CLAUDE.md invariant #1 covering the tenant-registry control plane only. The per-tenant SQLite file is created lazily on first data-plane use, NOT in this handler, so there's no node/edge state initialised here. A follow-up will either (a) introduce a `TenantCreated` WAL op or (b) formally document `tenant_registry` as a non-WAL control plane.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/api/ -run CreateTenant` — all 6 subtests pass
- [x] Admin happy path verifies registry row + owner membership side effects
- [x] Region defaults to served region when `req.region` is empty
- [x] Non-admin trusted actor → `PERMISSION_DENIED` (wire claim ignored)
- [x] Duplicate `tenant_id` → `ALREADY_EXISTS`
- [x] Empty `actor` / `tenant_id` / `name` → `INVALID_ARGUMENT`
- [x] Missing globalstore → `UNIMPLEMENTED`
- [x] `ruff check` + `ruff format --check` clean