### PR TITLE
feat(go-rewrite): GetUser RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_user.go
+++ b/server/go/internal/api/get_user.go
@@ -1,0 +1,129 @@
+// GetUser RPC — Wave 2 of the Python -> Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/GetUser.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:113 (rpc), :816-824
+// (request/response), :793-800 (UserInfo). Reference Python handler:
+// server/python/entdb_server/api/grpc_server.py:2149-2182.
+//
+// Semantics (preserved from the Python handler):
+//
+//   - Authenticated, but unrestricted. Any authenticated actor may
+//     read any user's profile. NO self/admin gate -- Python's
+//     `_is_self_or_admin` helper exists at grpc_server.py:2080-2086 but
+//     is intentionally NOT called from GetUser (spec "Auth").
+//   - Wire `actor` is UNTRUSTED. The trusted-actor invariant
+//     (CLAUDE.md, commit fece3fb) means we resolve identity via
+//     auth.Authoritative and ignore the wire claim for any auth
+//     decision. We still validate non-empty so the contract suite
+//     (which runs without an interceptor) can drive the validation
+//     branch -- pinned by tests/python/integration/test_grpc_contract.py:407-411.
+//   - Missing user is reported IN-BAND as `found=false` with codes.OK,
+//     NOT codes.NotFound. This is a deliberate asymmetry to mirror
+//     GetNode's "successful absence" shape (spec "Error contract"). Do
+//     NOT upgrade to NOT_FOUND -- existing SDK clients branch on
+//     `response.Found`.
+//   - When the global store is not wired, return codes.Unimplemented
+//     ("User registry not configured"), matching Python's `:2157-2161`
+//     guard.
+//   - Catch-all internal errors are swallowed into `found=false` with
+//     codes.OK to match Python's bare `except Exception` at
+//     `:2179-2182`. The status metric is recorded as "error" so the
+//     swallow doesn't inflate the ok counter.
+//
+// No WAL append, no SQLite write, no ACL check. Pure read off
+// global_store.
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const getUserMethod = "GetUser"
+
+// GetUser implements entdb.v1.EntDBService/GetUser. See file header
+// for the full contract; the body is intentionally a thin translation
+// layer over globalstore.GetUser.
+func (s *Server) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.GetUserResponse, error) {
+	start := time.Now()
+	resultStatus := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(getUserMethod, resultStatus, time.Since(start))
+	}()
+
+	// Guard the optional global_store dep. Python raises
+	// UNIMPLEMENTED("User registry not configured"); pinned by
+	// tests/python/unit/test_user_registry.py:433-444.
+	if s.global == nil {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "User registry not configured")
+	}
+
+	// Validate non-empty wire actor. The wire field is UNTRUSTED for
+	// auth decisions but still required for argument validation
+	// (spec "Wire contract" / contract pin :407-411).
+	if req.GetActor() == "" {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+
+	// Validate non-empty user_id (contract pin :412-416).
+	if req.GetUserId() == "" {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "user_id is required")
+	}
+
+	// Resolve trusted identity from ctx. The result is intentionally
+	// unused for any authorization decision (this RPC has none) -- the
+	// call exists so a future tightening to self-or-admin has a single
+	// chokepoint to bind against, and so we explicitly honour the
+	// trusted-actor pattern documented in CLAUDE.md / commit fece3fb.
+	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	// Read globalstore.user_registry. (nil, nil) on miss mirrors
+	// Python's `dict | None` contract.
+	user, err := s.global.GetUser(ctx, req.GetUserId())
+	if err != nil {
+		// Python's bare `except Exception` swallows internal errors
+		// into found=false with codes.OK (`:2179-2182`). We mirror
+		// that for parity but record the metric as "error" so the
+		// swallow doesn't inflate the ok counter.
+		resultStatus = "error"
+		return &pb.GetUserResponse{Found: false}, nil
+	}
+	if user == nil {
+		// In-band missing. NOT_FOUND would break SDK clients that
+		// branch on `response.Found`.
+		return &pb.GetUserResponse{Found: false}, nil
+	}
+
+	return &pb.GetUserResponse{
+		Found: true,
+		User:  userToProto(user),
+	}, nil
+}
+
+// userToProto mirrors `_user_dict_to_proto` in the Python handler
+// (server/python/entdb_server/api/grpc_server.py:2088-...). NULL columns
+// land as Go zero values via globalstore.User's plain-string fields,
+// which marshal to the proto's empty-string defaults -- the same shape
+// Python emits when it stringifies a None.
+func userToProto(u *globalstore.User) *pb.UserInfo {
+	return &pb.UserInfo{
+		UserId:    u.UserID,
+		Email:     u.Email,
+		Name:      u.Name,
+		Status:    u.Status,
+		CreatedAt: u.CreatedAt,
+		UpdatedAt: u.UpdatedAt,
+	}
+}

--- a/server/go/internal/api/get_user_test.go
+++ b/server/go/internal/api/get_user_test.go
@@ -1,0 +1,139 @@
+// Tests for the GetUser RPC (W2 — EPIC #407).
+//
+// Spec: docs/go-port/rpcs/GetUser.md. Three branches pinned here, one
+// per contract test referenced by the spec:
+//
+//  1. Happy round-trip: an existing user -> found=true with
+//     UserInfo populated (mirrors test_grpc_contract.py:396-400 and
+//     test_user_registry.py:196-217).
+//
+//  2. Missing user: unknown user_id -> found=false, no error
+//     (mirrors test_grpc_contract.py:401-406 and
+//     test_user_registry.py:219-231). DO NOT upgrade to NOT_FOUND.
+//
+//  3. Empty actor: -> codes.InvalidArgument (mirrors
+//     test_grpc_contract.py:407-411 and test_user_registry.py:233-245).
+//
+// The shared globalstore helper lives in helpers_external_test.go;
+// do NOT redeclare newGlobalStore here.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestGetUser_HappyRoundTrip seeds a user via globalstore.CreateUser
+// (the same chokepoint the CreateUser RPC will write through) and
+// asserts the GetUser response matches it field-for-field.
+func TestGetUser_HappyRoundTrip(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	created, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.GetUser(ctx, &pb.GetUserRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+	})
+	if err != nil {
+		t.Fatalf("GetUser: unexpected err: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetUser: nil response")
+	}
+	if !resp.GetFound() {
+		t.Fatalf("GetUser: found: got false, want true")
+	}
+	got := resp.GetUser()
+	if got == nil {
+		t.Fatalf("GetUser: user is nil despite found=true")
+	}
+	if got.GetUserId() != "alice" {
+		t.Fatalf("GetUser: user_id: got %q, want %q", got.GetUserId(), "alice")
+	}
+	if got.GetEmail() != "alice@example.com" {
+		t.Fatalf("GetUser: email: got %q, want %q", got.GetEmail(), "alice@example.com")
+	}
+	if got.GetName() != "Alice" {
+		t.Fatalf("GetUser: name: got %q, want %q", got.GetName(), "Alice")
+	}
+	if got.GetStatus() != "active" {
+		t.Fatalf("GetUser: status: got %q, want %q", got.GetStatus(), "active")
+	}
+	if got.GetCreatedAt() != created.CreatedAt {
+		t.Fatalf("GetUser: created_at: got %d, want %d", got.GetCreatedAt(), created.CreatedAt)
+	}
+	if got.GetUpdatedAt() != created.UpdatedAt {
+		t.Fatalf("GetUser: updated_at: got %d, want %d", got.GetUpdatedAt(), created.UpdatedAt)
+	}
+}
+
+// TestGetUser_MissingUser pins the in-band absence signal: an unknown
+// user_id returns found=false with codes.OK, NOT codes.NotFound. This
+// is the deliberate asymmetry called out in the spec — clients branch
+// on response.Found, so upgrading to a NOT_FOUND status code would be
+// a contract break.
+func TestGetUser_MissingUser(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.GetUser(context.Background(), &pb.GetUserRequest{
+		Actor:  "user:alice",
+		UserId: "ghost",
+	})
+	if err != nil {
+		t.Fatalf("GetUser: unexpected err for missing user: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetUser: nil response for missing user")
+	}
+	if resp.GetFound() {
+		t.Fatalf("GetUser: found: got true, want false for missing user")
+	}
+	if resp.GetUser() != nil {
+		t.Fatalf("GetUser: user populated despite found=false: %+v", resp.GetUser())
+	}
+}
+
+// TestGetUser_EmptyActor pins the argument-validation branch: an
+// empty wire actor produces codes.InvalidArgument. The wire field is
+// UNTRUSTED for auth decisions, but the contract test suite — which
+// runs without an auth interceptor — relies on this guard to drive
+// the validation branch.
+func TestGetUser_EmptyActor(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.GetUser(context.Background(), &pb.GetUserRequest{
+		Actor:  "",
+		UserId: "alice",
+	})
+	if err == nil {
+		t.Fatalf("GetUser: expected error for empty actor, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("GetUser: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("GetUser: code: got %v, want InvalidArgument", st.Code())
+	}
+}


### PR DESCRIPTION
## Summary

- Port `entdb.v1.EntDBService/GetUser` from Python to Go per [`docs/go-port/rpcs/GetUser.md`](docs/go-port/rpcs/GetUser.md). Pure read off `globalstore.user_registry` — no WAL append, no ACL, no self/admin gate.
- Wire `actor` validated non-empty for argument parity but ignored for auth (trusted-actor invariant via `auth.Authoritative`). Missing user is reported IN-BAND as `found=false` (NOT `codes.NotFound`) to preserve the SDK contract.
- Rebinds the Wave-1 default-Unimplemented probe in `server_test.go` from `GetSchema` (now implemented on main) to `UpdateUser`, the next not-yet-ported RPC.

Refs #407.

## Test plan

- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...`
- [x] `uvx ruff@0.15.7 check .`
- [x] `uvx ruff@0.15.7 format --check .`
- [x] Three new tests pin the spec branches: happy round-trip, missing user (`found=false` + no error), empty actor (`InvalidArgument`).