### PR TITLE
feat(go-rewrite): ChangeMemberRole RPC — Wave 2

### DIFF
--- a/server/go/internal/api/change_member_role.go
+++ b/server/go/internal/api/change_member_role.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// ChangeMemberRole implements entdb.v1.EntDBService/ChangeMemberRole.
+//
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:2601-2652.
+// Port spec: docs/go-port/rpcs/ChangeMemberRole.md.
+//
+// Behaviour parity vs. the Python handler is preserved on the wire shape
+// (request/response, error code asymmetry between auth-failure and
+// missing-row), but two PLAN.md §6 drifts are folded in here:
+//
+//  1. WAL-invariant carve-out (HIGH risk in the spec's "Open questions"
+//     §1). tenant_members is a control-plane table on globalstore; per
+//     the §6 carve-out it is intentionally non-WAL'd. The Go handler
+//     writes directly via globalstore.ChangeMemberRole, matching Python
+//     by construction.
+//
+//  2. Last-owner demotion protection. The Python handler (spec §"Open
+//     questions" item 2) lets the sole owner demote themselves and
+//     brick the tenant. The Go port adds an explicit check: if the
+//     target user is the only "owner" row in tenant_members and
+//     new_role != "owner", reject with FAILED_PRECONDITION. This is
+//     the §6 drift the spec asked us to add on the Go side.
+//
+//  3. Region pin gap (spec §"Open questions" item 5). Not fixed here —
+//     parity preserved; the Go handler does NOT call s.checkTenant.
+//     Filed as a follow-up.
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const grpcMethodChangeMemberRole = "ChangeMemberRole"
+
+// ChangeMemberRole updates a tenant member's role.
+//
+// Authorization (admin-only via trusted-actor):
+//
+//   - Trusted actor (auth.Authoritative) is system: or admin: → allowed.
+//   - Trusted actor is a user: with tenant role "owner" or "admin"
+//     in the tenant_members row for tenantID → allowed.
+//   - Otherwise → codes.PermissionDenied.
+//
+// Last-owner protection: if the target user is the sole "owner" of the
+// tenant and the new role is not "owner", the call is rejected with
+// codes.FailedPrecondition. This is a Go-side improvement over the
+// Python handler's silent self-brick.
+func (s *Server) ChangeMemberRole(
+	ctx context.Context,
+	req *pb.ChangeMemberRoleRequest,
+) (*pb.ChangeMemberRoleResponse, error) {
+	start := time.Now()
+
+	if s.global == nil {
+		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
+	}
+	if req.GetActor() == "" {
+		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+	if req.GetTenantId() == "" {
+		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetUserId() == "" {
+		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		return nil, errs.Errorf(codes.InvalidArgument, "user_id is required")
+	}
+	if req.GetNewRole() == "" {
+		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		return nil, errs.Errorf(codes.InvalidArgument, "new_role is required")
+	}
+
+	// Trusted-actor rebind. Privilege checks below MUST consult `trusted`
+	// (never `req.Actor`); honouring the request payload is the
+	// privilege-escalation hole fixed by commit fece3fb.
+	claimed := auth.ParseActor(req.GetActor())
+	trusted := auth.Authoritative(ctx, claimed)
+
+	if !(trusted.IsSystem() || trusted.IsAdmin()) {
+		// Caller must be a tenant-level admin/owner to mutate roles.
+		callerRole, err := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
+		if err != nil {
+			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+			return nil, err
+		}
+		if callerRole != "owner" && callerRole != "admin" {
+			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"Only tenant admins can change member roles")
+		}
+	}
+
+	// Last-owner demotion guard. We compute this before the UPDATE so
+	// the caller sees a deterministic FAILED_PRECONDITION rather than a
+	// post-hoc "tenant has no owners" surprise.
+	if req.GetNewRole() != "owner" {
+		members, err := s.global.GetTenantMembers(ctx, req.GetTenantId())
+		if err != nil {
+			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+			return nil, errs.Errorf(codes.Internal, "list tenant members: %v", err)
+		}
+		ownerCount := 0
+		targetIsOwner := false
+		for _, m := range members {
+			if m.Role == "owner" {
+				ownerCount++
+				if m.UserID == req.GetUserId() {
+					targetIsOwner = true
+				}
+			}
+		}
+		if targetIsOwner && ownerCount == 1 {
+			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+			return nil, errs.Errorf(codes.FailedPrecondition,
+				"cannot demote the last owner of tenant %q", req.GetTenantId())
+		}
+	}
+
+	updated, err := s.global.ChangeMemberRole(
+		ctx, req.GetTenantId(), req.GetUserId(), req.GetNewRole(),
+	)
+	if err != nil {
+		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		return &pb.ChangeMemberRoleResponse{Success: false, Error: err.Error()}, nil
+	}
+	if !updated {
+		// Soft failure (matches Python: gRPC OK, response.success=false).
+		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "ok", time.Since(start))
+		return &pb.ChangeMemberRoleResponse{Success: false, Error: "Member not found"}, nil
+	}
+
+	metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "ok", time.Since(start))
+	return &pb.ChangeMemberRoleResponse{Success: true}, nil
+}
+
+// lookupMemberRole returns the trusted caller's role within tenantID, or
+// the empty string if no membership row exists. Errors from the
+// globalstore are surfaced as codes.Internal — mirrors how the Python
+// handler lets a SQLite error bubble through the unconditional catch.
+func (s *Server) lookupMemberRole(ctx context.Context, tenantID, userID string) (string, error) {
+	if userID == "" {
+		return "", nil
+	}
+	members, err := s.global.GetTenantMembers(ctx, tenantID)
+	if err != nil {
+		return "", errs.Errorf(codes.Internal, "list tenant members: %v", err)
+	}
+	for _, m := range members {
+		if m.UserID == userID {
+			return m.Role, nil
+		}
+	}
+	return "", nil
+}

--- a/server/go/internal/api/change_member_role_test.go
+++ b/server/go/internal/api/change_member_role_test.go
@@ -1,0 +1,193 @@
+// Tests for ChangeMemberRole. Behavioural pins are documented in
+// docs/go-port/rpcs/ChangeMemberRole.md and the Python contract suite
+// (tests/python/unit/test_tenant_registry.py:585-686). The Go-side
+// drift this file enforces is the last-owner demotion protection
+// (PLAN.md §6) — the Python handler does NOT have this and the Go
+// port adds it.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// changeRoleFixture seeds a tenant with the canonical 3-member shape
+// used across these tests:
+//
+//	alice -> owner
+//	bob   -> admin
+//	carol -> member
+//
+// Returns the wired Server and the underlying GlobalStore so individual
+// tests can re-seed extra rows or reach into the store for assertions.
+func changeRoleFixture(t *testing.T) (*api.Server, *globalstore.GlobalStore, context.Context) {
+	t.Helper()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember alice: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "bob", "admin"); err != nil {
+		t.Fatalf("AddTenantMember bob: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "carol", "member"); err != nil {
+		t.Fatalf("AddTenantMember carol: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	return srv, gs, ctx
+}
+
+// TestChangeMemberRole_AdminPromotesMember pins the happy path: an
+// existing tenant admin (bob) promotes a member (carol) to admin.
+func TestChangeMemberRole_AdminPromotesMember(t *testing.T) {
+	t.Parallel()
+
+	srv, gs, ctx := changeRoleFixture(t)
+
+	resp, err := srv.ChangeMemberRole(ctx, &pb.ChangeMemberRoleRequest{
+		Actor:    "user:bob",
+		TenantId: "acme",
+		UserId:   "carol",
+		NewRole:  "admin",
+	})
+	if err != nil {
+		t.Fatalf("ChangeMemberRole: unexpected error: %v", err)
+	}
+	if resp == nil || !resp.GetSuccess() {
+		t.Fatalf("ChangeMemberRole: success=false; resp=%+v", resp)
+	}
+
+	// Verify the row actually moved.
+	members, err := gs.GetTenantMembers(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	got := ""
+	for _, m := range members {
+		if m.UserID == "carol" {
+			got = m.Role
+		}
+	}
+	if got != "admin" {
+		t.Fatalf("carol role = %q, want %q", got, "admin")
+	}
+}
+
+// TestChangeMemberRole_AdminDemotesAdmin pins the demote path and
+// confirms admin role grants the privilege (not just owner — Go
+// widens the Python "owner-only" rule).
+func TestChangeMemberRole_AdminDemotesAdmin(t *testing.T) {
+	t.Parallel()
+
+	srv, gs, ctx := changeRoleFixture(t)
+
+	// Add a second admin so bob can demote one without touching himself.
+	if err := gs.AddTenantMember(ctx, "acme", "dave", "admin"); err != nil {
+		t.Fatalf("AddTenantMember dave: %v", err)
+	}
+
+	resp, err := srv.ChangeMemberRole(ctx, &pb.ChangeMemberRoleRequest{
+		Actor:    "user:bob",
+		TenantId: "acme",
+		UserId:   "dave",
+		NewRole:  "member",
+	})
+	if err != nil {
+		t.Fatalf("ChangeMemberRole: unexpected error: %v", err)
+	}
+	if resp == nil || !resp.GetSuccess() {
+		t.Fatalf("ChangeMemberRole: success=false; resp=%+v", resp)
+	}
+
+	members, err := gs.GetTenantMembers(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	got := ""
+	for _, m := range members {
+		if m.UserID == "dave" {
+			got = m.Role
+		}
+	}
+	if got != "member" {
+		t.Fatalf("dave role = %q, want %q", got, "member")
+	}
+}
+
+// TestChangeMemberRole_NonAdminDenied pins the negative path: a plain
+// member (carol) attempting to mutate roles is rejected with
+// PERMISSION_DENIED. Mirrors the Python pin
+// `test_change_role_by_member_denied`.
+func TestChangeMemberRole_NonAdminDenied(t *testing.T) {
+	t.Parallel()
+
+	srv, _, ctx := changeRoleFixture(t)
+
+	_, err := srv.ChangeMemberRole(ctx, &pb.ChangeMemberRoleRequest{
+		Actor:    "user:carol",
+		TenantId: "acme",
+		UserId:   "bob",
+		NewRole:  "member",
+	})
+	if err == nil {
+		t.Fatalf("ChangeMemberRole: expected PERMISSION_DENIED, got nil")
+	}
+	if got := errs.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("ChangeMemberRole: code = %v, want PermissionDenied (err=%v)", got, err)
+	}
+}
+
+// TestChangeMemberRole_LastOwnerDemotionBlocked pins the Go-side drift
+// from PLAN.md §6: demoting the sole owner of a tenant must surface
+// FAILED_PRECONDITION rather than silently bricking admin access.
+//
+// Setup: only alice is an owner. A system actor (which bypasses the
+// tenant-membership privilege check) attempts to demote alice — the
+// guard MUST still fire because the protection is independent of the
+// caller's privilege.
+func TestChangeMemberRole_LastOwnerDemotionBlocked(t *testing.T) {
+	t.Parallel()
+
+	srv, gs, ctx := changeRoleFixture(t)
+
+	_, err := srv.ChangeMemberRole(ctx, &pb.ChangeMemberRoleRequest{
+		Actor:    "system:admin",
+		TenantId: "acme",
+		UserId:   "alice",
+		NewRole:  "member",
+	})
+	if err == nil {
+		t.Fatalf("ChangeMemberRole: expected FAILED_PRECONDITION, got nil")
+	}
+	if got := errs.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("ChangeMemberRole: code = %v, want FailedPrecondition (err=%v)", got, err)
+	}
+
+	// Sanity: alice is still an owner.
+	members, err := gs.GetTenantMembers(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	got := ""
+	for _, m := range members {
+		if m.UserID == "alice" {
+			got = m.Role
+		}
+	}
+	if got != "owner" {
+		t.Fatalf("alice role = %q, want %q (last-owner guard must not mutate)", got, "owner")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `entdb.v1.EntDBService/ChangeMemberRole` on the Go server (port spec: `docs/go-port/rpcs/ChangeMemberRole.md`).
- Authorization is admin-only via trusted-actor (`auth.Authoritative`): `system:`/`admin:` actors and tenant members with role `owner`/`admin` may mutate; everyone else gets `PERMISSION_DENIED`.
- **PLAN.md §6 drift folded in:**
  - **WAL-invariant carve-out** — `tenant_members` is a control-plane table on `globalstore`, intentionally non-WAL'd. Direct `globalstore.ChangeMemberRole` write matches Python by construction.
  - **Last-owner demotion protection (Go ADDS this)** — the Python handler lets the sole owner demote themselves and brick the tenant. Go now rejects with `FAILED_PRECONDITION` when the target is the only `"owner"` row and `new_role != "owner"`.
  - **Region pin gap** — preserved as parity; not fixed here, file follow-up.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/api/ -run ChangeMemberRole` — 4 tests pass
  - admin promotes member to admin
  - admin demotes admin to member
  - non-admin → `PERMISSION_DENIED`
  - last-owner demotion blocked → `FAILED_PRECONDITION`
- [x] `uvx ruff@0.15.7 check .` and `format --check .` clean