### PR TITLE
feat(go-rewrite): ListSharedWithMe RPC — Wave 2

### DIFF
--- a/server/go/internal/api/list_shared_with_me.go
+++ b/server/go/internal/api/list_shared_with_me.go
@@ -1,0 +1,226 @@
+// ListSharedWithMe RPC — Wave 2 of the Python -> Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/ListSharedWithMe.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:100 (rpc), :757-766
+// (request/response). Reference Python:
+// server/python/entdb_server/api/grpc_server.py:1877-1944.
+//
+// Semantics (preserved from the Python handler):
+//
+//   - Read-only. The caller is the IMPLICIT recipient — the actor
+//     identity in the wire payload is UNTRUSTED and is overwritten by
+//     the trusted Identity from the auth interceptor before any data
+//     access. This is the privilege-escalation invariant: a malicious
+//     `user:eve` MUST NOT be able to enumerate `user:alice`'s shares
+//     by setting context.actor = "user:alice" on the wire.
+//   - Aggregates two indexes:
+//     1. Per-tenant `node_access`: same-tenant grants where the caller
+//        (or any group they transitively belong to) is the grantee.
+//        Filters expired (`expires_at`) and `deny` permission.
+//     2. Cross-tenant `global_store.shared_index`: rows written by
+//        ShareNode when the recipient lives in a different tenant from
+//        the source node. The caller's BARE actor string only — group
+//        fan-out happens at write time. Cross-tenant `shared_index` has
+//        NO `expires_at` column (parity caveat — flagged in spec
+//        "Open questions / risks" #3).
+//   - Pagination is parity-bug-compatible: `limit`/`offset` are applied
+//     INDEPENDENTLY to each index then merged. Page boundaries do not
+//     line up; consecutive pages can overlap, and a single page can
+//     return up to 2*limit rows. Documented limitation; see spec
+//     "Pagination semantics".
+//   - `has_more` is `len(nodes) >= limit` AFTER the cross-tenant
+//     append, which over-reports `true`. Bug-compatible with Python
+//     (grpc_server.py:1939). Spec "Open questions / risks" #2.
+//   - Cross-tenant aggregation reads OTHER tenants' SQLite files via
+//     store.GetNode(source_tenant, node_id). This is the ONE allowed
+//     cross-tenant read in EntDB (CLAUDE.md invariant 4) and is only
+//     legal because the `shared_index` row IS the authorisation token —
+//     ShareNode wrote a `node_access` grant in the source tenant that
+//     authorises this read.
+//   - Stale entries (source tenant unloaded, node deleted, permission
+//     revoked but global index lagging) are silently skipped — bare
+//     `except` parity (grpc_server.py:1929-1931). They are
+//     eventual-consistency artefacts, not errors.
+//   - Globalstore failures degrade gracefully: log + return per-tenant
+//     results only. Python parity (grpc_server.py:1932-1933).
+//   - Per-tenant SQLite errors are also swallowed — the handler returns
+//     `nodes=[]` with status OK rather than surfacing the fault. This
+//     is hostile to debugging but load-bearing for parity
+//     (grpc_server.py:1941-1944); flagged for tightening in a separate
+//     issue.
+//   - Hardening delta vs Python: limit clamped to [0, 1000]; default
+//     when zero is 100 (matches Python). Negative limit/offset clamped
+//     to 0 instead of being passed through to SQLite (where negative
+//     LIMIT means "unlimited" — undefined behaviour).
+//
+// Note on group resolution: this implementation does NOT yet expand
+// groups for the per-tenant query (group_users-backed
+// `acl.Resolver.Expand` is wired only in W1.10). The bare actor is
+// passed as a single-element actor list, which is parity with the
+// "user has no groups" steady state. Group-share inclusion is covered
+// by the cross-tenant path because ShareNode fans out group → members
+// at write time and writes one `shared_index` row per (member,
+// source_tenant, node). When the per-tenant group resolver lands, swap
+// in `acl.Resolver.ExpandIDs(ctx, tenant, actor)` here.
+//
+// NOT modified by this PR: tests/python/integration/_go_parity.py and
+// server/go/internal/api/server.go (per task statement).
+
+package api
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+const (
+	listSharedWithMeMethod       = "ListSharedWithMe"
+	listSharedWithMeDefaultLimit = 100
+	listSharedWithMeMaxLimit     = 1000
+)
+
+// ListSharedWithMe implements entdb.v1.EntDBService/ListSharedWithMe.
+// See file header for the parity contract.
+func (s *Server) ListSharedWithMe(
+	ctx context.Context,
+	req *pb.ListSharedWithMeRequest,
+) (*pb.ListSharedWithMeResponse, error) {
+	start := time.Now()
+	statusLabel := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(listSharedWithMeMethod, statusLabel, time.Since(start))
+	}()
+
+	tenantID := req.GetContext().GetTenantId()
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		statusLabel = "error"
+		return nil, err
+	}
+
+	// Trusted-actor rebinding. The wire-claimed actor is IGNORED: the
+	// caller IS the implicit recipient. If the auth interceptor did not
+	// run (unit tests, no-auth deployments), Authoritative falls
+	// through to the wire claim — which is fine because tests opt into
+	// a known actor and production MUST run the interceptor.
+	claimed := auth.ParseActor(req.GetContext().GetActor())
+	actor := auth.Authoritative(ctx, claimed)
+	actorStr := actor.String()
+	if actorStr == "" {
+		// No identity available at all — Python parity treats this as
+		// "no shares" rather than an error (grpc_server.py:1893-1894
+		// returns whatever the actor string evaluates to; an empty
+		// string yields zero rows from both indexes).
+		return emptyListSharedWithMeResponse(), nil
+	}
+
+	// Limit/offset clamping. Python passes raw values through to
+	// SQLite; the Go port hardens this — see file header.
+	limit := req.GetLimit()
+	if limit <= 0 {
+		limit = listSharedWithMeDefaultLimit
+	}
+	if limit > listSharedWithMeMaxLimit {
+		limit = listSharedWithMeMaxLimit
+	}
+	offset := req.GetOffset()
+	if offset < 0 {
+		offset = 0
+	}
+
+	// 1. Per-tenant query against node_access. Group resolution is a
+	//    no-op for now (see file header). The bare actor is passed as
+	//    a single-element list. Errors are swallowed for parity with
+	//    grpc_server.py:1941-1944.
+	var nodes []*store.Node
+	if s.store != nil {
+		got, err := s.store.ListSharedWithMe(ctx, tenantID, []string{actorStr}, int(limit), int(offset))
+		if err != nil {
+			log.Printf("ListSharedWithMe: per-tenant query failed for %s/%s: %v", tenantID, actorStr, err)
+			// Parity swallow — keep going with empty per-tenant results.
+		} else {
+			nodes = got
+		}
+	}
+
+	// 2. Cross-tenant aggregation against globalstore.shared_index.
+	//    De-dupe against per-tenant results by (source_tenant, node_id).
+	seen := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		seen[n.TenantID+"\x00"+n.NodeID] = struct{}{}
+	}
+	if s.global != nil {
+		entries, gerr := s.global.ListSharedToUser(ctx, actorStr, int(limit), int(offset))
+		if gerr != nil {
+			log.Printf("ListSharedWithMe: shared_index read failed for %s: %v", actorStr, gerr)
+		} else {
+			for _, e := range entries {
+				key := e.SourceTenant + "\x00" + e.NodeID
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				if s.store == nil {
+					// No store wired — we can't fetch the full Node,
+					// so the cross-tenant path is unusable. Skip
+					// silently (matches the Python "no global_store"
+					// graceful degrade applied in reverse).
+					continue
+				}
+				n, err := s.store.GetNode(ctx, e.SourceTenant, e.NodeID)
+				if err != nil || n == nil {
+					// Stale shared_index entry: source tenant unloaded,
+					// node deleted, etc. Silently skip — these are
+					// eventual-consistency artefacts (spec "Side
+					// effects" / Python bare except at
+					// grpc_server.py:1929-1931).
+					if err != nil && !errors.Is(err, store.ErrNodeNotFound) {
+						log.Printf("ListSharedWithMe: skip stale shared_index (%s/%s): %v",
+							e.SourceTenant, e.NodeID, err)
+					}
+					continue
+				}
+				nodes = append(nodes, n)
+				seen[key] = struct{}{}
+			}
+		}
+	}
+
+	// Convert store.Node -> pb.Node. Payload translation lives in the
+	// payload package and is gated on a schema.Registry; in its absence
+	// we surface the field-id-keyed shape verbatim by leaving Payload
+	// nil — Wave-2 callers that need a typed payload pull it via
+	// GetNode anyway. ACL is similarly lifted into pb.AclEntry only
+	// when consumers need it; this RPC's contract test
+	// (test_grpc_contract.py:339-350) is permissive, asserting only
+	// well-formed nodes with non-empty IDs.
+	out := make([]*pb.Node, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, &pb.Node{
+			TenantId:   n.TenantID,
+			NodeId:     n.NodeID,
+			TypeId:     n.TypeID,
+			CreatedAt:  n.CreatedAt,
+			UpdatedAt:  n.UpdatedAt,
+			OwnerActor: n.OwnerActor,
+		})
+	}
+	return &pb.ListSharedWithMeResponse{
+		Nodes:   out,
+		HasMore: int32(len(out)) >= limit,
+	}, nil
+}
+
+// emptyListSharedWithMeResponse is the canned empty response. Nodes is
+// a non-nil empty slice for symmetry with Python's `nodes=[]`.
+func emptyListSharedWithMeResponse() *pb.ListSharedWithMeResponse {
+	return &pb.ListSharedWithMeResponse{
+		Nodes:   []*pb.Node{},
+		HasMore: false,
+	}
+}

--- a/server/go/internal/api/list_shared_with_me_test.go
+++ b/server/go/internal/api/list_shared_with_me_test.go
@@ -1,0 +1,371 @@
+// Tests for the ListSharedWithMe RPC (W2 — EPIC #407).
+//
+// The behaviours pinned here mirror the contract in
+// docs/go-port/rpcs/ListSharedWithMe.md and the Python reference
+// handler at server/python/entdb_server/api/grpc_server.py:1877-1944.
+// The Python contract tests are at:
+//   - tests/python/unit/test_acl_v2.py:455-481  (per-tenant index)
+//   - tests/python/unit/test_cross_tenant_read.py:309-356  (cross-tenant)
+//   - tests/python/unit/test_cross_tenant_read.py:362-400  (group share)
+//   - tests/python/integration/test_grpc_contract.py:339-350 (smoke)
+//
+// We deliberately seed via the typed store / globalstore helpers
+// rather than the gRPC ShareNode handler — Wave-2 ShareNode hasn't
+// landed yet, and the RPC under test is read-only.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+)
+
+// newCanonicalStoreForTest builds a CanonicalStore rooted at t.TempDir()
+// with WAL on, and registers a teardown hook. This is the per-test-file
+// helper because helpers_external_test.go intentionally only exposes a
+// globalstore helper today — adding a second one would have to go in
+// helpers_external_test.go which is out of scope for this PR.
+func newCanonicalStoreForTest(t *testing.T) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// seedSharedNode is a small builder: it creates a node owned by
+// `owner` in `tenantID`, then inserts a non-deny `node_access` grant
+// for `grantee`. This is the fully-loaded same-tenant share path —
+// what `ShareNode(tenant=t, recipient=u, node=n)` would produce when
+// the recipient lives in the same tenant as the node.
+func seedSharedNode(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner, grantee, perm string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant(%q): %v", tenantID, err)
+	}
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:     nodeID,
+		TypeID:     1,
+		Payload:    map[string]any{"1": "doc-" + nodeID},
+		OwnerActor: owner,
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw(%q,%q): %v", tenantID, nodeID, err)
+	}
+	if err := cs.ShareNode(ctx, tenantID, store.ShareNodeInput{
+		NodeID:     nodeID,
+		ActorID:    grantee,
+		ActorType:  "user",
+		Permission: perm,
+		GrantedBy:  owner,
+	}); err != nil {
+		t.Fatalf("ShareNode(%q,%q,%q): %v", tenantID, nodeID, grantee, err)
+	}
+}
+
+// seedSharedNodeExpired creates the same shape as seedSharedNode but
+// with an `expires_at` already in the past. Used to pin the "expired
+// grants are filtered" assertion (canonical_store.py:3460-3461).
+func seedSharedNodeExpired(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner, grantee, perm string, expiresAt int64) {
+	t.Helper()
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant(%q): %v", tenantID, err)
+	}
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:     nodeID,
+		TypeID:     1,
+		Payload:    map[string]any{"1": "expired-" + nodeID},
+		OwnerActor: owner,
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw(%q,%q): %v", tenantID, nodeID, err)
+	}
+	if err := cs.ShareNode(ctx, tenantID, store.ShareNodeInput{
+		NodeID:     nodeID,
+		ActorID:    grantee,
+		ActorType:  "user",
+		Permission: perm,
+		GrantedBy:  owner,
+		ExpiresAt:  expiresAt,
+	}); err != nil {
+		t.Fatalf("ShareNode(expired %q,%q,%q): %v", tenantID, nodeID, grantee, err)
+	}
+}
+
+// makeReq is a tiny request builder so each test reads as the wire
+// payload it exercises.
+func makeReq(tenantID, actor string, limit, offset int32) *pb.ListSharedWithMeRequest {
+	return &pb.ListSharedWithMeRequest{
+		Context: &pb.RequestContext{
+			TenantId: tenantID,
+			Actor:    actor,
+		},
+		Limit:  limit,
+		Offset: offset,
+	}
+}
+
+// TestListSharedWithMe_Empty: a caller with zero shares gets a
+// well-formed empty response — `nodes=[]`, `has_more=false`. Pinned
+// by spec error-contract row "Caller has no shares".
+func TestListSharedWithMe_Empty(t *testing.T) {
+	t.Parallel()
+	cs := newCanonicalStoreForTest(t)
+	if err := cs.OpenTenant(context.Background(), "acme"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.ListSharedWithMe(context.Background(), makeReq("acme", "user:alice", 0, 0))
+	if err != nil {
+		t.Fatalf("ListSharedWithMe: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("nil response")
+	}
+	if len(resp.GetNodes()) != 0 {
+		t.Fatalf("nodes: got %d, want 0", len(resp.GetNodes()))
+	}
+	if resp.GetHasMore() {
+		t.Fatalf("has_more: got true, want false")
+	}
+}
+
+// TestListSharedWithMe_SingleSameTenant: a caller with exactly one
+// non-expired, non-deny grant in the same tenant sees that one node.
+// Mirrors test_acl_v2.py:455-481 (per-tenant index / shared-nodes
+// union).
+func TestListSharedWithMe_SingleSameTenant(t *testing.T) {
+	t.Parallel()
+	cs := newCanonicalStoreForTest(t)
+	seedSharedNode(t, cs, "acme", "n1", "user:owner", "user:alice", "read")
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.ListSharedWithMe(context.Background(), makeReq("acme", "user:alice", 0, 0))
+	if err != nil {
+		t.Fatalf("ListSharedWithMe: %v", err)
+	}
+	if got, want := len(resp.GetNodes()), 1; got != want {
+		t.Fatalf("nodes: got %d, want %d (resp=%+v)", got, want, resp)
+	}
+	if got, want := resp.GetNodes()[0].GetNodeId(), "n1"; got != want {
+		t.Fatalf("node_id: got %q, want %q", got, want)
+	}
+	if got, want := resp.GetNodes()[0].GetTenantId(), "acme"; got != want {
+		t.Fatalf("tenant_id: got %q, want %q", got, want)
+	}
+}
+
+// TestListSharedWithMe_MultipleSameTenant: several non-deny grants
+// for the caller in one tenant all surface. Order is granted_at DESC
+// per canonical_store.py:3462; we don't pin order (parity-bug-
+// compatible cross-tenant merge breaks it later anyway), only the
+// set membership.
+func TestListSharedWithMe_MultipleSameTenant(t *testing.T) {
+	t.Parallel()
+	cs := newCanonicalStoreForTest(t)
+	for _, id := range []string{"n1", "n2", "n3"} {
+		seedSharedNode(t, cs, "acme", id, "user:owner", "user:alice", "read")
+	}
+	// Noise: a node shared with someone else MUST NOT leak.
+	seedSharedNode(t, cs, "acme", "n-other", "user:owner", "user:bob", "read")
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.ListSharedWithMe(context.Background(), makeReq("acme", "user:alice", 0, 0))
+	if err != nil {
+		t.Fatalf("ListSharedWithMe: %v", err)
+	}
+	if got, want := len(resp.GetNodes()), 3; got != want {
+		t.Fatalf("nodes: got %d, want %d", got, want)
+	}
+	got := map[string]bool{}
+	for _, n := range resp.GetNodes() {
+		got[n.GetNodeId()] = true
+	}
+	for _, want := range []string{"n1", "n2", "n3"} {
+		if !got[want] {
+			t.Fatalf("missing node %q from response: %v", want, got)
+		}
+	}
+	if got["n-other"] {
+		t.Fatalf("response leaked another grantee's node: n-other present")
+	}
+}
+
+// TestListSharedWithMe_MultipleTenantsCrossTenant: shares from
+// multiple foreign tenants surface via the global shared_index, are
+// resolved through cross-tenant store.GetNode, and union with same-
+// tenant grants. Pinned by test_cross_tenant_read.py:309-356.
+func TestListSharedWithMe_MultipleTenantsCrossTenant(t *testing.T) {
+	t.Parallel()
+	cs := newCanonicalStoreForTest(t)
+	gs := newGlobalStore(t)
+
+	// Register tenants in globalstore so the per-handler tenant gate
+	// passes; the gate dereferences `gs.GetTenant(tenant_id)` and
+	// raises NOT_FOUND otherwise.
+	for _, tn := range []string{"alice-tenant", "acme", "globex"} {
+		if _, err := gs.CreateTenant(context.Background(), tn, tn, ""); err != nil {
+			t.Fatalf("CreateTenant(%q): %v", tn, err)
+		}
+	}
+
+	// Same-tenant grant — caller's home tenant is "alice-tenant".
+	seedSharedNode(t, cs, "alice-tenant", "home-1", "user:owner", "user:alice", "read")
+
+	// Foreign tenant 1 — "acme" — owns a node shared cross-tenant
+	// with alice. seedSharedNode opens the tenant and inserts both the
+	// node and the per-tenant node_access row; for the cross-tenant
+	// path we additionally write the shared_index hint.
+	seedSharedNode(t, cs, "acme", "remote-acme-1", "user:bob", "user:alice", "read")
+	if err := gs.AddShared(context.Background(), "user:alice", "acme", "remote-acme-1", "read"); err != nil {
+		t.Fatalf("AddShared(acme): %v", err)
+	}
+
+	// Foreign tenant 2 — "globex".
+	seedSharedNode(t, cs, "globex", "remote-globex-1", "user:carol", "user:alice", "read")
+	if err := gs.AddShared(context.Background(), "user:alice", "globex", "remote-globex-1", "read"); err != nil {
+		t.Fatalf("AddShared(globex): %v", err)
+	}
+
+	// Bob is shared something else but is NOT alice; alice MUST NOT
+	// see bob's shares.
+	seedSharedNode(t, cs, "acme", "bob-only", "user:bob", "user:bob", "read")
+	if err := gs.AddShared(context.Background(), "user:bob", "acme", "bob-only", "read"); err != nil {
+		t.Fatalf("AddShared(bob): %v", err)
+	}
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithGlobalStore(gs),
+	)
+	// alice's home tenant is "alice-tenant"; cross-tenant rows surface
+	// regardless of which tenant the caller is currently bound to.
+	resp, err := srv.ListSharedWithMe(context.Background(), makeReq("alice-tenant", "user:alice", 0, 0))
+	if err != nil {
+		t.Fatalf("ListSharedWithMe: %v", err)
+	}
+
+	// Build a (tenant, node) set for assertion clarity.
+	type key struct{ t, n string }
+	got := map[key]bool{}
+	for _, n := range resp.GetNodes() {
+		got[key{n.GetTenantId(), n.GetNodeId()}] = true
+	}
+	want := []key{
+		{"alice-tenant", "home-1"},
+		{"acme", "remote-acme-1"},
+		{"globex", "remote-globex-1"},
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Fatalf("missing (tenant=%s, node=%s) from response. got=%v", w.t, w.n, got)
+		}
+	}
+	if got[key{"acme", "bob-only"}] {
+		t.Fatalf("response leaked bob's share into alice's results")
+	}
+	if n := len(resp.GetNodes()); n != 3 {
+		t.Fatalf("nodes: got %d, want 3 (resp=%+v)", n, resp)
+	}
+}
+
+// TestListSharedWithMe_ExpiredGrantsFiltered: a same-tenant grant
+// whose expires_at is in the past must NOT surface. Pinned by
+// canonical_store.py:3460-3461 (the per-tenant query filters
+// `expires_at IS NULL OR expires_at > now()`).
+//
+// Note: cross-tenant `shared_index` has NO expires_at column today
+// (spec "Open questions / risks" #3), so this case only covers the
+// per-tenant path.
+func TestListSharedWithMe_ExpiredGrantsFiltered(t *testing.T) {
+	t.Parallel()
+	cs := newCanonicalStoreForTest(t)
+
+	// Active grant — must surface.
+	seedSharedNode(t, cs, "acme", "active", "user:owner", "user:alice", "read")
+	// Expired grant — was valid until 5s before unix epoch, definitely
+	// in the past.
+	pastMS := int64(time.Now().Add(-1 * time.Hour).UnixMilli())
+	seedSharedNodeExpired(t, cs, "acme", "expired", "user:owner", "user:alice", "read", pastMS)
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.ListSharedWithMe(context.Background(), makeReq("acme", "user:alice", 0, 0))
+	if err != nil {
+		t.Fatalf("ListSharedWithMe: %v", err)
+	}
+	if got, want := len(resp.GetNodes()), 1; got != want {
+		t.Fatalf("nodes: got %d, want %d", got, want)
+	}
+	if got, want := resp.GetNodes()[0].GetNodeId(), "active"; got != want {
+		t.Fatalf("node_id: got %q, want %q (expired grant should be filtered)", got, want)
+	}
+}
+
+// TestListSharedWithMe_Pagination: with limit=2 and offset=0 we get
+// 2 rows out of 3 same-tenant grants and `has_more=true`; with
+// limit=2 and offset=2 we get the third row and `has_more=false`.
+// This test pins the steady-state pagination contract for a single
+// index — the cross-tenant overlap caveat is documented in spec
+// "Pagination semantics" but is hard to assert on without a stable
+// merge order, so we keep this case scoped to one index.
+func TestListSharedWithMe_Pagination(t *testing.T) {
+	t.Parallel()
+	cs := newCanonicalStoreForTest(t)
+	for _, id := range []string{"n1", "n2", "n3"} {
+		seedSharedNode(t, cs, "acme", id, "user:owner", "user:alice", "read")
+	}
+
+	srv := api.New(api.WithStore(cs))
+
+	// Page 1: limit=2, offset=0. Expect 2 nodes; has_more=true since
+	// len(nodes) >= limit.
+	page1, err := srv.ListSharedWithMe(context.Background(), makeReq("acme", "user:alice", 2, 0))
+	if err != nil {
+		t.Fatalf("ListSharedWithMe page1: %v", err)
+	}
+	if got, want := len(page1.GetNodes()), 2; got != want {
+		t.Fatalf("page1 nodes: got %d, want %d", got, want)
+	}
+	if !page1.GetHasMore() {
+		t.Fatalf("page1 has_more: got false, want true (len(nodes)>=limit)")
+	}
+
+	// Page 2: limit=2, offset=2. Expect the remaining 1 node;
+	// has_more=false.
+	page2, err := srv.ListSharedWithMe(context.Background(), makeReq("acme", "user:alice", 2, 2))
+	if err != nil {
+		t.Fatalf("ListSharedWithMe page2: %v", err)
+	}
+	if got, want := len(page2.GetNodes()), 1; got != want {
+		t.Fatalf("page2 nodes: got %d, want %d", got, want)
+	}
+	if page2.GetHasMore() {
+		t.Fatalf("page2 has_more: got true, want false")
+	}
+
+	// Across both pages, every seeded node appeared exactly once.
+	seen := map[string]int{}
+	for _, n := range page1.GetNodes() {
+		seen[n.GetNodeId()]++
+	}
+	for _, n := range page2.GetNodes() {
+		seen[n.GetNodeId()]++
+	}
+	for _, id := range []string{"n1", "n2", "n3"} {
+		if seen[id] != 1 {
+			t.Fatalf("node %q appeared %d times across both pages, want 1", id, seen[id])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `EntDBService/ListSharedWithMe` (Wave 2, EPIC #407) per `docs/go-port/rpcs/ListSharedWithMe.md`.
- Aggregates same-tenant `node_access` grants with cross-tenant `globalstore.shared_index` rows; de-duplicates by `(source_tenant, node_id)`.
- Trusted-actor: caller is the implicit recipient — wire-claimed actor is ignored in favour of `auth.Authoritative(ctx, ...)`.
- Cross-tenant aggregation reads other tenants' SQLite via `store.GetNode(source_tenant, node_id)` (the one allowed cross-tenant read; the `shared_index` row IS the authorisation token).
- Stale `shared_index` entries (source tenant unloaded, node deleted) silently skipped — eventual-consistency parity with `grpc_server.py:1929-1931`.
- Globalstore failures degrade gracefully to per-tenant results only; per-tenant SQLite errors are swallowed for parity (flagged in spec).
- Pagination + `has_more` are parity-bug-compatible: independent limit/offset per index, `has_more = len(nodes) >= limit` after the cross-tenant append over-reports `true`. Both behaviours match Python and are flagged for v2 follow-up.
- Hardening delta vs Python: limit clamped to `[0, 1000]`; negative offset clamped to 0.

## Test plan
- [x] `go test ./internal/api/ -run ListSharedWithMe` — 6 cases: empty, single same-tenant, multiple same-tenant (with cross-grantee leakage check), multi-tenant cross-tenant aggregation, expired-grant filtering, pagination.
- [x] `gofmt -l` clean on new files.
- [x] `uvx ruff@0.15.7 check .` and `format --check .` pass.
- [ ] CI: `Go Server Build` / `Go Server Contract` will exercise vet + the full test suite once the unrelated pre-existing dedupe failure on `main` is resolved.

Files:
- `server/go/internal/api/list_shared_with_me.go`
- `server/go/internal/api/list_shared_with_me_test.go`

Per task: `_go_parity.py` and `server.go` are unchanged.