### PR TITLE
feat(go-rewrite): AddGroupMember RPC — Wave 2 (WAL-first restoration)

### DIFF
--- a/server/go/internal/api/add_group_member.go
+++ b/server/go/internal/api/add_group_member.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// AddGroupMember implements entdb.v1.EntDBService/AddGroupMember.
+//
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:1946-1984.
+// Port spec: docs/go-port/rpcs/AddGroupMember.md.
+//
+// # WAL-first restoration
+//
+// The Python handler writes group_users DIRECTLY via canonical_store
+// (bypassing the WAL, in violation of CLAUDE.md §1). The Go port
+// restores the WAL-first invariant: this handler appends an
+// `add_group_member` op to the per-tenant WAL and lets the Applier
+// (server/go/internal/apply/ops_add_group_member.go, op-type wired in
+// W1.10) materialize the row. A rebuild-from-empty-WAL therefore
+// reconstructs membership; the Python path silently loses it.
+//
+// # Trusted-actor substitution
+//
+// The Python handler does NOT call `_trusted_actor` and never reads
+// `request.context.actor` for authorization — any authenticated caller
+// can mutate any group in any tenant they can reach. Pinned as a
+// privilege-escalation gap in commit fece3fb. The Go port closes it:
+//
+//  1. `auth.Authoritative(ctx, claimed)` is the single source of truth
+//     for caller identity. The wire-claimed `request.context.actor` is
+//     informational only.
+//  2. Authorization succeeds iff the trusted actor is admin: / system:,
+//     or holds the "owner" / "admin" role on the target tenant. v1
+//     "group admin" === "tenant admin" since no per-group ownership
+//     table exists yet (spec "Open questions" §1).
+//
+// # Idempotency
+//
+//   - The op uses `INSERT OR REPLACE INTO group_users` (apply path), so
+//     a re-add with the same (group_id, member_actor_id) overwrites
+//     role + joined_at. Matches Python parity.
+//   - The WAL Append carries an idempotency key derived from
+//     (tenant_id, group_id, member_actor_id, role) so a network retry
+//     of the same logical request returns the original StreamPos
+//     without writing a duplicate record.
+//
+// # Error contract
+//
+//	UNIMPLEMENTED       WAL producer not configured.
+//	NOT_FOUND / FAILED_PRECONDITION
+//	                    tenant missing/disabled (via checkTenant).
+//	INVALID_ARGUMENT    tenant_id / group_id / member_actor_id empty.
+//	PERMISSION_DENIED   trusted actor is neither admin/system nor
+//	                    owner/admin member of tenant_id.
+//	OK + success=false  WAL append failed (matches Python in-band
+//	                    error shape: gRPC OK, response.Error set).
+//	OK + success=true   WAL append accepted; apply happens
+//	                    asynchronously (caller fences via
+//	                    WaitForOffset on subsequent reads).
+
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// addGroupMemberWALTopic is the per-tenant WAL topic the handler appends
+// to. Mirrors the default `topic = "entdb-wal"` at
+// grpc_server.py:250 — the entire EntDB stream lives on a single topic
+// today; partitioning is by tenant_id (the Append key).
+const addGroupMemberWALTopic = "entdb-wal"
+
+// AddGroupMember adds (or re-adds, idempotently) a member to a group.
+// See package-level doc for the WAL-first restoration and trusted-actor
+// substitution that diverge from the Python source.
+func (s *Server) AddGroupMember(
+	ctx context.Context,
+	req *pb.GroupMemberRequest,
+) (*pb.GroupMemberResponse, error) {
+	start := time.Now()
+	statusLabel := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest("AddGroupMember", statusLabel, time.Since(start))
+	}()
+
+	if s.producer == nil {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "WAL producer not configured")
+	}
+
+	rc := req.GetContext()
+	tenantID := rc.GetTenantId()
+	groupID := req.GetGroupId()
+	memberActorID := req.GetMemberActorId()
+
+	// Required-arg validation BEFORE the tenant gate so a malformed
+	// request can never leak tenant existence via NOT_FOUND vs
+	// INVALID_ARGUMENT timing differences.
+	if tenantID == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if groupID == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "group_id is required")
+	}
+	if memberActorID == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "member_actor_id is required")
+	}
+
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		statusLabel = "error"
+		return nil, err
+	}
+
+	// Trusted-actor substitution: the wire-claimed actor is ignored.
+	// Every authorization branch consults `trusted` from this point on
+	// (privilege-escalation regression pinned by commit fece3fb).
+	claimed := auth.ParseActor(rc.GetActor())
+	trusted := auth.Authoritative(ctx, claimed)
+
+	// v1 group-admin === tenant-admin. The schema has no per-group
+	// ownership today (spec "Open questions" §1) so the only safe rule
+	// is "tenant admin only". Per-group admin is a follow-up.
+	if !(trusted.IsAdmin() || trusted.IsSystem()) {
+		if s.global == nil {
+			statusLabel = "error"
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"Only tenant admins can add group members")
+		}
+		role, err := s.lookupMemberRole(ctx, tenantID, trusted.ID())
+		if err != nil {
+			statusLabel = "error"
+			return nil, err
+		}
+		if role != "owner" && role != "admin" {
+			statusLabel = "error"
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"Only tenant admins can add group members")
+		}
+	}
+
+	role := req.GetRole()
+	if role == "" {
+		role = "member"
+	}
+
+	// Build the WAL event. The op shape is the contract that
+	// apply/ops_add_group_member.go consumes — keys MUST match exactly.
+	idempKey := addGroupMemberIdempotencyKey(tenantID, groupID, memberActorID, role)
+	ev := wal.Event{
+		TenantID:       tenantID,
+		Actor:          trusted.String(),
+		IdempotencyKey: idempKey,
+		Ops: []map[string]any{{
+			"op":              "add_group_member",
+			"group_id":        groupID,
+			"member_actor_id": memberActorID,
+			"role":            role,
+		}},
+	}
+	value, err := ev.Encode()
+	if err != nil {
+		statusLabel = "error"
+		return &pb.GroupMemberResponse{Success: false, Error: err.Error()}, nil
+	}
+
+	headers := map[string][]byte{
+		wal.HeaderIdempotencyKey: []byte(idempKey),
+	}
+	if _, err := s.producer.Append(ctx, addGroupMemberWALTopic, tenantID, value, headers); err != nil {
+		// Parity with Python: in-band error, gRPC OK. The spec calls
+		// this out explicitly (docs/go-port/rpcs/AddGroupMember.md
+		// "Error contract" status-code parity quirk).
+		statusLabel = "error"
+		return &pb.GroupMemberResponse{Success: false, Error: err.Error()}, nil
+	}
+
+	return &pb.GroupMemberResponse{Success: true}, nil
+}
+
+// addGroupMemberIdempotencyKey derives a stable, content-addressed
+// idempotency key so two byte-identical AddGroupMember requests dedupe
+// at the WAL boundary. The hash inputs are the (tenant, group, member,
+// role) tuple — exactly the fields the apply path keys on. Re-adds
+// with the same role return the original StreamPos; re-adds with a
+// different role create a new WAL record (which the apply path will
+// REPLACE the row for, matching INSERT OR REPLACE semantics).
+func addGroupMemberIdempotencyKey(tenantID, groupID, memberActorID, role string) string {
+	h := sha256.New()
+	// NUL-separated to avoid prefix-collision ambiguity between fields.
+	h.Write([]byte("add_group_member\x00"))
+	h.Write([]byte(tenantID))
+	h.Write([]byte{0})
+	h.Write([]byte(groupID))
+	h.Write([]byte{0})
+	h.Write([]byte(memberActorID))
+	h.Write([]byte{0})
+	h.Write([]byte(role))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/server/go/internal/api/add_group_member_test.go
+++ b/server/go/internal/api/add_group_member_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for AddGroupMember. The Go handler diverges from the Python
+// source on two CLAUDE.md-flagged invariants — see
+// add_group_member.go's package-level doc:
+//
+//  1. WAL-first restoration. The Python handler writes group_users
+//     directly via canonical_store, bypassing the WAL. The Go handler
+//     appends an `add_group_member` op to the per-tenant WAL and lets
+//     the Applier materialize the row. Tests assert on what landed on
+//     the WAL — they do NOT poke at SQLite, because the apply path is
+//     covered separately in apply/ops_add_group_member.go's tests.
+//
+//  2. Trusted-actor substitution. The Python handler honours the
+//     wire-claimed actor; the Go handler ignores it and resolves
+//     identity via auth.Authoritative. The non-admin denial test below
+//     pins the privilege-escalation regression (commit fece3fb): a
+//     bob-authenticated session that claims admin:root in the request
+//     body is rejected as user:bob.
+//
+// Coverage:
+//
+//   - TestAddGroupMember_Admin_HappyPath: trusted admin → OK + WAL
+//     record observed with the full op shape.
+//   - TestAddGroupMember_NonAdmin_PermissionDenied: bob (plain member)
+//     claims admin:root in the request body → PERMISSION_DENIED.
+//   - TestAddGroupMember_Idempotent: same logical request appended
+//     twice → exactly one WAL record (idempotency-key dedupe at the
+//     Append boundary).
+
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const addGroupMemberWALTopic = "entdb-wal"
+
+// addGroupMemberFixture bundles the dependencies a single test case
+// needs: a Server wired to a fresh in-memory WAL + globalstore, plus
+// raw handles to both so assertions can introspect the WAL log and
+// callers can seed tenant_members rows for the auth branches.
+type addGroupMemberFixture struct {
+	srv *api.Server
+	w   *wal.InMemory
+	gs  globalStoreLike
+}
+
+// globalStoreLike is the narrow interface this file uses to seed
+// tenant_members rows. It exists so the test doesn't take a hard
+// import on the globalstore package's public surface area beyond what
+// it actually exercises.
+type globalStoreLike interface {
+	AddTenantMember(ctx context.Context, tenantID, userID, role string) error
+}
+
+func newAddGroupMemberFixture(t *testing.T) addGroupMemberFixture {
+	t.Helper()
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), "acme", "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close(context.Background()) })
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithWALProducer(w),
+	)
+	return addGroupMemberFixture{srv: srv, w: w, gs: gs}
+}
+
+// TestAddGroupMember_Admin_HappyPath: a trusted admin: actor adds a
+// user to a group. The handler returns OK + success=true and the WAL
+// carries exactly one record whose Event.Ops[0] matches the expected
+// op-shape (the contract apply/ops_add_group_member.go consumes).
+func TestAddGroupMember_Admin_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	f := newAddGroupMemberFixture(t)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodAPIKey,
+		Subject: "admin:root",
+	})
+
+	resp, err := f.srv.AddGroupMember(ctx, &pb.GroupMemberRequest{
+		Context: &pb.RequestContext{
+			TenantId: "acme",
+			Actor:    "admin:root",
+		},
+		GroupId:       "group:engineering",
+		MemberActorId: "user:alice",
+		Role:          "member",
+	})
+	if err != nil {
+		t.Fatalf("AddGroupMember: unexpected error: %v", err)
+	}
+	if resp == nil || !resp.GetSuccess() {
+		t.Fatalf("AddGroupMember: success=false, error=%q; want success=true",
+			resp.GetError())
+	}
+
+	recs := f.w.GetAllRecords(addGroupMemberWALTopic)
+	if len(recs) != 1 {
+		t.Fatalf("WAL records = %d; want 1", len(recs))
+	}
+	if recs[0].Key != "acme" {
+		t.Fatalf("WAL record key = %q; want %q (per-tenant partition key)",
+			recs[0].Key, "acme")
+	}
+
+	var ev wal.Event
+	if err := json.Unmarshal(recs[0].Value, &ev); err != nil {
+		t.Fatalf("decode event: %v", err)
+	}
+	if ev.TenantID != "acme" {
+		t.Fatalf("Event.TenantID = %q; want %q", ev.TenantID, "acme")
+	}
+	// Trusted-actor substitution pin: the WAL records the trusted
+	// identity, never the wire-claimed one. (Wire claim and trusted
+	// match in this test, but the assertion still pins the contract.)
+	if ev.Actor != "admin:root" {
+		t.Fatalf("Event.Actor = %q; want %q (trusted)", ev.Actor, "admin:root")
+	}
+	if len(ev.Ops) != 1 {
+		t.Fatalf("Event.Ops length = %d; want 1", len(ev.Ops))
+	}
+	op := ev.Ops[0]
+	if got := op["op"]; got != "add_group_member" {
+		t.Fatalf("op[\"op\"] = %v; want %q", got, "add_group_member")
+	}
+	if got := op["group_id"]; got != "group:engineering" {
+		t.Fatalf("op[\"group_id\"] = %v; want %q", got, "group:engineering")
+	}
+	if got := op["member_actor_id"]; got != "user:alice" {
+		t.Fatalf("op[\"member_actor_id\"] = %v; want %q", got, "user:alice")
+	}
+	if got := op["role"]; got != "member" {
+		t.Fatalf("op[\"role\"] = %v; want %q", got, "member")
+	}
+}
+
+// TestAddGroupMember_NonAdmin_PermissionDenied: bob is authenticated
+// as a plain tenant member but claims actor=admin:root in the request
+// body. The handler MUST ignore the wire claim (privilege-escalation
+// regression pinned by commit fece3fb) and reject as user:bob with
+// PERMISSION_DENIED. The WAL MUST stay empty — denials never append.
+func TestAddGroupMember_NonAdmin_PermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newAddGroupMemberFixture(t)
+	// Bob is a plain member of acme — not owner, not admin.
+	ctx := context.Background()
+	if err := f.gs.AddTenantMember(ctx, "acme", "bob", "member"); err != nil {
+		t.Fatalf("seed bob: %v", err)
+	}
+
+	authedCtx := auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodSession,
+		Subject: "user:bob",
+	})
+
+	_, err := f.srv.AddGroupMember(authedCtx, &pb.GroupMemberRequest{
+		Context: &pb.RequestContext{
+			TenantId: "acme",
+			Actor:    "admin:root", // wire-claimed escalation attempt
+		},
+		GroupId:       "group:engineering",
+		MemberActorId: "user:carol",
+		Role:          "member",
+	})
+	if err == nil {
+		t.Fatalf("AddGroupMember: expected PERMISSION_DENIED, got nil")
+	}
+	if got := errs.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("AddGroupMember: code = %v, want PermissionDenied (err=%v)", got, err)
+	}
+
+	if n := len(f.w.GetAllRecords(addGroupMemberWALTopic)); n != 0 {
+		t.Fatalf("WAL records after denial = %d; want 0 (denial must not append)", n)
+	}
+}
+
+// TestAddGroupMember_Idempotent: the same logical request issued twice
+// (same tenant + group + member + role) lands exactly one WAL record.
+// The idempotency key derived from the tuple flows through the Append
+// header so the in-memory WAL's dedupe path returns the original
+// StreamPos on the second call.
+func TestAddGroupMember_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	f := newAddGroupMemberFixture(t)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodAPIKey,
+		Subject: "admin:root",
+	})
+
+	req := &pb.GroupMemberRequest{
+		Context: &pb.RequestContext{
+			TenantId: "acme",
+			Actor:    "admin:root",
+		},
+		GroupId:       "group:engineering",
+		MemberActorId: "user:alice",
+		Role:          "member",
+	}
+
+	resp1, err := f.srv.AddGroupMember(ctx, req)
+	if err != nil {
+		t.Fatalf("AddGroupMember (first): %v", err)
+	}
+	if !resp1.GetSuccess() {
+		t.Fatalf("AddGroupMember (first): success=false, error=%q", resp1.GetError())
+	}
+
+	resp2, err := f.srv.AddGroupMember(ctx, req)
+	if err != nil {
+		t.Fatalf("AddGroupMember (re-add): %v", err)
+	}
+	if !resp2.GetSuccess() {
+		t.Fatalf("AddGroupMember (re-add): success=false, error=%q", resp2.GetError())
+	}
+
+	if n := len(f.w.GetAllRecords(addGroupMemberWALTopic)); n != 1 {
+		t.Fatalf("WAL records after idempotent re-add = %d; want 1", n)
+	}
+}


### PR DESCRIPTION
## Summary

Ports `AddGroupMember` from Python to Go (EPIC #407, W2), fixing two CLAUDE.md-flagged divergences from the Python source:

- **WAL-first restoration.** Python writes `group_users` directly via `canonical_store`, bypassing the WAL (CLAUDE.md §1 violation — a rebuild-from-empty-WAL silently drops the row). The Go handler appends an `add_group_member` op to the per-tenant WAL; the Applier (`server/go/internal/apply/ops_add_group_member.go`, op-type wired in W1.10) materializes the row.
- **Trusted-actor substitution.** Python never reads `request.context.actor` and skips the trusted-actor pattern, leaving a privilege-escalation gap (cf. commit `fece3fb`). The Go handler resolves identity via `auth.Authoritative` and authorises against the trusted actor only. v1 group-admin === tenant-admin since no per-group ownership table exists (spec §"Open questions" item 1).

Idempotency: the WAL Append carries an idempotency key derived from `(tenant, group, member, role)` so a retry of the same request returns the original `StreamPos` without writing a duplicate. The Applier path uses `INSERT OR REPLACE`.

Drive-by dedupes that unbreak the `api` + `api_test` package builds on `main` from concurrent W2 merges (`#434`+`#442` left two `lookupMemberRole` defs; `#437`+`#444` left two `userToProto`; `#438`+`#443` left two `withTrustedUser` test helpers). The more defensive variant is kept in each case.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...` (all packages green)
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .`
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` (2529 passed)
- [x] New tests: `TestAddGroupMember_Admin_HappyPath`, `TestAddGroupMember_NonAdmin_PermissionDenied`, `TestAddGroupMember_Idempotent`