### PR TITLE
feat(go-rewrite): DelegateAccess RPC — Wave 2 (closes silent-drop bug)

### DIFF
--- a/server/go/internal/api/delegate_access.go
+++ b/server/go/internal/api/delegate_access.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// DelegateAccess implements entdb.v1.EntDBService/DelegateAccess.
+//
+// EPIC #407 / Wave 2 / W2 — DelegateAccess RPC.
+//
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:2747-2806;
+// WAL helper: server/python/entdb_server/api/admin_handlers.py:70-115.
+// Port spec: docs/go-port/rpcs/DelegateAccess.md.
+//
+// # Closes the silent-drop bug (Wave 0 finding)
+//
+// The Python handler appends an `admin_delegate_access` event to the WAL
+// but the Python applier (apply/applier.py:1231-1248) has NO dispatch
+// branch for it — events were silently dropped on replay. The
+// `test_admin_operations.py:514-536` happy-path test only passes because
+// the Python handler ALSO direct-writes via `canonical_store.delegate_access`,
+// bypassing the WAL (CLAUDE.md invariant #1 violation).
+//
+// W1.10 closed the applier-side gap on Go (apply/ops_delegate_access.go).
+// This handler closes the gRPC-side gap by emitting a per-node
+// `delegate_access` op for every node owned by `from_user`, so the
+// applier can materialise each grant. With W1.10 + W2.DelegateAccess in
+// place, an admin's bulk delegation survives a WAL replay — which is
+// the contract Python silently breaks.
+//
+// # Behavioural pins
+//
+//   - Tenant gate first (s.checkTenant) — sharding + region pinning.
+//   - Required-field validation (tenant_id / from_user / to_user).
+//   - Trusted-actor rebind via auth.Authoritative; the wire `actor` is
+//     UNTRUSTED. Privilege-escalation regression pinned by commit fece3fb.
+//   - Admin-or-owner gate (NOT a per-node ADMIN check). The delegator
+//     does not need any per-node grant — admin/owner is sufficient.
+//   - Permission default: empty string -> "read".
+//   - expires_at: 0 means "no expiry" (NULL in node_access). Past values
+//     are persisted but filtered at read time by the visibility joins.
+//   - WAL-first (CLAUDE.md invariant #1): we emit one
+//     `delegate_access` op per node owned by from_user inside a single
+//     TransactionEvent. The applier (W1.10) materialises each into a
+//     node_access row keyed (node_id, actor_id) with granted_by =
+//     trusted-actor.
+//   - `delegated` echo: the count of nodes the owner held at handler-call
+//     time — same pre-apply estimate Python returns
+//     (grpc_server.py:2786-2795).
+//   - Soft-fail shape: WAL backend / count failures collapse to OK +
+//     {success=false, error=<msg>}. Wire-level INTERNAL is intentionally
+//     avoided so SDK consumers parse the response field, not the status
+//     code (sdk/go/entdb/admin.go:95-104).
+
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const grpcMethodDelegateAccess = "DelegateAccess"
+
+// DelegateAccess bulk-grants `permission` on every node owned by
+// `from_user` to `to_user`, optionally time-bounded by `expires_at`.
+func (s *Server) DelegateAccess(
+	ctx context.Context,
+	req *pb.DelegateAccessRequest,
+) (*pb.DelegateAccessResponse, error) {
+	start := time.Now()
+
+	// 1. Tenant gate (sharding + region pinning).
+	if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return nil, err
+	}
+
+	// 2. Required-field validation. Mirrors grpc_server.py:2756-2761.
+	if req.GetTenantId() == "" {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetFromUser() == "" {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return nil, errs.Errorf(codes.InvalidArgument, "from_user is required")
+	}
+	if req.GetToUser() == "" {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return nil, errs.Errorf(codes.InvalidArgument, "to_user is required")
+	}
+
+	// 3. Trusted-actor rebind. The wire `actor` is UNTRUSTED — we
+	//    consult auth.Authoritative so a forged actor in the request body
+	//    cannot grant itself elevated privileges. fix-fece3fb.
+	claimed := auth.ParseActor(req.GetActor())
+	trusted := auth.Authoritative(ctx, claimed)
+
+	// 4. Admin-or-owner gate. Non-system/non-admin trusted actors must
+	//    hold tenant role "owner" or "admin". Mirrors
+	//    grpc_server.py:2656-2690 (`_require_admin_or_owner`).
+	if !(trusted.IsSystem() || trusted.IsAdmin()) {
+		if s.global == nil {
+			metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+			return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
+		}
+		role, err := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
+		if err != nil {
+			metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+			return nil, err
+		}
+		if role != "owner" && role != "admin" {
+			metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"Only tenant owner or admin can delegate access")
+		}
+	}
+
+	// 5. Resolve the writer prerequisites. Without a store + WAL the
+	//    handler cannot honour invariant #1 (every mutation through the
+	//    WAL); without them we soft-fail rather than wire-error so the
+	//    SDK shape stays parsable.
+	if s.store == nil || s.producer == nil {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return &pb.DelegateAccessResponse{
+			Success: false,
+			Error:   "DelegateAccess: store/wal not configured",
+		}, nil
+	}
+
+	// 6. Look up the nodes owned by from_user. The count becomes the
+	//    `delegated` echo AND drives the per-node ops we emit. Pre-apply
+	//    estimate by design (grpc_server.py:2787-2793) — new nodes
+	//    created between SELECT and apply inflate the actual grant count.
+	nodeIDs, err := listNodesByOwner(ctx, s, req.GetTenantId(), req.GetFromUser())
+	if err != nil {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return &pb.DelegateAccessResponse{
+			Success: false,
+			Error:   fmt.Sprintf("DelegateAccess: list owner nodes: %v", err),
+		}, nil
+	}
+
+	// 7. Build the WAL event. One delegate_access op per owned node;
+	//    op shape mirrors apply/ops_delegate_access.go (node_id +
+	//    actor_id keyed). Empty permission defaults to "read".
+	permission := req.GetPermission()
+	if permission == "" {
+		permission = "read"
+	}
+	expiresAt := req.GetExpiresAt() // 0 => no expiry; the applier maps that to NULL.
+
+	ops := make([]map[string]any, 0, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
+		op := map[string]any{
+			"op":         string(apply.OpDelegateAccess),
+			"node_id":    nodeID,
+			"actor_id":   req.GetToUser(),
+			"actor_type": "user",
+			"permission": permission,
+		}
+		if expiresAt != 0 {
+			op["expires_at"] = expiresAt
+		}
+		ops = append(ops, op)
+	}
+
+	idemKey, err := newDelegateIdempotencyKey()
+	if err != nil {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return &pb.DelegateAccessResponse{
+			Success: false,
+			Error:   fmt.Sprintf("DelegateAccess: idempotency key: %v", err),
+		}, nil
+	}
+
+	event := wal.Event{
+		TenantID:       req.GetTenantId(),
+		Actor:          trusted.String(),
+		IdempotencyKey: idemKey,
+		TsMs:           time.Now().UnixMilli(),
+		Ops:            ops,
+	}
+	value, err := event.Encode()
+	if err != nil {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return &pb.DelegateAccessResponse{
+			Success: false,
+			Error:   fmt.Sprintf("DelegateAccess: encode event: %v", err),
+		}, nil
+	}
+
+	headers := map[string][]byte{wal.HeaderIdempotencyKey: []byte(idemKey)}
+	if _, err := s.producer.Append(ctx, s.walTopic(), req.GetTenantId(), value, headers); err != nil {
+		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		return &pb.DelegateAccessResponse{
+			Success: false,
+			Error:   fmt.Sprintf("DelegateAccess: wal append: %v", err),
+		}, nil
+	}
+
+	resp := &pb.DelegateAccessResponse{
+		Success:   true,
+		Delegated: int32(len(nodeIDs)),
+	}
+	// Echo expires_at unchanged: 0 stays 0 (permanent), positive value
+	// echoes the request. Pinned by sdk/go/entdb/admin_test.go:291-333.
+	resp.ExpiresAt = expiresAt
+
+	metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "ok", time.Since(start))
+	return resp, nil
+}
+
+// listNodesByOwner returns every node_id whose owner_actor matches
+// fromUser inside tenantID. Mirrors the SELECT inside
+// canonical_store.py:3774-3810 that the Python applier branch *should*
+// have run on replay but didn't (the silent-drop bug).
+//
+// We open the tenant DB lazily so a fresh tenant with no nodes still
+// returns an empty slice rather than a "tenant not open" error.
+func listNodesByOwner(ctx context.Context, s *Server, tenantID, fromUser string) ([]string, error) {
+	if err := s.store.OpenTenant(ctx, tenantID); err != nil {
+		return nil, fmt.Errorf("open tenant: %w", err)
+	}
+	db, err := s.store.AdminDB(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("admin db: %w", err)
+	}
+	rows, err := db.QueryContext(ctx,
+		`SELECT node_id FROM nodes WHERE tenant_id = ? AND owner_actor = ? ORDER BY node_id`,
+		tenantID, fromUser,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query nodes: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan node_id: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate nodes: %w", err)
+	}
+	return out, nil
+}
+
+// newDelegateIdempotencyKey returns "admin-delegate-<32hex>". The 16
+// random bytes give us 128 bits of entropy — same magnitude as the
+// uuid4 the Python handler uses (admin_handlers.py:70-115's
+// "admin-delegate-<uuid4>"), without pulling a third-party dep.
+func newDelegateIdempotencyKey() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "admin-delegate-" + hex.EncodeToString(b[:]), nil
+}

--- a/server/go/internal/api/delegate_access_test.go
+++ b/server/go/internal/api/delegate_access_test.go
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// DelegateAccess RPC tests — Wave 2 of EPIC #407.
+//
+// These three tests pin the contract called out in
+// docs/go-port/rpcs/DelegateAccess.md "Implementation outline":
+//
+//  1. Admin delegates -> grant materialises after the applier picks up
+//     the WAL event. THIS is the test that proves the Wave-0
+//     silent-drop bug is fixed: the Python applier had no
+//     admin_delegate_access dispatch branch, so the WAL event was
+//     appended-and-ignored. With the Go applier (W1.10) + this handler
+//     (W2) wired through an in-memory WAL + canonical store, the grant
+//     becomes a row in node_access on replay -- which is the contract
+//     Python silently breaks today.
+//
+//  2. Non-admin caller -> PERMISSION_DENIED. Closes the wire-payload
+//     trust gap (privilege-escalation regression pinned by commit
+//     fece3fb).
+//
+//  3. Expired delegation -> filtered at read time by the visibility
+//     joins. Per spec "Open questions" §3 expiration is read-side only
+//     today; the materialised row stays put.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const (
+	delegateTopic   = "entdb-wal-test-delegate"
+	delegateGroupID = "applier-delegate-test"
+)
+
+// delegateFixture wires the full mutation path -- WAL producer + WAL
+// consumer (same in-memory backend) + per-tenant store + globalstore +
+// applier -- into one struct the tests can reach for. Cleanup runs via
+// t.Cleanup so individual tests don't have to remember to Stop / Close.
+type delegateFixture struct {
+	t       *testing.T
+	wal     *wal.InMemory
+	store   *store.CanonicalStore
+	global  *globalstore.GlobalStore
+	srv     *api.Server
+	applier *apply.Applier
+	cancel  context.CancelFunc
+	done    chan error
+}
+
+func newDelegateFixture(t *testing.T) *delegateFixture {
+	t.Helper()
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	dir := t.TempDir()
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+
+	a, err := apply.New(apply.Options{
+		Store:       cs,
+		Global:      gs,
+		Consumer:    w,
+		Topic:       delegateTopic,
+		GroupID:     delegateGroupID,
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithGlobalStore(gs),
+		api.WithWALProducer(w),
+		api.WithWALTopic(delegateTopic),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	return &delegateFixture{
+		t: t, wal: w, store: cs, global: gs,
+		srv: srv, applier: a, cancel: cancel, done: done,
+	}
+}
+
+// seedTenant registers tenantID in the global store so checkTenant
+// passes. Region is left blank so region pinning never fires under
+// the default WithRegion("") wiring.
+func (f *delegateFixture) seedTenant(t *testing.T, tenantID string) {
+	t.Helper()
+	if _, err := f.global.CreateTenant(context.Background(), tenantID, tenantID, ""); err != nil {
+		t.Fatalf("CreateTenant(%q): %v", tenantID, err)
+	}
+	if err := f.store.OpenTenant(context.Background(), tenantID); err != nil {
+		t.Fatalf("OpenTenant(%q): %v", tenantID, err)
+	}
+}
+
+// addMember inserts (tenantID, userID, role) into tenant_members.
+func (f *delegateFixture) addMember(t *testing.T, tenantID, userID, role string) {
+	t.Helper()
+	if err := f.global.AddTenantMember(context.Background(), tenantID, userID, role); err != nil {
+		t.Fatalf("AddTenantMember(%q,%q,%q): %v", tenantID, userID, role, err)
+	}
+}
+
+// appendCreateNode appends a synthetic create_node event that gives
+// `owner` an owned node, then waits for the applier to apply it.
+// This is how we seed the "from_user owns N nodes" precondition for
+// DelegateAccess; the handler's pre-apply count drives the bulk grant.
+func (f *delegateFixture) appendCreateNode(t *testing.T, tenantID, nodeID, owner, idemKey string) {
+	t.Helper()
+	ev := apply.Event{
+		TenantID:       tenantID,
+		Actor:          owner,
+		IdempotencyKey: idemKey,
+		Ops: []map[string]any{{
+			"op":      string(apply.OpCreateNode),
+			"id":      nodeID,
+			"type_id": int32(1),
+			"data":    map[string]any{"1": "secret"},
+		}},
+	}
+	value, err := ev.Encode()
+	if err != nil {
+		t.Fatalf("event.Encode: %v", err)
+	}
+	headers := map[string][]byte{wal.HeaderIdempotencyKey: []byte(idemKey)}
+	if _, err := f.wal.Append(context.Background(), delegateTopic, tenantID, value, headers); err != nil {
+		t.Fatalf("wal.Append: %v", err)
+	}
+	f.waitForIdempKey(t, tenantID, idemKey)
+}
+
+// waitForIdempKey polls until idemKey appears in applied_events for
+// tenantID, or the deadline fires. Mirrors the apply package's helper.
+func (f *delegateFixture) waitForIdempKey(t *testing.T, tenantID, idemKey string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ok, err := f.store.CheckIdempotency(context.Background(), tenantID, idemKey)
+		if err != nil {
+			t.Fatalf("CheckIdempotency: %v", err)
+		}
+		if ok {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("waitForIdempKey: %q never showed up", idemKey)
+}
+
+// waitForGrant polls the per-tenant SQLite for a non-empty node_access
+// row matching (nodeID, actorID). Returns the row's permission and
+// expires_at. Used to assert the applier materialised the WAL event --
+// which is exactly the "silent-drop bug closed" assertion.
+func (f *delegateFixture) waitForGrant(t *testing.T, tenantID, nodeID, actorID string) (perm string, expiresAt int64) {
+	t.Helper()
+	db, err := f.store.AdminDB(tenantID)
+	if err != nil {
+		t.Fatalf("AdminDB: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var p string
+		var exp interface{}
+		err := db.QueryRowContext(context.Background(),
+			`SELECT permission, expires_at FROM node_access
+			   WHERE node_id = ? AND actor_id = ?`,
+			nodeID, actorID,
+		).Scan(&p, &exp)
+		if err == nil {
+			if v, ok := exp.(int64); ok {
+				return p, v
+			}
+			return p, 0
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("waitForGrant: no node_access row for (%s, %s) within 2s", nodeID, actorID)
+	return "", 0
+}
+
+// TestDelegateAccess_AdminDelegatesGrantMaterialisesAfterApply is THE
+// regression test that proves the Wave-0 silent-drop bug is closed.
+//
+// Setup: alice (owner) owns two nodes in acme. carol (admin) calls
+// DelegateAccess(from=alice, to=bob, permission=read). The handler
+// emits two delegate_access ops on the WAL; the applier (W1.10
+// dispatch branch) materialises both into node_access rows.
+//
+// Pinned by docs/go-port/rpcs/DelegateAccess.md §"Open questions" item 1:
+// the Python applier silently drops admin_delegate_access events; the
+// Go applier MUST close that gap.
+func TestDelegateAccess_AdminDelegatesGrantMaterialisesAfterApply(t *testing.T) {
+	t.Parallel()
+	f := newDelegateFixture(t)
+
+	const tenantID = "acme"
+	f.seedTenant(t, tenantID)
+	f.addMember(t, tenantID, "alice", "owner")
+	f.addMember(t, tenantID, "carol", "admin")
+
+	// Seed two alice-owned nodes through the WAL so the applier
+	// materialises them first. The DelegateAccess handler's owner-count
+	// SELECT will pick them up.
+	f.appendCreateNode(t, tenantID, "doc1", "user:alice", "seed-doc1")
+	f.appendCreateNode(t, tenantID, "doc2", "user:alice", "seed-doc2")
+
+	// Trusted ctx: carol (tenant admin).
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "user:carol",
+	})
+
+	resp, err := f.srv.DelegateAccess(ctx, &pb.DelegateAccessRequest{
+		Actor:      "user:carol",
+		TenantId:   tenantID,
+		FromUser:   "user:alice",
+		ToUser:     "user:bob",
+		Permission: "read",
+	})
+	if err != nil {
+		t.Fatalf("DelegateAccess: unexpected error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("DelegateAccess: success=false, want true (resp=%+v)", resp)
+	}
+	if resp.GetDelegated() != 2 {
+		t.Fatalf("DelegateAccess: delegated=%d, want 2 (the alice-owned-node count)", resp.GetDelegated())
+	}
+	if resp.GetExpiresAt() != 0 {
+		t.Fatalf("DelegateAccess: expires_at=%d, want 0 (permanent grant)", resp.GetExpiresAt())
+	}
+
+	// THIS is the bug-closed assertion: the applier must materialise
+	// the grant for both nodes. If the applier silently dropped the
+	// event (the Python bug), waitForGrant times out.
+	for _, nodeID := range []string{"doc1", "doc2"} {
+		perm, exp := f.waitForGrant(t, tenantID, nodeID, "user:bob")
+		if perm != "read" {
+			t.Fatalf("node_access[%s].permission=%q, want %q", nodeID, perm, "read")
+		}
+		if exp != 0 {
+			t.Fatalf("node_access[%s].expires_at=%d, want 0 (permanent)", nodeID, exp)
+		}
+	}
+}
+
+// TestDelegateAccess_NonAdminPermissionDenied: a regular tenant member
+// trying to bulk-delegate is rejected with PERMISSION_DENIED. This pins
+// the trusted-actor contract: even if the wire actor claims
+// "user:eve", the role lookup fires against the trusted Identity --
+// closing the wire-payload trust gap from commit fece3fb.
+func TestDelegateAccess_NonAdminPermissionDenied(t *testing.T) {
+	t.Parallel()
+	f := newDelegateFixture(t)
+
+	const tenantID = "acme"
+	f.seedTenant(t, tenantID)
+	f.addMember(t, tenantID, "alice", "owner")
+	f.addMember(t, tenantID, "eve", "member") // not admin/owner
+
+	// Seed a node so we know the denial fires from the role gate, not
+	// from a "no nodes to delegate" short-circuit (the handler doesn't
+	// short-circuit, but the test stays robust against future tuning).
+	f.appendCreateNode(t, tenantID, "doc1", "user:alice", "seed-doc1")
+
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "user:eve",
+	})
+
+	resp, err := f.srv.DelegateAccess(ctx, &pb.DelegateAccessRequest{
+		Actor:      "user:eve",
+		TenantId:   tenantID,
+		FromUser:   "user:alice",
+		ToUser:     "user:bob",
+		Permission: "read",
+	})
+	if err == nil {
+		t.Fatalf("DelegateAccess: want PERMISSION_DENIED, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("DelegateAccess: not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("DelegateAccess: code=%v, want PermissionDenied", st.Code())
+	}
+
+	// Defence in depth: the WAL must not have grown a delegate_access
+	// op for bob -- and therefore node_access must have no row. We
+	// give the (non-existent) applier work a generous beat to be sure.
+	time.Sleep(150 * time.Millisecond)
+	db, err := f.store.AdminDB(tenantID)
+	if err != nil {
+		t.Fatalf("AdminDB: %v", err)
+	}
+	var n int
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM node_access WHERE actor_id = ?`,
+		"user:bob",
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("node_access for user:bob: got %d rows, want 0 (PERMISSION_DENIED must NOT WAL-append)", n)
+	}
+}
+
+// TestDelegateAccess_ExpiredDelegationFilteredAtRead: an admin
+// delegates with expires_at in the past. The applier still materialises
+// the row (storage is "tombstoned" lazily; spec §"Open questions" §3),
+// but the read-side visibility join must filter it out so a
+// VisibleNodeIDs(bob) query against the same tenant returns no
+// expired-grant rows.
+//
+// This pins the read-side filter at store/visibility.go:163
+// (`expires_at IS NULL OR expires_at > ?`).
+func TestDelegateAccess_ExpiredDelegationFilteredAtRead(t *testing.T) {
+	t.Parallel()
+	f := newDelegateFixture(t)
+
+	const tenantID = "acme"
+	f.seedTenant(t, tenantID)
+	f.addMember(t, tenantID, "alice", "owner")
+	f.addMember(t, tenantID, "carol", "admin")
+	f.appendCreateNode(t, tenantID, "doc1", "user:alice", "seed-doc1")
+
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "user:carol",
+	})
+
+	// A timestamp comfortably in the past.
+	expiredMs := time.Now().Add(-1 * time.Hour).UnixMilli()
+	resp, err := f.srv.DelegateAccess(ctx, &pb.DelegateAccessRequest{
+		Actor:      "user:carol",
+		TenantId:   tenantID,
+		FromUser:   "user:alice",
+		ToUser:     "user:bob",
+		Permission: "read",
+		ExpiresAt:  expiredMs,
+	})
+	if err != nil {
+		t.Fatalf("DelegateAccess: unexpected error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("DelegateAccess: success=false (resp=%+v)", resp)
+	}
+	if resp.GetExpiresAt() != expiredMs {
+		t.Fatalf("DelegateAccess: expires_at echoed %d, want %d", resp.GetExpiresAt(), expiredMs)
+	}
+
+	// The applier still writes the row -- expiration is read-side.
+	perm, exp := f.waitForGrant(t, tenantID, "doc1", "user:bob")
+	if perm != "read" {
+		t.Fatalf("perm=%q, want read", perm)
+	}
+	if exp != expiredMs {
+		t.Fatalf("expires_at=%d, want %d (expiration is materialised, then filtered at read)", exp, expiredMs)
+	}
+
+	// Read-side filter: ListSharedWithMe for bob must return ZERO nodes
+	// because the only grant is expired (the SQL applies
+	// `expires_at IS NULL OR expires_at > now`, store/visibility.go:163).
+	// This is the same code path read handlers exercise.
+	shared, err := f.store.ListSharedWithMe(context.Background(),
+		tenantID, []string{"user:bob"}, 100, 0)
+	if err != nil {
+		t.Fatalf("ListSharedWithMe: %v", err)
+	}
+	for _, n := range shared {
+		if n.NodeID == "doc1" {
+			t.Fatalf("ListSharedWithMe: doc1 surfaced to user:bob despite expired delegation (read-side filter regression)")
+		}
+	}
+}

--- a/server/go/internal/api/server.go
+++ b/server/go/internal/api/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	store    *store.CanonicalStore
 	global   *globalstore.GlobalStore
 	producer wal.Producer
+	topic    string
 	sharding *tenant.Sharding
 	region   string
 	registry *schema.Registry
@@ -55,6 +56,13 @@ func WithGlobalStore(g *globalstore.GlobalStore) Option {
 // WithWALProducer wires the WAL producer (for ExecuteAtomic in Wave 2).
 func WithWALProducer(p wal.Producer) Option {
 	return func(srv *Server) { srv.producer = p }
+}
+
+// WithWALTopic configures the WAL topic name handlers append to. When
+// unset (or empty), Wave-2 write RPCs default to "entdb-wal" — the
+// same default carried by cmd/entdb-server/main.go's --wal-topic flag.
+func WithWALTopic(topic string) Option {
+	return func(srv *Server) { srv.topic = topic }
 }
 
 // WithSharding wires the per-node tenant-ownership/redirect config the
@@ -98,4 +106,15 @@ func New(opts ...Option) *Server {
 // api/grpc_server.py:362).
 func (s *Server) checkTenant(ctx context.Context, tenantID string) error {
 	return tenant.CheckTenant(ctx, tenantID, s.global, s.sharding, tenant.Options{ServedRegion: s.region})
+}
+
+// walTopic returns the configured WAL topic, falling back to the
+// process-wide default ("entdb-wal", same as cmd/entdb-server/main.go's
+// --wal-topic flag default). Centralised here so every Wave-2 writer
+// reaches for the same string.
+func (s *Server) walTopic() string {
+	if s.topic == "" {
+		return "entdb-wal"
+	}
+	return s.topic
 }


### PR DESCRIPTION
## Summary

- Implements `DelegateAccess` for the Go server reimplementation of EPIC #407, Wave 2.
- **Closes the Wave-0 silent-drop bug**: the Python applier (`apply/applier.py:1231-1248`) had no dispatch branch for `admin_delegate_access` — events were appended-and-ignored on the WAL. The Python integration test only passes because the handler also direct-wrote via `canonical_store.delegate_access`, bypassing the WAL (CLAUDE.md invariant #1 violation). W1.10 added the Go applier branch (`apply/ops_delegate_access.go`); this PR closes the gRPC side by emitting one per-node `delegate_access` op for every node owned by `from_user` inside a single `TransactionEvent`.

Handler (`server/go/internal/api/delegate_access.go`):

- `s.checkTenant` (sharding + region pinning).
- Required-field validation (`tenant_id` / `from_user` / `to_user`).
- Trusted-actor rebind via `auth.Authoritative` — wire `actor` is UNTRUSTED (regression pinned by commit `fece3fb`).
- Admin-or-owner gate (system: / admin: trusted actors bypass; tenant members must hold role `owner` or `admin`).
- Empty permission defaults to `"read"`; `expires_at = 0` maps to `NULL` (permanent). Past `expires_at` values are persisted but read-side filtered by the visibility joins.
- `delegated` echo = pre-apply count of `from_user`-owned nodes (mirrors `grpc_server.py:2787-2793`).
- Soft-fail shape on WAL/store faults: `OK + success=false + error=<msg>` (SDK consumers parse the response field, not the status code).

Tests (`server/go/internal/api/delegate_access_test.go`, package `api_test`):

1. **Admin happy path** — proves the grant materialises in `node_access` after the applier picks up the event. **THIS is the bug-closed assertion.**
2. **Non-admin** → `PERMISSION_DENIED`; the WAL must not have grown a delegate op for the target.
3. **Expired delegation** → row is materialised, but read-side filtered by `ListSharedWithMe` (`expires_at IS NULL OR expires_at > now`, `store/visibility.go:163`).

### Drive-by build-unblock

`origin/main` was broken at the merge boundary by concurrent Wave-2 PRs that introduced duplicate symbols (`go build ./...` on the parent commit fails). To unblock CI for this branch:

- Drop the duplicate `userToProto` definition from `get_user.go` (PR #444); the `list_users.go` form (PR #437) carries the nil-row guard `ListUsers` needs and is kept as the canonical definition.
- Rename the duplicate `lookupMemberRole` on `change_member_role.go` (PR #442) to `lookupMemberRoleStrict`; the simpler `add_tenant_member.go` form (PR #434) is preserved.
- Rename the duplicate `withTrustedUser` test helper on `update_user_test.go` (PR #443) to `withTrustedOAuthUser`.

Refs #407 and the Wave-0 silent-drop finding documented in `docs/go-port/rpcs/DelegateAccess.md` "KNOWN GAP — fix in Go port".

## Test plan

- [x] `go vet ./...` (server/go) — clean
- [x] `go test ./...` (server/go) — all packages pass; new tests in `internal/api`
- [x] `go vet ./... && go test ./...` (sdk/go/entdb) — clean
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed
- [x] `uvx ruff@0.15.7 check .` — All checks passed
- [x] `uvx ruff@0.15.7 format --check .` — 220 files already formatted