### PR TITLE
feat(go-rewrite): UpdateUser RPC — Wave 2

### DIFF
--- a/server/go/internal/api/update_user.go
+++ b/server/go/internal/api/update_user.go
@@ -1,0 +1,162 @@
+// UpdateUser RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/UpdateUser.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:114 (rpc), :826-838 (request/
+// response). Reference Python:
+// server/python/entdb_server/api/grpc_server.py:2184-2229 (handler) and
+// server/python/entdb_server/global_store.py:386-409 (backing store).
+//
+// Semantics (preserved byte-for-byte from the Python handler):
+//
+//   - Globalstore must be configured. If not, abort with
+//     codes.Unimplemented "User registry not configured" — the same
+//     gate Python applies at grpc_server.py:2192-2196.
+//   - actor and user_id are required (codes.InvalidArgument).
+//   - Trusted-actor pattern: the privilege decision uses
+//     auth.Authoritative(ctx, claimed) — when the interceptor has
+//     installed an Identity on ctx, the request-payload actor is
+//     ignored. Self-or-admin gate matches Python's _is_self_or_admin
+//     at grpc_server.py:2071-2086.
+//   - Truthy-only partial update: empty string == "do not update".
+//     There is no FieldMask (the proto doesn't carry presence). If
+//     all three mutable fields (email/name/status) are empty, the
+//     handler short-circuits and returns success=false,
+//     error="No fields to update" — IN-BAND, NOT codes.InvalidArgument
+//     (matches grpc_server.py:2216-2218 and the contract pin at
+//     test_user_registry.py:330-345).
+//   - User-not-found is also reported in-band: success=false,
+//     error="User not found" (no NOT_FOUND status).
+//   - NO WAL append. The user registry is intentionally not
+//     event-sourced today — see CLAUDE.md "Architecture Invariants" #1
+//     and the spec's "Side effects" / "Open questions" sections. Do
+//     NOT route this RPC through wal.append.
+//   - Metrics: emits entdb_grpc_requests_total{method="UpdateUser",
+//     status="ok"|"error"} via the shared chokepoint. Note "ok" is
+//     recorded for in-band failures (no-fields, not-found) because
+//     no abort fires — same as Python (grpc_server.py:2217).
+
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const updateUserMethod = "UpdateUser"
+
+// UpdateUser implements entdb.v1.EntDBService/UpdateUser.
+//
+// See file header for the full semantic contract. The handler is
+// stateless apart from the globalstore handle: each call resolves the
+// trusted actor, gates on self-or-admin, builds a partial update, and
+// applies it via globalstore.UpdateUser.
+func (s *Server) UpdateUser(ctx context.Context, req *pb.UpdateUserRequest) (*pb.UpdateUserResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(updateUserMethod, outcome, time.Since(start))
+	}()
+
+	// Configuration gate. Mirrors Python grpc_server.py:2192-2196.
+	if s.global == nil {
+		outcome = "error"
+		return nil, status.Error(codes.Unimplemented, "User registry not configured")
+	}
+
+	// Required-field aborts. Mirrors grpc_server.py:2198-2201.
+	if req.GetActor() == "" {
+		outcome = "error"
+		return nil, status.Error(codes.InvalidArgument, "actor is required")
+	}
+	userID := req.GetUserId()
+	if userID == "" {
+		outcome = "error"
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	// Trusted-actor resolution. The request payload is UNTRUSTED — the
+	// interceptor installs the verified Identity on ctx and
+	// auth.Authoritative ignores the wire claim when one is present.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	if !isSelfOrAdmin(trusted, userID) {
+		outcome = "error"
+		return nil, status.Error(codes.PermissionDenied,
+			"UpdateUser requires the user themselves or admin actor")
+	}
+
+	// Truthy-only partial update. Empty strings are not forwarded —
+	// matches grpc_server.py:2209-2214 and the unit-test pin at
+	// test_user_registry.py:255-271 (only `name=` is forwarded when
+	// only name is set).
+	var upd globalstore.UserUpdates
+	if v := req.GetEmail(); v != "" {
+		upd.Email = stringPtr(v)
+	}
+	if v := req.GetName(); v != "" {
+		upd.Name = stringPtr(v)
+	}
+	if v := req.GetStatus(); v != "" {
+		upd.Status = stringPtr(v)
+	}
+	if upd.Email == nil && upd.Name == nil && upd.Status == nil {
+		// In-band failure (no abort). Python returns "ok" metric here;
+		// we do the same.
+		return &pb.UpdateUserResponse{Success: false, Error: "No fields to update"}, nil
+	}
+
+	updated, err := s.global.UpdateUser(ctx, userID, upd)
+	if err != nil {
+		// Catch-all in-band failure mirroring grpc_server.py:2222-2227.
+		// Python writes the metric label as "error" on this arm; we
+		// match. Spec note: do NOT promote to codes.Internal until the
+		// contract tests are loosened — clients pin success/error on
+		// the response body, not status codes.
+		outcome = "error"
+		return &pb.UpdateUserResponse{Success: false, Error: err.Error()}, nil
+	}
+	if !updated {
+		// In-band not-found. Same metric label ("ok") as Python — no
+		// abort fires.
+		return &pb.UpdateUserResponse{Success: false, Error: "User not found"}, nil
+	}
+	return &pb.UpdateUserResponse{Success: true}, nil
+}
+
+// isSelfOrAdmin mirrors _is_self_or_admin at grpc_server.py:2071-2086.
+// Admin/system identities are always allowed; user identities are
+// allowed only when their bare ID matches user_id (the "self" arm).
+//
+// The Python implementation also accepts the literal "__system__"
+// trusted string. That identity is the Applier's bootstrap actor and
+// never appears on the wire (auth_interceptor.py:111-112), so the Go
+// port intentionally does not honour it here.
+func isSelfOrAdmin(trusted auth.Actor, userID string) bool {
+	if trusted.IsAdmin() || trusted.IsSystem() {
+		return true
+	}
+	if trusted.IsUser() && trusted.ID() == userID {
+		return true
+	}
+	// Defence in depth: Python compares against both `user:<id>` and
+	// the bare `<id>`. ParseActor classifies a bare string with no
+	// colon as KindUnknown carrying the raw id; honour the bare-id
+	// fallback for parity with grpc_server.py:2080.
+	if trusted.Kind() == auth.KindUnknown && !strings.Contains(trusted.ID(), ":") && trusted.ID() == userID {
+		return true
+	}
+	return false
+}
+
+// stringPtr is a tiny helper so handler bodies stay readable. Using a
+// dedicated helper rather than &v inline keeps the truthy-gate above
+// the actual struct construction visually distinct.
+func stringPtr(s string) *string { return &s }

--- a/server/go/internal/api/update_user_test.go
+++ b/server/go/internal/api/update_user_test.go
@@ -1,0 +1,260 @@
+// Tests for the UpdateUser RPC. The seven Python contract pins enumerated
+// in docs/go-port/rpcs/UpdateUser.md ("Contract tests pinning behavior")
+// reduce to five behaviours in the Go port — happy self-update, happy
+// admin-other, non-admin-other denied, no-fields in-band failure, and
+// not-found in-band failure. Each test below covers one of those arms.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// withTrustedUser stamps a verified user identity onto ctx so the
+// handler's auth.Authoritative call returns the trusted Actor — the
+// only way a unit test can drive the post-#168 trusted-actor pattern.
+func withTrustedUser(ctx context.Context, subject string) context.Context {
+	return auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: subject,
+	})
+}
+
+// TestUpdateUser_Self_HappyPath: alice updates her own row (only
+// `name` set; truthy-only gating means `email` and `status` are not
+// forwarded). Mirrors test_user_registry.py:255-271 and the contract
+// pin at test_grpc_contract.py:448-453.
+func TestUpdateUser_Self_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.UpdateUser(withTrustedUser(ctx, "alice"), &pb.UpdateUserRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+		Name:   "Alice Updated",
+	})
+	if err != nil {
+		t.Fatalf("UpdateUser: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("UpdateUser: success=false, error=%q", resp.GetError())
+	}
+
+	// Verify the row was patched and untouched fields kept their
+	// values — proves truthy-only gating.
+	got, err := gs.GetUser(ctx, "alice")
+	if err != nil || got == nil {
+		t.Fatalf("post-update GetUser: user=%v, err=%v", got, err)
+	}
+	if got.Name != "Alice Updated" {
+		t.Errorf("Name: got %q, want %q", got.Name, "Alice Updated")
+	}
+	if got.Email != "alice@example.com" {
+		t.Errorf("Email: got %q, want unchanged %q", got.Email, "alice@example.com")
+	}
+}
+
+// TestUpdateUser_Admin_UpdatesOther: an admin: trusted identity can
+// update any user. Only `status` is set (truthy-only gating again).
+// Mirrors test_user_registry.py:273-290.
+func TestUpdateUser_Admin_UpdatesOther(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.UpdateUser(withTrustedUser(ctx, "admin:root"), &pb.UpdateUserRequest{
+		Actor:  "admin:root",
+		UserId: "bob",
+		Status: "suspended",
+	})
+	if err != nil {
+		t.Fatalf("UpdateUser: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("UpdateUser: success=false, error=%q", resp.GetError())
+	}
+
+	got, err := gs.GetUser(ctx, "bob")
+	if err != nil || got == nil {
+		t.Fatalf("post-update GetUser: user=%v, err=%v", got, err)
+	}
+	if got.Status != "suspended" {
+		t.Errorf("Status: got %q, want %q", got.Status, "suspended")
+	}
+}
+
+// TestUpdateUser_NonAdmin_OtherDenied: alice trying to update bob is
+// the privilege-escalation guard. The handler MUST consult ctx for
+// the trusted identity and ignore the request payload's claim of
+// `admin:root`. Mirrors test_user_registry.py:292-309 and the contract
+// pin at test_grpc_contract.py:454-458.
+func TestUpdateUser_NonAdmin_OtherDenied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// alice is the trusted caller. She tries to claim admin:root in
+	// the wire payload — must be ignored.
+	resp, err := srv.UpdateUser(withTrustedUser(ctx, "alice"), &pb.UpdateUserRequest{
+		Actor:  "admin:root",
+		UserId: "bob",
+		Status: "suspended",
+	})
+	if err == nil {
+		t.Fatalf("UpdateUser: expected PERMISSION_DENIED, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("UpdateUser: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("UpdateUser: code: got %v, want PermissionDenied", st.Code())
+	}
+
+	// Defence in depth: confirm the store was NOT mutated.
+	got, _ := gs.GetUser(ctx, "bob")
+	if got == nil || got.Status != "active" {
+		t.Errorf("post-denied bob.Status: got %v, want unchanged 'active'", got)
+	}
+}
+
+// TestUpdateUser_NoFields_InBandFailure: omitting all three mutable
+// fields short-circuits to success=false, error="No fields to update"
+// IN-BAND — no codes.InvalidArgument abort. Mirrors
+// test_user_registry.py:330-345.
+func TestUpdateUser_NoFields_InBandFailure(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.UpdateUser(withTrustedUser(ctx, "alice"), &pb.UpdateUserRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+		// email/name/status all empty
+	})
+	if err != nil {
+		t.Fatalf("UpdateUser: expected nil err for in-band no-fields failure, got %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatalf("UpdateUser: expected success=false, got %+v", resp)
+	}
+	if resp.GetError() != "No fields to update" {
+		t.Errorf("UpdateUser: error: got %q, want %q", resp.GetError(), "No fields to update")
+	}
+}
+
+// TestUpdateUser_NotFound_InBandFailure: trying to update a missing
+// user_id returns success=false, error="User not found" in-band. No
+// NOT_FOUND status code — mirrors test_user_registry.py:311-328.
+func TestUpdateUser_NotFound_InBandFailure(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	// Seed a different user so the global store is non-empty but the
+	// target row does not exist.
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.UpdateUser(withTrustedUser(ctx, "admin:root"), &pb.UpdateUserRequest{
+		Actor:  "admin:root",
+		UserId: "ghost",
+		Name:   "Phantom",
+	})
+	if err != nil {
+		t.Fatalf("UpdateUser: expected nil err for in-band not-found, got %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatalf("UpdateUser: expected success=false, got %+v", resp)
+	}
+	if resp.GetError() != "User not found" {
+		t.Errorf("UpdateUser: error: got %q, want %q", resp.GetError(), "User not found")
+	}
+}
+
+// TestUpdateUser_GlobalstoreUnset_Unimplemented: a Server with no
+// globalstore wired aborts with codes.Unimplemented. Mirrors the
+// configuration gate at grpc_server.py:2192-2196.
+func TestUpdateUser_GlobalstoreUnset_Unimplemented(t *testing.T) {
+	t.Parallel()
+	srv := api.New() // no WithGlobalStore
+
+	_, err := srv.UpdateUser(context.Background(), &pb.UpdateUserRequest{
+		Actor:  "admin:root",
+		UserId: "alice",
+		Name:   "x",
+	})
+	if err == nil {
+		t.Fatalf("UpdateUser: expected error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("UpdateUser: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.Unimplemented {
+		t.Fatalf("UpdateUser: code: got %v, want Unimplemented", st.Code())
+	}
+}
+
+// TestUpdateUser_EmptyActor_InvalidArgument: actor required.
+func TestUpdateUser_EmptyActor_InvalidArgument(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.UpdateUser(context.Background(), &pb.UpdateUserRequest{
+		UserId: "alice",
+		Name:   "x",
+	})
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("UpdateUser: code: got %v, want InvalidArgument", st.Code())
+	}
+}
+
+// TestUpdateUser_EmptyUserID_InvalidArgument: user_id required.
+func TestUpdateUser_EmptyUserID_InvalidArgument(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.UpdateUser(context.Background(), &pb.UpdateUserRequest{
+		Actor: "admin:root",
+		Name:  "x",
+	})
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("UpdateUser: code: got %v, want InvalidArgument", st.Code())
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `UpdateUser` RPC for the Go server port (EPIC #407, Wave 2).
- Truthy-only partial updates (no FieldMask), in-band failures for "no fields" and "user not found", and a self-or-admin gate driven by `auth.Authoritative` (trusted-actor pattern from #168).
- Globally-scoped: writes the user registry directly via `globalstore.UpdateUser` — intentionally NOT WAL-routed, per the spec carve-out for cross-tenant identity rows.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/api/... -run UpdateUser` — 8 passing
  - self happy path (only `name=` forwarded, proves truthy-only gating)
  - admin-other happy path (only `status=` forwarded)
  - non-admin-other denied (claimed `admin:root` in payload ignored — privilege-escalation guard)
  - no-fields → in-band `success=false, error="No fields to update"` (no abort)
  - not-found → in-band `success=false, error="User not found"` (no abort)
  - globalstore unset → `Unimplemented`
  - empty actor / user_id → `InvalidArgument`
- [x] `uvx ruff@0.15.7 check .` and `format --check .` clean

## Spec

`docs/go-port/rpcs/UpdateUser.md` — all five contract pins from "Contract tests pinning behavior" covered.