### PR TITLE
feat(go-rewrite): RevokeAccess RPC — Wave 2 (WAL-first restoration)

### DIFF
--- a/server/go/internal/api/revoke_access.go
+++ b/server/go/internal/api/revoke_access.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// RevokeAccess RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/RevokeAccess.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:97 (rpc), :746-755 (messages).
+// Reference Python: server/python/entdb_server/api/grpc_server.py:1828-1875.
+//
+// # WAL-first restoration (PLAN.md §6.1, fixed on port)
+//
+// The Python handler bypasses the WAL and writes directly to per-tenant
+// SQLite via canonical_store.revoke_access (DELETE on node_access).
+// Revocations are silently lost on rebuild — a documented violation of
+// CLAUDE.md invariant #1 ("all writes go through the WAL"). The Go port
+// fixes this: the handler appends a "revoke_access" op to the WAL and
+// the applier handler in apply/ops_revoke_access.go performs the DELETE
+// (and the cross-tenant shared_index cleanup hook). See spec §"Side
+// effects" and §"Open questions" item 1.
+//
+// # Auth model — trusted-actor, ADMIN capability
+//
+//  1. Authentication is required (handler is NOT in
+//     AuthInterceptor.UNAUTHENTICATED_METHODS).
+//  2. The wire-claimed actor is UNTRUSTED — auth.Authoritative rebinds
+//     to the interceptor-attested identity. Privilege-escalation
+//     regression pinned by commit fece3fb.
+//  3. Authorization: trusted actor must be either
+//      a. system: / admin: prefixed (server-side actor), OR
+//      b. an "owner" or "admin" member of the tenant per
+//         globalstore.tenant_members.
+//     This mirrors the Python ADMIN capability check
+//     (capability_registry.py:74). The Go port narrows the per-node
+//     ADMIN-grant satisfaction (an explicit ADMIN grant on the node)
+//     to membership-based admin for now; the per-node grant satisfaction
+//     can land alongside the full capability registry port.
+//
+// # Tenant gate
+//
+// Calls s.checkTenant before authorization to surface NOT_FOUND /
+// FAILED_PRECONDITION / UNAVAILABLE-with-redirect on missing or
+// mis-routed tenants — same gate every Wave-2 handler uses.
+//
+// # Error contract
+//
+// Mirrors the Python contract: errors come back as
+// RevokeAccessResponse{Found:false, Error:<string>} on the response,
+// NOT as a gRPC status error. Three observable paths:
+//
+//	PermissionDenied    Found=false, Error="permission denied: ..."
+//	WAL/append failure  Found=false, Error=<err>
+//	Happy path          Found=true,  Error=""
+//
+// On the happy path, Found=true means "the revoke intent has been
+// durably recorded in the WAL". The applier will perform the DELETE
+// asynchronously; idempotent revoke-not-granted is therefore a no-op
+// at apply time but still success on the wire. This matches the spec's
+// "fix on port" direction (PLAN.md §6.1) — the wire contract returns
+// success for both first-revoke and revoke-not-granted, and the
+// applier is responsible for making both converge to the same SQLite
+// state.
+//
+// Tenant-gate errors (NOT_FOUND / FAILED_PRECONDITION / UNAVAILABLE)
+// propagate as gRPC status errors. Required-arg validation is
+// INVALID_ARGUMENT. These are the only paths that surface as gRPC
+// status errors; all others use the response-error convention.
+//
+// # Metrics
+//
+// Emits entdb_grpc_requests_total{method="RevokeAccess",
+// status="ok"|"denied"|"error"} via the shared metrics chokepoint.
+// Labels follow the Python convention: "denied" specifically for
+// PermissionDenied, "error" for any other failure, "ok" for the happy
+// path including idempotent revoke-not-granted.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const (
+	revokeAccessMethod = "RevokeAccess"
+
+	// revokeAccessTopic is the WAL topic the handler appends to. Mirrors
+	// the default in cmd/entdb-server/main.go (--wal-topic). Hardcoded
+	// here so the handler does not need a server-level Option for the
+	// topic; the applier reads from the same topic per main.go wiring.
+	revokeAccessTopic = "entdb-wal"
+)
+
+// RevokeAccess removes a single direct grant on a node for one actor.
+// See file header for the full contract.
+func (s *Server) RevokeAccess(
+	ctx context.Context,
+	req *pb.RevokeAccessRequest,
+) (*pb.RevokeAccessResponse, error) {
+	start := time.Now()
+	statusLabel := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(revokeAccessMethod, statusLabel, time.Since(start))
+	}()
+
+	// Required-arg validation. Empty actor / tenant_id / node_id /
+	// actor_id surface as INVALID_ARGUMENT before any privilege or
+	// tenant-gate work — wire-contract pin (parity with Python's
+	// argument check at grpc_server.py:1830-1834).
+	rctx := req.GetContext()
+	if rctx == nil || rctx.GetTenantId() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if rctx.GetActor() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+	if req.GetNodeId() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "node_id is required")
+	}
+	if req.GetActorId() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor_id is required")
+	}
+
+	// Tenant gate: NOT_FOUND on missing tenant, FAILED_PRECONDITION on
+	// region mismatch, UNAVAILABLE-with-redirect on shard mis-route.
+	// Errors propagate as gRPC status errors per the spec (the
+	// response-error convention only applies to authz / apply paths).
+	if cerr := s.checkTenant(ctx, rctx.GetTenantId()); cerr != nil {
+		statusLabel = "error"
+		return nil, cerr
+	}
+
+	// Trusted-actor rebind. Privilege checks below MUST consult
+	// `trusted` (never req.Context.Actor); honouring the request payload
+	// is the privilege-escalation hole fixed by commit fece3fb.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(rctx.GetActor()))
+
+	// Admin / system bypass + tenant-membership admin path. Mirrors the
+	// Python ADMIN capability check (capability_registry.py:74). We
+	// narrow to membership-based admin/owner for now; the per-node
+	// ADMIN grant satisfaction lands with the full capability registry
+	// port (spec §"Auth" item 3).
+	if !(trusted.IsAdmin() || trusted.IsSystem()) {
+		role := ""
+		if s.global != nil {
+			r, err := s.lookupMemberRole(ctx, rctx.GetTenantId(), trusted.ID())
+			if err != nil {
+				statusLabel = "error"
+				return &pb.RevokeAccessResponse{
+					Found: false,
+					Error: err.Error(),
+				}, nil
+			}
+			role = r
+		}
+		if role != "owner" && role != "admin" {
+			statusLabel = "denied"
+			return &pb.RevokeAccessResponse{
+				Found: false,
+				Error: "permission denied: RevokeAccess requires ADMIN capability",
+			}, nil
+		}
+	}
+
+	// WAL append. The applier (apply/ops_revoke_access.go) performs the
+	// per-tenant SQLite DELETE on node_access and the cross-tenant
+	// shared_index cleanup. Idempotency: deterministic key per
+	// (tenant, node, actor) so retries collapse to a single WAL record
+	// and the applier sees one apply. Revoke-not-granted is naturally
+	// no-op at apply time (0 rows affected) — which the spec's
+	// idempotency contract requires (spec §"Open questions" item 2).
+	if s.producer == nil {
+		statusLabel = "error"
+		return &pb.RevokeAccessResponse{
+			Found: false,
+			Error: "wal producer not configured",
+		}, nil
+	}
+
+	idempKey := fmt.Sprintf("revoke_access:%s:%s:%s",
+		rctx.GetTenantId(), req.GetNodeId(), req.GetActorId())
+	ev := wal.Event{
+		TenantID:       rctx.GetTenantId(),
+		Actor:          trusted.String(),
+		IdempotencyKey: idempKey,
+		Ops: []map[string]any{{
+			"op":       "revoke_access",
+			"node_id":  req.GetNodeId(),
+			"actor_id": req.GetActorId(),
+		}},
+	}
+	value, err := ev.Encode()
+	if err != nil {
+		statusLabel = "error"
+		return &pb.RevokeAccessResponse{
+			Found: false,
+			Error: fmt.Sprintf("encode event: %v", err),
+		}, nil
+	}
+	headers := map[string][]byte{
+		wal.HeaderIdempotencyKey: []byte(idempKey),
+	}
+	if _, err := s.producer.Append(ctx, revokeAccessTopic, ev.TenantID, value, headers); err != nil {
+		statusLabel = "error"
+		return &pb.RevokeAccessResponse{
+			Found: false,
+			Error: fmt.Sprintf("wal append: %v", err),
+		}, nil
+	}
+
+	// Happy path. Found=true means the revoke intent has been durably
+	// recorded; the applier converges SQLite state asynchronously. This
+	// covers both first-revoke and revoke-not-granted — the latter
+	// applies as a 0-row DELETE, which is a normal no-op apply (spec
+	// §"Open questions" item 2).
+	return &pb.RevokeAccessResponse{Found: true}, nil
+}

--- a/server/go/internal/api/revoke_access_test.go
+++ b/server/go/internal/api/revoke_access_test.go
@@ -1,0 +1,232 @@
+// Tests for RevokeAccess. Behavioural parity with the Python handler
+// (server/python/entdb_server/api/grpc_server.py:1828-1875) is pinned
+// by the cross-language contract suite at
+// tests/python/integration/test_grpc_contract.py:351-361 and the unit
+// tests at tests/python/unit/test_acl_v2.py:443-452. This file covers
+// the three branches the spec calls out:
+//
+//  1. Happy revoke -> OK + Found=true; WAL event durably appended.
+//  2. Idempotent revoke-not-granted -> OK + Found=true; WAL event
+//     appended (apply is a no-op DELETE — applier-side concern).
+//  3. Non-admin caller -> response.Error="permission denied: ..."
+//     (response-error convention; no gRPC status error).
+
+package api_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// revokeAccessTestTopic must match the topic the handler appends to
+// (see revoke_access.go:revokeAccessTopic). Hardcoded mirror is fine —
+// the test file is colocated with the handler, so a topic-rename will
+// be caught by the constant going out of sync at the same review step.
+const revokeAccessTestTopic = "entdb-wal"
+
+// newRevokeAccessServer wires a server with a globalstore + in-memory
+// WAL producer + sharding gate. The returned wal.InMemory lets tests
+// assert on the appended events.
+func newRevokeAccessServer(t *testing.T) (*api.Server, *wal.InMemory) {
+	t.Helper()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	w := wal.NewInMemory(0)
+	if err := w.Connect(ctx); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close(context.Background()) })
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithWALProducer(w),
+		api.WithSharding(&tenant.Sharding{NodeID: "node-a"}),
+	)
+	return srv, w
+}
+
+// TestRevokeAccess_HappyRevoke: a trusted admin: actor revokes a grant
+// on a node; handler returns OK + Found=true and a "revoke_access" op
+// is durably appended to the WAL. Mirrors the Python contract pin at
+// test_acl_v2.py:443-448.
+func TestRevokeAccess_HappyRevoke(t *testing.T) {
+	t.Parallel()
+
+	srv, w := newRevokeAccessServer(t)
+	authedCtx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodAPIKey,
+		Subject: "admin:root",
+	})
+
+	resp, err := srv.RevokeAccess(authedCtx, &pb.RevokeAccessRequest{
+		Context: &pb.RequestContext{
+			TenantId: "acme",
+			Actor:    "admin:root",
+		},
+		NodeId:  "node-1",
+		ActorId: "user:bob",
+	})
+	if err != nil {
+		t.Fatalf("RevokeAccess: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("RevokeAccess: nil response")
+	}
+	if !resp.GetFound() {
+		t.Fatalf("RevokeAccess: Found=false, Error=%q; want Found=true", resp.GetError())
+	}
+	if resp.GetError() != "" {
+		t.Fatalf("RevokeAccess: Error=%q; want empty", resp.GetError())
+	}
+
+	// One WAL record must be present, encoding the revoke_access op.
+	recs := w.GetAllRecords(revokeAccessTestTopic)
+	if len(recs) != 1 {
+		t.Fatalf("WAL: got %d records, want 1", len(recs))
+	}
+	ev, derr := wal.DecodeEvent(recs[0].Value)
+	if derr != nil {
+		t.Fatalf("DecodeEvent: %v", derr)
+	}
+	if ev.TenantID != "acme" {
+		t.Fatalf("event TenantID = %q; want acme", ev.TenantID)
+	}
+	if len(ev.Ops) != 1 {
+		t.Fatalf("event Ops len = %d; want 1", len(ev.Ops))
+	}
+	op := ev.Ops[0]
+	if op["op"] != "revoke_access" {
+		t.Fatalf("op[op] = %v; want revoke_access", op["op"])
+	}
+	if op["node_id"] != "node-1" {
+		t.Fatalf("op[node_id] = %v; want node-1", op["node_id"])
+	}
+	if op["actor_id"] != "user:bob" {
+		t.Fatalf("op[actor_id] = %v; want user:bob", op["actor_id"])
+	}
+}
+
+// TestRevokeAccess_IdempotentRevokeNotGranted: revoking a grant that
+// never existed returns OK + Found=true (success=true, no-op at apply
+// time). Two back-to-back revokes for the same (node, actor) collapse
+// to one WAL record via the deterministic idempotency key — matching
+// the Python pin at test_acl_v2.py:450-452 (revoke without prior grant
+// returns no-error) and the spec's idempotency contract (§"Open
+// questions" item 2).
+func TestRevokeAccess_IdempotentRevokeNotGranted(t *testing.T) {
+	t.Parallel()
+
+	srv, w := newRevokeAccessServer(t)
+	authedCtx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodAPIKey,
+		Subject: "admin:root",
+	})
+
+	req := &pb.RevokeAccessRequest{
+		Context: &pb.RequestContext{
+			TenantId: "acme",
+			Actor:    "admin:root",
+		},
+		NodeId:  "ghost-node",
+		ActorId: "user:nobody",
+	}
+
+	// First revoke against a non-existent grant.
+	resp1, err := srv.RevokeAccess(authedCtx, req)
+	if err != nil {
+		t.Fatalf("RevokeAccess (first): %v", err)
+	}
+	if !resp1.GetFound() {
+		t.Fatalf("RevokeAccess (first): Found=false, Error=%q; want Found=true (no-op success)", resp1.GetError())
+	}
+	if resp1.GetError() != "" {
+		t.Fatalf("RevokeAccess (first): Error=%q; want empty", resp1.GetError())
+	}
+
+	// Second revoke for the same (tenant, node, actor) must dedupe at
+	// the WAL via the deterministic idempotency key. Still success on
+	// the wire.
+	resp2, err := srv.RevokeAccess(authedCtx, req)
+	if err != nil {
+		t.Fatalf("RevokeAccess (second): %v", err)
+	}
+	if !resp2.GetFound() {
+		t.Fatalf("RevokeAccess (second): Found=false, Error=%q; want Found=true", resp2.GetError())
+	}
+	if resp2.GetError() != "" {
+		t.Fatalf("RevokeAccess (second): Error=%q; want empty", resp2.GetError())
+	}
+
+	// WAL must contain exactly one record despite two handler calls —
+	// idempotent dedupe by (topic, key, idempotency-key).
+	recs := w.GetAllRecords(revokeAccessTestTopic)
+	if len(recs) != 1 {
+		t.Fatalf("WAL: got %d records, want 1 (idempotent dedupe)", len(recs))
+	}
+}
+
+// TestRevokeAccess_NonAdminPermissionDenied: a regular member without
+// owner/admin role on the tenant gets a response-level error
+// containing "permission denied", and NO WAL record is appended. The
+// privilege-escalation regression (commit fece3fb) is pinned here by
+// having bob's session attest user:bob while the wire claims
+// actor=admin:root — the handler MUST ignore the wire claim.
+//
+// Note: the response-error convention (no gRPC status) is preserved
+// from Python (grpc_server.py:1849-1851) for client compatibility.
+func TestRevokeAccess_NonAdminPermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	srv, w := newRevokeAccessServer(t)
+	ctx := context.Background()
+
+	// bob has no membership row in tenant_members at all — the default
+	// "no role" state, which the handler treats as not owner / not
+	// admin. We don't need to seed anything.
+
+	// Privilege-escalation regression pin: bob's session attests
+	// user:bob, but the request claims actor=admin:root. The handler
+	// MUST authorise as user:bob and reject.
+	authedCtx := auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodSession,
+		Subject: "user:bob",
+	})
+
+	resp, err := srv.RevokeAccess(authedCtx, &pb.RevokeAccessRequest{
+		Context: &pb.RequestContext{
+			TenantId: "acme",
+			Actor:    "admin:root", // wire-claimed escalation attempt
+		},
+		NodeId:  "node-1",
+		ActorId: "user:carol",
+	})
+	if err != nil {
+		t.Fatalf("RevokeAccess: expected nil gRPC error (response-error convention), got %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("RevokeAccess: nil response")
+	}
+	if resp.GetFound() {
+		t.Fatalf("RevokeAccess: Found=true; want false on permission denied")
+	}
+	if !strings.Contains(strings.ToLower(resp.GetError()), "permission denied") {
+		t.Fatalf("RevokeAccess: Error=%q; want it to contain 'permission denied'", resp.GetError())
+	}
+
+	// Crucially: no WAL append on the denied path. The privilege-
+	// escalation guard MUST short-circuit before any WAL I/O.
+	if recs := w.GetAllRecords(revokeAccessTestTopic); len(recs) != 0 {
+		t.Fatalf("WAL: got %d records on denied path, want 0", len(recs))
+	}
+}
+


### PR DESCRIPTION
## Summary
- WAL-first port of `RevokeAccess` (EPIC #407, Wave 2). The Python handler bypasses the WAL and writes directly to per-tenant SQLite, silently losing revocations on rebuild. Go handler appends a `revoke_access` op to the WAL; the applier (W1.10 `ops_revoke_access.go`) performs the DELETE plus shared_index cleanup.
- Auth: trusted-actor admin/owner gate (`auth.Authoritative` + tenant membership lookup). Per-node ADMIN-grant satisfaction is narrowed to membership-based admin/owner for now; the full capability-registry path lands later.
- Idempotency: deterministic `revoke_access:<tenant>:<node>:<actor>` key collapses retries to a single WAL record, so revoke-not-granted is a natural no-op DELETE at apply time.
- Drive-by: removed duplicate symbols pre-existing on `main` (`userToProto`, `lookupMemberRole`, `withTrustedUser`) so the package compiles. Parallel feature branches landed redundant declarations.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (api package + everything downstream)
- [x] `go test ./internal/api/ -run RevokeAccess -v` — 3/3 pass (happy revoke, idempotent revoke-not-granted, non-admin → permission-denied response-error)
- [x] `go test ./internal/api/ -run Unimplemented -v` — ExecuteAtomic canary still returns Unimplemented
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [x] No modifications to `_go_parity.py` or `server.go`