### PR TITLE
feat(go-rewrite): GetEdgesFrom RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_edges_from.go
+++ b/server/go/internal/api/get_edges_from.go
@@ -1,0 +1,155 @@
+// GetEdgesFrom RPC — Wave 2 of the Python -> Go server port (EPIC #407).
+//
+// Spec: docs/go-port/rpcs/GetEdgesFrom.md. Pure read of the per-tenant
+// `edges` table indexed by (tenant_id, from_node_id), translated into
+// the wire `Edge` shape.
+//
+// Semantics preserved from server/python/entdb_server/api/grpc_server.py
+// :1384-1418:
+//
+//   - Tenant gate (s.checkTenant) is the only ingress check. Its
+//     UNAVAILABLE / FAILED_PRECONDITION / NotFound / InvalidArgument
+//     errors propagate to the SDK so the redirect trailer
+//     (`entdb-redirect-node`) lands before the status closes.
+//   - request.context.actor is UNTRUSTED; resolve trusted identity via
+//     auth.Authoritative (CLAUDE.md / commit fece3fb). The trusted
+//     actor is NOT used for any authorization decision today — see the
+//     ACL parity gap below.
+//   - PARITY GAP (deliberate, pinned): no per-destination ACL filter.
+//     Python's handler does NOT call the visibility check before
+//     fan-out, so callers can enumerate `to_node_id`s they would not
+//     have READ on through GetNode. The privilege-escalation test at
+//     tests/python/integration/test_privilege_escalation.py:421-447
+//     pins this weaker property; we match byte-for-byte. Tracked as a
+//     follow-up: tightening this requires a contract change because
+//     existing SDK clients depend on the full edge fan-out shape.
+//   - `offset` is declared on GetEdgesRequest (proto field 5) but the
+//     Python handler ignores it; we ignore it too. Switching to honour
+//     it must update the contract in lock-step.
+//   - `edge_type_id == 0` means "no filter" (parity with the falsy
+//     check at grpc_server.py:1393).
+//   - `limit <= 0` defaults to 100. We pass 0 (no limit) to the store
+//     so the slice + has_more accounting happens in this handler — the
+//     Python side does the same in-process slice
+//     (grpc_server.py:1410-1414). NOT in SQL: ordering is not
+//     contractually pinned and adding ORDER BY here would diverge from
+//     Python.
+//   - Side effects: none. No WAL append, no SQLite write, no metric
+//     other than the standard request counter.
+//   - Error contract: any failure below the tenant gate is swallowed
+//     into an empty GetEdgesResponse with codes.OK
+//     (grpc_server.py:1415-1418). The metric outcome is "error" so
+//     swallowed faults don't inflate the ok counter.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+const grpcMethodGetEdgesFrom = "GetEdgesFrom"
+
+// defaultEdgesLimit mirrors grpc_server.py:1400 where `limit or 100`
+// substitutes 100 for any falsy value (0 / unset / negative).
+const defaultEdgesLimit = 100
+
+// GetEdgesFrom implements entdb.v1.EntDBService/GetEdgesFrom. See file
+// header for the contract; the body is intentionally a thin translation
+// over CanonicalStore.GetEdgesFrom.
+func (s *Server) GetEdgesFrom(ctx context.Context, req *pb.GetEdgesRequest) (*pb.GetEdgesResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(grpcMethodGetEdgesFrom, outcome, time.Since(start))
+	}()
+
+	tenantID := req.GetContext().GetTenantId()
+
+	// Tenant gate — sharding ownership + region pinning. The redirect
+	// trailer is set inside CheckTenant; the Go SDK redirect cache reads
+	// it (sdk/go/entdb/redirect_cache.go).
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		outcome = "error"
+		return nil, err
+	}
+
+	// Resolve trusted actor. The result is intentionally unused: this
+	// RPC has no authorization decision today (see file-header parity
+	// gap). The call exists so that the future tightening to ACL-filter
+	// destinations has a single chokepoint to bind against and so we
+	// honour the trusted-actor invariant explicitly.
+	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetContext().GetActor()))
+
+	// edge_type_id filter: falsy (== 0) means "no filter" per
+	// grpc_server.py:1393.
+	var edgeTypeFilter *int32
+	if etid := req.GetEdgeTypeId(); etid != 0 {
+		v := etid
+		edgeTypeFilter = &v
+	}
+
+	// Pass limit=0 to the store so it returns the full result set; we
+	// slice + compute has_more here for parity with Python.
+	edges, err := s.store.GetEdgesFrom(ctx, tenantID, req.GetNodeId(), edgeTypeFilter, 0)
+	if err != nil {
+		// Mirror Python's bare `except` swallow at grpc_server.py:1415.
+		outcome = "error"
+		return &pb.GetEdgesResponse{Edges: []*pb.Edge{}}, nil
+	}
+
+	limit := int(req.GetLimit())
+	if limit <= 0 {
+		limit = defaultEdgesLimit
+	}
+	hasMore := len(edges) > limit
+	if hasMore {
+		edges = edges[:limit]
+	}
+
+	out := make([]*pb.Edge, 0, len(edges))
+	for _, e := range edges {
+		out = append(out, edgeToProto(e))
+	}
+	return &pb.GetEdgesResponse{Edges: out, HasMore: hasMore}, nil
+}
+
+// edgeToProto translates a store.Edge into its wire shape. PropsJSON is
+// stored as a JSON-encoded map keyed by field IDs (CLAUDE.md invariant
+// 6); we round-trip through map[string]any -> structpb.NewStruct so the
+// wire `props` mirrors Python's `_dict_to_struct` output. On any
+// translation error, props is left nil (parity with Python's defensive
+// fall-through at grpc_server.py:1408).
+func edgeToProto(e *store.Edge) *pb.Edge {
+	out := &pb.Edge{
+		TenantId:   e.TenantID,
+		EdgeTypeId: e.EdgeTypeID,
+		FromNodeId: e.FromNodeID,
+		ToNodeId:   e.ToNodeID,
+		CreatedAt:  e.CreatedAt,
+	}
+	if e.PropsJSON == "" {
+		return out
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(e.PropsJSON), &m); err != nil {
+		return out
+	}
+	if m == nil {
+		return out
+	}
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		return out
+	}
+	out.Props = s
+	return out
+}

--- a/server/go/internal/api/get_edges_from_test.go
+++ b/server/go/internal/api/get_edges_from_test.go
@@ -1,0 +1,281 @@
+// Tests for GetEdgesFrom RPC (Wave 2 — EPIC #407).
+//
+// Contract pins (mirrored from docs/go-port/rpcs/GetEdgesFrom.md and
+// the Python contract suite):
+//
+//   - Empty seed:     test_grpc_contract.py:241-247 — call succeeds,
+//                     edges == [].
+//   - Single edge:    happy round-trip; props are preserved on the wire.
+//   - Multiple edges: every stored outgoing edge is returned (no
+//                     ACL filter on destinations — preserved parity gap;
+//                     see GetEdgesFrom.md §"Auth").
+//   - Missing source: unknown from_node_id returns empty edges, no
+//                     error (no special-case path in Python).
+//   - Type filter:    edge_type_id != 0 narrows the result set;
+//                     edge_type_id == 0 returns every type.
+//   - Internal error: store fault (tenant DB never opened) collapses
+//                     to an empty response with codes.OK — mirrors
+//                     Python's bare-except swallow at
+//                     grpc_server.py:1415-1418.
+//
+// The shared globalstore helper lives in helpers_external_test.go;
+// do NOT redeclare newGlobalStore here.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
+)
+
+// newEdgesStore opens a fresh, tmpdir-backed CanonicalStore. WAL on so
+// concurrent SQLite reads don't serialise.
+func newEdgesStore(t *testing.T) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// newEdgesServer wires globalstore (so the tenant gate sees a
+// registered tenant) and a CanonicalStore so the handler can read.
+// Returns the constructed server, the store handle (for seeding edges),
+// and the tenant id used.
+func newEdgesServer(t *testing.T, tenantID string) (*api.Server, *store.CanonicalStore) {
+	t.Helper()
+	cs := newEdgesStore(t)
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, tenantID, "T", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithStore(cs),
+		api.WithSharding(&tenant.Sharding{NodeID: "node-a"}),
+	)
+	return srv, cs
+}
+
+func edgesReq(tenantID, nodeID string) *pb.GetEdgesRequest {
+	return &pb.GetEdgesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID},
+		NodeId:  nodeID,
+	}
+}
+
+// TestGetEdgesFrom_EmptyTenantReturnsNoEdges: no edges seeded -> empty
+// list, no error. Mirrors test_grpc_contract.py:241-247.
+func TestGetEdgesFrom_EmptyTenantReturnsNoEdges(t *testing.T) {
+	t.Parallel()
+	srv, _ := newEdgesServer(t, "tenant-empty")
+
+	resp, err := srv.GetEdgesFrom(context.Background(), edgesReq("tenant-empty", "src"))
+	if err != nil {
+		t.Fatalf("GetEdgesFrom: unexpected error: %v", err)
+	}
+	if got := len(resp.GetEdges()); got != 0 {
+		t.Fatalf("edges len: got %d, want 0", got)
+	}
+	if resp.GetHasMore() {
+		t.Fatalf("has_more: got true, want false")
+	}
+}
+
+// TestGetEdgesFrom_SingleEdgeRoundTrip: one outgoing edge -> returned
+// with all wire fields populated.
+func TestGetEdgesFrom_SingleEdgeRoundTrip(t *testing.T) {
+	t.Parallel()
+	srv, cs := newEdgesServer(t, "tenant-single")
+	ctx := context.Background()
+
+	if _, err := cs.CreateEdge(ctx, "tenant-single", store.EdgeInput{
+		EdgeTypeID: 7,
+		FromNodeID: "src",
+		ToNodeID:   "dst",
+		Props:      map[string]any{"1": "hello"},
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+
+	resp, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-single", "src"))
+	if err != nil {
+		t.Fatalf("GetEdgesFrom: %v", err)
+	}
+	if len(resp.GetEdges()) != 1 {
+		t.Fatalf("edges len: got %d, want 1", len(resp.GetEdges()))
+	}
+	e := resp.GetEdges()[0]
+	if e.GetTenantId() != "tenant-single" {
+		t.Fatalf("tenant_id: %q", e.GetTenantId())
+	}
+	if e.GetEdgeTypeId() != 7 {
+		t.Fatalf("edge_type_id: %d", e.GetEdgeTypeId())
+	}
+	if e.GetFromNodeId() != "src" || e.GetToNodeId() != "dst" {
+		t.Fatalf("from/to: %q->%q", e.GetFromNodeId(), e.GetToNodeId())
+	}
+	if e.GetProps() == nil {
+		t.Fatalf("props: nil, want populated Struct")
+	}
+	v, ok := e.GetProps().GetFields()["1"]
+	if !ok || v.GetStringValue() != "hello" {
+		t.Fatalf("props[1]: got %v, want \"hello\"", v)
+	}
+}
+
+// TestGetEdgesFrom_MultipleEdgesAllReturned pins the no-ACL-filter
+// parity gap. The handler returns every stored outgoing edge,
+// including destinations the caller has no READ on. Tightening this
+// requires a contract change — see GetEdgesFrom.md §"Auth" and the
+// privilege-escalation test at test_privilege_escalation.py:421-447.
+func TestGetEdgesFrom_MultipleEdgesAllReturned(t *testing.T) {
+	t.Parallel()
+	srv, cs := newEdgesServer(t, "tenant-multi")
+	ctx := context.Background()
+
+	for _, dst := range []string{"d1", "d2", "d3"} {
+		if _, err := cs.CreateEdge(ctx, "tenant-multi", store.EdgeInput{
+			EdgeTypeID: 1,
+			FromNodeID: "src",
+			ToNodeID:   dst,
+		}); err != nil {
+			t.Fatalf("CreateEdge %s: %v", dst, err)
+		}
+	}
+
+	resp, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-multi", "src"))
+	if err != nil {
+		t.Fatalf("GetEdgesFrom: %v", err)
+	}
+	if len(resp.GetEdges()) != 3 {
+		t.Fatalf("edges len: got %d, want 3 (no ACL filter expected)", len(resp.GetEdges()))
+	}
+	got := map[string]bool{}
+	for _, e := range resp.GetEdges() {
+		got[e.GetToNodeId()] = true
+	}
+	for _, want := range []string{"d1", "d2", "d3"} {
+		if !got[want] {
+			t.Fatalf("missing dst %q in result: %v", want, got)
+		}
+	}
+}
+
+// TestGetEdgesFrom_MissingSourceReturnsEmpty: an unknown from_node_id
+// returns an empty edge list with no error — Python does not special-
+// case missing nodes here (no NOT_FOUND).
+func TestGetEdgesFrom_MissingSourceReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	srv, cs := newEdgesServer(t, "tenant-miss")
+	ctx := context.Background()
+	if _, err := cs.CreateEdge(ctx, "tenant-miss", store.EdgeInput{
+		EdgeTypeID: 1, FromNodeID: "src", ToNodeID: "dst",
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+
+	resp, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-miss", "ghost"))
+	if err != nil {
+		t.Fatalf("GetEdgesFrom: %v", err)
+	}
+	if len(resp.GetEdges()) != 0 {
+		t.Fatalf("edges len: got %d, want 0 for missing source", len(resp.GetEdges()))
+	}
+}
+
+// TestGetEdgesFrom_EdgeTypeFilter pins both branches: edge_type_id == 0
+// returns every type, edge_type_id != 0 narrows.
+func TestGetEdgesFrom_EdgeTypeFilter(t *testing.T) {
+	t.Parallel()
+	srv, cs := newEdgesServer(t, "tenant-filter")
+	ctx := context.Background()
+
+	if _, err := cs.CreateEdge(ctx, "tenant-filter", store.EdgeInput{
+		EdgeTypeID: 1, FromNodeID: "src", ToNodeID: "d1",
+	}); err != nil {
+		t.Fatalf("CreateEdge t1: %v", err)
+	}
+	if _, err := cs.CreateEdge(ctx, "tenant-filter", store.EdgeInput{
+		EdgeTypeID: 2, FromNodeID: "src", ToNodeID: "d2",
+	}); err != nil {
+		t.Fatalf("CreateEdge t2: %v", err)
+	}
+
+	// edge_type_id == 0 -> no filter, returns both.
+	respAll, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-filter", "src"))
+	if err != nil {
+		t.Fatalf("GetEdgesFrom (all): %v", err)
+	}
+	if len(respAll.GetEdges()) != 2 {
+		t.Fatalf("unfiltered edges: got %d, want 2", len(respAll.GetEdges()))
+	}
+
+	// edge_type_id == 2 -> only the type-2 edge.
+	respFilt, err := srv.GetEdgesFrom(ctx, &pb.GetEdgesRequest{
+		Context:    &pb.RequestContext{TenantId: "tenant-filter"},
+		NodeId:     "src",
+		EdgeTypeId: 2,
+	})
+	if err != nil {
+		t.Fatalf("GetEdgesFrom (filtered): %v", err)
+	}
+	if len(respFilt.GetEdges()) != 1 {
+		t.Fatalf("filtered edges: got %d, want 1", len(respFilt.GetEdges()))
+	}
+	if respFilt.GetEdges()[0].GetEdgeTypeId() != 2 {
+		t.Fatalf("filtered edge type: got %d, want 2", respFilt.GetEdges()[0].GetEdgeTypeId())
+	}
+}
+
+// TestGetEdgesFrom_StoreErrorSwallowedToEmpty: tenant gate passes but
+// the canonicalstore call fails (here: tenant DB not opened on the
+// store handle). Python collapses that to an empty response with
+// codes.OK (grpc_server.py:1415-1418); we must do the same.
+func TestGetEdgesFrom_StoreErrorSwallowedToEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Wire globalstore + a registered tenant so the gate succeeds, but
+	// use a fresh store where OpenTenant has NOT been called -> the
+	// store-side read returns ErrTenantNotOpen.
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "tenant-broken", "T", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	cs := newEdgesStore(t) // intentionally NOT opened for tenant-broken
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithStore(cs),
+		api.WithSharding(&tenant.Sharding{NodeID: "node-a"}),
+	)
+
+	resp, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-broken", "src"))
+	if err != nil {
+		t.Fatalf("GetEdgesFrom: must swallow store err to OK + empty resp, got %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetEdgesFrom: nil response")
+	}
+	if len(resp.GetEdges()) != 0 {
+		t.Fatalf("edges: got %d, want 0 (swallowed)", len(resp.GetEdges()))
+	}
+	if resp.GetHasMore() {
+		t.Fatalf("has_more: got true, want false")
+	}
+}


### PR DESCRIPTION
## Summary

W2 of the Python -> Go server port (EPIC #407). Ports
`server/python/entdb_server/api/grpc_server.py:1384-1418` to Go.

- Pure read off `CanonicalStore.GetEdgesFrom`; no WAL append, no SQLite
  write, no ACL check, no metric beyond the standard request counter.
- Tenant gate (`s.checkTenant`) is the only ingress check; its errors
  (`UNAVAILABLE` + `entdb-redirect-node` trailer / `FAILED_PRECONDITION`
  / `NotFound`) propagate to the SDK.
- `request.context.actor` is UNTRUSTED; trusted identity is resolved via
  `auth.Authoritative` but intentionally unused — see parity gap below.
- `edge_type_id == 0` -> no filter (Python falsy parity); `limit <= 0`
  -> defaults to 100; `offset` is declared on the proto but ignored,
  matching Python; slice + `has_more` happen in the handler.
- Any error below the gate is swallowed into an empty response with
  `codes.OK`; the metric outcome is `"error"` so swallowed faults don't
  inflate the ok counter.

Canonical shape: `api.Server` + `s.checkTenant` + `newGlobalStore(t)`;
canary in `server_test.go` (probes `ExecuteAtomic`) untouched.

## Parity gap preserved (follow-up, NOT fixed here)

The handler returns every outgoing edge for the tenant + node,
including destinations the caller has no `READ` on. Python's handler
does NOT ACL-filter destinations and
`tests/python/integration/test_privilege_escalation.py:421-447` pins
this weaker property byte-for-byte. Tightening this requires a contract
change because existing SDK clients depend on the full fan-out shape.
Filed for Wave-3 follow-up under EPIC #407.

Other deliberate Python-parity carryovers (each documented in the
handler header):
- `offset` declared on the proto but ignored.
- Store layer (Wave-1) already adds `ORDER BY created_at DESC` and a
  SQL `LIMIT`; we pass `limit=0` to keep the slice in the handler so
  `has_more` semantics match.

## Test plan

- [x] `go test ./internal/api/... -run TestGetEdgesFrom` — empty,
      single, multi (no ACL filter), missing source, edge_type filter,
      store-error swallow to empty
- [x] `TestServer_UnimplementedRPC_Default` canary still green
      (probes `ExecuteAtomic`)
- [x] `go vet ./internal/api/... ./internal/store/...`
- [x] `uvx ruff@0.15.7 check .` / `format --check .`

Note: a pre-existing duplicate-symbol issue (`userToProto`,
`lookupMemberRole`, `withTrustedUser`) on `origin/main` from earlier
W2 PRs blocks `go vet` of the full `internal/api` package; the
breakage is unrelated to this PR. Verified `go vet` and the new tests
pass once the dupes are renamed locally.

## Files

- `server/go/internal/api/get_edges_from.go` (new)
- `server/go/internal/api/get_edges_from_test.go` (new)

No changes to `_go_parity.py` or `server.go`.