### PR TITLE
feat(go-rewrite): GetTenantQuota RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_tenant_quota.go
+++ b/server/go/internal/api/get_tenant_quota.go
@@ -1,0 +1,150 @@
+// GetTenantQuota RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/GetTenantQuota.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:142 (rpc), :1063-1068 (request),
+// :1070-1085 (response). Reference Python:
+// server/python/entdb_server/api/grpc_server.py:3106-3163.
+//
+// Semantics:
+//
+//   - Read-only. No WAL append, no per-tenant SQLite touch. Reads two rows
+//     out of globalstore (tenant_quotas + tenant_usage); both fall back to
+//     zero-valued defaults when the row is absent.
+//   - Auth: trusted-actor. The proto `actor` field is a hint only and is
+//     deliberately ignored for authorization (see commit fece3fb,
+//     "Fix privilege escalation"). Authoritative actor is taken from the
+//     interceptor-populated Identity on ctx.
+//   - Authorization gate: caller must be a member of the tenant
+//     (any role, including admin/owner). Non-members → PERMISSION_DENIED.
+//     Empty tenant_id → INVALID_ARGUMENT.
+//   - period_end_ms is computed locally from time.Now(), never read from
+//     the DB — keeps dashboards correct for tenants with no writes this
+//     period (parity with grpc_server.py:3137-3141).
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const grpcMethodGetTenantQuota = "GetTenantQuota"
+
+// GetTenantQuota implements entdb.v1.EntDBService/GetTenantQuota.
+func (s *Server) GetTenantQuota(
+	ctx context.Context,
+	req *pb.GetTenantQuotaRequest,
+) (*pb.GetTenantQuotaResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(grpcMethodGetTenantQuota, outcome, time.Since(start))
+	}()
+
+	tenantID := req.GetTenantId()
+	if tenantID == "" {
+		outcome = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+
+	// Tenant gate (sharding ownership / region pin / NotFound). Same
+	// ingress contract as every other tenant-scoped RPC; matches the
+	// Python `_check_tenant` call before the admin gate at
+	// grpc_server.py:3122-3128.
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		outcome = "error"
+		return nil, err
+	}
+
+	// Trusted actor: proto `actor` is ignored. The interceptor places
+	// the verified Identity on ctx; auth.Authoritative normalises it to
+	// an Actor. If the test/server is wired without an auth interceptor,
+	// Authoritative falls through to the claimed actor — but we then
+	// drop it on the floor and require a real trusted identity below.
+	id, ok := auth.IdentityFromContext(ctx)
+	if !ok {
+		outcome = "error"
+		return nil, errs.Errorf(codes.PermissionDenied,
+			"GetTenantQuota: no trusted identity")
+	}
+	trusted := auth.Authoritative(ctx, auth.User(id.Subject))
+
+	// Membership gate: any member (including admin/owner) may read the
+	// tenant's quota dashboard. Non-members are rejected. Mirrors
+	// "_require_admin_or_owner" semantics relaxed to member-or-admin
+	// per the W2 task spec for parity dashboards.
+	if s.global == nil {
+		outcome = "error"
+		return nil, errs.Errorf(codes.Unimplemented,
+			"GetTenantQuota: quota registry not configured")
+	}
+	member, err := s.global.IsMember(ctx, tenantID, trusted.ID())
+	if err != nil {
+		outcome = "error"
+		return nil, errs.Errorf(codes.Internal,
+			"GetTenantQuota: membership probe: %v", err)
+	}
+	if !member {
+		outcome = "error"
+		return nil, errs.Errorf(codes.PermissionDenied,
+			"GetTenantQuota: caller is not a member of %q", tenantID)
+	}
+
+	cfg, err := s.global.GetTenantQuota(ctx, tenantID)
+	if err != nil {
+		outcome = "error"
+		return nil, errs.Errorf(codes.Internal,
+			"GetTenantQuota: read quota config: %v", err)
+	}
+	usage, err := s.global.GetUsage(ctx, tenantID)
+	if err != nil {
+		outcome = "error"
+		return nil, errs.Errorf(codes.Internal,
+			"GetTenantQuota: read usage: %v", err)
+	}
+
+	// period_end_ms is computed locally — never read from the DB row.
+	// See spec, "Phase 1 — monthly write quota": dashboards must show a
+	// fresh upcoming-rollover even for tenants with no writes this
+	// period.
+	periodEnd := nextCalendarMonthStartMs(time.Now())
+
+	resp := &pb.GetTenantQuotaResponse{
+		TenantId:      tenantID,
+		WritesUsed:    usage.WritesCount,
+		PeriodStartMs: usage.PeriodStartMs,
+		PeriodEndMs:   periodEnd,
+	}
+	if cfg != nil {
+		resp.MaxWritesPerMonth = cfg.MaxWritesPerMonth
+		resp.MaxRpsSustained = int32(cfg.MaxRPSSustained)
+		resp.MaxRpsBurst = int32(cfg.MaxRPSBurst)
+		resp.MaxRpsPerUserSustained = int32(cfg.MaxRPSPerUserSustained)
+		resp.MaxRpsPerUserBurst = int32(cfg.MaxRPSPerUserBurst)
+		resp.HardEnforce = cfg.HardEnforce
+	}
+	return resp, nil
+}
+
+// nextCalendarMonthStartMs returns the Unix-millisecond timestamp of the
+// start of the UTC calendar month immediately following the one
+// containing t. Mirrors `_next_calendar_month_start_ms`
+// (auth/quota_interceptor.py:65-71). Kept local to this file to avoid
+// adding new exported helpers / fields per the W2 task constraints; the
+// equivalent for the start-of-current-month lives in the globalstore
+// package as calendarMonthStartMs.
+func nextCalendarMonthStartMs(t time.Time) int64 {
+	t = t.UTC()
+	year, month := t.Year(), t.Month()
+	// time.Date normalises month=13 → next year's January, so we let
+	// the stdlib do the rollover math.
+	next := time.Date(year, month+1, 1, 0, 0, 0, 0, time.UTC)
+	return next.UnixMilli()
+}

--- a/server/go/internal/api/get_tenant_quota_test.go
+++ b/server/go/internal/api/get_tenant_quota_test.go
@@ -1,0 +1,232 @@
+// Tests for GetTenantQuota (Wave 2 / EPIC #407). Behavioural pins:
+//
+//  1. Member happy path — tenant member sees configured quota + usage.
+//  2. Admin happy path — admin role works the same as member.
+//  3. Non-member → PERMISSION_DENIED, even with claimed actor on the wire.
+//  4. Quota not configured → defaults (zero-valued cfg fields) but
+//     period_end_ms is still computed and writes_used / period_start_ms
+//     come from the synthesized usage row.
+//  5. Empty tenant_id → INVALID_ARGUMENT (gate runs before tenant check).
+//
+// Spec: docs/go-port/rpcs/GetTenantQuota.md.
+// Privilege-escalation pin: claim-on-wire is ignored, trusted Identity wins.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// withTrustedUser returns a ctx that carries the given subject as the
+// trusted user identity, mirroring what the auth interceptor sets on
+// every authenticated request.
+func withTrustedUser(ctx context.Context, subject string) context.Context {
+	return auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodSession,
+		Subject: subject,
+	})
+}
+
+// TestGetTenantQuota_Member_HappyPath: a tenant member with role=member
+// can read the quota dashboard; configured cfg + usage round-trip into
+// the response and period_end_ms is in the future.
+func TestGetTenantQuota_Member_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "member"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	if _, err := gs.SetTenantQuota(ctx, globalstore.QuotaConfig{
+		TenantID:               "acme",
+		MaxWritesPerMonth:      1_000_000,
+		HardEnforce:            true,
+		MaxRPSSustained:        100,
+		MaxRPSBurst:            200,
+		MaxRPSPerUserSustained: 10,
+		MaxRPSPerUserBurst:     20,
+	}); err != nil {
+		t.Fatalf("SetTenantQuota: %v", err)
+	}
+	if _, err := gs.IncrementUsage(ctx, "acme", 7); err != nil {
+		t.Fatalf("IncrementUsage: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	ctx = withTrustedUser(ctx, "alice")
+
+	resp, err := srv.GetTenantQuota(ctx, &pb.GetTenantQuotaRequest{TenantId: "acme"})
+	if err != nil {
+		t.Fatalf("GetTenantQuota: unexpected error: %v", err)
+	}
+	if resp.GetTenantId() != "acme" {
+		t.Errorf("TenantId = %q, want %q", resp.GetTenantId(), "acme")
+	}
+	if resp.GetMaxWritesPerMonth() != 1_000_000 {
+		t.Errorf("MaxWritesPerMonth = %d, want 1000000", resp.GetMaxWritesPerMonth())
+	}
+	if resp.GetWritesUsed() != 7 {
+		t.Errorf("WritesUsed = %d, want 7", resp.GetWritesUsed())
+	}
+	if resp.GetPeriodStartMs() <= 0 {
+		t.Errorf("PeriodStartMs = %d, want > 0", resp.GetPeriodStartMs())
+	}
+	if resp.GetPeriodEndMs() <= resp.GetPeriodStartMs() {
+		t.Errorf("PeriodEndMs (%d) must be strictly after PeriodStartMs (%d)",
+			resp.GetPeriodEndMs(), resp.GetPeriodStartMs())
+	}
+	if resp.GetPeriodEndMs() <= time.Now().UnixMilli() {
+		t.Errorf("PeriodEndMs (%d) must be strictly after now", resp.GetPeriodEndMs())
+	}
+	if resp.GetMaxRpsSustained() != 100 || resp.GetMaxRpsBurst() != 200 {
+		t.Errorf("rps sustained/burst = %d/%d, want 100/200",
+			resp.GetMaxRpsSustained(), resp.GetMaxRpsBurst())
+	}
+	if resp.GetMaxRpsPerUserSustained() != 10 || resp.GetMaxRpsPerUserBurst() != 20 {
+		t.Errorf("per-user rps sustained/burst = %d/%d, want 10/20",
+			resp.GetMaxRpsPerUserSustained(), resp.GetMaxRpsPerUserBurst())
+	}
+	if !resp.GetHardEnforce() {
+		t.Errorf("HardEnforce = false, want true")
+	}
+}
+
+// TestGetTenantQuota_Admin_HappyPath: an admin role is treated identically
+// to a member for read access (per W2 spec — read is gated by membership,
+// admin is just one specific role).
+func TestGetTenantQuota_Admin_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "boss", "admin"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	if _, err := gs.SetTenantQuota(ctx, globalstore.QuotaConfig{
+		TenantID:          "acme",
+		MaxWritesPerMonth: 42,
+	}); err != nil {
+		t.Fatalf("SetTenantQuota: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	ctx = withTrustedUser(ctx, "boss")
+
+	resp, err := srv.GetTenantQuota(ctx, &pb.GetTenantQuotaRequest{TenantId: "acme"})
+	if err != nil {
+		t.Fatalf("GetTenantQuota: unexpected error: %v", err)
+	}
+	if resp.GetMaxWritesPerMonth() != 42 {
+		t.Errorf("MaxWritesPerMonth = %d, want 42", resp.GetMaxWritesPerMonth())
+	}
+}
+
+// TestGetTenantQuota_NonMember_PermissionDenied: a caller who is NOT a
+// member of the tenant — even one who claims to be `system:root` on the
+// wire actor field — must be rejected. Pins the privilege-escalation
+// guard for this RPC.
+func TestGetTenantQuota_NonMember_PermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	// "mallory" is authenticated but NOT a member of acme.
+	srv := api.New(api.WithGlobalStore(gs))
+	ctx = withTrustedUser(ctx, "mallory")
+
+	_, err := srv.GetTenantQuota(ctx, &pb.GetTenantQuotaRequest{
+		TenantId: "acme",
+		Actor:    "system:root", // wire-claimed; MUST be ignored.
+	})
+	if err == nil {
+		t.Fatalf("GetTenantQuota: expected PermissionDenied, got nil")
+	}
+	if got := errs.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("GetTenantQuota: code = %v, want PermissionDenied (err=%v)", got, err)
+	}
+}
+
+// TestGetTenantQuota_NoQuotaConfigured_ReturnsDefaults: when no
+// tenant_quotas row exists, all cfg-derived fields are zero but the
+// response is still OK and period_end_ms is computed.
+func TestGetTenantQuota_NoQuotaConfigured_ReturnsDefaults(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "member"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	ctx = withTrustedUser(ctx, "alice")
+
+	resp, err := srv.GetTenantQuota(ctx, &pb.GetTenantQuotaRequest{TenantId: "acme"})
+	if err != nil {
+		t.Fatalf("GetTenantQuota: unexpected error: %v", err)
+	}
+	if resp.GetMaxWritesPerMonth() != 0 {
+		t.Errorf("MaxWritesPerMonth = %d, want 0 (default)", resp.GetMaxWritesPerMonth())
+	}
+	if resp.GetWritesUsed() != 0 {
+		t.Errorf("WritesUsed = %d, want 0 (default)", resp.GetWritesUsed())
+	}
+	if resp.GetPeriodStartMs() <= 0 {
+		t.Errorf("PeriodStartMs = %d, want > 0 (synthesized current month)", resp.GetPeriodStartMs())
+	}
+	if resp.GetPeriodEndMs() <= time.Now().UnixMilli() {
+		t.Errorf("PeriodEndMs (%d) must be strictly after now", resp.GetPeriodEndMs())
+	}
+	if resp.GetMaxRpsSustained() != 0 || resp.GetMaxRpsBurst() != 0 {
+		t.Errorf("rps fields = %d/%d, want 0/0",
+			resp.GetMaxRpsSustained(), resp.GetMaxRpsBurst())
+	}
+	if resp.GetHardEnforce() {
+		t.Errorf("HardEnforce = true, want false (default)")
+	}
+}
+
+// TestGetTenantQuota_EmptyTenantID_InvalidArgument: empty tenant_id is
+// rejected before any DB read or auth check.
+func TestGetTenantQuota_EmptyTenantID_InvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	ctx := withTrustedUser(context.Background(), "alice")
+	_, err := srv.GetTenantQuota(ctx, &pb.GetTenantQuotaRequest{TenantId: ""})
+	if err == nil {
+		t.Fatalf("GetTenantQuota: expected InvalidArgument, got nil")
+	}
+	if got := errs.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("GetTenantQuota: code = %v, want InvalidArgument (err=%v)", got, err)
+	}
+}


### PR DESCRIPTION
## Summary

- W2 — GetTenantQuota RPC for EPIC #407.
- Read-only handler over `globalstore.tenant_quotas` + `tenant_usage`.
- `period_end_ms` computed locally (next UTC calendar-month start) so dashboards stay correct for tenants with no writes this period.
- Auth uses the trusted-actor pattern: proto `actor` is ignored, identity is taken from interceptor-populated ctx; access is gated on tenant membership.

## Behaviour

| Condition | Status |
|---|---|
| Empty `tenant_id` | `INVALID_ARGUMENT` |
| No trusted identity / non-member | `PERMISSION_DENIED` |
| `global_store` not wired | `UNIMPLEMENTED` |
| Member or admin role | `OK` with cfg-or-zero + usage-or-synthesised |
| No quota row configured | `OK` with zero-valued cfg fields, real `period_start_ms` / `period_end_ms` |

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — all 5 new GetTenantQuota tests pass; pre-existing `TestServer_UnimplementedRPC_Default` failure is on `origin/main` and unrelated.
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [x] Member happy path: configured cfg + usage round-trip; `period_end_ms > now > period_start_ms`.
- [x] Admin happy path: admin role granted same access as member.
- [x] Non-member with wire-claimed `actor: "system:root"` → `PERMISSION_DENIED` (privilege-escalation guard).
- [x] Quota not configured → defaults; `period_end_ms` still computed.
- [x] Empty `tenant_id` → `INVALID_ARGUMENT`.