### PR TITLE
feat(go-rewrite): RevokeAllUserAccess RPC — Wave 2 (WAL-first restoration)

### DIFF
--- a/server/go/internal/api/revoke_all_user_access.go
+++ b/server/go/internal/api/revoke_all_user_access.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// RevokeAllUserAccess RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/RevokeAllUserAccess.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:133 (rpc), :994-1006 (messages).
+// Reference Python: server/python/entdb_server/api/grpc_server.py:2864-2921.
+//
+// # Behavioural pins
+//
+//   - WAL-FIRST RESTORATION (Go HARDENS vs Python). The Python handler
+//     writes directly to per-tenant SQLite via `revoke_user_access`
+//     (canonical_store.py:3871) — a CLAUDE.md invariant #1 violation
+//     pinned by docs/go-port/rpcs/RevokeAllUserAccess.md "WAL invariant
+//     gap (Go port MUST fix)". The Go port appends a single
+//     `admin_revoke_access` op into the WAL; the Wave-1 broadened
+//     applier (server/go/internal/apply/ops_admin_revoke_access.go)
+//     deletes from node_access AND group_users AND node_visibility for
+//     the user. PLAN.md §6.4 item 2.
+//
+//   - Trusted-actor authz. The wire `actor` field is UNTRUSTED. We
+//     rebind to the auth.Authoritative identity from ctx before any
+//     privilege decision (CLAUDE.md trusted-actor invariant; see commit
+//     fece3fb). Caller must be system:/admin: prefix OR carry the
+//     tenant member role of "owner"/"admin"; anything else returns
+//     PERMISSION_DENIED.
+//
+//   - Tenant gate. checkTenant runs first (sharding redirect via the
+//     `entdb-redirect-node` trailer when this node does not own the
+//     tenant). Mirrors grpc_server.py:362.
+//
+//   - Validation order. tenant_id non-empty THEN user_id non-empty,
+//     before the auth gate. Mirrors grpc_server.py:2873-2876 — pinned
+//     by tests/python/integration/test_grpc_contract.py:584-596 and
+//     tests/python/unit/test_admin_operations.py:781-797.
+//
+//   - Tally semantics. Python returns rowcounts from the synchronous
+//     SQLite delete. The Go path is WAL-first (asynchronous applier),
+//     so we read the current row counts BEFORE appending the WAL event
+//     and return those as the tallies. Re-running is idempotent (the
+//     applier's per-event dedupe via applied_events) and the second
+//     call will see zero rows pre-append, matching Python's "no-op on
+//     retry" tally.
+//
+//   - Cross-tenant cleanup (shared_index). Best-effort, does NOT fail
+//     the RPC. Mirrors grpc_server.py:2891-2907: list shared rows for
+//     the user (capped at 10k), delete only those whose source_tenant
+//     equals req.tenant_id, leave other-tenant rows intact. Errors are
+//     swallowed; revoked_shared reflects whatever was successfully
+//     removed before the failure.
+//
+//   - Idempotency key. Synthesized from (tenant_id, user_id,
+//     trusted_actor) so retries within the same admin's session
+//     dedupe via the WAL backend's idempotency table. Different admins
+//     issuing the same revoke produce distinct events — at worst the
+//     second is a no-op on the applier side. Spec "Open questions"
+//     item §2 calls this out.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const revokeAllUserAccessMethod = "RevokeAllUserAccess"
+
+// revokeAllUserAccessTopic is the WAL topic the handler appends to.
+// Mirrors the cmd/entdb-server/main.go default flag value
+// ("entdb-wal"). Hard-coded here because the Server type has no topic
+// option in Wave 1; centralizing this constant keeps the api package
+// self-contained until the cross-RPC topic wiring lands.
+const revokeAllUserAccessTopic = "entdb-wal"
+
+// revokeAllUserAccessSharedLimit caps the cross-tenant shared_index
+// scan. Mirrors grpc_server.py:2895 (limit=10000). Users shared on
+// more than 10k nodes won't be fully cleaned in one call — admins can
+// re-run the RPC to drain the rest. Spec "Open questions" §5.
+const revokeAllUserAccessSharedLimit = 10000
+
+// RevokeAllUserAccess implements entdb.v1.EntDBService/RevokeAllUserAccess.
+// See file header for the full contract.
+func (s *Server) RevokeAllUserAccess(
+	ctx context.Context, req *pb.RevokeAllUserAccessRequest,
+) (*pb.RevokeAllUserAccessResponse, error) {
+	start := time.Now()
+	status := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(revokeAllUserAccessMethod, status, time.Since(start))
+	}()
+
+	// Required-field validation BEFORE auth, in the order Python uses
+	// (grpc_server.py:2873-2876).
+	if req.GetTenantId() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetUserId() == "" {
+		status = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "user_id is required")
+	}
+
+	// Sharding gate. Sets `entdb-redirect-node` trailer + aborts
+	// FAILED_PRECONDITION when this node does not own the tenant.
+	if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
+		status = "error"
+		return nil, err
+	}
+
+	// Trusted-actor rebinding. Wire actor is UNTRUSTED.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	// Admin-or-owner gate. system:/admin: prefixes bypass; everyone
+	// else must carry the tenant member role "owner" or "admin".
+	if !trusted.IsAdmin() && !trusted.IsSystem() {
+		role := ""
+		if s.global != nil {
+			r, err := s.getTenantMemberRole(ctx, req.GetTenantId(), trusted.ID())
+			if err != nil {
+				status = "error"
+				return nil, errs.Errorf(codes.Internal,
+					"RevokeAllUserAccess: lookup caller role: %v", err)
+			}
+			role = r
+		}
+		if role != "owner" && role != "admin" {
+			status = "error"
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"Only tenant owner or admin can revoke all user access")
+		}
+	}
+
+	// Required deps for the WAL-first path. Without a producer or a
+	// store we can't honour the contract; surface UNIMPLEMENTED so the
+	// caller sees a structural problem instead of silent success.
+	if s.producer == nil || s.store == nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Unimplemented,
+			"RevokeAllUserAccess: WAL/store not wired")
+	}
+
+	// Pre-append tallies. Reading from the per-tenant SQLite gives the
+	// "rows that will be deleted by the applier" count, matching
+	// Python's synchronous-rowcount semantics. Idempotent retries
+	// (which the applier dedupes) will see zero rows here on the
+	// second call — same shape as Python's repeat-call no-op.
+	revokedGrants, revokedGroups, err := s.countAccessRowsForUser(
+		ctx, req.GetTenantId(), req.GetUserId(),
+	)
+	if err != nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Internal,
+			"RevokeAllUserAccess: count rows: %v", err)
+	}
+
+	// WAL append: a single `admin_revoke_access` op. The applier's
+	// W1.10-broadened branch (apply/ops_admin_revoke_access.go) deletes
+	// node_access + group_users + node_visibility in one BEGIN
+	// IMMEDIATE txn — atomic on the tenant SQLite side.
+	idempKey := fmt.Sprintf("revoke-all:%s:%s:%s",
+		req.GetTenantId(), req.GetUserId(), trusted.String())
+	ev := apply.Event{
+		TenantID:       req.GetTenantId(),
+		Actor:          trusted.String(),
+		IdempotencyKey: idempKey,
+		Ops: []map[string]any{{
+			"op":      string(apply.OpAdminRevokeAccess),
+			"user_id": req.GetUserId(),
+		}},
+	}
+	encoded, err := ev.Encode()
+	if err != nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Internal,
+			"RevokeAllUserAccess: encode event: %v", err)
+	}
+	headers := map[string][]byte{
+		wal.HeaderIdempotencyKey: []byte(idempKey),
+	}
+	if _, err := s.producer.Append(ctx,
+		revokeAllUserAccessTopic, req.GetTenantId(), encoded, headers,
+	); err != nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Internal,
+			"RevokeAllUserAccess: wal append: %v", err)
+	}
+
+	// Cross-tenant shared_index cleanup. Best-effort: errors are
+	// logged but never fail the RPC, mirroring grpc_server.py:2891-2907.
+	revokedShared := s.cleanupSharedIndex(ctx, req.GetUserId(), req.GetTenantId())
+
+	return &pb.RevokeAllUserAccessResponse{
+		Success:       true,
+		RevokedGrants: int32(revokedGrants),
+		RevokedGroups: int32(revokedGroups),
+		RevokedShared: int32(revokedShared),
+	}, nil
+}
+
+// countAccessRowsForUser reads node_access and group_users counts for
+// userID from the per-tenant SQLite. Returns (grants, groups). A
+// missing tenant DB is treated as "no rows" (matches Python's empty-
+// store semantics — no rows to revoke).
+func (s *Server) countAccessRowsForUser(
+	ctx context.Context, tenantID, userID string,
+) (int64, int64, error) {
+	db, err := s.store.AdminDB(tenantID)
+	if err != nil || db == nil {
+		// No tenant DB yet → nothing to revoke. Idempotent no-op path.
+		return 0, 0, nil
+	}
+	var grants, groups int64
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM node_access WHERE actor_id = ?`, userID,
+	).Scan(&grants); err != nil {
+		return 0, 0, fmt.Errorf("count node_access: %w", err)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM group_users WHERE member_actor_id = ?`, userID,
+	).Scan(&groups); err != nil {
+		return 0, 0, fmt.Errorf("count group_users: %w", err)
+	}
+	return grants, groups, nil
+}
+
+// cleanupSharedIndex removes shared_index rows for userID whose
+// source_tenant matches tenantID. Best-effort; errors are logged at
+// WARN and the function returns whatever was successfully removed.
+// Mirrors grpc_server.py:2891-2907.
+func (s *Server) cleanupSharedIndex(
+	ctx context.Context, userID, tenantID string,
+) int {
+	if s.global == nil {
+		return 0
+	}
+	entries, err := s.global.ListSharedToUser(ctx, userID, revokeAllUserAccessSharedLimit, 0)
+	if err != nil {
+		log.Printf("RevokeAllUserAccess: list shared_index for %q: %v", userID, err)
+		return 0
+	}
+	revoked := 0
+	for _, e := range entries {
+		if e.SourceTenant != tenantID {
+			continue
+		}
+		ok, err := s.global.RemoveShared(ctx, userID, e.SourceTenant, e.NodeID)
+		if err != nil {
+			log.Printf("RevokeAllUserAccess: remove shared (%q,%q,%q): %v",
+				userID, e.SourceTenant, e.NodeID, err)
+			continue
+		}
+		if ok {
+			revoked++
+		}
+	}
+	return revoked
+}

--- a/server/go/internal/api/revoke_all_user_access_test.go
+++ b/server/go/internal/api/revoke_all_user_access_test.go
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for RevokeAllUserAccess (EPIC #407, Wave 2). Pin the WAL-first
+// restoration: the handler MUST emit an admin_revoke_access event so
+// the applier can drain node_access + group_users + node_visibility on
+// replay. See docs/go-port/rpcs/RevokeAllUserAccess.md "WAL invariant
+// gap (Go port MUST fix)".
+
+package api_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// revokeAllFixture wires the api.Server + WAL + applier + stores
+// together. The applier runs in a background goroutine so the WAL
+// event the handler appends is materialized into per-tenant SQLite
+// before the test asserts on the final state.
+type revokeAllFixture struct {
+	t       *testing.T
+	srv     *api.Server
+	store   *store.CanonicalStore
+	global  *globalstore.GlobalStore
+	walImpl *wal.InMemory
+	applier *apply.Applier
+}
+
+func newRevokeAllFixture(t *testing.T) *revokeAllFixture {
+	t.Helper()
+	dir := t.TempDir()
+
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+
+	a, err := apply.New(apply.Options{
+		Store:       cs,
+		Global:      gs,
+		Consumer:    w,
+		Topic:       "entdb-wal", // matches the handler's hard-coded topic.
+		GroupID:     "applier-test",
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithGlobalStore(gs),
+		api.WithWALProducer(w),
+	)
+
+	return &revokeAllFixture{
+		t:       t,
+		srv:     srv,
+		store:   cs,
+		global:  gs,
+		walImpl: w,
+		applier: a,
+	}
+}
+
+// openTenant opens the per-tenant SQLite so the seed helpers below
+// can write directly.
+func (f *revokeAllFixture) openTenant(tenantID string) {
+	f.t.Helper()
+	if err := f.store.OpenTenant(context.Background(), tenantID); err != nil {
+		f.t.Fatalf("OpenTenant(%q): %v", tenantID, err)
+	}
+}
+
+// seedGrant inserts a node_access row for (node_id, actor_id) with
+// "read" permission. The test uses ShareNode which is the public
+// idempotent upsert; node existence is not enforced at the row level.
+func (f *revokeAllFixture) seedGrant(tenantID, nodeID, actorID string) {
+	f.t.Helper()
+	err := f.store.ShareNode(context.Background(), tenantID, store.ShareNodeInput{
+		NodeID:     nodeID,
+		ActorID:    actorID,
+		Permission: "read",
+		GrantedBy:  "user:owner",
+	})
+	if err != nil {
+		f.t.Fatalf("ShareNode: %v", err)
+	}
+}
+
+// seedGroupMember inserts a group_users row.
+func (f *revokeAllFixture) seedGroupMember(tenantID, groupID, memberActorID string) {
+	f.t.Helper()
+	if err := f.store.AddGroupMember(context.Background(), tenantID, groupID, memberActorID, "member"); err != nil {
+		f.t.Fatalf("AddGroupMember: %v", err)
+	}
+}
+
+// countAccess returns the (node_access, group_users) row counts for
+// userID inside tenantID. Used to assert pre/post state.
+func (f *revokeAllFixture) countAccess(tenantID, userID string) (int, int) {
+	f.t.Helper()
+	db, err := f.store.AdminDB(tenantID)
+	if err != nil {
+		f.t.Fatalf("AdminDB: %v", err)
+	}
+	var grants, groups int
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM node_access WHERE actor_id = ?`, userID,
+	).Scan(&grants); err != nil {
+		f.t.Fatalf("scan node_access: %v", err)
+	}
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM group_users WHERE member_actor_id = ?`, userID,
+	).Scan(&groups); err != nil {
+		f.t.Fatalf("scan group_users: %v", err)
+	}
+	return grants, groups
+}
+
+// waitDrained polls until both node_access and group_users counts for
+// userID drop to zero, or the deadline fires. The applier is async so
+// the handler returns before the deletes have landed.
+func (f *revokeAllFixture) waitDrained(tenantID, userID string) {
+	f.t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		g, gr := f.countAccess(tenantID, userID)
+		if g == 0 && gr == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	g, gr := f.countAccess(tenantID, userID)
+	f.t.Fatalf("waitDrained: applier never drained user=%q (grants=%d groups=%d)", userID, g, gr)
+}
+
+// seedTenantMembership seeds a tenant_members row for callers whose
+// authority comes from member-role, not actor prefix.
+func (f *revokeAllFixture) seedTenantMembership(tenantID, userID, role string) {
+	f.t.Helper()
+	if _, err := f.global.CreateTenant(context.Background(), tenantID, tenantID, "us-east-1"); err != nil {
+		// CreateTenant may fail if already exists in a prior helper —
+		// ignore the error and continue.
+		_ = err
+	}
+	if err := f.global.AddTenantMember(context.Background(), tenantID, userID, role); err != nil {
+		f.t.Fatalf("AddTenantMember(%q,%q,%q): %v", tenantID, userID, role, err)
+	}
+}
+
+// TestRevokeAllUserAccess_AdminHappyPath: an admin: trusted actor
+// revokes a user with grants and group memberships. The WAL event
+// is appended, the applier drains node_access + group_users, and the
+// response tallies match. Mirrors the contract pinned by
+// test_admin_operations.py:711-734 (Python rowcount semantics).
+func TestRevokeAllUserAccess_AdminHappyPath(t *testing.T) {
+	t.Parallel()
+	f := newRevokeAllFixture(t)
+	const tenantID = "acme"
+	const target = "user:bob"
+	f.openTenant(tenantID)
+	if _, err := f.global.CreateTenant(context.Background(), tenantID, tenantID, "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant(%q): %v", tenantID, err)
+	}
+
+	// Seed two grants and two group memberships for bob.
+	f.seedGrant(tenantID, "doc1", target)
+	f.seedGrant(tenantID, "doc2", target)
+	f.seedGroupMember(tenantID, "g-eng", target)
+	f.seedGroupMember(tenantID, "g-design", target)
+
+	// Sanity: pre-revoke counts are non-zero.
+	if g, gr := f.countAccess(tenantID, target); g != 2 || gr != 2 {
+		t.Fatalf("pre-revoke counts: grants=%d groups=%d, want 2,2", g, gr)
+	}
+
+	// Cross-tenant shared_index: 2 rows in acme + 1 in another tenant.
+	// The handler must clean only the acme rows.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "admin:root",
+	})
+	if err := f.global.AddShared(ctx, target, tenantID, "doc1", "read"); err != nil {
+		t.Fatalf("AddShared acme/doc1: %v", err)
+	}
+	if err := f.global.AddShared(ctx, target, tenantID, "doc2", "read"); err != nil {
+		t.Fatalf("AddShared acme/doc2: %v", err)
+	}
+	if err := f.global.AddShared(ctx, target, "other-tenant", "doc3", "read"); err != nil {
+		t.Fatalf("AddShared other-tenant/doc3: %v", err)
+	}
+
+	resp, err := f.srv.RevokeAllUserAccess(ctx, &pb.RevokeAllUserAccessRequest{
+		Actor:    "admin:root",
+		TenantId: tenantID,
+		UserId:   target,
+	})
+	if err != nil {
+		t.Fatalf("RevokeAllUserAccess: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("RevokeAllUserAccess: success=false, err=%q", resp.GetError())
+	}
+	if got, want := resp.GetRevokedGrants(), int32(2); got != want {
+		t.Errorf("RevokedGrants=%d, want %d", got, want)
+	}
+	if got, want := resp.GetRevokedGroups(), int32(2); got != want {
+		t.Errorf("RevokedGroups=%d, want %d", got, want)
+	}
+	if got, want := resp.GetRevokedShared(), int32(2); got != want {
+		t.Errorf("RevokedShared=%d, want %d (other-tenant row must survive)", got, want)
+	}
+
+	// Wait for the applier to process the WAL event, then assert the
+	// per-tenant SQLite is fully drained for bob.
+	f.waitDrained(tenantID, target)
+
+	// Other-tenant shared_index row must survive — pinned by
+	// test_admin_operations.py:776-779.
+	rows, err := f.global.ListSharedToUser(ctx, target, 100, 0)
+	if err != nil {
+		t.Fatalf("ListSharedToUser: %v", err)
+	}
+	if len(rows) != 1 || rows[0].SourceTenant != "other-tenant" {
+		t.Fatalf("ListSharedToUser: got %+v, want exactly 1 row in other-tenant", rows)
+	}
+}
+
+// TestRevokeAllUserAccess_NonAdminDenied: a regular member calling
+// against another user is rejected with PERMISSION_DENIED. No WAL
+// event is appended, no SQLite state changes. Pinned by
+// test_admin_operations.py:735-751.
+func TestRevokeAllUserAccess_NonAdminDenied(t *testing.T) {
+	t.Parallel()
+	f := newRevokeAllFixture(t)
+	const tenantID = "acme"
+	const target = "user:bob"
+	f.openTenant(tenantID)
+
+	f.seedGrant(tenantID, "doc1", target)
+	f.seedGroupMember(tenantID, "g-eng", target)
+
+	// Mallory is a "member" — not owner/admin.
+	f.seedTenantMembership(tenantID, "mallory", "member")
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "user:mallory",
+	})
+
+	resp, err := f.srv.RevokeAllUserAccess(ctx, &pb.RevokeAllUserAccessRequest{
+		Actor:    "user:mallory",
+		TenantId: tenantID,
+		UserId:   target,
+	})
+	if err == nil {
+		t.Fatalf("RevokeAllUserAccess: expected PERMISSION_DENIED, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("RevokeAllUserAccess: not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("RevokeAllUserAccess: code=%v, want PermissionDenied", st.Code())
+	}
+
+	// State must be untouched: bob's grant + group still present.
+	if g, gr := f.countAccess(tenantID, target); g != 1 || gr != 1 {
+		t.Errorf("post-deny counts: grants=%d groups=%d, want 1,1", g, gr)
+	}
+	// And nothing landed in the WAL.
+	if n := f.walImpl.GetRecordCount("entdb-wal"); n != 0 {
+		t.Errorf("WAL records after deny: got %d, want 0", n)
+	}
+}
+
+// TestRevokeAllUserAccess_NoGrantsIdempotent: revoking a user with
+// zero grants/groups returns success=true with all-zero tallies. The
+// WAL event is still appended (the applier dedupes); the response is
+// the parity-clean idempotent shape pinned by test_admin_ops.py:223-264.
+func TestRevokeAllUserAccess_NoGrantsIdempotent(t *testing.T) {
+	t.Parallel()
+	f := newRevokeAllFixture(t)
+	const tenantID = "acme"
+	const target = "user:ghost"
+	f.openTenant(tenantID)
+	if _, err := f.global.CreateTenant(context.Background(), tenantID, tenantID, "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant(%q): %v", tenantID, err)
+	}
+
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "system:admin",
+	})
+
+	resp, err := f.srv.RevokeAllUserAccess(ctx, &pb.RevokeAllUserAccessRequest{
+		Actor:    "system:admin",
+		TenantId: tenantID,
+		UserId:   target,
+	})
+	if err != nil {
+		t.Fatalf("RevokeAllUserAccess: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("RevokeAllUserAccess: success=false, err=%q", resp.GetError())
+	}
+	if resp.GetRevokedGrants() != 0 || resp.GetRevokedGroups() != 0 || resp.GetRevokedShared() != 0 {
+		t.Fatalf("idempotent no-op: tallies=(%d,%d,%d), want all zero",
+			resp.GetRevokedGrants(), resp.GetRevokedGroups(), resp.GetRevokedShared())
+	}
+
+	// Second call: same shape (still zero, still success). Confirms
+	// the applier's per-event dedupe doesn't flip the response code.
+	resp2, err := f.srv.RevokeAllUserAccess(ctx, &pb.RevokeAllUserAccessRequest{
+		Actor:    "system:admin",
+		TenantId: tenantID,
+		UserId:   target,
+	})
+	if err != nil {
+		t.Fatalf("RevokeAllUserAccess (retry): %v", err)
+	}
+	if !resp2.GetSuccess() {
+		t.Fatalf("RevokeAllUserAccess (retry): success=false, err=%q", resp2.GetError())
+	}
+	if resp2.GetRevokedGrants() != 0 || resp2.GetRevokedGroups() != 0 {
+		t.Fatalf("retry tallies non-zero: (%d,%d)",
+			resp2.GetRevokedGrants(), resp2.GetRevokedGroups())
+	}
+}
+
+// TestRevokeAllUserAccess_RequiredFields: empty tenant_id / user_id
+// surface as INVALID_ARGUMENT before the auth gate. Pinned by
+// test_grpc_contract.py:593-595 + test_admin_operations.py:781-797.
+func TestRevokeAllUserAccess_RequiredFields(t *testing.T) {
+	t.Parallel()
+	f := newRevokeAllFixture(t)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		Method:  auth.MethodOAuth,
+		Subject: "admin:root",
+	})
+
+	cases := []struct {
+		name string
+		req  *pb.RevokeAllUserAccessRequest
+	}{
+		{"empty tenant_id", &pb.RevokeAllUserAccessRequest{Actor: "admin:root", UserId: "user:bob"}},
+		{"empty user_id", &pb.RevokeAllUserAccessRequest{Actor: "admin:root", TenantId: "acme"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := f.srv.RevokeAllUserAccess(ctx, tc.req)
+			if err == nil {
+				t.Fatalf("expected INVALID_ARGUMENT, got nil")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("not a grpc status: %v", err)
+			}
+			if st.Code() != codes.InvalidArgument {
+				t.Fatalf("code=%v, want InvalidArgument", st.Code())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `entdb.v1.EntDBService/RevokeAllUserAccess` (EPIC #407, Wave 2). Bulk emergency-offboarding: admin/compliance officer yanks every form of access a user has inside a tenant — direct ACL grants, group memberships, plus cross-tenant `shared_index` rows pointing at the tenant.
- WAL-first restoration. The Python handler bypasses the WAL and writes directly to per-tenant SQLite (`revoke_user_access`); on a full WAL rebuild the revocation is silently lost. The Go port closes this CLAUDE.md invariant #1 violation by appending a single `admin_revoke_access` op — the W1.10-broadened applier (`apply/ops_admin_revoke_access.go`) deletes `node_access` + `group_users` + `node_visibility` in one BEGIN IMMEDIATE txn on replay.
- Cross-tenant `shared_index` cleanup remains best-effort (errors logged at WARN, never fail the RPC) — parity with `grpc_server.py:2891-2907`.

Spec: `docs/go-port/rpcs/RevokeAllUserAccess.md`. Source-of-truth Python: `server/python/entdb_server/api/grpc_server.py:2864-2921`.

## Behavioural contract (tests pin these)

- Admin happy path: trusted admin actor revokes a user; WAL event lands, applier drains tenant SQLite, response tallies match `(grants=2, groups=2, shared=2)`. Other-tenant `shared_index` rows survive.
- Non-admin denied: `PERMISSION_DENIED`, no WAL event written, no SQLite state changes.
- No-grants idempotent: `success=true` with all-zero tallies; second call returns the same shape (applier dedupes via `applied_events`).
- Required fields: empty `tenant_id` / `user_id` surface as `INVALID_ARGUMENT` before the auth gate (validation order matches Python).

Trusted-actor authz: wire `actor` is UNTRUSTED. We rebind to `auth.Authoritative` on entry; `system:`/`admin:` prefixes bypass, otherwise the caller must carry tenant member role `owner`/`admin`. Mirrors the post-`fece3fb` privilege-escalation invariant.

## Test plan

- [x] `go test ./internal/api/ -run "RevokeAllUserAccess"` — all 4 tests pass (4 subtests under RequiredFields).
- [x] `gofmt -l` clean on new files.
- [x] `ruff check .` and `ruff format --check .` pass.
- [ ] CI: full `go test ./...` (note: `internal/api` has pre-existing duplicate-symbol breakage from PRs #437 + #444 + #442 merging in parallel — unrelated to this change).