### PR TITLE
feat(go-rewrite): RemoveTenantMember RPC — Wave 2

### DIFF
--- a/server/go/internal/api/remove_tenant_member.go
+++ b/server/go/internal/api/remove_tenant_member.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// RemoveTenantMember drops a (tenant_id, user_id) row from the
+// cross-tenant tenant_members table. EPIC #407 Wave 2.
+//
+// Spec: docs/go-port/rpcs/RemoveTenantMember.md.
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:2492-2541.
+//
+// # Behavioural pins
+//
+//   - Auth (Go HARDENS vs Python): the Python handler skips the
+//     admin/owner role check entirely (a latent privilege escalation —
+//     any authenticated caller can remove any member). The Go port
+//     closes that gap mirroring AddTenantMember/ChangeMemberRole:
+//     non-admin callers must be the tenant's "owner" or "admin" role,
+//     otherwise PERMISSION_DENIED.
+//
+//     The actor on the wire is UNTRUSTED. We rebind to the trusted
+//     actor returned by auth.Authoritative before any privilege check,
+//     so a forged `actor="system:admin"` from a regular user loses.
+//
+//   - WAL: this RPC bypasses the WAL — direct globalstore write. This
+//     is the documented control-plane carve-out (CLAUDE.md invariant
+//     #1 violation, ported as-is from Python for parity; see spec
+//     "Open questions" §1). Do NOT add WAL coupling to this handler
+//     without an ADR.
+//
+//   - Tenant gate: NOT called. The tenant registry is global, not
+//     region-pinned. (spec §"Side effects" step 2 only checks
+//     globalstore != nil; cross-region pinning explicitly out of
+//     scope, spec "Open questions" §6.)
+//
+//   - ACL/mailbox cascade: NOT performed. Direct grants, group
+//     memberships, shared_index rows, and owned nodes survive. The
+//     caller is responsible for chaining TransferUserContent →
+//     RevokeAllUserAccess → RemoveTenantMember for a complete
+//     off-board (sdk/go/entdb/admin.go:68-71).
+//
+//   - Last-OWNER protection: removing the only "owner" returns
+//     success=false with error="Cannot remove the last owner of a
+//     tenant" (NOT a gRPC error code — this is a domain-level "no-op"
+//     per Python's contract). "admin" is NOT protected — only "owner".
+//     Do NOT add an admin guard without an ADR (spec §"Last-admin
+//     nuance").
+//
+//   - Idempotent removal of a non-member: success=false,
+//     error="Member not found", gRPC code OK. Metric label = "ok"
+//     (Python's distribution: dashboards depend on it).
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const removeTenantMemberMethod = "RemoveTenantMember"
+
+// RemoveTenantMember implements entdb.v1.EntDBService/RemoveTenantMember.
+func (s *Server) RemoveTenantMember(
+	ctx context.Context, req *pb.TenantMemberRequest,
+) (*pb.TenantMemberResponse, error) {
+	start := time.Now()
+	status := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(removeTenantMemberMethod, status, time.Since(start))
+	}()
+
+	// Registry-less deployment guard. Mirrors grpc_server.py:2500-2504.
+	if s.global == nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
+	}
+
+	// Required-field validation. Mirrors grpc_server.py:2506-2511. Note:
+	// `role` is silently ignored — the request type is shared with
+	// AddTenantMember (proto/entdb/v1/entdb.proto:909-919).
+	if req.GetActor() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+	if req.GetTenantId() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetUserId() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "user_id is required")
+	}
+
+	// Trusted-actor rebinding. The wire `actor` is UNTRUSTED. The
+	// auth interceptor (when enabled) installs a verified Identity on
+	// ctx; auth.Authoritative substitutes it for the wire claim. In
+	// no-auth dev/test mode (no interceptor) the claim flows through
+	// unchanged — same behaviour as Python's
+	// auth_interceptor.get_authoritative_actor.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	// Admin/owner gate — Go HARDENS vs Python (closes the privilege-
+	// escalation gap at grpc_server.py:2492-2541). Mirrors the pattern
+	// in AddTenantMember (grpc_server.py:2466-2474) and
+	// ChangeMemberRole (grpc_server.py:2627-2634).
+	if !isAdminOrSystemActor(trusted) {
+		role, err := s.getTenantMemberRole(ctx, req.GetTenantId(), trusted.ID())
+		if err != nil {
+			status = "error"
+			return nil, errs.Errorf(codes.Internal, "RemoveTenantMember: lookup caller role: %v", err)
+		}
+		if role != "owner" && role != "admin" {
+			status = "error"
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"Only owner or admin can remove members")
+		}
+	}
+
+	// Single-pass scan: count owners and locate the target row. Matches
+	// grpc_server.py:2515-2521 — one read, no transaction wrapping.
+	members, err := s.global.GetTenantMembers(ctx, req.GetTenantId())
+	if err != nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Internal, "RemoveTenantMember: list members: %v", err)
+	}
+	var (
+		target     *string // role of the target user, nil if not a member
+		ownerCount int
+	)
+	for _, m := range members {
+		if m.Role == "owner" {
+			ownerCount++
+		}
+		if m.UserID == req.GetUserId() {
+			role := m.Role
+			target = &role
+		}
+	}
+
+	// Not-a-member: idempotent no-op. NOT a gRPC error code; Python
+	// records metric label "ok" (grpc_server.py:2523-2525).
+	if target == nil {
+		return &pb.TenantMemberResponse{
+			Success: false,
+			Error:   "Member not found",
+		}, nil
+	}
+
+	// Last-owner protection. Only "owner" is protected — "admin" is
+	// not (spec §"Last-admin nuance"). Python records metric label
+	// "error" here (grpc_server.py:2527-2532).
+	if *target == "owner" && ownerCount <= 1 {
+		status = "error"
+		return &pb.TenantMemberResponse{
+			Success: false,
+			Error:   "Cannot remove the last owner of a tenant",
+		}, nil
+	}
+
+	// Direct globalstore DELETE — control-plane carve-out from
+	// invariant #1. global_store.py:582-596.
+	removed, err := s.global.RemoveTenantMember(ctx, req.GetTenantId(), req.GetUserId())
+	if err != nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Internal, "RemoveTenantMember: delete: %v", err)
+	}
+	return &pb.TenantMemberResponse{Success: removed}, nil
+}
+
+// isAdminOrSystemActor mirrors grpc_server.py:2053-2069. The trusted
+// actor is admin/system iff it carries the "system:" or "admin:"
+// prefix.
+func isAdminOrSystemActor(a auth.Actor) bool {
+	return a.IsSystem() || a.IsAdmin()
+}
+
+// getTenantMemberRole returns the role of userID inside tenantID, or
+// "" if the user is not a member. Mirrors grpc_server.py:2290-2296
+// (`_get_member_role`).
+func (s *Server) getTenantMemberRole(ctx context.Context, tenantID, userID string) (string, error) {
+	members, err := s.global.GetTenantMembers(ctx, tenantID)
+	if err != nil {
+		return "", err
+	}
+	for _, m := range members {
+		if m.UserID == userID {
+			return m.Role, nil
+		}
+	}
+	return "", nil
+}

--- a/server/go/internal/api/remove_tenant_member_test.go
+++ b/server/go/internal/api/remove_tenant_member_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for RemoveTenantMember (EPIC #407, Wave 2). The Go port closes
+// the auth-parity gap against Python — see RemoveTenantMember.md
+// "Auth (admin only; trusted-actor)".
+
+package api_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// seedTenantWithMembers creates `tenantID` and inserts the supplied
+// (user_id, role) memberships. Helper for RemoveTenantMember tests.
+func seedTenantWithMembers(t *testing.T, gs *globalstore.GlobalStore, tenantID string, members map[string]string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, tenantID, tenantID, "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant(%q): %v", tenantID, err)
+	}
+	for uid, role := range members {
+		if err := gs.AddTenantMember(ctx, tenantID, uid, role); err != nil {
+			t.Fatalf("AddTenantMember(%q,%q,%q): %v", tenantID, uid, role, err)
+		}
+	}
+}
+
+// TestRemoveTenantMember_AdminHappyPath: an admin caller removes a
+// regular member; the row is deleted and Success is true. Mirrors
+// test_tenant_registry.py:462-479 (Python happy path), with the added
+// admin-role enforcement that Go layers on top.
+func TestRemoveTenantMember_AdminHappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	seedTenantWithMembers(t, gs, "acme", map[string]string{
+		"alice": "owner",
+		"carol": "admin",
+		"bob":   "member",
+	})
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Trusted actor on ctx is admin "carol"; the wire actor matches.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "user:carol",
+	})
+
+	resp, err := srv.RemoveTenantMember(ctx, &pb.TenantMemberRequest{
+		Actor:    "user:carol",
+		TenantId: "acme",
+		UserId:   "bob",
+	})
+	if err != nil {
+		t.Fatalf("RemoveTenantMember: unexpected error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("RemoveTenantMember: success=false, want true (resp=%+v)", resp)
+	}
+	if resp.GetError() != "" {
+		t.Fatalf("RemoveTenantMember: error=%q, want empty", resp.GetError())
+	}
+
+	// Verify bob is gone, owner + admin remain.
+	members, err := gs.GetTenantMembers(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("members after delete: got %d, want 2 (rows=%+v)", len(members), members)
+	}
+	for _, m := range members {
+		if m.UserID == "bob" {
+			t.Fatalf("RemoveTenantMember: bob still present (%+v)", m)
+		}
+	}
+}
+
+// TestRemoveTenantMember_NonAdminDenied: a regular member trying to
+// remove another member is rejected with PERMISSION_DENIED. This is
+// the auth-parity-gap fix — Python lets this succeed (latent privilege
+// escalation; spec §"Auth").
+func TestRemoveTenantMember_NonAdminDenied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	seedTenantWithMembers(t, gs, "acme", map[string]string{
+		"alice": "owner",
+		"eve":   "member",
+		"bob":   "member",
+	})
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Trusted actor: eve, who is just a "member" — not admin/owner.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "user:eve",
+	})
+
+	resp, err := srv.RemoveTenantMember(ctx, &pb.TenantMemberRequest{
+		Actor:    "user:eve",
+		TenantId: "acme",
+		UserId:   "bob",
+	})
+	if err == nil {
+		t.Fatalf("RemoveTenantMember: expected PERMISSION_DENIED, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("RemoveTenantMember: not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("RemoveTenantMember: code=%v, want PermissionDenied", st.Code())
+	}
+
+	// Bob must still be present — no row was deleted.
+	members, err := gs.GetTenantMembers(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	bobPresent := false
+	for _, m := range members {
+		if m.UserID == "bob" {
+			bobPresent = true
+			break
+		}
+	}
+	if !bobPresent {
+		t.Fatalf("RemoveTenantMember: denied, but bob was deleted anyway (rows=%+v)", members)
+	}
+}
+
+// TestRemoveTenantMember_LastOwnerBlocked: removing the only "owner"
+// returns success=false with the canonical "last owner" error string.
+// Mirrors test_tenant_registry.py:481-495.
+func TestRemoveTenantMember_LastOwnerBlocked(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	seedTenantWithMembers(t, gs, "acme", map[string]string{
+		"alice": "owner",
+		"bob":   "member",
+	})
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// alice is the sole owner — and is calling. As owner, she passes
+	// the admin gate.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "user:alice",
+	})
+
+	resp, err := srv.RemoveTenantMember(ctx, &pb.TenantMemberRequest{
+		Actor:    "user:alice",
+		TenantId: "acme",
+		UserId:   "alice",
+	})
+	if err != nil {
+		t.Fatalf("RemoveTenantMember: unexpected error: %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatalf("RemoveTenantMember: success=true, want false (resp=%+v)", resp)
+	}
+	if !strings.Contains(strings.ToLower(resp.GetError()), "last owner") {
+		t.Fatalf("RemoveTenantMember: error=%q, want substring %q", resp.GetError(), "last owner")
+	}
+
+	// alice must still be present.
+	members, err := gs.GetTenantMembers(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	alicePresent := false
+	for _, m := range members {
+		if m.UserID == "alice" {
+			alicePresent = true
+			break
+		}
+	}
+	if !alicePresent {
+		t.Fatalf("RemoveTenantMember: last owner was deleted anyway (rows=%+v)", members)
+	}
+}
+
+// TestRemoveTenantMember_IdempotentNonMember: removing a user who is
+// not a member returns success=false with "Member not found" — gRPC
+// code OK (idempotent no-op). Mirrors test_tenant_registry.py:513-526.
+func TestRemoveTenantMember_IdempotentNonMember(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	seedTenantWithMembers(t, gs, "acme", map[string]string{
+		"alice": "owner",
+	})
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// admin caller bypasses the role gate via the system: prefix on
+	// the trusted Identity.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "system:admin",
+	})
+
+	resp, err := srv.RemoveTenantMember(ctx, &pb.TenantMemberRequest{
+		Actor:    "system:admin",
+		TenantId: "acme",
+		UserId:   "ghost",
+	})
+	if err != nil {
+		t.Fatalf("RemoveTenantMember: unexpected error: %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatalf("RemoveTenantMember: success=true, want false (resp=%+v)", resp)
+	}
+	if !strings.Contains(strings.ToLower(resp.GetError()), "not found") {
+		t.Fatalf("RemoveTenantMember: error=%q, want substring %q", resp.GetError(), "not found")
+	}
+}


### PR DESCRIPTION
## Summary

Ports `entdb.v1.EntDBService/RemoveTenantMember` from the Python reference handler (`server/python/entdb_server/api/grpc_server.py:2492-2541`) to the Go server. EPIC #407, Wave 2.

**Auth-gap fix vs Python.** The Python handler skips the admin/owner role check entirely — a latent privilege escalation where any authenticated caller can remove any tenant member. The Go port closes that gap by mirroring `AddTenantMember` / `ChangeMemberRole`: non-admin/non-owner callers receive `PERMISSION_DENIED`. Wire `actor` is rebound through `auth.Authoritative` before any privilege decision, so a forged `actor="system:admin"` from a regular user loses.

## Behavioural pins (parity unless noted)

- Trusted-actor admin/owner gate — **HARDENS vs Python** (closes privilege-escalation gap pinned by the new `TestRemoveTenantMember_NonAdminDenied`).
- Direct `globalstore` write (control-plane carve-out from invariant #1; ported as-is per spec, tracked as invariant-debt).
- Last-OWNER protection only — `admin` deliberately not protected per spec "Last-admin nuance". Returns OK with `success=false`, `error="Cannot remove the last owner of a tenant"`.
- Idempotent non-member removal: OK with `success=false`, `error="Member not found"`. Metric label `"ok"`.
- No tenant gate (registry is global, not region-pinned).
- No ACL / mailbox / shared_index cascade — caller is responsible for chaining `TransferUserContent` → `RevokeAllUserAccess` → `RemoveTenantMember`.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/api/ -run RemoveTenantMember` — 4/4 pass
  - `TestRemoveTenantMember_AdminHappyPath`
  - `TestRemoveTenantMember_NonAdminDenied` (Go-only auth-gap regression guard)
  - `TestRemoveTenantMember_LastOwnerBlocked`
  - `TestRemoveTenantMember_IdempotentNonMember`
- [x] `uvx ruff check .` clean
- [x] `uvx ruff format --check .` clean
- [ ] Note: `TestServer_UnimplementedRPC_Default` failure on `internal/api` is pre-existing on `main` (GetSchema is now implemented; the probe uses an obsolete RPC) and unrelated to this PR.

## Spec

`docs/go-port/rpcs/RemoveTenantMember.md`.