### PR TITLE
fix(go-rewrite): rotate Unimplemented canary RPC

### DIFF
--- a/server/go/internal/api/server_test.go
+++ b/server/go/internal/api/server_test.go
@@ -12,22 +12,21 @@ import (
 
 // TestServer_UnimplementedRPC_Default pins the Wave-1 contract: any RPC
 // that hasn't been ported yet still returns codes.Unimplemented via the
-// embedded UnimplementedEntDBServiceServer. We probe a representative
-// not-yet-ported method (GetSchema) rather than Health because Health
-// has now landed (W2.01) and returns OK.
+// embedded UnimplementedEntDBServiceServer. We probe `ExecuteAtomic`
+// because it's still Unimplemented as of this PR; rotate when it ships.
 func TestServer_UnimplementedRPC_Default(t *testing.T) {
 	t.Parallel()
 	srv := New()
 
-	_, err := srv.GetSchema(context.Background(), &pb.GetSchemaRequest{})
+	_, err := srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{})
 	if err == nil {
-		t.Fatalf("GetSchema: expected Unimplemented error, got nil")
+		t.Fatalf("ExecuteAtomic: expected Unimplemented error, got nil")
 	}
 	st, ok := status.FromError(err)
 	if !ok {
-		t.Fatalf("GetSchema: error is not a grpc status: %v", err)
+		t.Fatalf("ExecuteAtomic: error is not a grpc status: %v", err)
 	}
 	if st.Code() != codes.Unimplemented {
-		t.Fatalf("GetSchema: expected code Unimplemented, got %v", st.Code())
+		t.Fatalf("ExecuteAtomic: expected code Unimplemented, got %v", st.Code())
 	}
 }


### PR DESCRIPTION
## Summary

- `TestServer_UnimplementedRPC_Default` was probing `GetSchema`, which has since been implemented (#427), causing the test to fail on `main`.
- Rotate the canary to `ExecuteAtomic` — a representative method that is still served by the embedded `UnimplementedEntDBServiceServer` default and will remain unimplemented for the foreseeable future (lynchpin write path, lands later).
- Comment updated to call out the rotation policy: swap when the probed method ships.

Refs #407

## Test plan

- [x] `cd server/go && go vet ./...` clean
- [x] `cd server/go && go test ./...` all packages green (including `internal/api`)
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean