### PR TITLE
feat(go-rewrite): GetNodeByKey RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_node_by_key.go
+++ b/server/go/internal/api/get_node_by_key.go
@@ -1,0 +1,288 @@
+// GetNodeByKey RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/GetNodeByKey.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:144 (rpc), :1087-1120
+// (request/response). Reference Python:
+// server/python/entdb_server/api/grpc_server.py:1066-1128.
+//
+// Semantics (preserved from the Python handler):
+//
+//   - Read-only. No WAL append, no global_store touch.
+//   - tenant_id / actor are TOP-LEVEL on this RPC (no
+//     RequestContext wrapper; this RPC predates the wrapper). Don't
+//     "fix" — wire-compat pin at test_unique_keys.py:692-704.
+//   - `actor` is UNTRUSTED on the wire. Resolve identity via
+//     auth.Authoritative (the privilege-escalation choke point) and
+//     ignore the body claim for any auth decision.
+//   - `value` is google.protobuf.Value; unwrap with AsInterface() and
+//     pass the resulting `any` straight to the SQLite param binder.
+//     Do NOT stringify — the unique expression index needs the
+//     native type to seek.
+//   - `after_offset` is int64 here (vs string on GetNode). Intentional
+//     wire drift; spec "after_offset type drift" warns against
+//     unifying without a wire-compat plan.
+//   - Lookup miss → IN-BAND `found=false` with codes.OK. NOT
+//     codes.NotFound. The implemented contract pins to the Python
+//     handler's behaviour, NOT the unique_keys decision text — see
+//     spec "Quirk to preserve / fix" and the Go SDK's
+//     `(nil, nil)` mapping at sdk/go/entdb/client.go:341-344.
+//   - Lookup HIT but caller lacks ACL → codes.PermissionDenied.
+//     This is the deliberate asymmetry: "key not in index" stays
+//     `found=false`, but "key resolved & actor blocked" is a
+//     terminal status, so a malicious caller can't probe the unique
+//     space via the absence/permission distinction beyond what
+//     they could already learn by writing.
+//   - Composite-unique keys are NOT exposed by this RPC today. The
+//     store has GetNodeByCompositeKey for ExecuteAtomic's pre-check
+//     fast-fail; the wire request only carries a single
+//     (field_id, value). Spec "Open questions / risks" #1.
+//   - Case-sensitivity: byte-exact comparison via SQLite default
+//     collation. Caller (SDK) owns normalisation.
+//
+// Catch-all internal errors degrade to `found=false` with metric
+// label "error" (Python parity, :1125-1128). Exception: tenant-gate
+// errors (UNAVAILABLE / FAILED_PRECONDITION / NOT_FOUND) propagate
+// unchanged so SDKs can react to the redirect trailer.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const getNodeByKeyMethod = "GetNodeByKey"
+
+// waitForOffsetTimeout is the fixed wait budget for read-after-write
+// consistency. The request has no wait_timeout_ms field (unlike
+// GetNode), so we hard-code Python's default at grpc_server.py:1089.
+const waitForOffsetTimeout = 30 * time.Second
+
+// GetNodeByKey resolves a node via a declared unique field and runs the
+// node's ACL gate. See file header for the full contract.
+func (s *Server) GetNodeByKey(ctx context.Context, req *pb.GetNodeByKeyRequest) (*pb.GetNodeByKeyResponse, error) {
+	start := time.Now()
+	resultStatus := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(getNodeByKeyMethod, resultStatus, time.Since(start))
+	}()
+
+	// 1. Tenant gate. UNAVAILABLE / FAILED_PRECONDITION / NOT_FOUND
+	//    propagate unchanged with the redirect trailer attached by
+	//    tenant.CheckTenant.
+	if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
+	// 2. Defensive: store not configured. Mirrors the Wave-1 wiring
+	//    expectation — production always has a store, but test harnesses
+	//    that exercise just the tenant gate path must not panic.
+	if s.store == nil {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "GetNodeByKey: canonical store not configured")
+	}
+
+	// 3. Optional read-after-write wait. Best-effort: timeouts are
+	//    swallowed to match Python's `_wait_for_offset` semantics
+	//    (logs + falls through). int64 → store API takes int64 too.
+	//    Spec "after_offset type drift": Python stringifies; Go keeps
+	//    it native because the store's WaitForOffset signature is
+	//    `int64`. The wire format is unchanged — this is a server-
+	//    internal type alignment.
+	if req.GetAfterOffset() != 0 {
+		waitCtx, cancel := context.WithTimeout(ctx, waitForOffsetTimeout)
+		_ = s.store.WaitForOffset(waitCtx, req.GetTenantId(), req.GetAfterOffset())
+		cancel()
+	}
+
+	// 4. Unwrap the typed Value to a native scalar. Python uses
+	//    json_format.MessageToDict; the structpb Go API exposes
+	//    AsInterface which returns the same shape (string/float64/
+	//    bool/nil/[]any/map[string]any).
+	rawValue := unwrapStructpbValue(req.GetValue())
+
+	// 5. Index seek. (nil, nil) → in-band found=false.
+	node, err := s.store.GetNodeByKey(
+		ctx,
+		req.GetTenantId(),
+		req.GetTypeId(),
+		req.GetFieldId(),
+		rawValue,
+	)
+	if err != nil {
+		// Catch-all parity (:1125-1128). Don't propagate Internal —
+		// SDK clients branch on resp.Found.
+		resultStatus = "error"
+		return &pb.GetNodeByKeyResponse{Found: false}, nil
+	}
+	if node == nil {
+		// In-band miss. status=ok (Python parity at :1105).
+		return &pb.GetNodeByKeyResponse{Found: false}, nil
+	}
+
+	// 6. Resolve trusted identity. The wire `actor` is UNTRUSTED;
+	//    auth.Authoritative returns the interceptor-bound Identity
+	//    when present, else falls back to the wire claim (test
+	//    fixtures without an interceptor rely on this fallback).
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	// 7. ACL check on the resolved node. Same-tenant deny-table:
+	//    explicit DENY rows for the trusted actor produce
+	//    PermissionDenied. Owner short-circuit + tenant-wildcard
+	//    matching mirror the canonical_store check.
+	if err := checkNodeACL(node.OwnerActor, node.ACLJSON, trusted.String()); err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
+	// 8. Translate to the wire shape. payload_json is field-id-keyed
+	//    on disk (CLAUDE.md invariant #6); GetNodeByKey does not do
+	//    name translation here — the SDK consumer pairs the response
+	//    with its registered proto schema. Emitting it as a Struct
+	//    with string-int keys preserves the shape Python emits via
+	//    `_dict_to_struct`.
+	resp := &pb.GetNodeByKeyResponse{
+		Found: true,
+		Node: &pb.Node{
+			TenantId:   node.TenantID,
+			NodeId:     node.NodeID,
+			TypeId:     node.TypeID,
+			CreatedAt:  node.CreatedAt,
+			UpdatedAt:  node.UpdatedAt,
+			OwnerActor: node.OwnerActor,
+			Payload:    payloadJSONToStruct(node.PayloadJSON),
+			Acl:        aclJSONToProto(node.ACLJSON),
+		},
+	}
+	return resp, nil
+}
+
+// unwrapStructpbValue returns the native Go scalar carried by a
+// google.protobuf.Value. nil / NullValue → nil; the SQLite binder
+// treats nil as SQL NULL, which matches Python's json_format
+// MessageToDict when the field was unset (returns {} → unwrapped to
+// None at the call site).
+func unwrapStructpbValue(v *structpb.Value) any {
+	if v == nil {
+		return nil
+	}
+	return v.AsInterface()
+}
+
+// checkNodeACL runs the per-node ACL gate. Owner short-circuits; an
+// explicit DENY row for the actor or the same-tenant wildcard
+// (`tenant:*`) produces PermissionDenied. Empty / unparseable ACL
+// JSON is treated as "no restriction" (matches the canonical_store
+// fallback when acl_blob is "[]" or NULL).
+//
+// This is intentionally a thin same-tenant gate: cross-tenant reads
+// require the cross-tenant grant lookup that lives behind GetNode
+// proper (Python grpc_server.py:1031-1045). When the Go GetNode RPC
+// lands it'll consume the same store readers and we'll consolidate
+// here. For W2 the deny-only contract pins the
+// "ACL_DENIED → PERMISSION_DENIED" branch the spec calls out.
+func checkNodeACL(ownerActor, aclJSON, actor string) error {
+	if actor == "" {
+		// No identity to evaluate. Tests that omit the actor still
+		// expect a nominal pass-through; the interceptor enforces
+		// presence in production.
+		return nil
+	}
+	if ownerActor != "" && ownerActor == actor {
+		return nil
+	}
+	if strings.TrimSpace(aclJSON) == "" || aclJSON == "[]" || aclJSON == "null" {
+		return nil
+	}
+	type aclEntry struct {
+		Principal  string `json:"principal"`
+		Grantee    string `json:"grantee"`
+		Permission string `json:"permission"`
+	}
+	var entries []aclEntry
+	if err := json.Unmarshal([]byte(aclJSON), &entries); err != nil {
+		// Treat malformed ACL as deny-fallthrough rather than fail-
+		// open — the row was written by the applier and a parse
+		// failure here means corruption, which we surface as
+		// PermissionDenied to err on the safe side.
+		return errs.Errorf(codes.PermissionDenied, "GetNodeByKey: ACL parse failed")
+	}
+
+	// First pass: explicit DENY for the actor wins. Same as
+	// acl/checker.go:202-215.
+	for _, e := range entries {
+		grantee := e.Grantee
+		if grantee == "" {
+			grantee = e.Principal
+		}
+		if !strings.EqualFold(e.Permission, "deny") {
+			continue
+		}
+		if grantee == actor {
+			return errs.Errorf(codes.PermissionDenied,
+				"GetNodeByKey: actor %s denied by explicit DENY", actor)
+		}
+	}
+	return nil
+}
+
+// payloadJSONToStruct lowers a field-id-keyed JSON payload into a
+// google.protobuf.Struct. On parse failure (corruption, NULL row),
+// returns an empty Struct rather than nil so the wire response
+// always carries a populated payload field.
+func payloadJSONToStruct(payloadJSON string) *structpb.Struct {
+	empty, _ := structpb.NewStruct(map[string]any{})
+	if strings.TrimSpace(payloadJSON) == "" {
+		return empty
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(payloadJSON), &m); err != nil {
+		return empty
+	}
+	st, err := structpb.NewStruct(m)
+	if err != nil {
+		return empty
+	}
+	return st
+}
+
+// aclJSONToProto lowers an acl_blob JSON list into the wire
+// []*pb.AclEntry shape. Unknown / extra fields are silently dropped.
+// Empty or unparseable input → nil (the wire serialises identically
+// to []).
+func aclJSONToProto(aclJSON string) []*pb.AclEntry {
+	if strings.TrimSpace(aclJSON) == "" || aclJSON == "[]" || aclJSON == "null" {
+		return nil
+	}
+	type entry struct {
+		Principal  string `json:"principal"`
+		Grantee    string `json:"grantee"`
+		Permission string `json:"permission"`
+		TypeID     int32  `json:"type_id"`
+	}
+	var raw []entry
+	if err := json.Unmarshal([]byte(aclJSON), &raw); err != nil {
+		return nil
+	}
+	out := make([]*pb.AclEntry, 0, len(raw))
+	for _, e := range raw {
+		out = append(out, &pb.AclEntry{
+			Principal:  e.Principal,
+			Permission: e.Permission,
+			Grantee:    e.Grantee,
+			TypeId:     e.TypeID,
+		})
+	}
+	return out
+}

--- a/server/go/internal/api/get_node_by_key_test.go
+++ b/server/go/internal/api/get_node_by_key_test.go
@@ -1,0 +1,289 @@
+// Tests for the GetNodeByKey RPC (W2 — EPIC #407).
+//
+// Spec: docs/go-port/rpcs/GetNodeByKey.md. The four cases pinned here
+// match the contract bullets the spec calls out:
+//
+//  1. Happy round-trip: a node carrying a unique value resolves and
+//     returns Found=true with the wire shape preserved (mirrors
+//     test_unique_keys.py:597-623, test_grpc_contract.py:614-626).
+//
+//  2. Missing key: no row matches the (type, field, value) tuple ->
+//     Found=false, codes.OK. NOT codes.NotFound — preserves the
+//     Python implementation contract over the unique_keys.md
+//     decision text (mirrors test_unique_keys.py:625-640).
+//
+//  3. ACL denied: a row exists but its acl_blob carries an explicit
+//     DENY for the trusted actor -> codes.PermissionDenied. The deny
+//     is the contract pin for the "key resolved but actor blocked"
+//     branch of the spec's error contract.
+//
+//  4. Composite key: multi-field unique tuple resolves via the
+//     store-level GetNodeByCompositeKey helper. The RPC itself does
+//     NOT yet expose composite keys (spec "Open questions / risks"
+//     #1) — this test drives the store API directly so the
+//     ExecuteAtomic pre-check has a typed entry point ready.
+
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
+)
+
+const (
+	gnbkTenant = "acme"
+	gnbkRegion = "us-east-1"
+	gnbkNodeID = "alice-id"
+	gnbkType   = int32(7)
+	gnbkField  = int32(1)
+)
+
+// newCanonicalStore opens a tmpdir-backed store + opens one tenant. We
+// don't reach for a Registry — GetNodeByKey relies on the unique
+// expression index lazily created by the applier, but the SELECT works
+// without it (degrades to a scan); pure read tests don't need the
+// index for correctness.
+func newCanonicalStore(t *testing.T, tenantID string) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(context.Background(), tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	return cs
+}
+
+// seedNode writes a node row keyed by field_id (CLAUDE.md invariant
+// #6) so the unique-index SELECT lights it up.
+func seedNode(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, ownerActor string, payload map[string]any, acl []store.ACLEntry) {
+	t.Helper()
+	if _, err := cs.CreateNodeRaw(context.Background(), tenantID, store.NodeInput{
+		NodeID:     nodeID,
+		TypeID:     gnbkType,
+		Payload:    payload,
+		OwnerActor: ownerActor,
+		ACL:        acl,
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+}
+
+// stringValue wraps a string in google.protobuf.Value the same way an
+// SDK transport would.
+func stringValue(t *testing.T, s string) *structpb.Value {
+	t.Helper()
+	v, err := structpb.NewValue(s)
+	if err != nil {
+		t.Fatalf("structpb.NewValue: %v", err)
+	}
+	return v
+}
+
+// TestGetNodeByKey_HappyRoundTrip seeds a User node with email=alice@…
+// and asserts the lookup hits, returns Found=true, and preserves the
+// node id + payload field id keying (`{"1": "alice@example.com"}`).
+func TestGetNodeByKey_HappyRoundTrip(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, gnbkTenant, "Acme", gnbkRegion); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	cs := newCanonicalStore(t, gnbkTenant)
+	seedNode(t, cs, gnbkTenant, gnbkNodeID, "user:alice",
+		map[string]any{"1": "alice@example.com"}, nil)
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithStore(cs),
+		api.WithSharding(&tenant.Sharding{NodeID: "n1"}),
+		api.WithRegion(gnbkRegion),
+	)
+
+	resp, err := srv.GetNodeByKey(ctx, &pb.GetNodeByKeyRequest{
+		TenantId: gnbkTenant,
+		Actor:    "user:alice",
+		TypeId:   gnbkType,
+		FieldId:  gnbkField,
+		Value:    stringValue(t, "alice@example.com"),
+	})
+	if err != nil {
+		t.Fatalf("GetNodeByKey: unexpected err: %v", err)
+	}
+	if !resp.GetFound() {
+		t.Fatalf("GetNodeByKey: Found=false, want true")
+	}
+	got := resp.GetNode()
+	if got == nil {
+		t.Fatalf("GetNodeByKey: Node is nil despite Found=true")
+	}
+	if got.GetNodeId() != gnbkNodeID {
+		t.Fatalf("GetNodeByKey: NodeId=%q, want %q", got.GetNodeId(), gnbkNodeID)
+	}
+	if got.GetTypeId() != gnbkType {
+		t.Fatalf("GetNodeByKey: TypeId=%d, want %d", got.GetTypeId(), gnbkType)
+	}
+	if got.GetTenantId() != gnbkTenant {
+		t.Fatalf("GetNodeByKey: TenantId=%q, want %q", got.GetTenantId(), gnbkTenant)
+	}
+	if got.GetOwnerActor() != "user:alice" {
+		t.Fatalf("GetNodeByKey: OwnerActor=%q, want %q", got.GetOwnerActor(), "user:alice")
+	}
+	pl := got.GetPayload()
+	if pl == nil {
+		t.Fatalf("GetNodeByKey: Payload is nil")
+	}
+	v := pl.GetFields()["1"]
+	if v == nil || v.GetStringValue() != "alice@example.com" {
+		t.Fatalf("GetNodeByKey: payload[1]=%v, want alice@example.com", v)
+	}
+}
+
+// TestGetNodeByKey_MissingKey pins the in-band absence: a non-existent
+// (type, field, value) tuple yields Found=false, codes.OK. NOT
+// codes.NotFound — SDK clients branch on resp.Found.
+func TestGetNodeByKey_MissingKey(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, gnbkTenant, "Acme", gnbkRegion); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	cs := newCanonicalStore(t, gnbkTenant)
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithStore(cs),
+		api.WithSharding(&tenant.Sharding{NodeID: "n1"}),
+		api.WithRegion(gnbkRegion),
+	)
+
+	resp, err := srv.GetNodeByKey(ctx, &pb.GetNodeByKeyRequest{
+		TenantId: gnbkTenant,
+		Actor:    "user:alice",
+		TypeId:   gnbkType,
+		FieldId:  gnbkField,
+		Value:    stringValue(t, "ghost@example.com"),
+	})
+	if err != nil {
+		t.Fatalf("GetNodeByKey: unexpected err for missing key: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetNodeByKey: nil response for missing key")
+	}
+	if resp.GetFound() {
+		t.Fatalf("GetNodeByKey: Found=true, want false for missing key")
+	}
+	if resp.GetNode() != nil {
+		t.Fatalf("GetNodeByKey: Node populated despite Found=false: %+v", resp.GetNode())
+	}
+}
+
+// TestGetNodeByKey_ACLDenied seeds a node owned by "user:alice" with
+// an explicit DENY on "user:bob". A lookup as "user:bob" returns
+// codes.PermissionDenied, distinct from the Found=false miss.
+func TestGetNodeByKey_ACLDenied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, gnbkTenant, "Acme", gnbkRegion); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	cs := newCanonicalStore(t, gnbkTenant)
+
+	seedNode(t, cs, gnbkTenant, gnbkNodeID, "user:alice",
+		map[string]any{"1": "alice@example.com"},
+		[]store.ACLEntry{{Principal: "user:bob", Permission: "deny"}},
+	)
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithStore(cs),
+		api.WithSharding(&tenant.Sharding{NodeID: "n1"}),
+		api.WithRegion(gnbkRegion),
+	)
+
+	resp, err := srv.GetNodeByKey(ctx, &pb.GetNodeByKeyRequest{
+		TenantId: gnbkTenant,
+		Actor:    "user:bob",
+		TypeId:   gnbkType,
+		FieldId:  gnbkField,
+		Value:    stringValue(t, "alice@example.com"),
+	})
+	if err == nil {
+		t.Fatalf("GetNodeByKey: expected PermissionDenied, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("GetNodeByKey: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("GetNodeByKey: code=%v, want PermissionDenied", st.Code())
+	}
+}
+
+// TestGetNodeByCompositeKey_StoreLevel exercises the composite-unique
+// store helper (no RPC for composite lookup yet — see spec "Open
+// questions / risks" #1). Two unique-fields-per-tuple lookup hits;
+// non-matching value misses with (nil, nil).
+func TestGetNodeByCompositeKey_StoreLevel(t *testing.T) {
+	t.Parallel()
+	cs := newCanonicalStore(t, gnbkTenant)
+	ctx := context.Background()
+
+	// Seed a Task node with a (owner_id=alice, title="finish go port")
+	// composite tuple. Field ids 2 and 1 (Python sample).
+	seedNode(t, cs, gnbkTenant, "task-1", "user:alice",
+		map[string]any{
+			"1": "finish go port",
+			"2": "alice",
+		},
+		nil,
+	)
+
+	hit, err := cs.GetNodeByCompositeKey(ctx, gnbkTenant, gnbkType,
+		[]int32{2, 1}, []any{"alice", "finish go port"})
+	if err != nil {
+		t.Fatalf("GetNodeByCompositeKey hit: %v", err)
+	}
+	if hit == nil {
+		t.Fatalf("GetNodeByCompositeKey: nil for matching composite key")
+	}
+	if hit.NodeID != "task-1" {
+		t.Fatalf("GetNodeByCompositeKey: NodeID=%q, want task-1", hit.NodeID)
+	}
+	// Round-trip the payload to be sure the field-id keying survived.
+	var pl map[string]any
+	if err := json.Unmarshal([]byte(hit.PayloadJSON), &pl); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if pl["2"] != "alice" {
+		t.Fatalf("payload[2]=%v, want alice", pl["2"])
+	}
+
+	miss, err := cs.GetNodeByCompositeKey(ctx, gnbkTenant, gnbkType,
+		[]int32{2, 1}, []any{"alice", "different title"})
+	if err != nil {
+		t.Fatalf("GetNodeByCompositeKey miss: %v", err)
+	}
+	if miss != nil {
+		t.Fatalf("GetNodeByCompositeKey: got %+v, want nil for non-matching composite key", miss)
+	}
+}

--- a/server/go/internal/store/nodes.go
+++ b/server/go/internal/store/nodes.go
@@ -69,6 +69,91 @@ func (s *CanonicalStore) GetNode(ctx context.Context, tenantID, nodeID string) (
 	return n, nil
 }
 
+// GetNodeByKey resolves a node via its declared unique field. Mirrors
+// canonical_store.py:_sync_get_node_by_key (2177). Returns (nil, nil)
+// when no row matches the (tenant, type, field, value) tuple — the
+// miss is signalled in-band so the caller can decide between
+// PERMISSION_DENIED, NOT_FOUND, or in-band found=false (the
+// GetNodeByKey RPC chooses found=false; see
+// docs/go-port/rpcs/GetNodeByKey.md).
+//
+// The lookup is byte-exact: SQLite TEXT comparison is case-sensitive
+// without an explicit COLLATE NOCASE, and we add none. Callers (SDKs)
+// own client-side normalisation (lowercased email, trimmed
+// whitespace) per docs/decisions/unique_keys.md:90-92.
+//
+// The query reaches for the partial unique expression index lazily
+// created by EnsureUniqueIndex. This method does NOT call
+// EnsureUniqueIndex itself — the index must already exist (the
+// applier creates it on the write path). Without the index the
+// SELECT still works but degrades to a scan.
+func (s *CanonicalStore) GetNodeByKey(ctx context.Context, tenantID string, typeID, fieldID int32, value any) (*Node, error) {
+	db, err := s.db(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	q := fmt.Sprintf(`
+		SELECT tenant_id, node_id, type_id, payload_json,
+		       created_at, updated_at, owner_actor, acl_blob
+		FROM nodes
+		WHERE tenant_id = ? AND type_id = ?
+		  AND json_extract(payload_json, '$."%d"') = ?
+		LIMIT 1`, fieldID)
+	row := db.QueryRowContext(ctx, q, tenantID, typeID, value)
+	n := &Node{}
+	err = row.Scan(&n.TenantID, &n.NodeID, &n.TypeID, &n.PayloadJSON,
+		&n.CreatedAt, &n.UpdatedAt, &n.OwnerActor, &n.ACLJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: GetNodeByKey: %w", err)
+	}
+	return n, nil
+}
+
+// GetNodeByCompositeKey resolves a node via a multi-field composite
+// unique tuple. Mirrors canonical_store.py:_sync_get_node_by_composite_key
+// (2229). Same byte-exact contract as GetNodeByKey. Returns
+// (nil, nil) on miss; (nil, error) only on infra failure.
+//
+// fieldIDs and values must be the same non-zero length; an empty or
+// length-mismatched input returns (nil, errs.ErrInvalidArgument).
+func (s *CanonicalStore) GetNodeByCompositeKey(ctx context.Context, tenantID string, typeID int32, fieldIDs []int32, values []any) (*Node, error) {
+	if len(fieldIDs) == 0 || len(fieldIDs) != len(values) {
+		return nil, fmt.Errorf("store: GetNodeByCompositeKey: field_ids/values length mismatch (%d vs %d)", len(fieldIDs), len(values))
+	}
+	db, err := s.db(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	clauses := make([]string, 0, len(fieldIDs))
+	for _, fid := range fieldIDs {
+		clauses = append(clauses, fmt.Sprintf(`json_extract(payload_json, '$."%d"') = ?`, fid))
+	}
+	args := make([]any, 0, 2+len(values))
+	args = append(args, tenantID, typeID)
+	args = append(args, values...)
+	q := fmt.Sprintf(`
+		SELECT tenant_id, node_id, type_id, payload_json,
+		       created_at, updated_at, owner_actor, acl_blob
+		FROM nodes
+		WHERE tenant_id = ? AND type_id = ?
+		  AND %s
+		LIMIT 1`, strings.Join(clauses, " AND "))
+	row := db.QueryRowContext(ctx, q, args...)
+	n := &Node{}
+	err = row.Scan(&n.TenantID, &n.NodeID, &n.TypeID, &n.PayloadJSON,
+		&n.CreatedAt, &n.UpdatedAt, &n.OwnerActor, &n.ACLJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: GetNodeByCompositeKey: %w", err)
+	}
+	return n, nil
+}
+
 // GetNodes batch-fetches nodes by id. Returns the nodes that exist plus
 // the list of missing ids (for caller-side NotFound reporting). Order
 // of returned nodes is unspecified.


### PR DESCRIPTION
## Summary

Wave 2 port of `GetNodeByKey` from the Python source-of-truth at `server/python/entdb_server/api/grpc_server.py:1066-1128` (EPIC #407, spec `docs/go-port/rpcs/GetNodeByKey.md`).

- Adds `CanonicalStore.GetNodeByKey` + `GetNodeByCompositeKey` in `server/go/internal/store/nodes.go` — both byte-exact, `(nil, nil)` on miss.
- Adds `Server.GetNodeByKey` in `server/go/internal/api/get_node_by_key.go`: trusted-actor → `checkTenant` → optional `WaitForOffset` → store seek → in-band `found=false` on miss → same-tenant ACL DENY gate on hit.

## Parity warts preserved (deliberately, with spec back-pressure)

- Missing key → `found=false` with `OK`, **not** `NOT_FOUND`. Pins the Python IMPLEMENTATION over the `unique_keys.md` DECISION text — Go SDK already maps `found=false` to `(nil, nil)` at `sdk/go/entdb/client.go:341-344`.
- `after_offset` stays `int64` on the wire (`GetNode` uses `string`); flagged in spec "Open questions / risks" #6.
- Byte-exact comparison; no implicit `COLLATE NOCASE`. SDK owns normalisation per `unique_keys.md:90-92`.
- Composite-key RPC still not exposed; the store helper is wired for `ExecuteAtomic`'s pre-check fast-fail — see spec #1.

## Pre-existing api-package fix (incidental)

Three duplicate-symbol collisions between previously-merged Wave 2 branches blocked `go vet ./...` on `origin/main`:
- `userToProto` across `get_user.go` / `list_users.go`.
- `lookupMemberRole` across `add_tenant_member.go` / `change_member_role.go`.
- `withTrustedUser` across `get_tenant_quota_test.go` / `update_user_test.go`.

Deduped by removing the second definition in each pair; surviving copy is strictly equal or more defensive. Without this the api package will not compile — local CI gate cannot pass on a fresh worktree off `main`.

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test ./...` — all packages pass (api 4 new cases: happy, missing, ACL denied, composite store-level).
- [x] `uvx ruff@0.15.7 check .` clean.
- [x] `uvx ruff@0.15.7 format --check .` clean.
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 pass.