### PR TITLE
feat(go-rewrite): TransferUserContent RPC — Wave 2

### DIFF
--- a/server/go/internal/api/transfer_user_content.go
+++ b/server/go/internal/api/transfer_user_content.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// TransferUserContent implements entdb.v1.EntDBService/TransferUserContent.
+//
+// EPIC #407 Wave 2. Spec: docs/go-port/rpcs/TransferUserContent.md.
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:2692-2745.
+//
+// # Behaviour pins
+//
+//   - WAL-FIRST. The per-tenant ownership change is appended to the WAL
+//     as one (or more, see below) `admin_transfer_content` events.
+//     Direct canonical-store writes from this handler are FORBIDDEN
+//     (CLAUDE.md invariant #1, pinned by
+//     tests/python/unit/test_admin_ops.py:373-407).
+//
+//   - Trusted-actor. The wire `actor` is UNTRUSTED. We rebind to the
+//     trusted actor returned by auth.Authoritative before any privilege
+//     check. A claimed `actor="system:admin"` from a non-admin trusted
+//     identity MUST PERMISSION_DENY *and* MUST NOT append to the WAL
+//     (test_privilege_escalation.py:344-365).
+//
+//   - Auth: trusted-actor must be system:* / admin:*, OR have role
+//     "owner" / "admin" in tenant_members for tenantID. Anything else
+//     -> PERMISSION_DENIED.
+//
+//   - Tenant gate. s.checkTenant runs before any other side effect so
+//     unknown / archived / wrong-region tenants reject cleanly.
+//
+//   - INVALID_ARGUMENT validation. tenant_id, from_user, to_user, and
+//     the wire actor must all be non-empty BEFORE the auth substitution
+//     (mirrors :2701-2706 — non-empty `actor` quirk preserved).
+//
+//   - Side effects, in order:
+//       1. global_store.TransferUserContent — idempotent membership
+//          upsert for `to_user` with role 'member'. Direct write; this
+//          is the documented control-plane carve-out.
+//       2. WAL append of `admin_transfer_content`. Single event for
+//          small batches; chunked into multiple events for large
+//          owners (CHUNK_SIZE) so a single SQLite write transaction
+//          stays bounded — addresses the spec "Open question" §2
+//          (large user → write-lock spike).
+//       3. Pre-apply count via store.CountOwnedNodes — best-effort,
+//          errors swallowed (returns 0). This count reflects nodes
+//          *still* owned at the time of the call (the Applier
+//          materialises the rename asynchronously). Pinned semantics.
+//
+//   - Visibility refresh. Performed by the Applier handler
+//     (apply/ops_admin_transfer_content.go). The handler does NOT
+//     touch node_visibility — that would violate WAL-first.
+//
+//   - Mailbox / notifications cascade. Out of scope. Existing per-node
+//     ACL grants survive — only owner_actor changes.
+//
+//   - On global-store failure or WAL-append failure, the handler
+//     returns gRPC OK with `success=false`, `error=<msg>` (matches
+//     Python's :2740-2745 catch-all). gRPC-level codes are reserved
+//     for tenant gate, validation, and auth.
+
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const (
+	transferUserContentMethod = "TransferUserContent"
+
+	// transferUserContentChunkSize bounds the number of node_ids attached
+	// to a single `admin_transfer_content` op. The Applier rewrites
+	// owner_actor inside one SQLite write transaction; without a chunk
+	// cap a 10M-owned-node tenant would hold the per-tenant write lock
+	// for the duration of the UPDATE, blocking other writers.
+	//
+	// The Python handler emits exactly ONE event regardless of size —
+	// see spec "Open questions" §2 for the documented risk. Chunking is
+	// the Go-side mitigation. Chunk size is conservative; the Applier
+	// op handler accepts both the un-chunked form (no node_ids field —
+	// rewrite all rows for `from_user`) and the chunked form (explicit
+	// node_ids list) so behaviour is identical for small batches.
+	transferUserContentChunkSize = 1000
+
+	// transferUserContentTopic is the WAL topic used for tenant-scoped
+	// transaction events. Matches Python's `self.topic` default
+	// ("entdb-wal", grpc_server.py:2718-2724).
+	transferUserContentTopic = "entdb-wal"
+)
+
+// TransferUserContent reassigns ownership of every node owned by
+// `from_user` inside `tenant_id` to `to_user`. Bulk offboarding flow.
+//
+// See file-level comment for the full pin list.
+func (s *Server) TransferUserContent(
+	ctx context.Context, req *pb.TransferUserContentRequest,
+) (*pb.TransferUserContentResponse, error) {
+	start := time.Now()
+	statusLabel := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(transferUserContentMethod, statusLabel, time.Since(start))
+	}()
+
+	// Wave-2 dependency guard. A node booted without a globalstore can
+	// not honour admin RPCs.
+	if s.global == nil {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
+	}
+
+	// INVALID_ARGUMENT validation. The non-empty `actor` check runs
+	// BEFORE the trusted-actor substitution to mirror the Python quirk
+	// (spec "Open questions" §6, test_admin_operations.py:806-820).
+	if req.GetActor() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+	if req.GetTenantId() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetFromUser() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "from_user is required")
+	}
+	if req.GetToUser() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "to_user is required")
+	}
+
+	// Tenant gate. Catches unknown / archived tenants and wrong-region
+	// requests before any side effect. Mirrors grpc_server.py:2700.
+	if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
+		statusLabel = "error"
+		return nil, err
+	}
+
+	// Trusted-actor rebinding. Privilege checks below MUST consult
+	// `trusted` (never `req.Actor`). Closing the privilege-escalation
+	// hole is the entire point of fece3fb / auth.Authoritative.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+
+	// Auth: system / admin trusted actors bypass the membership lookup.
+	// Otherwise the trusted user must be owner or admin of this tenant.
+	if !(trusted.IsSystem() || trusted.IsAdmin()) {
+		role, err := s.getTenantMemberRole(ctx, req.GetTenantId(), trusted.ID())
+		if err != nil {
+			statusLabel = "error"
+			return nil, errs.Errorf(codes.Internal,
+				"TransferUserContent: lookup caller role: %v", err)
+		}
+		if role != "owner" && role != "admin" {
+			statusLabel = "error"
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"TransferUserContent requires admin/owner")
+		}
+	}
+
+	// Side effect 1: idempotent global-store membership upsert for
+	// to_user. Direct write — control-plane carve-out (spec §"Side
+	// effects" #1, admin_handlers.py:7-11).
+	if _, err := s.global.TransferUserContent(
+		ctx, req.GetTenantId(), req.GetFromUser(), req.GetToUser(),
+	); err != nil {
+		statusLabel = "error"
+		return &pb.TransferUserContentResponse{
+			Success: false,
+			Error:   err.Error(),
+		}, nil
+	}
+
+	// Side effect 2: WAL append. Source of truth for the rename. The
+	// op shape mirrors apply/ops_admin_transfer_content.go (W1.10).
+	//
+	// Chunking: when the producer is wired AND a canonical store is
+	// available we enumerate owned node_ids first and split into
+	// multiple events of size <= transferUserContentChunkSize. The
+	// Applier handler rewrites by `(tenant_id, owner_actor)` so each
+	// chunk converges to the same end state idempotently. When the
+	// canonical store is absent (Wave-1 deployments without store
+	// wiring) we fall through to the un-chunked single-event shape.
+	if s.producer == nil {
+		statusLabel = "error"
+		return &pb.TransferUserContentResponse{
+			Success: false,
+			Error:   "WAL producer not configured",
+		}, nil
+	}
+
+	chunks := s.transferUserContentChunks(ctx, req.GetTenantId(), req.GetFromUser())
+	for _, chunk := range chunks {
+		op := map[string]any{
+			"op":        "admin_transfer_content",
+			"from_user": req.GetFromUser(),
+			"to_user":   req.GetToUser(),
+		}
+		if len(chunk) > 0 {
+			// Convert []string -> []any so JSON marshalling preserves
+			// the ordering Python's json.dumps emits.
+			ids := make([]any, 0, len(chunk))
+			for _, id := range chunk {
+				ids = append(ids, id)
+			}
+			op["node_ids"] = ids
+		}
+		event := wal.Event{
+			TenantID:       req.GetTenantId(),
+			Actor:          trusted.String(),
+			IdempotencyKey: "admin-transfer-" + randHex16(),
+			TsMs:           time.Now().UnixMilli(),
+			Ops:            []map[string]any{op},
+		}
+		payload, err := event.Encode()
+		if err != nil {
+			statusLabel = "error"
+			return &pb.TransferUserContentResponse{
+				Success: false,
+				Error:   err.Error(),
+			}, nil
+		}
+		headers := map[string][]byte{
+			wal.HeaderIdempotencyKey: []byte(event.IdempotencyKey),
+		}
+		if _, err := s.producer.Append(
+			ctx, transferUserContentTopic, req.GetTenantId(), payload, headers,
+		); err != nil {
+			statusLabel = "error"
+			return &pb.TransferUserContentResponse{
+				Success: false,
+				Error:   err.Error(),
+			}, nil
+		}
+	}
+
+	// Side effect 3: best-effort pre-apply count. Errors swallowed —
+	// matches grpc_server.py:2735-2736.
+	var transferred int32
+	if s.store != nil {
+		if n, err := s.store.CountOwnedNodes(
+			ctx, req.GetTenantId(), req.GetFromUser(),
+		); err == nil {
+			transferred = n
+		}
+	}
+
+	return &pb.TransferUserContentResponse{
+		Success:     true,
+		Transferred: transferred,
+	}, nil
+}
+
+// transferUserContentChunks enumerates the node_ids `fromUser` owns in
+// `tenantID` and returns them split into chunks of size
+// transferUserContentChunkSize. When the canonical store is unwired
+// (or returns no rows / errors) it returns a single empty chunk so the
+// caller still emits exactly one un-chunked event (parity with the
+// Python single-event shape).
+func (s *Server) transferUserContentChunks(
+	ctx context.Context, tenantID, fromUser string,
+) [][]string {
+	if s.store == nil {
+		return [][]string{nil}
+	}
+	ids, err := s.store.ListOwnedNodeIDs(ctx, tenantID, fromUser)
+	if err != nil || len(ids) == 0 {
+		return [][]string{nil}
+	}
+	chunks := make([][]string, 0, (len(ids)+transferUserContentChunkSize-1)/transferUserContentChunkSize)
+	for i := 0; i < len(ids); i += transferUserContentChunkSize {
+		end := i + transferUserContentChunkSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunks = append(chunks, ids[i:end])
+	}
+	return chunks
+}
+
+// randHex16 returns a 32-char lowercase hex string. Used as the random
+// suffix on the idempotency key. The Python handler uses uuid4 hex
+// (32 chars) — same alphabet, same length. Falls back to a
+// nanosecond-timestamp on rand failure (defensive — crypto/rand on
+// Linux has not failed in production memory).
+func randHex16() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Extremely unlikely. Compose from time so we still emit a
+		// non-empty key (Event.Encode would reject "").
+		ns := time.Now().UnixNano()
+		out := make([]byte, 16)
+		for i := range out {
+			out[i] = byte(ns >> (i % 8 * 8))
+		}
+		return hex.EncodeToString(out)
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/server/go/internal/api/transfer_user_content_test.go
+++ b/server/go/internal/api/transfer_user_content_test.go
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for TransferUserContent. Pin set is documented in
+// docs/go-port/rpcs/TransferUserContent.md "Contract tests pinning
+// behavior". The Go-side concerns this file enforces:
+//
+//  1. Admin happy path, small batch (single WAL event).
+//  2. Admin large-batch path: owned-set straddles the chunk size,
+//     producing multiple WAL events of `admin_transfer_content`.
+//  3. Recipient sees all transferred nodes after the applier consumes
+//     the WAL events (visibility refresh wiring).
+//  4. Non-admin caller -> PERMISSION_DENIED + zero WAL events appended
+//     (privilege-escalation regression).
+
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// transferFixture wires globalstore + canonical store + in-memory WAL
+// + applier so a test can call srv.TransferUserContent and observe
+// both the WAL trace and the post-apply SQLite state.
+type transferFixture struct {
+	srv       *api.Server
+	gs        *globalstore.GlobalStore
+	cs        *store.CanonicalStore
+	w         *wal.InMemory
+	applier   *apply.Applier
+	stopApply context.CancelFunc
+	doneApply chan error
+	tenantID  string
+}
+
+func newTransferFixture(t *testing.T) *transferFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	// Seed canonical members. alice = owner (admin power), carol = plain
+	// member (used as the negative-auth caller).
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember alice: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "carol", "member"); err != nil {
+		t.Fatalf("AddTenantMember carol: %v", err)
+	}
+
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(ctx, "acme"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	w := wal.NewInMemory(1)
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithStore(cs),
+		api.WithWALProducer(w),
+	)
+
+	return &transferFixture{
+		srv:      srv,
+		gs:       gs,
+		cs:       cs,
+		w:        w,
+		tenantID: "acme",
+	}
+}
+
+// startApplier launches the apply.Applier in a background goroutine so
+// the test can observe post-apply SQLite state. Returns a stop func
+// the test must invoke before assertions on terminal state.
+func (f *transferFixture) startApplier(t *testing.T) {
+	t.Helper()
+	a, err := apply.New(apply.Options{
+		Store:    f.cs,
+		Consumer: f.w,
+		Topic:    "entdb-wal",
+		GroupID:  "test-applier",
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	f.applier = a
+	ctx, cancel := context.WithCancel(context.Background())
+	f.stopApply = cancel
+	f.doneApply = make(chan error, 1)
+	go func() { f.doneApply <- a.Run(ctx) }()
+}
+
+func (f *transferFixture) stopApplier(t *testing.T) {
+	t.Helper()
+	if f.stopApply == nil {
+		return
+	}
+	f.stopApply()
+	select {
+	case <-f.doneApply:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("applier did not stop")
+	}
+}
+
+// seedNodes inserts `count` nodes owned by `owner` in tenant "acme".
+func (f *transferFixture) seedNodes(t *testing.T, owner string, count int) []string {
+	t.Helper()
+	ctx := context.Background()
+	ids := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		id := uniqueNodeID(i)
+		ids = append(ids, id)
+		if _, err := f.cs.CreateNodeRaw(ctx, f.tenantID, store.NodeInput{
+			NodeID:     id,
+			TypeID:     1,
+			Payload:    map[string]any{"1": "x"},
+			OwnerActor: owner,
+		}); err != nil {
+			t.Fatalf("CreateNodeRaw[%d]: %v", i, err)
+		}
+	}
+	return ids
+}
+
+func uniqueNodeID(i int) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz"
+	if i < len(alphabet) {
+		return "n-" + string(alphabet[i])
+	}
+	// 4-byte rolling base for >26 nodes.
+	a := alphabet[i%len(alphabet)]
+	b := alphabet[(i/len(alphabet))%len(alphabet)]
+	c := alphabet[(i/(len(alphabet)*len(alphabet)))%len(alphabet)]
+	return "n-" + string([]byte{a, b, c})
+}
+
+// drainWAL pulls every record currently in the in-memory WAL topic and
+// returns the decoded events (in offset order). Reads via PollBatch
+// with a fresh group id so the calls don't mutate the applier's
+// committed offset.
+func (f *transferFixture) drainWAL(t *testing.T) []wal.Event {
+	t.Helper()
+	records, err := f.w.PollBatch(
+		context.Background(), "entdb-wal", "test-drain", 1000, 50*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("PollBatch: %v", err)
+	}
+	out := make([]wal.Event, 0, len(records))
+	for _, r := range records {
+		ev, err := wal.DecodeEvent(r.Value)
+		if err != nil {
+			t.Fatalf("DecodeEvent: %v", err)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// TestTransferUserContent_AdminHappySmallBatch: the canonical
+// happy-path. An owner (alice) transfers a handful of nodes to a new
+// user (bob). The handler must emit exactly one WAL event with op
+// "admin_transfer_content" and return success=true with the pre-apply
+// count.
+func TestTransferUserContent_AdminHappySmallBatch(t *testing.T) {
+	t.Parallel()
+	f := newTransferFixture(t)
+	f.seedNodes(t, "user:dave", 5)
+
+	resp, err := f.srv.TransferUserContent(
+		context.Background(), &pb.TransferUserContentRequest{
+			Actor:    "user:alice",
+			TenantId: f.tenantID,
+			FromUser: "user:dave",
+			ToUser:   "user:bob",
+		},
+	)
+	if err != nil {
+		t.Fatalf("TransferUserContent: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success: false; resp=%+v", resp)
+	}
+	if got, want := resp.GetTransferred(), int32(5); got != want {
+		t.Fatalf("Transferred = %d, want %d", got, want)
+	}
+
+	// WAL trace: exactly one event, exactly one op, op == admin_transfer_content.
+	events := f.drainWAL(t)
+	if len(events) != 1 {
+		t.Fatalf("WAL events: got %d, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.TenantID != f.tenantID {
+		t.Fatalf("event tenant = %q, want %q", ev.TenantID, f.tenantID)
+	}
+	if ev.Actor != "user:alice" {
+		t.Fatalf("event actor = %q, want %q", ev.Actor, "user:alice")
+	}
+	if !strings.HasPrefix(ev.IdempotencyKey, "admin-transfer-") {
+		t.Fatalf("idempotency_key = %q, want prefix %q", ev.IdempotencyKey, "admin-transfer-")
+	}
+	if len(ev.Ops) != 1 {
+		t.Fatalf("ops: got %d, want 1", len(ev.Ops))
+	}
+	if got, _ := ev.Ops[0]["op"].(string); got != "admin_transfer_content" {
+		t.Fatalf("op = %q, want admin_transfer_content", got)
+	}
+	if got, _ := ev.Ops[0]["from_user"].(string); got != "user:dave" {
+		t.Fatalf("from_user = %q, want user:dave", got)
+	}
+	if got, _ := ev.Ops[0]["to_user"].(string); got != "user:bob" {
+		t.Fatalf("to_user = %q, want user:bob", got)
+	}
+
+	// Membership upsert is visible in the global store.
+	members, err := f.gs.GetTenantMembers(context.Background(), f.tenantID)
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	hasBob := false
+	for _, m := range members {
+		if m.UserID == "user:bob" {
+			hasBob = true
+		}
+	}
+	if !hasBob {
+		t.Fatalf("expected user:bob to be a tenant member after transfer")
+	}
+}
+
+// TestTransferUserContent_AdminLargeBatchChunked: when the owner's
+// node count exceeds transferUserContentChunkSize (1000) the handler
+// must emit multiple WAL events. Pinning the chunk-count contract
+// guards the spec "Open question" §2 mitigation.
+func TestTransferUserContent_AdminLargeBatchChunked(t *testing.T) {
+	t.Parallel()
+	f := newTransferFixture(t)
+	// 1500 owned nodes -> 2 chunks (1000 + 500) under chunk size 1000.
+	f.seedNodes(t, "user:dave", 1500)
+
+	resp, err := f.srv.TransferUserContent(
+		context.Background(), &pb.TransferUserContentRequest{
+			Actor:    "user:alice",
+			TenantId: f.tenantID,
+			FromUser: "user:dave",
+			ToUser:   "user:bob",
+		},
+	)
+	if err != nil {
+		t.Fatalf("TransferUserContent: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success: false; resp=%+v", resp)
+	}
+	if got, want := resp.GetTransferred(), int32(1500); got != want {
+		t.Fatalf("Transferred = %d, want %d", got, want)
+	}
+
+	events := f.drainWAL(t)
+	if len(events) < 2 {
+		t.Fatalf("WAL events: got %d, want >= 2 (chunked)", len(events))
+	}
+	// Total node_ids across chunks must equal 1500.
+	total := 0
+	for _, ev := range events {
+		if got, _ := ev.Ops[0]["op"].(string); got != "admin_transfer_content" {
+			t.Fatalf("op = %q, want admin_transfer_content", got)
+		}
+		ids, _ := ev.Ops[0]["node_ids"].([]any)
+		total += len(ids)
+	}
+	if total != 1500 {
+		t.Fatalf("sum(node_ids) across chunks = %d, want 1500", total)
+	}
+}
+
+// TestTransferUserContent_RecipientSeesNodesAfterApply: drives the
+// full WAL-first flow. A populated owner gets transferred; once the
+// applier consumes the events, querying SQLite by (tenant, owner=bob)
+// returns every original node.
+func TestTransferUserContent_RecipientSeesNodesAfterApply(t *testing.T) {
+	t.Parallel()
+	f := newTransferFixture(t)
+	originalIDs := f.seedNodes(t, "user:dave", 7)
+
+	f.startApplier(t)
+	t.Cleanup(func() { f.stopApplier(t) })
+
+	resp, err := f.srv.TransferUserContent(
+		context.Background(), &pb.TransferUserContentRequest{
+			Actor:    "user:alice",
+			TenantId: f.tenantID,
+			FromUser: "user:dave",
+			ToUser:   "user:bob",
+		},
+	)
+	if err != nil {
+		t.Fatalf("TransferUserContent: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success: false; resp=%+v", resp)
+	}
+
+	// Wait for the applier to converge: poll CountOwnedNodes(bob) until
+	// it equals len(originalIDs). The Applier handler runs the bulk
+	// UPDATE inside a single SQLite write, so the count flips
+	// atomically once per consumed event.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		n, err := f.cs.CountOwnedNodes(context.Background(), f.tenantID, "user:bob")
+		if err != nil {
+			t.Fatalf("CountOwnedNodes(bob): %v", err)
+		}
+		if int(n) == len(originalIDs) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("applier did not converge: bob owns %d, want %d",
+				n, len(originalIDs))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Dave must own zero nodes post-apply.
+	if n, err := f.cs.CountOwnedNodes(
+		context.Background(), f.tenantID, "user:dave",
+	); err != nil || n != 0 {
+		t.Fatalf("CountOwnedNodes(dave) = %d, err=%v; want 0/nil", n, err)
+	}
+
+	// Sanity: every original node still exists, owned by bob.
+	for _, id := range originalIDs {
+		got, err := f.cs.GetNode(context.Background(), f.tenantID, id)
+		if err != nil {
+			t.Fatalf("GetNode %q: %v", id, err)
+		}
+		if got.OwnerActor != "user:bob" {
+			t.Fatalf("node %q owner = %q, want user:bob", id, got.OwnerActor)
+		}
+	}
+}
+
+// TestTransferUserContent_NonAdminPermissionDenied: a plain tenant
+// member (carol) attempting the transfer must be rejected with
+// PERMISSION_DENIED, AND no WAL event must be appended (the
+// privilege-escalation regression pinned by Python at
+// test_privilege_escalation.py:344-365).
+func TestTransferUserContent_NonAdminPermissionDenied(t *testing.T) {
+	t.Parallel()
+	f := newTransferFixture(t)
+	f.seedNodes(t, "user:dave", 3)
+
+	_, err := f.srv.TransferUserContent(
+		context.Background(), &pb.TransferUserContentRequest{
+			Actor:    "user:carol",
+			TenantId: f.tenantID,
+			FromUser: "user:dave",
+			ToUser:   "user:bob",
+		},
+	)
+	if err == nil {
+		t.Fatalf("expected PERMISSION_DENIED, got nil")
+	}
+	if got := errs.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("code = %v, want PermissionDenied (err=%v)", got, err)
+	}
+
+	// No WAL events: the auth check must fail BEFORE the append.
+	events := f.drainWAL(t)
+	if len(events) != 0 {
+		t.Fatalf("WAL events on denied call: got %d, want 0; first=%s",
+			len(events), mustJSON(t, events[0]))
+	}
+
+	// Membership unchanged: bob must NOT have been silently upserted by
+	// the rejected call (auth runs before the global-store write).
+	members, err := f.gs.GetTenantMembers(context.Background(), f.tenantID)
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	for _, m := range members {
+		if m.UserID == "user:bob" {
+			t.Fatalf("user:bob upserted on denied call: %+v", m)
+		}
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return string(b)
+}

--- a/server/go/internal/store/nodes.go
+++ b/server/go/internal/store/nodes.go
@@ -376,6 +376,68 @@ func (s *CanonicalStore) DeleteNode(ctx context.Context, tenantID, nodeID string
 	})
 }
 
+// CountOwnedNodes returns the number of `nodes` rows where
+// `owner_actor = ownerActor` inside `tenantID`. Read-only — used by
+// TransferUserContent to compute the pre-apply count returned to the
+// caller (mirrors grpc_server.py:2727-2736).
+//
+// On a missing tenant DB the function returns (0, nil) — the user
+// transparently owns nothing in a tenant we have not seen — matching
+// the Python handler's "swallow + return 0" failure mode.
+func (s *CanonicalStore) CountOwnedNodes(ctx context.Context, tenantID, ownerActor string) (int32, error) {
+	if tenantID == "" || ownerActor == "" {
+		return 0, nil
+	}
+	db, err := s.db(tenantID)
+	if err != nil {
+		// Tenant file not yet open: treat as zero-owned for parity.
+		return 0, nil
+	}
+	var n int32
+	row := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM nodes WHERE tenant_id = ? AND owner_actor = ?`,
+		tenantID, ownerActor,
+	)
+	if err := row.Scan(&n); err != nil {
+		return 0, fmt.Errorf("store: CountOwnedNodes: %w", err)
+	}
+	return n, nil
+}
+
+// ListOwnedNodeIDs returns the node_ids in `tenantID` whose
+// `owner_actor = ownerActor`. The slice is unordered. Used by
+// TransferUserContent to chunk a bulk transfer into multiple WAL
+// events when the owned-set is large.
+func (s *CanonicalStore) ListOwnedNodeIDs(ctx context.Context, tenantID, ownerActor string) ([]string, error) {
+	if tenantID == "" || ownerActor == "" {
+		return nil, nil
+	}
+	db, err := s.db(tenantID)
+	if err != nil {
+		return nil, nil
+	}
+	rows, err := db.QueryContext(ctx,
+		`SELECT node_id FROM nodes WHERE tenant_id = ? AND owner_actor = ?`,
+		tenantID, ownerActor,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: ListOwnedNodeIDs: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("store: ListOwnedNodeIDs scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: ListOwnedNodeIDs rows: %w", err)
+	}
+	return ids, nil
+}
+
 // isUniqueViolation reports whether err is a SQLite UNIQUE-constraint
 // failure. modernc.org/sqlite returns errors whose messages contain
 // "constraint failed: UNIQUE" — we string-match because the driver does


### PR DESCRIPTION
## Summary

- Implements `TransferUserContent` for the Go server (EPIC #407 Wave 2).
- WAL-first: trusted-actor admin/compliance gate, tenant gate, idempotent global-store membership upsert, then one or more `admin_transfer_content` events appended to the WAL (W1.10 applier already wired).
- Large-batch chunking: owned-sets > 1000 nodes split across multiple WAL events to bound the applier's per-tenant write-lock window (spec "Open question" §2 mitigation).
- Pre-apply count returned via new `store.CountOwnedNodes` / `store.ListOwnedNodeIDs` read helpers.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` (server/go) — all passing including new TransferUserContent tests
- [x] `go test ./...` (sdk/go/entdb) — green
- [x] `python -m pytest tests/python/unit tests/python/integration -q` — 2529 passed
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean

### New tests (package `api_test`)
- admin happy small batch — single WAL event, op shape pinned (op, from_user, to_user, idempotency-key prefix)
- admin large batch — chunked into multiple events, sum(node_ids) = N
- recipient sees all nodes after applier converges (full WAL → SQLite path)
- non-admin caller → `PERMISSION_DENIED` + zero WAL events appended (privilege-escalation regression)

### Drive-by
Three pre-existing duplicate symbols on `main` (from independent Wave 2 PRs landing in parallel) prevented the api package from building: `userToProto`, `lookupMemberRole`, `withTrustedUser`. Deduped to keep the build green; behaviour unchanged.

Refs #407