### PR TITLE
feat(go-rewrite): ListTenants RPC — Wave 2

### DIFF
--- a/server/go/internal/api/list_tenants.go
+++ b/server/go/internal/api/list_tenants.go
@@ -1,0 +1,190 @@
+// ListTenants RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/ListTenants.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:82 (rpc), :611-619 (messages).
+// Reference Python: server/python/entdb_server/api/grpc_server.py:1537-1603.
+//
+// Identity-driven, request-empty handler:
+//
+//   - Request carries no actor field — there is nothing on the wire to
+//     validate. The "trusted-actor" rule has the trusted Identity
+//     established by the auth interceptor as its sole input. Pinned by
+//     tests/python/integration/test_privilege_escalation.py:386-417
+//     (claimed admin actor in metadata MUST NOT bypass membership
+//     filtering for user:eve).
+//
+//   - Visibility classes:
+//
+//   - No trusted Identity on ctx (interceptor missing) →
+//     PERMISSION_DENIED, never falls open. Pinned by
+//     tests/python/unit/test_listtenants_auth.py:179-192 and
+//     tests/python/integration/test_grpc_contract.py:288-295.
+//
+//   - "__system__", "system:*", "admin:*" → all tenants this node
+//     hosts (sharding still applied). Pinned by
+//     test_listtenants_auth.py:99-111 and :200-230.
+//
+//   - "user:<id>" or any other bare id → intersection of node-local
+//     tenants ∩ globalstore.GetUserTenants(<id>). Strip the "user:"
+//     prefix before the lookup. Pinned by
+//     test_listtenants_auth.py:119-137 and :157-171.
+//
+//   - Read-only. No WAL append, no canonical_store write, no
+//     globalstore write.
+//
+//   - Swallow-as-empty. Any unhandled error path inside the handler
+//     returns &ListTenantsResponse{} with grpc.OK and metric
+//     status="error", matching the Python `except Exception` at
+//     grpc_server.py:1600-1603. Returning codes.Internal would be a
+//     contract break. PERMISSION_DENIED is the *intended* error path
+//     and MUST escape the swallow.
+//
+// Source-of-truth: the Go port reads its tenant inventory from
+// globalstore.ListTenants("active") (the registry table) rather than
+// the Python directory scan over `data_dir/tenant_*.db`. The two land
+// on the same set in production deployments because tenant creation
+// always inserts into the registry first; the empty-globalstore branch
+// from Python (test harness with no globalstore) is preserved by the
+// nil-globalstore short-circuit below.
+
+package api
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const listTenantsMethod = "ListTenants"
+
+// ListTenants implements entdb.v1.EntDBService/ListTenants. See file
+// header for the identity-driven visibility rules and swallow-as-empty
+// error contract.
+func (s *Server) ListTenants(
+	ctx context.Context,
+	_ *pb.ListTenantsRequest,
+) (resp *pb.ListTenantsResponse, err error) {
+	start := time.Now()
+	stat := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(listTenantsMethod, stat, time.Since(start))
+	}()
+
+	// Swallow panics → empty + OK. PERMISSION_DENIED returns through
+	// the explicit `return` below, NOT via panic, so it escapes this
+	// recover unchanged. Mirrors Python's outer except at
+	// grpc_server.py:1600-1603.
+	defer func() {
+		if r := recover(); r != nil {
+			stat = "error"
+			resp = &pb.ListTenantsResponse{Tenants: []*pb.TenantInfo{}}
+			err = nil
+			_ = r
+		}
+	}()
+
+	// 1. Trusted identity is required. Nil → PERMISSION_DENIED.
+	id, ok := auth.IdentityFromContext(ctx)
+	if !ok || id.Subject == "" {
+		stat = "error"
+		return nil, status.Errorf(codes.PermissionDenied,
+			"ListTenants requires an authenticated caller")
+	}
+	trusted := id.Subject
+
+	// 2. Admin classification — same prefix scheme the Python handler
+	//    uses at grpc_server.py:1568-1572.
+	isAdmin := trusted == "__system__" ||
+		strings.HasPrefix(trusted, "system:") ||
+		strings.HasPrefix(trusted, "admin:")
+
+	// 3. Node-local tenant inventory. Source of truth in the Go port
+	//    is the globalstore tenant_registry; if it isn't wired, the
+	//    embedded-harness branch below returns empty for non-admin
+	//    callers (matches test_listtenants_auth.py:238-258).
+	all, lerr := s.listLocalTenantIDs(ctx)
+	if lerr != nil {
+		// Swallow → empty + OK. Matches Python's `except Exception`
+		// at grpc_server.py:1600-1603.
+		stat = "error"
+		return &pb.ListTenantsResponse{Tenants: []*pb.TenantInfo{}}, nil
+	}
+
+	// 4. Sharding filter. nil sharding == single-node default; nothing
+	//    to strip. Matches grpc_server.py:1575-1576.
+	if s.sharding != nil && s.sharding.IsMine != nil {
+		filtered := all[:0]
+		for _, tid := range all {
+			if s.sharding.IsMine(tid) {
+				filtered = append(filtered, tid)
+			}
+		}
+		all = filtered
+	}
+
+	// 5. Visibility intersection.
+	var visible []string
+	switch {
+	case isAdmin:
+		visible = all
+	case s.global != nil:
+		userID := strings.TrimPrefix(trusted, "user:")
+		members, gerr := s.global.GetUserTenants(ctx, userID)
+		if gerr != nil {
+			stat = "error"
+			return &pb.ListTenantsResponse{Tenants: []*pb.TenantInfo{}}, nil
+		}
+		set := make(map[string]struct{}, len(members))
+		for _, m := range members {
+			set[m.TenantID] = struct{}{}
+		}
+		visible = make([]string, 0, len(all))
+		for _, tid := range all {
+			if _, ok := set[tid]; ok {
+				visible = append(visible, tid)
+			}
+		}
+	default:
+		// No globalstore wired (embedded harness) — empty, not all.
+		// Matches grpc_server.py:1588-1591.
+		visible = []string{}
+	}
+
+	// Stable ascending order. Spec note: Python returns sorted glob
+	// order; explicit sort.Strings defends against future drift.
+	sort.Strings(visible)
+
+	out := make([]*pb.TenantInfo, 0, len(visible))
+	for _, tid := range visible {
+		out = append(out, &pb.TenantInfo{TenantId: tid})
+	}
+	return &pb.ListTenantsResponse{Tenants: out}, nil
+}
+
+// listLocalTenantIDs returns the node-local tenant inventory as a flat
+// slice of tenant_ids. Source: globalstore.ListTenants("active"). When
+// no globalstore is wired (Wave-1 bring-up / embedded harness), the
+// inventory is empty — admins see [], regular users see [] via the
+// nil-globalstore branch in the caller.
+func (s *Server) listLocalTenantIDs(ctx context.Context) ([]string, error) {
+	if s.global == nil {
+		return []string{}, nil
+	}
+	tenants, err := s.global.ListTenants(ctx, "active")
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(tenants))
+	for _, t := range tenants {
+		ids = append(ids, t.TenantID)
+	}
+	return ids, nil
+}

--- a/server/go/internal/api/list_tenants_test.go
+++ b/server/go/internal/api/list_tenants_test.go
@@ -1,0 +1,409 @@
+// Tests for the ListTenants RPC. Pinned by:
+//   - tests/python/unit/test_listtenants_auth.py:99-258 (admin/user
+//     visibility, nil identity → PERMISSION_DENIED, sharding still
+//     applies, no globalstore → empty for users).
+//   - tests/python/integration/test_privilege_escalation.py:386-417
+//     (claimed admin actor on the wire MUST NOT bypass membership
+//     filtering).
+//   - tests/python/integration/test_grpc_contract.py:288-295
+//     (over-the-wire empty request without auth interceptor →
+//     PERMISSION_DENIED).
+//
+// The Go port maps these onto auth.WithIdentity(ctx, ...) instead of
+// the Python ContextVar, but the visibility classes and error contract
+// are identical.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
+)
+
+// withIdentitySubject is a thin helper: wrap ctx with a verified
+// identity carrying the given prefix-encoded subject ("user:alice",
+// "system:admin", etc). Mirrors what the auth interceptor does in
+// production.
+func withIdentitySubject(ctx context.Context, subject string) context.Context {
+	return auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: subject,
+	})
+}
+
+// tenantIDs flattens a *ListTenantsResponse into the stable string
+// slice that test asserts compare against.
+func tenantIDs(resp *pb.ListTenantsResponse) []string {
+	if resp == nil {
+		return nil
+	}
+	out := make([]string, 0, len(resp.GetTenants()))
+	for _, t := range resp.GetTenants() {
+		out = append(out, t.GetTenantId())
+	}
+	return out
+}
+
+// TestListTenants_Admin_SeesAll: every admin-class identity
+// ("__system__", "system:*", "admin:*") sees every tenant on the
+// node. Pinned by test_listtenants_auth.py:99-111.
+func TestListTenants_Admin_SeesAll(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"acme", "beta", "carrot"} {
+		if _, err := gs.CreateTenant(ctx, name, name, "us-east-1"); err != nil {
+			t.Fatalf("CreateTenant(%q): %v", name, err)
+		}
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	cases := []string{
+		"__system__",
+		"system:admin",
+		"system:gdpr-worker",
+		"admin:root",
+	}
+	for _, subject := range cases {
+		t.Run(subject, func(t *testing.T) {
+			actx := withIdentitySubject(ctx, subject)
+			resp, err := srv.ListTenants(actx, &pb.ListTenantsRequest{})
+			if err != nil {
+				t.Fatalf("ListTenants: unexpected err: %v", err)
+			}
+			got := tenantIDs(resp)
+			want := []string{"acme", "beta", "carrot"}
+			if len(got) != len(want) {
+				t.Fatalf("tenants: got %v, want %v", got, want)
+			}
+			for i, g := range got {
+				if g != want[i] {
+					t.Fatalf("tenants[%d]: got %q, want %q (full %v)", i, g, want[i], got)
+				}
+			}
+		})
+	}
+}
+
+// TestListTenants_RegularUser_SeesOwnOnly: a "user:<id>" caller sees
+// only the tenants they are a member of. Non-member tenants stay
+// invisible — no enumeration leak. Pinned by
+// test_listtenants_auth.py:119-137.
+func TestListTenants_RegularUser_SeesOwnOnly(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"acme", "beta", "carrot"} {
+		if _, err := gs.CreateTenant(ctx, name, name, "us-east-1"); err != nil {
+			t.Fatalf("CreateTenant(%q): %v", name, err)
+		}
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "member"); err != nil {
+		t.Fatalf("AddTenantMember(acme,alice): %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "carrot", "alice", "member"); err != nil {
+		t.Fatalf("AddTenantMember(carrot,alice): %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "beta", "bob", "member"); err != nil {
+		t.Fatalf("AddTenantMember(beta,bob): %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	actx := withIdentitySubject(ctx, "user:alice")
+	resp, err := srv.ListTenants(actx, &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("ListTenants: %v", err)
+	}
+	got := tenantIDs(resp)
+	want := []string{"acme", "carrot"}
+	if len(got) != len(want) {
+		t.Fatalf("tenants: got %v, want %v", got, want)
+	}
+	for i, g := range got {
+		if g != want[i] {
+			t.Fatalf("tenants[%d]: got %q, want %q (full %v)", i, g, want[i], got)
+		}
+	}
+}
+
+// TestListTenants_RegularUser_NoMemberships_Empty: a user with zero
+// memberships sees an empty list — no enumeration leak. Pinned by
+// test_listtenants_auth.py:140-154.
+func TestListTenants_RegularUser_NoMemberships_Empty(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	actx := withIdentitySubject(ctx, "user:eve")
+	resp, err := srv.ListTenants(actx, &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("ListTenants: %v", err)
+	}
+	if got := tenantIDs(resp); len(got) != 0 {
+		t.Fatalf("tenants: got %v, want []", got)
+	}
+}
+
+// TestListTenants_UserPrefix_Stripped: the "user:" prefix is stripped
+// before the membership lookup, so a session subject "user:alice" and
+// a bare-id subject "alice" both resolve to alice's memberships.
+// Pinned by test_listtenants_auth.py:157-171.
+func TestListTenants_UserPrefix_Stripped(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "member"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	prefixed, err := srv.ListTenants(withIdentitySubject(ctx, "user:alice"), &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("prefixed: %v", err)
+	}
+	bare, err := srv.ListTenants(withIdentitySubject(ctx, "alice"), &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("bare: %v", err)
+	}
+	if got := tenantIDs(prefixed); len(got) != 1 || got[0] != "acme" {
+		t.Fatalf("prefixed: got %v, want [acme]", got)
+	}
+	if got := tenantIDs(bare); len(got) != 1 || got[0] != "acme" {
+		t.Fatalf("bare: got %v, want [acme]", got)
+	}
+}
+
+// TestListTenants_NoIdentity_PermissionDenied: with no trusted
+// identity on the context (interceptor missing), the handler MUST
+// return PERMISSION_DENIED and NOT fall open. Pinned by
+// test_listtenants_auth.py:179-192 and test_grpc_contract.py:288-295.
+func TestListTenants_NoIdentity_PermissionDenied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Bare context — no auth.WithIdentity attached.
+	resp, err := srv.ListTenants(ctx, &pb.ListTenantsRequest{})
+	if err == nil {
+		t.Fatalf("expected error, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("err is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("code: got %v, want PermissionDenied", st.Code())
+	}
+}
+
+// TestListTenants_EmptyIdentity_PermissionDenied: an Identity
+// attached to ctx but with no Subject is treated the same as no
+// identity at all (IdentityFromContext returns ok=false for the
+// zero value). The handler MUST return PERMISSION_DENIED.
+func TestListTenants_EmptyIdentity_PermissionDenied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{})
+	resp, err := srv.ListTenants(ctx, &pb.ListTenantsRequest{})
+	if err == nil {
+		t.Fatalf("expected error, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("err is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("code: got %v, want PermissionDenied", st.Code())
+	}
+}
+
+// TestListTenants_NoGlobalStore_RegularUser_Empty: in the embedded
+// harness (no globalstore wired), a regular user sees the empty
+// list rather than the unfiltered inventory. Pinned by
+// test_listtenants_auth.py:238-258.
+func TestListTenants_NoGlobalStore_RegularUser_Empty(t *testing.T) {
+	t.Parallel()
+	srv := api.New() // no WithGlobalStore.
+
+	ctx := withIdentitySubject(context.Background(), "user:alice")
+	resp, err := srv.ListTenants(ctx, &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("ListTenants: %v", err)
+	}
+	if got := tenantIDs(resp); len(got) != 0 {
+		t.Fatalf("tenants: got %v, want []", got)
+	}
+}
+
+// TestListTenants_Sharding_AppliesToAdmin: even an admin caller is
+// filtered by the node's sharding view. Tenants the node does not
+// own are stripped from the response. Pinned by
+// test_listtenants_auth.py:200-230.
+func TestListTenants_Sharding_AppliesToAdmin(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"acme", "beta", "carrot"} {
+		if _, err := gs.CreateTenant(ctx, name, name, "us-east-1"); err != nil {
+			t.Fatalf("CreateTenant(%q): %v", name, err)
+		}
+	}
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithSharding(&tenant.Sharding{
+			NodeID: "node-a",
+			IsMine: func(tid string) bool { return tid == "acme" || tid == "carrot" },
+		}),
+	)
+
+	actx := withIdentitySubject(ctx, "system:admin")
+	resp, err := srv.ListTenants(actx, &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("ListTenants: %v", err)
+	}
+	got := tenantIDs(resp)
+	want := []string{"acme", "carrot"}
+	if len(got) != len(want) {
+		t.Fatalf("tenants: got %v, want %v", got, want)
+	}
+	for i, g := range got {
+		if g != want[i] {
+			t.Fatalf("tenants[%d]: got %q, want %q", i, g, want[i])
+		}
+	}
+}
+
+// TestListTenants_PrivilegeEscalation_BodyClaimIgnored: the request
+// payload has no actor field, so there's nothing for a malicious
+// caller to spoof at this RPC. The handler MUST derive visibility
+// purely from the trusted Identity on ctx, even if a sibling RPC
+// idiom would have looked at a request-context actor. Mirrors
+// test_privilege_escalation.py:386-417 (eve cannot claim admin and
+// see everything).
+func TestListTenants_PrivilegeEscalation_BodyClaimIgnored(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"acme", "beta", "carrot"} {
+		if _, err := gs.CreateTenant(ctx, name, name, "us-east-1"); err != nil {
+			t.Fatalf("CreateTenant(%q): %v", name, err)
+		}
+	}
+	if err := gs.AddTenantMember(ctx, "beta", "eve", "member"); err != nil {
+		t.Fatalf("AddTenantMember(beta,eve): %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Trusted subject is user:eve — eve cannot escalate to admin via
+	// any wire path. ListTenantsRequest is empty; there is no actor
+	// field to spoof.
+	actx := withIdentitySubject(ctx, "user:eve")
+	resp, err := srv.ListTenants(actx, &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("ListTenants: %v", err)
+	}
+	got := tenantIDs(resp)
+	want := []string{"beta"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("tenants: got %v, want %v", got, want)
+	}
+}
+
+// TestListTenants_EmptyResponse_Wire: the response has a non-nil
+// empty Tenants slice. protobuf-go marshals nil and []*TenantInfo{}
+// identically, but the explicit empty slice is the documented Go
+// shape (see GetMailbox.go for the same pattern).
+func TestListTenants_EmptyResponse_Wire(t *testing.T) {
+	t.Parallel()
+	srv := api.New() // no globalstore — admin still gets [] because the
+	// inventory is empty.
+
+	ctx := withIdentitySubject(context.Background(), "system:admin")
+	resp, err := srv.ListTenants(ctx, &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("ListTenants: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("nil response")
+	}
+	if resp.GetTenants() == nil {
+		t.Fatalf("Tenants slice should be non-nil even when empty")
+	}
+	if len(resp.GetTenants()) != 0 {
+		t.Fatalf("expected empty tenants, got %v", tenantIDs(resp))
+	}
+}
+
+// TestListTenants_GlobalStoreError_SwallowToEmpty: an internal error
+// from globalstore.GetUserTenants MUST be swallowed to an empty,
+// OK-coded response — matches Python's `except Exception` at
+// grpc_server.py:1600-1603. Surfacing codes.Internal is a contract
+// break.
+//
+// We trigger the error by closing the globalstore before the RPC so
+// the underlying *sql.DB returns "database is closed" on every query.
+func TestListTenants_GlobalStoreError_SwallowToEmpty(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Close the underlying store to force every subsequent query to
+	// error. The Cleanup in newGlobalStore is idempotent (uses _ =
+	// gs.Close()).
+	if err := gs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	actx := withIdentitySubject(ctx, "user:alice")
+	resp, err := srv.ListTenants(actx, &pb.ListTenantsRequest{})
+	if err != nil {
+		t.Fatalf("ListTenants: expected swallow-to-OK, got err=%v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil empty response")
+	}
+	if got := tenantIDs(resp); len(got) != 0 {
+		t.Fatalf("tenants: got %v, want []", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `entdb.v1.EntDBService/ListTenants` in the Go server (EPIC #407, W2). Identity-driven, request-empty handler.
- Visibility: `__system__`/`system:*`/`admin:*` see all node-local tenants (sharding still applies); `user:<id>` (or bare id) sees the intersection with `globalstore.GetUserTenants(<id>)`; nil/empty trusted Identity rejected with `PERMISSION_DENIED`; no globalstore wired → empty list for non-admin callers.
- Read-only. Swallow-on-error contract: any unhandled internal error returns `ListTenantsResponse{}` with `grpc.OK` and `status="error"` metric — matches Python at `grpc_server.py:1600-1603`. `PERMISSION_DENIED` escapes the swallow.

## Test plan
- [x] `go vet ./...` clean.
- [x] `go test -run ListTenants ./internal/api/...` passes (11 tests, including all admin variants, regular user filtering, prefix-strip, no-identity, empty-identity, no-globalstore, sharding-applies-to-admin, privilege-escalation, empty-response shape, and swallow-on-error via closed globalstore).
- [x] `gofmt -l` clean.
- [x] `uvx ruff@0.15.7 check` and `format --check` clean.
- [ ] Pre-existing `TestServer_UnimplementedRPC_Default` failure on `main` is unrelated (probes `GetSchema` which is now implemented; reproduced on `origin/main` without these changes).

Spec: `docs/go-port/rpcs/ListTenants.md`. Pinned by `tests/python/unit/test_listtenants_auth.py` and `tests/python/integration/test_privilege_escalation.py`.