### PR TITLE
feat(go-rewrite): DeleteUser RPC — Wave 2

### DIFF
--- a/server/go/internal/api/delete_user.go
+++ b/server/go/internal/api/delete_user.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// DeleteUser RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/DeleteUser.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:136 (rpc), :1010-1025
+// (messages). Reference Python:
+// server/python/entdb_server/api/grpc_server.py:2925-2981 (handler) and
+// server/python/entdb_server/global_store.py:800-822 (queue_deletion).
+//
+// Semantics (preserved byte-for-byte from the Python handler unless noted):
+//
+//   - Globalstore must be configured. If not, abort with
+//     codes.Unimplemented "User registry not configured" (parity with
+//     grpc_server.py:2939).
+//   - actor and user_id are required (codes.InvalidArgument). Order of
+//     validation matches Python: actor before user_id.
+//   - Trusted-actor pattern: the privilege decision uses
+//     auth.Authoritative(ctx, claimed). The wire `actor` field is
+//     UNTRUSTED and only consulted as the fallback when no interceptor
+//     ran (unit tests). Self-or-admin gate matches Python's
+//     _is_self_or_admin (grpc_server.py:2071-2086) and shares the helper
+//     defined in update_user.go.
+//   - Idempotent re-queue: if a deletion_queue row with status='pending'
+//     already exists, return the EXISTING requested_at / execute_at
+//     unchanged. Matches grpc_server.py:2950-2956 and the contract pin
+//     at test_gdpr_engine.py:637-643.
+//   - User not found is reported IN-BAND: success=false,
+//     error="User not found" (no NOT_FOUND status) — pinned by
+//     test_gdpr_engine.py:658-662.
+//   - grace_days <= 0 is normalized to 30 (Python grpc_server.py:2965).
+//     Note that the underlying globalstore.QueueDeletion does NOT clamp
+//     itself; the handler is the single source of normalization.
+//   - On success returns success=true, status="pending" along with the
+//     unix-second timestamps the queue row carries. The state machine is
+//     scheduled (=='pending') -> executing -> completed. The handler only
+//     ever returns the scheduled state; the worker advances the row.
+//   - User status flipped to "pending_deletion" via SetUserStatus AFTER
+//     the queue insert. A failure here is non-fatal — the queue row is
+//     the source of truth (parity with grpc_server.py:2967).
+//
+// Legal-hold gate (NEW behavior, behind a flag):
+//
+// The Python handler does not check legal hold at queue time. Per spec
+// "Side effects" / "Open questions" §4 the Go port adds an explicit
+// FAILED_PRECONDITION gate: before queueing, walk
+// globalstore.GetUserTenants and reject if any tenant has a legal_holds
+// row (globalstore.IsLegalHoldSet). The check is gated on
+// Server.WithLegalHoldOnDelete(true) so day-zero parity tests pass with
+// the gate disabled; production deployments MUST flip this on once a
+// contract test has pinned the new behavior.
+//
+// NO WAL append. The user registry and deletion_queue are global_store
+// control-plane state, not per-tenant event-sourced data — see
+// CLAUDE.md "Architecture Invariants" #4 and the spec's "Side effects"
+// section. The actual erasure events emitted by the GDPR worker
+// (anonymize_user, delete_tenant, remove_membership) DO go through
+// per-tenant WALs; the DeleteUser handler itself never appends.
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const deleteUserMethod = "DeleteUser"
+
+// defaultDeleteUserGraceDays is the Python normalization fallback for
+// grace_days <= 0 (grpc_server.py:2965). Pulled out as a constant so
+// tests can reference it without re-deriving.
+const defaultDeleteUserGraceDays = 30
+
+// DeleteUser implements entdb.v1.EntDBService/DeleteUser.
+//
+// See file header for the full semantic contract. The handler is
+// stateless apart from the globalstore handle: it gates on
+// trusted-actor + self-or-admin, looks up an existing queue row to
+// preserve idempotency, optionally enforces a legal-hold precondition,
+// then queues the deletion and flips the user's status.
+func (s *Server) DeleteUser(ctx context.Context, req *pb.DeleteUserRequest) (*pb.DeleteUserResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(deleteUserMethod, outcome, time.Since(start))
+	}()
+
+	// Configuration gate. Mirrors Python grpc_server.py:2939.
+	if s.global == nil {
+		outcome = "error"
+		return nil, status.Error(codes.Unimplemented, "User registry not configured")
+	}
+
+	// Required-field aborts. Mirrors grpc_server.py:2940-2943.
+	if req.GetActor() == "" {
+		outcome = "error"
+		return nil, status.Error(codes.InvalidArgument, "actor is required")
+	}
+	userID := req.GetUserId()
+	if userID == "" {
+		outcome = "error"
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	// Trusted-actor resolution. The interceptor-bound identity wins over
+	// the wire claim — the request payload is UNTRUSTED. In no-auth
+	// deployments / unit tests with no Identity on ctx, the claimed
+	// actor is returned as-is (auth.Authoritative documented fallback).
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	if !isSelfOrAdmin(trusted, userID) {
+		outcome = "error"
+		return nil, status.Error(codes.PermissionDenied,
+			"DeleteUser requires the user themselves or an admin actor")
+	}
+
+	// Existence check. The Python handler returns OK + success=false on
+	// a missing user — keep that asymmetric contract for SDK parity. Do
+	// NOT promote to NOT_FOUND.
+	user, err := s.global.GetUser(ctx, userID)
+	if err != nil {
+		outcome = "error"
+		return &pb.DeleteUserResponse{Success: false, Error: err.Error()}, nil
+	}
+	if user == nil {
+		return &pb.DeleteUserResponse{Success: false, Error: "User not found"}, nil
+	}
+
+	// Idempotency: if a pending entry exists, return it unchanged. The
+	// Python handler short-circuits here (grpc_server.py:2950-2956) and
+	// re-queueing must NOT push execute_at forward.
+	if existing, eerr := s.global.GetDeletionEntry(ctx, userID); eerr == nil && existing != nil && existing.Status == "pending" {
+		return &pb.DeleteUserResponse{
+			Success:     true,
+			RequestedAt: existing.RequestedAt,
+			ExecuteAt:   existing.ExecuteAt,
+			Status:      "pending",
+		}, nil
+	}
+
+	// Optional legal-hold gate (Go-port addition). Walk the user's
+	// tenants and reject with FAILED_PRECONDITION if any is held. The
+	// gate is off by default to keep day-zero parity with Python; flip
+	// via api.WithLegalHoldOnDelete(true).
+	if s.legalHoldOnDelete {
+		members, mErr := s.global.GetUserTenants(ctx, userID)
+		if mErr != nil {
+			outcome = "error"
+			return &pb.DeleteUserResponse{Success: false, Error: mErr.Error()}, nil
+		}
+		for _, m := range members {
+			held, hErr := s.global.IsLegalHoldSet(ctx, m.TenantID)
+			if hErr != nil {
+				outcome = "error"
+				return &pb.DeleteUserResponse{Success: false, Error: hErr.Error()}, nil
+			}
+			if held {
+				outcome = "error"
+				return nil, status.Errorf(codes.FailedPrecondition,
+					"DeleteUser blocked: tenant %q is under legal hold", m.TenantID)
+			}
+		}
+	}
+
+	// Normalize grace days (parity with grpc_server.py:2965).
+	grace := int(req.GetGraceDays())
+	if grace <= 0 {
+		grace = defaultDeleteUserGraceDays
+	}
+
+	entry, qErr := s.global.QueueDeletion(ctx, userID, grace)
+	if qErr != nil {
+		// Catch-all in-band failure mirroring grpc_server.py:2976-2981.
+		outcome = "error"
+		return &pb.DeleteUserResponse{Success: false, Error: qErr.Error()}, nil
+	}
+
+	// Flip user status to "pending_deletion". Failure here is non-fatal
+	// — the queue row is the source of truth. We deliberately ignore
+	// the (bool, error) return for parity with the Python handler which
+	// also doesn't gate on it (grpc_server.py:2967).
+	_, _ = s.global.SetUserStatus(ctx, userID, "pending_deletion")
+
+	return &pb.DeleteUserResponse{
+		Success:     true,
+		RequestedAt: entry.RequestedAt,
+		ExecuteAt:   entry.ExecuteAt,
+		Status:      "pending",
+	}, nil
+}

--- a/server/go/internal/api/delete_user_test.go
+++ b/server/go/internal/api/delete_user_test.go
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for the DeleteUser RPC. Behaviours pinned (per
+// docs/go-port/rpcs/DeleteUser.md "Contract tests pinning behavior"):
+//
+//   1. Self-deletion happy path — alice queues her own erasure with
+//      grace_days=7; status="pending", user.Status="pending_deletion",
+//      execute_at = requested_at + 7d.
+//   2. Admin happy path — admin:root queues bob's erasure; same
+//      assertions modulo the actor.
+//   3. Legal-hold gate (NEW Go-port behaviour, opt-in via
+//      WithLegalHoldOnDelete(true)) — a user with a held tenant gets
+//      FAILED_PRECONDITION.
+//   4. Already-pending → idempotent: re-queueing returns the EXISTING
+//      requested_at / execute_at (does NOT push the timestamps forward).
+//
+// Plus the standard config / required-arg gates carried over from the
+// Python contract: Unimplemented when globalstore is not wired,
+// InvalidArgument for empty actor / user_id, PermissionDenied when a
+// non-admin tries to delete another user, and OK + success=false +
+// error="User not found" for an unknown user.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const secondsPerDay = int64(86400)
+
+// TestDeleteUser_Self_HappyPath: alice queues her own erasure with a
+// 7-day grace. Mirrors test_gdpr_engine.py:625-633.
+func TestDeleteUser_Self_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.DeleteUser(withTrustedUser(ctx, "alice"), &pb.DeleteUserRequest{
+		Actor:     "user:alice",
+		UserId:    "alice",
+		GraceDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("DeleteUser: success=false, error=%q", resp.GetError())
+	}
+	if resp.GetStatus() != "pending" {
+		t.Errorf("Status: got %q, want %q", resp.GetStatus(), "pending")
+	}
+	if got, want := resp.GetExecuteAt()-resp.GetRequestedAt(), 7*secondsPerDay; got != want {
+		t.Errorf("ExecuteAt-RequestedAt: got %d, want %d", got, want)
+	}
+
+	// Queue row was inserted as 'pending'.
+	entry, err := gs.GetDeletionEntry(ctx, "alice")
+	if err != nil || entry == nil {
+		t.Fatalf("post-delete GetDeletionEntry: entry=%v err=%v", entry, err)
+	}
+	if entry.Status != "pending" {
+		t.Errorf("entry.Status: got %q, want %q", entry.Status, "pending")
+	}
+
+	// User status flipped.
+	got, err := gs.GetUser(ctx, "alice")
+	if err != nil || got == nil {
+		t.Fatalf("post-delete GetUser: user=%v err=%v", got, err)
+	}
+	if got.Status != "pending_deletion" {
+		t.Errorf("user.Status: got %q, want %q", got.Status, "pending_deletion")
+	}
+}
+
+// TestDeleteUser_Admin_HappyPath: admin:root queues bob's erasure.
+// Default grace (grace_days=0) normalizes to 30 days.
+func TestDeleteUser_Admin_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.DeleteUser(withTrustedUser(ctx, "admin:root"), &pb.DeleteUserRequest{
+		Actor:  "admin:root",
+		UserId: "bob",
+		// grace_days unset -> normalized to 30
+	})
+	if err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("DeleteUser: success=false, error=%q", resp.GetError())
+	}
+	if resp.GetStatus() != "pending" {
+		t.Errorf("Status: got %q, want %q", resp.GetStatus(), "pending")
+	}
+	if got, want := resp.GetExecuteAt()-resp.GetRequestedAt(), 30*secondsPerDay; got != want {
+		t.Errorf("ExecuteAt-RequestedAt (default grace): got %d, want %d", got, want)
+	}
+
+	// User status flipped.
+	got, err := gs.GetUser(ctx, "bob")
+	if err != nil || got == nil {
+		t.Fatalf("post-delete GetUser: user=%v err=%v", got, err)
+	}
+	if got.Status != "pending_deletion" {
+		t.Errorf("user.Status: got %q, want %q", got.Status, "pending_deletion")
+	}
+}
+
+// TestDeleteUser_LegalHold_Blocks: when WithLegalHoldOnDelete(true), a
+// user belonging to a tenant with a legal_holds row gets
+// FAILED_PRECONDITION. NEW Go-port behaviour (Python has no such gate
+// at queue time); see DeleteUser.md "Side effects" §4.
+func TestDeleteUser_LegalHold_Blocks(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+	if _, err := gs.CreateTenant(ctx, "t1", "Alice's Tenant", "us-east-1"); err != nil {
+		t.Fatalf("seed CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "t1", "alice", "owner"); err != nil {
+		t.Fatalf("seed AddTenantMember: %v", err)
+	}
+	if _, err := gs.SetLegalHold(ctx, "t1", "compliance:legal", "litigation hold"); err != nil {
+		t.Fatalf("seed SetLegalHold: %v", err)
+	}
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithLegalHoldOnDelete(true),
+	)
+
+	_, err := srv.DeleteUser(withTrustedUser(ctx, "alice"), &pb.DeleteUserRequest{
+		Actor:     "user:alice",
+		UserId:    "alice",
+		GraceDays: 30,
+	})
+	if err == nil {
+		t.Fatalf("DeleteUser: expected FAILED_PRECONDITION, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("DeleteUser: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.FailedPrecondition {
+		t.Fatalf("DeleteUser: code: got %v, want FailedPrecondition", st.Code())
+	}
+
+	// Defence in depth: no queue row was created.
+	entry, _ := gs.GetDeletionEntry(ctx, "alice")
+	if entry != nil {
+		t.Errorf("expected no deletion_queue row after legal-hold block, got %+v", entry)
+	}
+	// User status NOT flipped.
+	got, _ := gs.GetUser(ctx, "alice")
+	if got == nil || got.Status != "active" {
+		t.Errorf("user.Status: got %v, want unchanged 'active'", got)
+	}
+}
+
+// TestDeleteUser_Idempotent_ReturnsExisting: re-queueing returns the
+// existing requested_at / execute_at unchanged. Pinned by
+// test_gdpr_engine.py:637-643.
+func TestDeleteUser_Idempotent_ReturnsExisting(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	first, err := srv.DeleteUser(withTrustedUser(ctx, "alice"), &pb.DeleteUserRequest{
+		Actor:     "user:alice",
+		UserId:    "alice",
+		GraceDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("first DeleteUser: %v", err)
+	}
+	if !first.GetSuccess() {
+		t.Fatalf("first DeleteUser: success=false")
+	}
+
+	// Re-queue with a *different* grace period — the handler MUST
+	// return the original timestamps, not push them forward.
+	second, err := srv.DeleteUser(withTrustedUser(ctx, "alice"), &pb.DeleteUserRequest{
+		Actor:     "user:alice",
+		UserId:    "alice",
+		GraceDays: 99,
+	})
+	if err != nil {
+		t.Fatalf("second DeleteUser: %v", err)
+	}
+	if !second.GetSuccess() {
+		t.Fatalf("second DeleteUser: success=false, error=%q", second.GetError())
+	}
+	if second.GetRequestedAt() != first.GetRequestedAt() {
+		t.Errorf("RequestedAt: got %d, want unchanged %d", second.GetRequestedAt(), first.GetRequestedAt())
+	}
+	if second.GetExecuteAt() != first.GetExecuteAt() {
+		t.Errorf("ExecuteAt: got %d, want unchanged %d", second.GetExecuteAt(), first.GetExecuteAt())
+	}
+	if second.GetStatus() != "pending" {
+		t.Errorf("Status: got %q, want %q", second.GetStatus(), "pending")
+	}
+}
+
+// TestDeleteUser_NonAdmin_OtherDenied: alice tries to delete bob with
+// a forged admin:root claim on the wire — the trusted identity wins
+// and the request is denied. Mirrors test_gdpr_engine.py:646-654.
+func TestDeleteUser_NonAdmin_OtherDenied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// alice is the trusted caller; she claims admin:root in the wire
+	// payload. The handler MUST ignore the wire claim.
+	_, err := srv.DeleteUser(withTrustedUser(ctx, "alice"), &pb.DeleteUserRequest{
+		Actor:     "admin:root",
+		UserId:    "bob",
+		GraceDays: 30,
+	})
+	if err == nil {
+		t.Fatalf("DeleteUser: expected PERMISSION_DENIED, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("DeleteUser: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("DeleteUser: code: got %v, want PermissionDenied", st.Code())
+	}
+
+	// No queue row created.
+	entry, _ := gs.GetDeletionEntry(ctx, "bob")
+	if entry != nil {
+		t.Errorf("expected no deletion_queue row after denied call, got %+v", entry)
+	}
+}
+
+// TestDeleteUser_NotFound_InBandFailure: unknown user_id returns
+// success=false, error="User not found" IN-BAND (no NOT_FOUND code).
+// Mirrors test_gdpr_engine.py:658-662.
+func TestDeleteUser_NotFound_InBandFailure(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.DeleteUser(withTrustedUser(context.Background(), "admin:root"), &pb.DeleteUserRequest{
+		Actor:     "admin:root",
+		UserId:    "ghost",
+		GraceDays: 30,
+	})
+	if err != nil {
+		t.Fatalf("DeleteUser: expected nil err for in-band not-found, got %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatalf("DeleteUser: expected success=false, got %+v", resp)
+	}
+	if resp.GetError() != "User not found" {
+		t.Errorf("DeleteUser: error: got %q, want %q", resp.GetError(), "User not found")
+	}
+}
+
+// TestDeleteUser_GlobalstoreUnset_Unimplemented: a Server with no
+// globalstore wired aborts with codes.Unimplemented.
+func TestDeleteUser_GlobalstoreUnset_Unimplemented(t *testing.T) {
+	t.Parallel()
+	srv := api.New() // no WithGlobalStore
+
+	_, err := srv.DeleteUser(context.Background(), &pb.DeleteUserRequest{
+		Actor:  "admin:root",
+		UserId: "alice",
+	})
+	if err == nil {
+		t.Fatalf("DeleteUser: expected error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("DeleteUser: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.Unimplemented {
+		t.Fatalf("DeleteUser: code: got %v, want Unimplemented", st.Code())
+	}
+}
+
+// TestDeleteUser_EmptyActor_InvalidArgument: actor required.
+func TestDeleteUser_EmptyActor_InvalidArgument(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.DeleteUser(context.Background(), &pb.DeleteUserRequest{
+		UserId: "alice",
+	})
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("DeleteUser: code: got %v, want InvalidArgument", st.Code())
+	}
+}
+
+// TestDeleteUser_EmptyUserID_InvalidArgument: user_id required.
+func TestDeleteUser_EmptyUserID_InvalidArgument(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.DeleteUser(context.Background(), &pb.DeleteUserRequest{
+		Actor: "admin:root",
+	})
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("DeleteUser: code: got %v, want InvalidArgument", st.Code())
+	}
+}

--- a/server/go/internal/api/server.go
+++ b/server/go/internal/api/server.go
@@ -35,6 +35,13 @@ type Server struct {
 	sharding *tenant.Sharding
 	region   string
 	registry *schema.Registry
+
+	// legalHoldOnDelete gates the Go-port addition of a legal-hold
+	// precondition check at GDPR queue time (DeleteUser). Off by
+	// default to keep day-zero parity with the Python handler, which
+	// has no such gate. See docs/go-port/rpcs/DeleteUser.md "Side
+	// effects" / "Open questions" §4.
+	legalHoldOnDelete bool
 }
 
 // Option is a functional-options configurator for New.
@@ -77,6 +84,15 @@ func WithRegion(region string) Option {
 // (CLAUDE.md schema invariant), so post-boot reads are lock-free.
 func WithSchemaRegistry(r *schema.Registry) Option {
 	return func(srv *Server) { srv.registry = r }
+}
+
+// WithLegalHoldOnDelete enables the Go-port-only legal-hold gate at
+// DeleteUser queue time. When true, the handler walks the user's
+// tenants and rejects with codes.FailedPrecondition if any tenant has
+// a legal_holds row. Off by default for byte-for-byte parity with the
+// Python handler at HEAD. See docs/go-port/rpcs/DeleteUser.md.
+func WithLegalHoldOnDelete(enabled bool) Option {
+	return func(srv *Server) { srv.legalHoldOnDelete = enabled }
 }
 
 // New constructs a Server. All RPCs return Unimplemented in Wave 1;


### PR DESCRIPTION
## Summary

Wave-2 port of the GDPR right-to-erasure entry point. Spec: `docs/go-port/rpcs/DeleteUser.md` (EPIC #407, W2). Reference Python: `server/python/entdb_server/api/grpc_server.py:2925-2981`.

- Trusted-actor self-or-admin gate (re-uses `isSelfOrAdmin` from `update_user.go`); wire `actor` claim is UNTRUSTED.
- Idempotent re-queue: an existing pending `deletion_queue` row short-circuits with the original `requested_at` / `execute_at`.
- Unknown user surfaces in-band as `success=false, error="User not found"` — no `NOT_FOUND` (Python SDK contract preserved).
- `grace_days <= 0` normalised to 30. On success the queue row is `'pending'` and `user.status` flips to `'pending_deletion'`.

### Go-port addition: legal-hold gate at queue time

The Python handler does **not** check legal hold at queue time. Per the spec's "Side effects" / "Open questions" §4, the Go port adds an explicit `FAILED_PRECONDITION` gate behind a new `api.WithLegalHoldOnDelete(true)` `Option`. Off by default for byte-for-byte parity with Python at HEAD; flip the flag once the cross-impl contract test pins the new behaviour. Walks `globalstore.GetUserTenants` then `globalstore.IsLegalHoldSet` per tenant.

### Constraints respected

- No WAL append (user registry + `deletion_queue` are global-store control-plane state per CLAUDE.md invariant #4).
- Does NOT modify `_go_parity.py` or `server.go`'s gRPC registration — handler + option + tests only.

## Test plan

- [x] `go test -run 'TestDeleteUser' ./internal/api/` — all 9 cases pass (self happy, admin happy, legal-hold blocks, idempotent, non-admin denied, not-found, globalstore-unset, empty actor, empty user_id).
- [x] `go vet ./internal/globalstore/... ./internal/auth/...` clean.
- [x] `uvx ruff@0.15.7 check .` clean.
- [x] `uvx ruff@0.15.7 format --check .` clean.
- [ ] Cross-impl contract test (`tests/contract/`) once `_go_parity.py` is flipped in a follow-up.

Note: `go vet ./...` on `server/go/internal/api` reveals pre-existing duplicate symbol declarations (`userToProto`, `lookupMemberRole`, `withTrustedUser`) introduced by parallel Wave-2 PR merges on `origin/main` — not caused by this PR. Those are tracked separately on `fix/go-api-test-helper-dedupe`. To validate this PR's tests in isolation, the conflicting files were temporarily moved aside; with this PR's files plus a non-duplicated baseline, all 9 new tests pass.