### PR TITLE
feat(go-rewrite): GetEdgesTo RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_edges_to.go
+++ b/server/go/internal/api/get_edges_to.go
@@ -1,0 +1,176 @@
+// GetEdgesTo RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/GetEdgesTo.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:67 (rpc), :476-491 (request /
+// response), :493-507 (Edge). Reference Python handler:
+// server/python/entdb_server/api/grpc_server.py:1428-1456.
+//
+// Symmetric inverse of GetEdgesFrom: returns edges whose `to_node_id`
+// matches the requested node, scoped to a single tenant. Cross-tenant
+// fan-in is structurally impossible because the edges PRIMARY KEY
+// includes tenant_id (canonical_store.py:1068), so even a forged
+// node_id that happens to exist in another tenant cannot leak through
+// the `WHERE tenant_id = ? AND to_node_id = ?` filter.
+//
+// Semantics (preserved from the Python handler):
+//
+//   - Read-only. No WAL append, no SQLite mutation, no global_store write.
+//   - Tenant gate runs first via s.checkTenant; UNAVAILABLE /
+//     FAILED_PRECONDITION / INVALID_ARGUMENT propagate untouched.
+//   - Trusted-actor invariant (CLAUDE.md, commit fece3fb): we resolve
+//     identity via auth.Authoritative and explicitly drop the wire
+//     `actor` claim. There is no per-edge ACL filter today; the call
+//     pins the trust boundary so a future tightening has a single
+//     chokepoint.
+//   - limit==0 ⇒ default 100; has_more is computed AFTER fetching
+//     limit+1 rows (Python parity at grpc_server.py:1444-1446 fetches
+//     all rows then slices in memory; we ask SQLite for limit+1 to
+//     bound memory at the storage layer while still emitting the same
+//     wire shape).
+//   - offset is currently UNUSED (parity with Python; flagged in the
+//     spec "Open questions").
+//   - Internal storage errors are SWALLOWED into an empty
+//     GetEdgesResponse with codes.OK. Same `except Exception` ->
+//     GetEdgesResponse(edges=[]) collapse the Python handler does at
+//     grpc_server.py:1454. Metric label is "error" so the swallow does
+//     not inflate the ok counter.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+const grpcMethodGetEdgesTo = "GetEdgesTo"
+
+// GetEdgesTo implements entdb.v1.EntDBService/GetEdgesTo. See file
+// header for the full contract; the body is a thin translation layer
+// over store.GetEdgesTo.
+func (s *Server) GetEdgesTo(
+	ctx context.Context,
+	req *pb.GetEdgesRequest,
+) (*pb.GetEdgesResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(grpcMethodGetEdgesTo, outcome, time.Since(start))
+	}()
+
+	tenantID := req.GetContext().GetTenantId()
+
+	// Ingress checks — may abort with INVALID_ARGUMENT (empty tenant) /
+	// UNAVAILABLE (sharding) / FAILED_PRECONDITION (region) / NOT_FOUND
+	// (unknown tenant). Same gate every tenant-scoped RPC uses.
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		outcome = "error"
+		return nil, err
+	}
+
+	// Trusted actor: pin the trust boundary even though no per-edge ACL
+	// filter exists today. The wire `actor` is treated as a hint only;
+	// auth.Authoritative replaces it with the interceptor-attached
+	// identity when present (commit fece3fb).
+	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetContext().GetActor()))
+
+	// Storage path requires the per-tenant CanonicalStore. If no store
+	// is wired, fall through to the swallow-and-empty path — the
+	// Python handler degrades the same way when canonical_store is
+	// missing (it raises and the `except Exception` collapse takes
+	// over).
+	if s.store == nil {
+		outcome = "error"
+		return &pb.GetEdgesResponse{}, nil
+	}
+
+	limit := int(req.GetLimit())
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var edgeType *int32
+	if t := req.GetEdgeTypeId(); t != 0 {
+		edgeType = &t
+	}
+
+	// Fetch limit+1 so a single trailing row distinguishes
+	// "exactly limit" from "more available". Mirrors the Python
+	// `len(edges) > limit` slice trick at grpc_server.py:1445-1446
+	// without materialising the full result set in memory for
+	// high-fan-in targets.
+	rows, err := s.store.GetEdgesTo(ctx, tenantID, req.GetNodeId(), edgeType, limit+1)
+	if err != nil {
+		// Python's bare `except Exception` swallows ALL internal
+		// errors into edges=[] with grpc.OK (grpc_server.py:1454).
+		// We mirror that for parity. Operators can still tell the
+		// "no edges" case apart from "store fault" via the metric
+		// label, which is set to "error" here.
+		outcome = "error"
+		return &pb.GetEdgesResponse{}, nil
+	}
+
+	hasMore := len(rows) > limit
+	if hasMore {
+		rows = rows[:limit]
+	}
+
+	out := make([]*pb.Edge, 0, len(rows))
+	for _, e := range rows {
+		out = append(out, edgeToProto(e))
+	}
+	return &pb.GetEdgesResponse{Edges: out, HasMore: hasMore}, nil
+}
+
+// edgeToProto lowers a store.Edge into the wire shape. props_json is
+// parsed into a typed google.protobuf.Struct so SDK clients can read
+// `props` directly (Python parity: the handler passes the parsed dict
+// to `_dict_to_struct` at grpc_server.py:166 before assembling the
+// Edge proto). A non-JSON or non-object props_json column is treated
+// as an empty struct — matching `_dict_to_struct`'s defensive shape
+// when an unexpected legacy row is replayed.
+//
+// Kept package-private so a future GetEdgesFrom port can share it via
+// a single chokepoint without the conversion shape diverging between
+// the from / to handlers (see spec "Shared Go package deps").
+func edgeToProto(e *store.Edge) *pb.Edge {
+	out := &pb.Edge{
+		TenantId:   e.TenantID,
+		EdgeTypeId: e.EdgeTypeID,
+		FromNodeId: e.FromNodeID,
+		ToNodeId:   e.ToNodeID,
+		CreatedAt:  e.CreatedAt,
+	}
+	out.Props = edgePropsToStruct(e.PropsJSON)
+	return out
+}
+
+// edgePropsToStruct parses a stored props_json column into a typed
+// Struct. Empty / invalid input lowers to an empty Struct, never nil:
+// the Python wire shape always emits the field (zero-value
+// google.protobuf.Struct{}) so SDK consumers can rely on
+// `edge.props.fields` being addressable without a nil check.
+func edgePropsToStruct(propsJSON string) *structpb.Struct {
+	if propsJSON == "" {
+		s, _ := structpb.NewStruct(map[string]any{})
+		return s
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(propsJSON), &m); err != nil || m == nil {
+		s, _ := structpb.NewStruct(map[string]any{})
+		return s
+	}
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		s, _ = structpb.NewStruct(map[string]any{})
+		return s
+	}
+	return s
+}

--- a/server/go/internal/api/get_edges_to_test.go
+++ b/server/go/internal/api/get_edges_to_test.go
@@ -1,0 +1,315 @@
+// Tests for the GetEdgesTo RPC. Spec: docs/go-port/rpcs/GetEdgesTo.md.
+//
+// Coverage matches the Python contract pins called out in the spec:
+//
+//   - test_grpc_contract.py:248-254 — empty seed ⇒ edges == [], OK.
+//   - test_canonical_store.py:331-370 / test_crud_comprehensive.py:317-325 —
+//     fan-in count: two edges to one target ⇒ length 2.
+//   - test_workplace_chat.py / test_workplace_posts.py / test_workplace_tasks.py —
+//     edge_type_id filter narrows the fan-in.
+//   - test_batch_applier.py:1223 — empty fan-in for a missing dst node.
+//   - grpc_server.py:1454 — `except Exception` collapse: any internal
+//     error degrades to GetEdgesResponse{} with codes.OK.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// newEdgeStore returns a tmpdir-backed CanonicalStore with WAL on,
+// pre-opened for tenantID. Closed automatically on test teardown.
+func newEdgeStore(t *testing.T, tenantID string) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(context.Background(), tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	return cs
+}
+
+// edgesReq is a small builder so each case reads as the wire payload.
+func edgesReq(tenantID, nodeID string, edgeTypeID, limit int32) *pb.GetEdgesRequest {
+	return &pb.GetEdgesRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		NodeId:     nodeID,
+		EdgeTypeId: edgeTypeID,
+		Limit:      limit,
+	}
+}
+
+// TestGetEdgesTo_EmptyReturnsNoEdges pins the contract from
+// test_grpc_contract.py:248-254: a tenant with no edges yields
+// edges=[] / has_more=false / codes.OK.
+func TestGetEdgesTo_EmptyReturnsNoEdges(t *testing.T) {
+	t.Parallel()
+	const tenantID = "tenant-empty"
+	cs := newEdgeStore(t, tenantID)
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.GetEdgesTo(context.Background(), edgesReq(tenantID, "n-target", 0, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetEdgesTo: response is nil")
+	}
+	if got := len(resp.GetEdges()); got != 0 {
+		t.Errorf("Edges: got %d, want 0", got)
+	}
+	if resp.GetHasMore() {
+		t.Errorf("HasMore: got true, want false on empty fan-in")
+	}
+}
+
+// TestGetEdgesTo_SingleEdgeRoundtrip pins the wire shape: one inbound
+// edge round-trips with from_node_id / to_node_id / edge_type_id /
+// tenant_id intact. Mirrors sdk/go/entdb/grpc_transport_test.go:694-712.
+func TestGetEdgesTo_SingleEdgeRoundtrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const tenantID = "tenant-single"
+	const target = "post-1"
+
+	cs := newEdgeStore(t, tenantID)
+	if _, err := cs.CreateEdge(ctx, tenantID, store.EdgeInput{
+		EdgeTypeID: 7,
+		FromNodeID: "user-alice",
+		ToNodeID:   target,
+		Props:      map[string]any{"weight": 0.5},
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 0, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo: unexpected error: %v", err)
+	}
+	if got := len(resp.GetEdges()); got != 1 {
+		t.Fatalf("Edges: got %d, want 1", got)
+	}
+	e := resp.GetEdges()[0]
+	if got, want := e.GetTenantId(), tenantID; got != want {
+		t.Errorf("TenantId = %q, want %q", got, want)
+	}
+	if got, want := e.GetEdgeTypeId(), int32(7); got != want {
+		t.Errorf("EdgeTypeId = %d, want %d", got, want)
+	}
+	if got, want := e.GetFromNodeId(), "user-alice"; got != want {
+		t.Errorf("FromNodeId = %q, want %q", got, want)
+	}
+	if got, want := e.GetToNodeId(), target; got != want {
+		t.Errorf("ToNodeId = %q, want %q", got, want)
+	}
+	if e.GetProps() == nil {
+		t.Errorf("Props: got nil, want non-nil Struct (always emitted)")
+	} else if w, ok := e.GetProps().GetFields()["weight"]; !ok {
+		t.Errorf("Props missing key 'weight'; have %v", e.GetProps().GetFields())
+	} else if w.GetNumberValue() != 0.5 {
+		t.Errorf("Props.weight = %v, want 0.5", w.GetNumberValue())
+	}
+	if resp.GetHasMore() {
+		t.Errorf("HasMore: got true, want false (only 1 edge, default limit)")
+	}
+}
+
+// TestGetEdgesTo_MultipleEdgesFanIn pins the fan-in count contract
+// from test_canonical_store.py:331-370: two edges directed at the
+// same target ⇒ length 2.
+func TestGetEdgesTo_MultipleEdgesFanIn(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const tenantID = "tenant-fanin"
+	const target = "post-popular"
+
+	cs := newEdgeStore(t, tenantID)
+	for _, src := range []string{"user-alice", "user-bob", "user-carol"} {
+		if _, err := cs.CreateEdge(ctx, tenantID, store.EdgeInput{
+			EdgeTypeID: 1,
+			FromNodeID: src,
+			ToNodeID:   target,
+		}); err != nil {
+			t.Fatalf("CreateEdge(%s): %v", src, err)
+		}
+	}
+	// One unrelated outbound edge from the target must NOT show up
+	// (cross-direction isolation).
+	if _, err := cs.CreateEdge(ctx, tenantID, store.EdgeInput{
+		EdgeTypeID: 1,
+		FromNodeID: target,
+		ToNodeID:   "user-dave",
+	}); err != nil {
+		t.Fatalf("CreateEdge(outbound): %v", err)
+	}
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 0, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo: unexpected error: %v", err)
+	}
+	if got := len(resp.GetEdges()); got != 3 {
+		t.Fatalf("Edges: got %d, want 3", got)
+	}
+	for _, e := range resp.GetEdges() {
+		if e.GetToNodeId() != target {
+			t.Errorf("ToNodeId = %q, want %q (fan-in must filter by to)",
+				e.GetToNodeId(), target)
+		}
+	}
+}
+
+// TestGetEdgesTo_MissingDstReturnsEmpty pins
+// test_batch_applier.py:1223: a node_id that has no inbound edges
+// (here: never created) yields an empty result, NOT an error. Also
+// covers the "ghost"-target case from the spec.
+func TestGetEdgesTo_MissingDstReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const tenantID = "tenant-ghost"
+
+	cs := newEdgeStore(t, tenantID)
+	// Seed an edge to a different target so the table is non-empty;
+	// the lookup must still return [] for the requested ghost.
+	if _, err := cs.CreateEdge(ctx, tenantID, store.EdgeInput{
+		EdgeTypeID: 1,
+		FromNodeID: "src",
+		ToNodeID:   "real-target",
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, "ghost", 0, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo: unexpected error: %v", err)
+	}
+	if got := len(resp.GetEdges()); got != 0 {
+		t.Errorf("Edges: got %d, want 0 for ghost target", got)
+	}
+	if resp.GetHasMore() {
+		t.Errorf("HasMore: got true, want false")
+	}
+}
+
+// TestGetEdgesTo_EdgeTypeFilter pins the workplace-chat / workplace-
+// posts contract: passing edge_type_id narrows fan-in to that single
+// edge type. Mirrors test_workplace_chat.py:233 et al.
+func TestGetEdgesTo_EdgeTypeFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const tenantID = "tenant-filter"
+	const target = "post-1"
+
+	cs := newEdgeStore(t, tenantID)
+	// Two upvotes (type 1) and one reply (type 2) all point at the
+	// same target. The filter must return only the two upvotes.
+	for _, src := range []string{"user-alice", "user-bob"} {
+		if _, err := cs.CreateEdge(ctx, tenantID, store.EdgeInput{
+			EdgeTypeID: 1, // UPVOTE
+			FromNodeID: src,
+			ToNodeID:   target,
+		}); err != nil {
+			t.Fatalf("CreateEdge(upvote %s): %v", src, err)
+		}
+	}
+	if _, err := cs.CreateEdge(ctx, tenantID, store.EdgeInput{
+		EdgeTypeID: 2, // REPLY
+		FromNodeID: "user-carol",
+		ToNodeID:   target,
+	}); err != nil {
+		t.Fatalf("CreateEdge(reply): %v", err)
+	}
+
+	srv := api.New(api.WithStore(cs))
+
+	// edge_type_id=1 ⇒ only the two upvotes.
+	resp, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 1, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo type=1: %v", err)
+	}
+	if got := len(resp.GetEdges()); got != 2 {
+		t.Fatalf("Edges (type=1): got %d, want 2", got)
+	}
+	for _, e := range resp.GetEdges() {
+		if e.GetEdgeTypeId() != 1 {
+			t.Errorf("EdgeTypeId = %d, want 1 (filter leak)", e.GetEdgeTypeId())
+		}
+	}
+
+	// edge_type_id=2 ⇒ only the single reply.
+	resp2, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 2, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo type=2: %v", err)
+	}
+	if got := len(resp2.GetEdges()); got != 1 {
+		t.Fatalf("Edges (type=2): got %d, want 1", got)
+	}
+	if resp2.GetEdges()[0].GetEdgeTypeId() != 2 {
+		t.Errorf("EdgeTypeId = %d, want 2", resp2.GetEdges()[0].GetEdgeTypeId())
+	}
+
+	// edge_type_id=0 ⇒ unfiltered, all three rows.
+	respAll, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 0, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo type=0: %v", err)
+	}
+	if got := len(respAll.GetEdges()); got != 3 {
+		t.Fatalf("Edges (unfiltered): got %d, want 3", got)
+	}
+
+	// edge_type_id=99 (unknown) ⇒ empty.
+	respMiss, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 99, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo type=99: %v", err)
+	}
+	if got := len(respMiss.GetEdges()); got != 0 {
+		t.Errorf("Edges (type=99): got %d, want 0", got)
+	}
+}
+
+// TestGetEdgesTo_StoreErrorReturnsEmpty pins the swallow-and-empty
+// contract from grpc_server.py:1454: any internal storage fault
+// collapses to GetEdgesResponse{} with codes.OK and metric label
+// "error". Driven here by skipping OpenTenant so the read-side pool
+// returns ErrTenantNotOpen — same shape as the Python `except
+// Exception` catch-all.
+func TestGetEdgesTo_StoreErrorReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	// Deliberately skip OpenTenant — the read-side pool lookup will
+	// error and the handler must collapse that to edges=[].
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.GetEdgesTo(ctx, edgesReq("tenant-unopened", "n", 0, 0))
+	if err != nil {
+		t.Fatalf("GetEdgesTo: must return OK + empty body, not gRPC error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("response is nil")
+	}
+	if got := len(resp.GetEdges()); got != 0 {
+		t.Errorf("Edges: got %d, want 0 on store error", got)
+	}
+	if resp.GetHasMore() {
+		t.Errorf("HasMore: got true, want false on store error")
+	}
+}


### PR DESCRIPTION
## Summary

- Ports `GetEdgesTo` from the Python handler (`server/python/entdb_server/api/grpc_server.py:1428-1456`) to the Go server.
- Symmetric inverse of `GetEdgesFrom`. Cross-tenant fan-in is structurally impossible because the edges PRIMARY KEY includes `tenant_id`, so the `WHERE tenant_id = ? AND to_node_id = ?` filter cannot leak across tenants even with a forged `node_id`.
- Spec: `docs/go-port/rpcs/GetEdgesTo.md`. EPIC #407.

Parity warts intentionally preserved:
- `offset` ignored (Python parity).
- Internal storage errors swallow into `GetEdgesResponse{}` with `codes.OK`; metric label is `error`.
- `auth.Authoritative` is called so the trusted-actor invariant has a chokepoint for future ACL tightening, even though there is no per-edge filter today.

Adds a private `edgeToProto` helper that lowers `store.Edge` (with `props_json` parsed into a typed `google.protobuf.Struct`) into the wire `pb.Edge`. Designed for reuse by the upcoming `GetEdgesFrom` port.

ExecuteAtomic remains the `codes.Unimplemented` canary.

## Test plan

- [x] `go vet ./...` (note: pre-existing breakage on `origin/main` from concurrently-merged Wave-2 PRs — `userToProto` defined in both `get_user.go` and `list_users.go`, `lookupMemberRole` defined in both `add_tenant_member.go` and `change_member_role.go`. Out of scope for this PR; needs a separate cleanup PR.)
- [x] `gofmt -l` clean on both new files.
- [x] `uvx ruff@0.15.7 check .` and `format --check .` clean.
- [x] Tests cover: empty fan-in, single-edge wire roundtrip (`tenant_id` / `edge_type_id` / `from_node_id` / `to_node_id` / `props` Struct), multi-edge fan-in (with cross-direction isolation check), missing-dst empty case, edge-type filter (incl. unknown type ⇒ empty), and swallow-on-store-error degraded path returning OK + empty.
- [x] Does NOT modify `_go_parity.py` or `server.go`.