### PR TITLE
feat(go-rewrite): FreezeUser RPC — Wave 2

### DIFF
--- a/server/go/internal/api/freeze_gate.go
+++ b/server/go/internal/api/freeze_gate.go
@@ -1,0 +1,150 @@
+// Freeze gate — load-bearing enforcement for FreezeUser
+// (docs/go-port/rpcs/FreezeUser.md). FreezeUser only sets the
+// `user_registry.status` flag; this gate is what actually blocks the
+// frozen user's mutating RPCs.
+//
+// Mirrors the Python check at api/grpc_server.py:548-557 (the
+// `_check_tenant_access(..., require_write=True)` arm) and the contract
+// pin at tests/python/unit/test_gdpr_engine.py:734-751
+// (`test_freeze_user_rejects_writes`). Reads remain allowed
+// (test_frozen_user_can_still_read at test_gdpr_engine.py:754-767).
+//
+// The gate consults `GlobalStore.GetUser(userID).Status` and rejects
+// any mutating RPC when the status is `frozen` or `pending_deletion`.
+// `pending_deletion` is treated identically to `frozen` here because
+// the Python gate at grpc_server.py:552 uses the same predicate; this
+// preserves bug-for-bug parity with DeleteUser scheduling.
+//
+// Wiring: cmd/entdb-server/main.go registers this interceptor in the
+// chain AFTER the auth interceptor (so a trusted Identity is on ctx)
+// and BEFORE the per-handler logic. A nil globalstore means
+// "freeze-gate disabled" — every request passes (matches the Python
+// guard at grpc_server.py:548 which short-circuits when
+// `self.global_store is None`).
+
+package api
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+)
+
+// mutatingMethods is the allow-list of gRPC full method names that
+// trigger the freeze gate. Reads (Get*, List*, Search*, Query*,
+// Health, GetSchema, GetReceiptStatus, WaitForOffset, ExportUserData)
+// are intentionally absent — Python's
+// `_check_tenant_access(require_write=False)` returns the role even
+// for frozen users (test_frozen_user_can_still_read).
+//
+// Self-targeted admin RPCs (FreezeUser unfreeze, CancelUserDeletion,
+// DeleteUser) are also absent because they MUST remain callable
+// against a frozen user — the Python handlers gate those through
+// `_is_self_or_admin`, not `_check_tenant_access`. See spec
+// "Read-still-allowed scope".
+var mutatingMethods = map[string]struct{}{
+	"/entdb.v1.EntDBService/ExecuteAtomic":      {},
+	"/entdb.v1.EntDBService/ShareNode":          {},
+	"/entdb.v1.EntDBService/RevokeAccess":       {},
+	"/entdb.v1.EntDBService/AddGroupMember":     {},
+	"/entdb.v1.EntDBService/RemoveGroupMember":  {},
+	"/entdb.v1.EntDBService/TransferOwnership":  {},
+	"/entdb.v1.EntDBService/AddTenantMember":    {},
+	"/entdb.v1.EntDBService/RemoveTenantMember": {},
+	"/entdb.v1.EntDBService/ChangeMemberRole":   {},
+	"/entdb.v1.EntDBService/CreateTenant":       {},
+	"/entdb.v1.EntDBService/ArchiveTenant":      {},
+	"/entdb.v1.EntDBService/UpdateUser":         {},
+}
+
+// FreezeGateInterceptor returns a grpc.UnaryServerInterceptor that
+// rejects mutating RPCs from frozen users with codes.PermissionDenied.
+// It depends on:
+//
+//   - the auth interceptor having installed an Identity on ctx (so
+//     the trusted user_id is available), and
+//   - a non-nil GlobalStore on the Server (so user_registry.status is
+//     reachable).
+//
+// When either is missing the gate is a no-op pass-through — same as
+// the Python guard which short-circuits when global_store is unset.
+//
+// The error message mirrors the Python one at grpc_server.py:553-556
+// ("User '<id>' is frozen and cannot write") so existing client tests
+// pinning the substring keep passing under the Go port.
+func (s *Server) FreezeGateInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := s.checkFreezeGate(ctx, info.FullMethod); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// checkFreezeGate is the testable inner of the interceptor. Returns
+// nil to admit the request, or a codes.PermissionDenied status to
+// abort. Exported via the interceptor wrapper above; kept as a method
+// on Server so tests can drive it without standing up a full gRPC
+// pipeline.
+func (s *Server) checkFreezeGate(ctx context.Context, fullMethod string) error {
+	// Disabled when no globalstore is wired (single-node bring-up,
+	// unit tests that don't exercise the user registry).
+	if s.global == nil {
+		return nil
+	}
+	// Reads, health, schema, and self-targeted admin RPCs bypass the
+	// gate — only listed mutating methods consult it.
+	if _, gated := mutatingMethods[fullMethod]; !gated {
+		return nil
+	}
+	// Need a trusted user identity to look up. If no interceptor
+	// installed one, fall through — auth itself will have rejected the
+	// request before reaching here in production.
+	id, ok := auth.IdentityFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	trusted := auth.Authoritative(ctx, auth.ParseActor(id.Subject))
+	// Only user identities can be frozen; system / admin / api-key
+	// callers bypass the registry lookup. Mirrors Python's
+	// `_check_tenant_access` short-circuit at grpc_server.py:496-499.
+	if !trusted.IsUser() {
+		return nil
+	}
+	user, err := s.global.GetUser(ctx, trusted.ID())
+	if err != nil {
+		// Globalstore IO error — surface as Internal so the operator
+		// can detect it. Do NOT swallow as "passed" — that would let
+		// a flaky DB silently disable the gate.
+		return status.Errorf(codes.Internal, "freeze-gate: lookup user %q: %v", trusted.ID(), err)
+	}
+	if user == nil {
+		// Unknown user — fail closed (Python does the same: an
+		// unknown user has no membership, so `_check_tenant_access`
+		// aborts PERMISSION_DENIED). The exact message differs from
+		// Python; keep it precise.
+		return status.Errorf(codes.PermissionDenied, "freeze-gate: user %q not found", trusted.ID())
+	}
+	if isFrozenStatus(user.Status) {
+		return status.Errorf(codes.PermissionDenied,
+			"User '%s' is frozen and cannot write", trusted.ID())
+	}
+	return nil
+}
+
+// isFrozenStatus reports whether a user_registry.status value blocks
+// mutations. Mirrors the Python predicate at grpc_server.py:552 which
+// rejects both `frozen` and `pending_deletion`.
+func isFrozenStatus(status string) bool {
+	return status == "frozen" || status == "pending_deletion"
+}
+
+// Compile-time guard: avoid unused-import warnings if globalstore is
+// trimmed in a future refactor. globalstore.User.Status is what we
+// actually read above.
+var _ = (*globalstore.User)(nil)

--- a/server/go/internal/api/freeze_user.go
+++ b/server/go/internal/api/freeze_user.go
@@ -1,0 +1,132 @@
+// FreezeUser RPC — Wave 2 of the Python -> Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/FreezeUser.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:138 (rpc), :1039-1050
+// (request/response). Reference Python:
+// server/python/entdb_server/api/grpc_server.py:3072-3104 (handler) and
+// server/python/entdb_server/global_store.py:434-447
+// (`set_user_status`).
+//
+// GDPR Article 18 ("restrict processing"): toggle a user between
+// `active` and `frozen`. Freeze blocks user-initiated mutations but
+// preserves all data (vs `DeleteUser` which tombstones, vs
+// `RevokeAllUserAccess` which removes ACL grants).
+//
+// Semantics (deliberate carve-out from the CLAUDE.md "all writes go
+// through the WAL" invariant — user_registry is global_store
+// control-plane state, not per-tenant event-sourced data; same shape as
+// CreateUser / UpdateUser):
+//
+//   - Globalstore must be configured. If not, abort with
+//     codes.Unimplemented "User registry not configured" — mirrors
+//     grpc_server.py:3080-3081.
+//   - actor and user_id are required (codes.InvalidArgument).
+//   - Trusted-actor pattern: the privilege decision uses
+//     auth.Authoritative(ctx, claimed) — when the interceptor has
+//     installed an Identity on ctx, the request-payload actor is
+//     ignored. Self-or-admin gate matches Python's _is_self_or_admin
+//     at grpc_server.py:2071-2086 (admin/system, or the user
+//     themselves).
+//   - No tenant scope. FreezeUser is a global-store operation;
+//     CheckTenant is NOT called. Mirrors the Python handler which
+//     delegates only to global_store.set_user_status.
+//   - Direct globalstore write (NO WAL append). Wave 2 preserves
+//     bug-for-bug parity with Python — the user-registry status flag
+//     is control-plane state, written directly. Same carve-out as
+//     CreateUser, UpdateUser, RevokeAccess. Future fix-on-port (per
+//     spec "Side effects" section) will route through wal.append +
+//     applier; out of scope here.
+//   - User-not-found is reported in-band: success=false,
+//     error="User not found" (no NOT_FOUND status; mirrors
+//     grpc_server.py:3094-3096).
+//   - Idempotency: freezing an already-frozen user (or unfreezing an
+//     already-active one) returns success=true with the new status,
+//     because SetUserStatus UPDATEs unconditionally and rowcount > 0
+//     iff a row matched. Pinned by the Python
+//     test_unfreeze_user_handler contract test
+//     (test_gdpr_engine.py:721-731).
+//
+// The freeze flag is consulted by the freeze gate
+// (auth.CheckUserNotFrozen) on every subsequent mutating RPC; this
+// handler only sets the bit. Reads remain allowed under freeze
+// (test_frozen_user_can_still_read at test_gdpr_engine.py:754-767).
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+const freezeUserMethod = "FreezeUser"
+
+// FreezeUser implements entdb.v1.EntDBService/FreezeUser. See file
+// header for the full semantic contract.
+func (s *Server) FreezeUser(ctx context.Context, req *pb.FreezeUserRequest) (*pb.FreezeUserResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(freezeUserMethod, outcome, time.Since(start))
+	}()
+
+	// Configuration gate. Mirrors Python grpc_server.py:3080-3081.
+	if s.global == nil {
+		outcome = "error"
+		return nil, status.Error(codes.Unimplemented, "User registry not configured")
+	}
+
+	// Required-field aborts. Mirrors grpc_server.py:3082-3085.
+	if req.GetActor() == "" {
+		outcome = "error"
+		return nil, status.Error(codes.InvalidArgument, "actor is required")
+	}
+	userID := req.GetUserId()
+	if userID == "" {
+		outcome = "error"
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	// Trusted-actor resolution. The request payload is UNTRUSTED — the
+	// interceptor installs the verified Identity on ctx and
+	// auth.Authoritative ignores the wire claim when one is present.
+	// Self-or-admin gate mirrors grpc_server.py:3086-3090.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	if !isSelfOrAdmin(trusted, userID) {
+		outcome = "error"
+		return nil, status.Error(codes.PermissionDenied,
+			"FreezeUser requires the user themselves or an admin actor")
+	}
+
+	// Translate enabled bool → status string. Mirrors
+	// grpc_server.py:3092 ("frozen" if request.enabled else "active").
+	newStatus := "active"
+	if req.GetEnabled() {
+		newStatus = "frozen"
+	}
+
+	// Direct globalstore write (control-plane carve-out). Mirrors
+	// grpc_server.py:3093 — global_store.set_user_status(user_id,
+	// new_status). Returns true iff a row matched.
+	updated, err := s.global.SetUserStatus(ctx, userID, newStatus)
+	if err != nil {
+		// Catch-all in-band failure mirroring grpc_server.py:3099-3104.
+		// Python writes the metric label as "error" on this arm; we
+		// match. Spec note: do NOT promote to codes.Internal — clients
+		// pin success/error on the response body, not status codes.
+		outcome = "error"
+		return &pb.FreezeUserResponse{Success: false, Error: err.Error()}, nil
+	}
+	if !updated {
+		// In-band not-found. Same metric label ("ok") as Python — no
+		// abort fires. Mirrors grpc_server.py:3094-3096.
+		return &pb.FreezeUserResponse{Success: false, Error: "User not found"}, nil
+	}
+	return &pb.FreezeUserResponse{Success: true, Status: newStatus}, nil
+}

--- a/server/go/internal/api/freeze_user_test.go
+++ b/server/go/internal/api/freeze_user_test.go
@@ -1,0 +1,411 @@
+// Tests for the FreezeUser RPC and the freeze-gate interceptor that
+// enforces it. The Python contract pins enumerated in
+// docs/go-port/rpcs/FreezeUser.md ("Contract tests pinning behavior")
+// reduce in the Go port to:
+//
+//   - admin happy path        (sets status to "frozen", success=true);
+//   - frozen user's mutating RPC → PERMISSION_DENIED via interceptor
+//     (the load-bearing test for the freeze gate, mirroring
+//     test_freeze_user_rejects_writes at test_gdpr_engine.py:734-751);
+//   - frozen user's read RPC still allowed (mirroring
+//     test_frozen_user_can_still_read at test_gdpr_engine.py:754-767);
+//
+// plus the standard pre-check arms (UNIMPLEMENTED, INVALID_ARGUMENT,
+// PERMISSION_DENIED for non-admin/non-self, in-band "User not found").
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestFreezeUser_Admin_HappyPath: admin freezes alice. Status is
+// flipped to "frozen"; response carries success=true and status="frozen".
+// Mirrors test_freeze_user_handler at test_gdpr_engine.py:707-717.
+func TestFreezeUser_Admin_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.FreezeUser(withTrustedUser(ctx, "admin:root"), &pb.FreezeUserRequest{
+		Actor:   "admin:root",
+		UserId:  "alice",
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("FreezeUser: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("FreezeUser: success=false, error=%q", resp.GetError())
+	}
+	if resp.GetStatus() != "frozen" {
+		t.Errorf("FreezeUser: status: got %q, want %q", resp.GetStatus(), "frozen")
+	}
+
+	// Verify the row was patched.
+	got, err := gs.GetUser(ctx, "alice")
+	if err != nil || got == nil {
+		t.Fatalf("post-freeze GetUser: user=%v, err=%v", got, err)
+	}
+	if got.Status != "frozen" {
+		t.Errorf("alice.Status: got %q, want %q", got.Status, "frozen")
+	}
+}
+
+// TestFreezeUser_FrozenUserMutation_DeniedViaInterceptor: the
+// load-bearing test for the freeze gate. After alice is frozen, her
+// next mutating RPC (driven through the FreezeGateInterceptor) MUST
+// abort PERMISSION_DENIED. The interceptor consults
+// user_registry.status; FreezeUser only sets the bit. Mirrors
+// test_freeze_user_rejects_writes at test_gdpr_engine.py:734-751.
+func TestFreezeUser_FrozenUserMutation_DeniedViaInterceptor(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Step 1: admin freezes alice.
+	if _, err := srv.FreezeUser(withTrustedUser(ctx, "admin:root"), &pb.FreezeUserRequest{
+		Actor:   "admin:root",
+		UserId:  "alice",
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("seed FreezeUser: %v", err)
+	}
+
+	// Step 2: alice attempts a mutating RPC. The FreezeGateInterceptor
+	// is the layer that rejects her. Use ExecuteAtomic as the
+	// representative mutating method (the canary the spec calls out).
+	interceptor := srv.FreezeGateInterceptor()
+	called := false
+	handler := func(ctx context.Context, req any) (any, error) {
+		called = true
+		return nil, nil
+	}
+	info := &grpc.UnaryServerInfo{FullMethod: "/entdb.v1.EntDBService/ExecuteAtomic"}
+
+	_, err := interceptor(withTrustedUser(ctx, "alice"), nil, info, handler)
+	if err == nil {
+		t.Fatalf("FreezeGateInterceptor: expected PERMISSION_DENIED, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("FreezeGateInterceptor: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("FreezeGateInterceptor: code: got %v, want PermissionDenied", st.Code())
+	}
+	if called {
+		t.Errorf("FreezeGateInterceptor: handler was invoked despite freeze; gate failed open")
+	}
+}
+
+// TestFreezeUser_FrozenUserRead_StillAllowed: reads bypass the freeze
+// gate. The interceptor MUST admit a frozen user's read RPC (e.g.
+// GetNode) so the user can still see her data. Mirrors
+// test_frozen_user_can_still_read at test_gdpr_engine.py:754-767.
+func TestFreezeUser_FrozenUserRead_StillAllowed(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Freeze alice.
+	if _, err := srv.FreezeUser(withTrustedUser(ctx, "admin:root"), &pb.FreezeUserRequest{
+		Actor:   "admin:root",
+		UserId:  "alice",
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("seed FreezeUser: %v", err)
+	}
+
+	// alice attempts a read RPC. The gate must NOT reject it.
+	interceptor := srv.FreezeGateInterceptor()
+	called := false
+	handler := func(ctx context.Context, req any) (any, error) {
+		called = true
+		return "ok", nil
+	}
+	info := &grpc.UnaryServerInfo{FullMethod: "/entdb.v1.EntDBService/GetNode"}
+
+	resp, err := interceptor(withTrustedUser(ctx, "alice"), nil, info, handler)
+	if err != nil {
+		t.Fatalf("FreezeGateInterceptor on read: got error %v, want nil (reads must pass)", err)
+	}
+	if !called {
+		t.Errorf("FreezeGateInterceptor: handler was NOT invoked on a read RPC; gate failed closed")
+	}
+	if resp != "ok" {
+		t.Errorf("FreezeGateInterceptor: response: got %v, want %q", resp, "ok")
+	}
+}
+
+// TestFreezeUser_Unfreeze_Idempotent: unfreezing returns success=true
+// status="active" even when the user is already active — SetUserStatus
+// UPDATEs unconditionally and rowcount > 0 iff the row existed.
+// Mirrors test_unfreeze_user_handler at test_gdpr_engine.py:721-731.
+func TestFreezeUser_Unfreeze_Idempotent(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// Unfreeze (alice is already active).
+	resp, err := srv.FreezeUser(withTrustedUser(ctx, "admin:root"), &pb.FreezeUserRequest{
+		Actor:   "admin:root",
+		UserId:  "alice",
+		Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("FreezeUser: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("FreezeUser: success=false, error=%q", resp.GetError())
+	}
+	if resp.GetStatus() != "active" {
+		t.Errorf("FreezeUser: status: got %q, want %q", resp.GetStatus(), "active")
+	}
+}
+
+// TestFreezeUser_Self_HappyPath: alice can freeze herself (the "self"
+// arm of _is_self_or_admin). Spec flags this as debatable for GDPR
+// Article 18 but matches Python today.
+func TestFreezeUser_Self_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.FreezeUser(withTrustedUser(ctx, "alice"), &pb.FreezeUserRequest{
+		Actor:   "user:alice",
+		UserId:  "alice",
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("FreezeUser: %v", err)
+	}
+	if !resp.GetSuccess() || resp.GetStatus() != "frozen" {
+		t.Fatalf("FreezeUser self: got %+v, want success=true status=frozen", resp)
+	}
+}
+
+// TestFreezeUser_NonAdminOther_Denied: alice trying to freeze bob is
+// the privilege-escalation guard. The handler MUST consult ctx for the
+// trusted identity and ignore the request payload's claim of
+// `admin:root`. Mirrors the privilege-escalation matrix in
+// tests/python/integration/test_privilege_escalation.py.
+func TestFreezeUser_NonAdminOther_Denied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// alice is the trusted caller; she claims admin:root in the wire
+	// payload — must be ignored.
+	resp, err := srv.FreezeUser(withTrustedUser(ctx, "alice"), &pb.FreezeUserRequest{
+		Actor:   "admin:root",
+		UserId:  "bob",
+		Enabled: true,
+	})
+	if err == nil {
+		t.Fatalf("FreezeUser: expected PERMISSION_DENIED, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("FreezeUser: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("FreezeUser: code: got %v, want PermissionDenied", st.Code())
+	}
+
+	// Defence in depth: confirm the store was NOT mutated.
+	got, _ := gs.GetUser(ctx, "bob")
+	if got == nil || got.Status != "active" {
+		t.Errorf("post-denied bob.Status: got %v, want unchanged 'active'", got)
+	}
+}
+
+// TestFreezeUser_NotFound_InBandFailure: freezing a missing user_id
+// returns success=false, error="User not found" in-band. No NOT_FOUND
+// status code — clients pin the in-band shape. Mirrors
+// grpc_server.py:3094-3096.
+func TestFreezeUser_NotFound_InBandFailure(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	// Seed a different user so the global store is non-empty but the
+	// target row does not exist.
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.FreezeUser(withTrustedUser(ctx, "admin:root"), &pb.FreezeUserRequest{
+		Actor:   "admin:root",
+		UserId:  "ghost",
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("FreezeUser: expected nil err for in-band not-found, got %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatalf("FreezeUser: expected success=false, got %+v", resp)
+	}
+	if resp.GetError() != "User not found" {
+		t.Errorf("FreezeUser: error: got %q, want %q", resp.GetError(), "User not found")
+	}
+	if resp.GetStatus() != "" {
+		t.Errorf("FreezeUser: status on not-found: got %q, want empty", resp.GetStatus())
+	}
+}
+
+// TestFreezeUser_GlobalstoreUnset_Unimplemented: a Server with no
+// globalstore wired aborts with codes.Unimplemented. Mirrors the
+// configuration gate at grpc_server.py:3080-3081.
+func TestFreezeUser_GlobalstoreUnset_Unimplemented(t *testing.T) {
+	t.Parallel()
+	srv := api.New() // no WithGlobalStore
+
+	_, err := srv.FreezeUser(context.Background(), &pb.FreezeUserRequest{
+		Actor:   "admin:root",
+		UserId:  "alice",
+		Enabled: true,
+	})
+	if err == nil {
+		t.Fatalf("FreezeUser: expected error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("FreezeUser: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.Unimplemented {
+		t.Fatalf("FreezeUser: code: got %v, want Unimplemented", st.Code())
+	}
+}
+
+// TestFreezeUser_EmptyActor_InvalidArgument: actor is required.
+func TestFreezeUser_EmptyActor_InvalidArgument(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.FreezeUser(context.Background(), &pb.FreezeUserRequest{
+		UserId:  "alice",
+		Enabled: true,
+	})
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("FreezeUser: code: got %v, want InvalidArgument", st.Code())
+	}
+}
+
+// TestFreezeUser_EmptyUserID_InvalidArgument: user_id is required.
+func TestFreezeUser_EmptyUserID_InvalidArgument(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	_, err := srv.FreezeUser(context.Background(), &pb.FreezeUserRequest{
+		Actor:   "admin:root",
+		Enabled: true,
+	})
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("FreezeUser: code: got %v, want InvalidArgument", st.Code())
+	}
+}
+
+// TestFreezeGate_PendingDeletion_BlocksMutations: pending_deletion is
+// treated identically to frozen by the gate (Python predicate at
+// grpc_server.py:552). DeleteUser writes pending_deletion; the gate
+// must reject the user's mutating RPCs the same way.
+func TestFreezeGate_PendingDeletion_BlocksMutations(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("seed CreateUser: %v", err)
+	}
+	if _, err := gs.SetUserStatus(ctx, "alice", "pending_deletion"); err != nil {
+		t.Fatalf("seed SetUserStatus: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	interceptor := srv.FreezeGateInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/entdb.v1.EntDBService/ExecuteAtomic"}
+	handler := func(ctx context.Context, req any) (any, error) { return nil, nil }
+
+	_, err := interceptor(withTrustedUser(ctx, "alice"), nil, info, handler)
+	if err == nil {
+		t.Fatalf("FreezeGateInterceptor: expected PERMISSION_DENIED for pending_deletion, got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("FreezeGateInterceptor: code: got %v, want PermissionDenied", st.Code())
+	}
+}
+
+// TestFreezeGate_AdminCaller_BypassesGate: admin/system callers
+// bypass the freeze gate even when (hypothetically) the registry knows
+// about them — the gate only consults user-kind identities. Mirrors
+// _check_tenant_access short-circuit at grpc_server.py:496-499.
+func TestFreezeGate_AdminCaller_BypassesGate(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	srv := api.New(api.WithGlobalStore(gs))
+
+	interceptor := srv.FreezeGateInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/entdb.v1.EntDBService/ExecuteAtomic"}
+	called := false
+	handler := func(ctx context.Context, req any) (any, error) {
+		called = true
+		return nil, nil
+	}
+
+	_, err := interceptor(withTrustedUser(context.Background(), "admin:root"), nil, info, handler)
+	if err != nil {
+		t.Fatalf("FreezeGateInterceptor on admin: got %v, want nil", err)
+	}
+	if !called {
+		t.Error("FreezeGateInterceptor: handler not invoked for admin caller")
+	}
+}
+
+// guard against the WithIdentity helper drifting away from the auth
+// package — keeps the test file's imports honest.
+var _ = auth.WithIdentity


### PR DESCRIPTION
## Summary

Implements the FreezeUser RPC and its load-bearing freeze-gate interceptor for EPIC #407 (GDPR Article 18 — restrict processing). Spec: `docs/go-port/rpcs/FreezeUser.md`.

- **`freeze_user.go`** — trusted-actor, self-or-admin gate, direct `globalstore.SetUserStatus` write. Direct-write parity preserved as a control-plane carve-out (same shape as `CreateUser` / `UpdateUser` / `RevokeAccess`); WAL-routing fix-on-port deferred per spec.
- **`freeze_gate.go`** — `grpc.UnaryServerInterceptor` that consults `user_registry.status` and rejects mutating RPCs from `frozen` / `pending_deletion` users with `PERMISSION_DENIED`. Reads, health, schema, and self-targeted admin RPCs bypass.
- **`freeze_user_test.go`** — admin happy path, frozen user's mutating RPC denied via interceptor (load-bearing), frozen user's read still allowed, plus pre-check / privilege-escalation / idempotency arms (12 tests).

Also dedupes pre-existing duplicate declarations on `main` (`userToProto` in `get_user.go` / `list_users.go`, `lookupMemberRole` in `add_tenant_member.go` / `change_member_role.go`, `withTrustedUser` in `get_tenant_quota_test.go` / `update_user_test.go`) — required for `go vet` and `go test` to pass. Same pattern as #429.

`server.go` and `_go_parity.py` are intentionally untouched.

## Test plan
- [x] `cd server/go && go vet ./...` clean
- [x] `cd server/go && go test ./...` — all packages green; 12 new FreezeUser/FreezeGate tests pass
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [x] `cd sdk/go/entdb && go vet ./... && go test ./...` clean