### PR TITLE
feat(go-rewrite): ExportUserData RPC — Wave 2

### DIFF
--- a/server/go/internal/api/export_user_data.go
+++ b/server/go/internal/api/export_user_data.go
@@ -1,0 +1,165 @@
+// ExportUserData RPC — Wave 2 of the Python → Go server port (EPIC #407).
+//
+// Spec: docs/go-port/rpcs/ExportUserData.md (GDPR Article 20 portability).
+// Source-of-truth Python:
+//   - server/python/entdb_server/api/grpc_server.py:3014-3070 (handler)
+//   - server/python/entdb_server/apply/canonical_store.py:5174-5249
+//     (per-tenant collector)
+//
+// Behavioral contract preserved byte-for-byte from the Python handler:
+//
+//   - global_store == nil → codes.Unimplemented "User registry not configured"
+//     (grpc_server.py:3022-3023).
+//   - actor / user_id required (codes.InvalidArgument), in that
+//     validation order (grpc_server.py:3024-3027).
+//   - Trusted-actor pattern: the privilege decision uses
+//     auth.Authoritative(ctx, claimed) — the wire-supplied actor is
+//     IGNORED for the self-or-admin gate. Allowed identities: the user
+//     themselves, or an admin: / system: caller. Anyone else →
+//     codes.PermissionDenied with the exact Python message
+//     (grpc_server.py:3028-3032).
+//   - Cross-tenant walk: enumerate via globalstore.GetUserTenants and
+//     query each tenant's SQLite with its own connection — never a
+//     cross-tenant transaction (CLAUDE.md invariant #4).
+//   - Per-tenant collector failures are SWALLOWED (logged, tenant
+//     omitted from `tenants[]`) so one corrupt tenant cannot block the
+//     bundle (grpc_server.py:3048-3053).
+//   - Bundle shape pinned by tests/python/unit/test_gdpr_engine.py:678-692:
+//     {"user_id", "generated_at", "tenants": [{"tenant_id", "nodes":
+//     [{"tenant_id","node_id","type_id","payload","created_at",
+//     "updated_at","owner_actor","data_policy"}]}]}.
+//   - `payload` stays field-id-keyed (CLAUDE.md invariant #6) — the
+//     handler does not translate to field names.
+//   - Read-only RPC: no WAL append, no SQLite writes. Python's open
+//     question #3 (audit-record the export itself via WAL) is left as
+//     a follow-up — preserving current behavior keeps parity tight.
+//   - Streaming export is deferred to Phase 2 (open question #1 in the
+//     spec): the bundle is built in-memory and returned inline as
+//     `export_json`. A 10M-node user will OOM the server today; the
+//     port matches that pathology rather than silently changing the
+//     wire shape.
+//   - Go-port delta vs Python: aborts use real status.Errorf returns
+//     rather than the Python try/except envelope. The
+//     `success=false, error=…` in-band branch only fires for genuine
+//     internal errors (json.Marshal of the bundle), matching the spec's
+//     "real aborts" note.
+//
+// Metrics: emits entdb_grpc_requests_total{method="ExportUserData",
+// status="ok"|"error"} via the shared chokepoint, on every code path
+// (including aborts) — matches the Python handler which always records
+// before re-raising.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+const exportUserDataMethod = "ExportUserData"
+
+// ExportUserData implements entdb.v1.EntDBService/ExportUserData.
+//
+// See file header for the full semantic contract. The handler is a
+// fan-in over per-tenant SQLite reads — each tenant is queried with its
+// own connection so the cross-tenant invariant (#4) is never violated.
+func (s *Server) ExportUserData(
+	ctx context.Context,
+	req *pb.ExportUserDataRequest,
+) (*pb.ExportUserDataResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(exportUserDataMethod, outcome, time.Since(start))
+	}()
+
+	// Configuration gate. Python: grpc_server.py:3022-3023.
+	if s.global == nil {
+		outcome = "error"
+		return nil, status.Error(codes.Unimplemented, "User registry not configured")
+	}
+	// Required-field aborts. Python: grpc_server.py:3024-3027.
+	if req.GetActor() == "" {
+		outcome = "error"
+		return nil, status.Error(codes.InvalidArgument, "actor is required")
+	}
+	userID := req.GetUserId()
+	if userID == "" {
+		outcome = "error"
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	// Trusted-actor resolution. The wire `actor` is UNTRUSTED — the
+	// interceptor installs the verified Identity on ctx and
+	// auth.Authoritative collapses to the trusted Actor when one is
+	// present. Mirrors `_is_self_or_admin(actor, user_id)` at
+	// grpc_server.py:2071-2086 + the `get_authoritative_actor` indirection.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	if !isSelfOrAdmin(trusted, userID) {
+		outcome = "error"
+		return nil, status.Error(codes.PermissionDenied,
+			"ExportUserData requires the user themselves or an admin actor")
+	}
+
+	memberships, err := s.global.GetUserTenants(ctx, userID)
+	if err != nil {
+		// Python's bare-except envelope at grpc_server.py:3065-3070
+		// returns success=false in-band on this failure mode (membership
+		// lookup throws). Preserve the wire shape — the SDK pins it.
+		outcome = "error"
+		return &pb.ExportUserDataResponse{Success: false, Error: err.Error()}, nil
+	}
+
+	// Per-tenant nodes store owner_actor as the `user:<id>` principal.
+	// Python: grpc_server.py:3036-3040.
+	principal := userID
+	if !strings.HasPrefix(principal, "user:") {
+		principal = "user:" + userID
+	}
+
+	tenants := make([]store.TenantExport, 0, len(memberships))
+	for _, m := range memberships {
+		// Per-tenant exception swallow — one corrupted DB must not fail
+		// the whole bundle. Python: grpc_server.py:3048-3053.
+		export, perr := s.store.ExportUserData(ctx, m.TenantID, principal, s.registry)
+		if perr != nil {
+			log.Printf("ExportUserData tenant %q failed: %v", m.TenantID, perr)
+			continue
+		}
+		tenants = append(tenants, export)
+	}
+
+	// Bundle shape pinned by test_gdpr_engine.py:678-692. `tenants` is
+	// always a list (never null) so the JSON shape matches Python's
+	// `[]` on the empty path.
+	bundle := map[string]any{
+		"user_id":      userID,
+		"generated_at": time.Now().Unix(),
+		"tenants":      tenants,
+	}
+	raw, err := json.Marshal(bundle)
+	if err != nil {
+		// Genuine internal error — the only Marshal failure mode that
+		// can fire here is an unsupported type smuggled through a
+		// payload, which the canonical store has already validated. Use
+		// the in-band failure shape (success=false, error=…) for parity
+		// with the Python except branch at grpc_server.py:3065-3070.
+		outcome = "error"
+		return &pb.ExportUserDataResponse{Success: false, Error: err.Error()}, nil
+	}
+	return &pb.ExportUserDataResponse{
+		Success:    true,
+		ExportJson: string(raw),
+	}, nil
+}

--- a/server/go/internal/api/export_user_data_test.go
+++ b/server/go/internal/api/export_user_data_test.go
@@ -1,0 +1,265 @@
+// Tests for the ExportUserData RPC (W2 — EPIC #407, GDPR Article 20).
+//
+// Spec: docs/go-port/rpcs/ExportUserData.md.
+//
+// Pinned behaviours (one test per arm):
+//
+//  1. Self happy path — alice exports her own bundle across all tenants
+//     she's a member of (mirrors test_gdpr_engine.py:678-692 and
+//     test_grpc_contract.py:643-648).
+//  2. Admin happy path — admin:root exports bob's bundle without
+//     needing to be a member of bob's tenants.
+//  3. No-data user — a user with zero memberships → empty bundle, the
+//     `tenants` array is `[]` not `null` (Python json.dumps([])).
+//  4. Non-self / non-admin → PERMISSION_DENIED (mirrors
+//     test_gdpr_engine.py:696-704 and test_grpc_contract.py:649-653).
+
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// newCanonicalStore returns a tmpdir-backed *store.CanonicalStore. Used
+// by the cross-tenant ExportUserData tests so each one gets a fresh
+// per-tenant SQLite tree on disk.
+func newCanonicalStore(t *testing.T) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// seedAliceNode creates a single owner-matching node in `tenant` with
+// owner_actor=user:alice. Returns the node id so callers can assert on
+// the bundle contents.
+func seedAliceNode(t *testing.T, cs *store.CanonicalStore, tenant string) string {
+	t.Helper()
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, tenant); err != nil {
+		t.Fatalf("OpenTenant(%q): %v", tenant, err)
+	}
+	const nodeID = "node-alice-1"
+	_, err := cs.CreateNodeRaw(ctx, tenant, store.NodeInput{
+		NodeID:     nodeID,
+		TypeID:     7,
+		Payload:    map[string]any{"1": "alice@example.com"},
+		OwnerActor: "user:alice",
+	})
+	if err != nil {
+		t.Fatalf("CreateNodeRaw(%q): %v", tenant, err)
+	}
+	return nodeID
+}
+
+// decodeBundle parses the JSON envelope returned by ExportUserData. The
+// helper exists so each test reads as a structural assertion rather
+// than a raw map dance.
+func decodeBundle(t *testing.T, raw string) (userID string, generatedAt int64, tenants []map[string]any) {
+	t.Helper()
+	var b struct {
+		UserID      string                   `json:"user_id"`
+		GeneratedAt int64                    `json:"generated_at"`
+		Tenants     []map[string]any         `json:"tenants"`
+	}
+	if err := json.Unmarshal([]byte(raw), &b); err != nil {
+		t.Fatalf("decode bundle: %v\nraw=%s", err, raw)
+	}
+	return b.UserID, b.GeneratedAt, b.Tenants
+}
+
+// TestExportUserData_Self_HappyPath: alice owns nodes in two tenants
+// she's a member of. The bundle must contain both tenants' slices in
+// joined-at order, with the owned nodes present.
+func TestExportUserData_Self_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	cs := newCanonicalStore(t)
+	ctx := context.Background()
+
+	// Two tenants alice is a member of, plus one she is NOT — to prove
+	// the cross-tenant walk only follows memberships.
+	for _, tenantID := range []string{"tenant-a", "tenant-b"} {
+		if err := gs.AddTenantMember(ctx, tenantID, "alice", "member"); err != nil {
+			t.Fatalf("AddTenantMember(%q): %v", tenantID, err)
+		}
+		seedAliceNode(t, cs, tenantID)
+	}
+	// Bob's tenant: alice is not a member; her node here MUST NOT
+	// appear in the export. (We only have to seed memberships — the
+	// canonical store doesn't get walked for tenants she isn't in.)
+	if err := gs.AddTenantMember(ctx, "tenant-c", "bob", "owner"); err != nil {
+		t.Fatalf("seed AddTenantMember bob: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+
+	resp, err := srv.ExportUserData(withTrustedUser(ctx, "alice"), &pb.ExportUserDataRequest{
+		Actor:  "user:alice",
+		UserId: "alice",
+	})
+	if err != nil {
+		t.Fatalf("ExportUserData: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success: got false, error=%q", resp.GetError())
+	}
+
+	userID, generatedAt, tenants := decodeBundle(t, resp.GetExportJson())
+	if userID != "alice" {
+		t.Errorf("user_id: got %q, want %q", userID, "alice")
+	}
+	if generatedAt <= 0 {
+		t.Errorf("generated_at: got %d, want > 0", generatedAt)
+	}
+	if len(tenants) != 2 {
+		t.Fatalf("tenants: got %d, want 2 (tenant-a, tenant-b); bundle=%s", len(tenants), resp.GetExportJson())
+	}
+	for _, te := range tenants {
+		nodes, ok := te["nodes"].([]any)
+		if !ok {
+			t.Fatalf("tenant entry missing nodes array: %+v", te)
+		}
+		if len(nodes) != 1 {
+			t.Errorf("tenant %v: got %d nodes, want 1", te["tenant_id"], len(nodes))
+		}
+	}
+}
+
+// TestExportUserData_Admin_HappyPath: an admin: trusted identity can
+// export any user's bundle without being a tenant member.
+func TestExportUserData_Admin_HappyPath(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	cs := newCanonicalStore(t)
+	ctx := context.Background()
+
+	if err := gs.AddTenantMember(ctx, "tenant-a", "alice", "member"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	seedAliceNode(t, cs, "tenant-a")
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+
+	// admin:root is the trusted caller; the wire `actor` is also set to
+	// admin:root for parity with how Python's contract test invokes it.
+	resp, err := srv.ExportUserData(withTrustedUser(ctx, "admin:root"), &pb.ExportUserDataRequest{
+		Actor:  "admin:root",
+		UserId: "alice",
+	})
+	if err != nil {
+		t.Fatalf("ExportUserData: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success: got false, error=%q", resp.GetError())
+	}
+	userID, _, tenants := decodeBundle(t, resp.GetExportJson())
+	if userID != "alice" {
+		t.Errorf("user_id: got %q, want %q", userID, "alice")
+	}
+	if len(tenants) != 1 {
+		t.Errorf("tenants: got %d, want 1", len(tenants))
+	}
+}
+
+// TestExportUserData_NoData_EmptyBundle: a user with zero memberships
+// gets a well-formed bundle whose `tenants` slice is empty. The slice
+// must be `[]` not `null` so the SDK's JSON consumer doesn't crash on
+// nil — pinned by sdk/go/entdb/admin_gdpr_test.go:76-94.
+func TestExportUserData_NoData_EmptyBundle(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	cs := newCanonicalStore(t)
+	ctx := context.Background()
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+
+	resp, err := srv.ExportUserData(withTrustedUser(ctx, "ghost"), &pb.ExportUserDataRequest{
+		Actor:  "user:ghost",
+		UserId: "ghost",
+	})
+	if err != nil {
+		t.Fatalf("ExportUserData: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success: got false, error=%q", resp.GetError())
+	}
+	raw := resp.GetExportJson()
+	userID, _, tenants := decodeBundle(t, raw)
+	if userID != "ghost" {
+		t.Errorf("user_id: got %q, want %q", userID, "ghost")
+	}
+	if tenants == nil {
+		t.Errorf("tenants: got nil, want []; raw=%s", raw)
+	}
+	if len(tenants) != 0 {
+		t.Errorf("tenants: got %d, want 0; raw=%s", len(tenants), raw)
+	}
+	// Verify the JSON literal contains "tenants":[] not "tenants":null.
+	// json.Marshal of an empty []store.TenantExport -> "[]" — the test
+	// would catch a regression to nil-slice handling.
+	if !containsBracket(raw) {
+		t.Errorf("expected literal []\"tenants\":[]\" in bundle, got %s", raw)
+	}
+}
+
+// containsBracket is a tiny string check used by the no-data test to
+// guarantee the wire payload doesn't smuggle JSON `null` past consumers
+// who expect an empty array.
+func containsBracket(raw string) bool {
+	// Substring match is sufficient — we are looking for the literal
+	// `"tenants":[]` regardless of whitespace, which json.Marshal does
+	// not insert.
+	for i := 0; i+len(`"tenants":[]`) <= len(raw); i++ {
+		if raw[i:i+len(`"tenants":[]`)] == `"tenants":[]` {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExportUserData_NonSelfNonAdmin_PermissionDenied: alice trying to
+// export bob's bundle is the privilege-escalation guard. The wire
+// `actor` claims admin:root but the trusted Identity says alice — must
+// be ignored. Pinned by test_grpc_contract.py:649-653.
+func TestExportUserData_NonSelfNonAdmin_PermissionDenied(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	cs := newCanonicalStore(t)
+	ctx := context.Background()
+
+	if err := gs.AddTenantMember(ctx, "tenant-b", "bob", "member"); err != nil {
+		t.Fatalf("AddTenantMember bob: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+
+	// alice is the trusted caller; she claims admin:root on the wire.
+	// The handler MUST ignore the wire claim.
+	resp, err := srv.ExportUserData(withTrustedUser(ctx, "alice"), &pb.ExportUserDataRequest{
+		Actor:  "admin:root",
+		UserId: "bob",
+	})
+	if err == nil {
+		t.Fatalf("expected PERMISSION_DENIED, got resp=%+v", resp)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("code: got %v, want PermissionDenied", st.Code())
+	}
+}

--- a/server/go/internal/store/nodes.go
+++ b/server/go/internal/store/nodes.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
 )
 
 // Node is the in-Go representation of one row of the `nodes` table.
@@ -521,6 +523,138 @@ func (s *CanonicalStore) ListOwnedNodeIDs(ctx context.Context, tenantID, ownerAc
 		return nil, fmt.Errorf("store: ListOwnedNodeIDs rows: %w", err)
 	}
 	return ids, nil
+}
+
+// TenantExportNode is one row in the per-tenant export bundle assembled
+// by ExportUserData. Mirrors the dict shape returned by Python
+// _sync_export_user_data (canonical_store.py:5223-5234):
+//
+//	{ tenant_id, node_id, type_id, payload, created_at, updated_at,
+//	  owner_actor, data_policy }
+//
+// `Payload` is field-id-keyed (CLAUDE.md invariant #6) — the JSON
+// returned to the client preserves the on-disk shape verbatim.
+type TenantExportNode struct {
+	TenantID   string         `json:"tenant_id"`
+	NodeID     string         `json:"node_id"`
+	TypeID     int32          `json:"type_id"`
+	Payload    map[string]any `json:"payload"`
+	CreatedAt  int64          `json:"created_at"`
+	UpdatedAt  int64          `json:"updated_at"`
+	OwnerActor string         `json:"owner_actor"`
+	DataPolicy string         `json:"data_policy"`
+}
+
+// TenantExport is the per-tenant slice of the cross-tenant
+// ExportUserData bundle. Mirrors `{tenant_id, nodes}` returned by
+// canonical_store.export_user_data_for_tenant (canonical_store.py:5236).
+type TenantExport struct {
+	TenantID string             `json:"tenant_id"`
+	Nodes    []TenantExportNode `json:"nodes"`
+}
+
+// ExportUserData collects every node in `tenantID` that the caller
+// owns or is the subject of, excluding `data_policy=audit` types.
+// Port of canonical_store.py:_sync_export_user_data (5174-5236).
+//
+// `principal` is the per-tenant principal form (`user:<id>`). `reg` is
+// the schema registry used for data-policy / subject-field lookups; nil
+// is permitted and triggers the same fall-back as Python's KeyError
+// branch (DataPolicyPersonal, no subject field).
+//
+// The returned `Nodes` slice is non-nil even when empty — JSON consumers
+// expect `[]`, not `null`, to match the Python `json.dumps([])` shape.
+func (s *CanonicalStore) ExportUserData(
+	ctx context.Context,
+	tenantID, principal string,
+	reg *schema.Registry,
+) (TenantExport, error) {
+	out := TenantExport{TenantID: tenantID, Nodes: []TenantExportNode{}}
+	db, err := s.db(tenantID)
+	if err != nil {
+		return out, err
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT node_id, type_id, payload_json,
+		       created_at, updated_at, owner_actor
+		FROM nodes WHERE tenant_id = ?`,
+		tenantID,
+	)
+	if err != nil {
+		return out, fmt.Errorf("store: ExportUserData: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			nodeID, payloadJSON, owner string
+			typeID                     int32
+			createdAt, updatedAt       int64
+		)
+		if err := rows.Scan(&nodeID, &typeID, &payloadJSON, &createdAt, &updatedAt, &owner); err != nil {
+			return out, fmt.Errorf("store: ExportUserData scan: %w", err)
+		}
+
+		// Schema lookups: missing type → PERSONAL, no subject field.
+		// Mirrors the KeyError fallback at canonical_store.py:5206-5208.
+		var (
+			policy       schema.DataPolicy = schema.DataPolicyPersonal
+			subjectField string
+		)
+		if reg != nil {
+			if nt := reg.NodeTypeByID(typeID); nt != nil {
+				policy = reg.DataPolicyOf(typeID)
+				subjectField = reg.SubjectField(typeID)
+			}
+		}
+
+		// AUDIT records are NOT subject-access-requestable (ADR-004).
+		if policy == schema.DataPolicyAudit {
+			continue
+		}
+
+		payload := map[string]any{}
+		if payloadJSON != "" {
+			// Best-effort parse: a malformed payload becomes {} rather
+			// than failing the whole export — matches Python's
+			// json.JSONDecodeError swallow at canonical_store.py:5212-5213.
+			_ = json.Unmarshal([]byte(payloadJSON), &payload)
+		}
+
+		isOwner := owner == principal
+		isSubject := false
+		if subjectField != "" {
+			// Latent-bug parity: Python compares payload[subject_field]
+			// to the *user_id* (bare, e.g. "alice"), not the principal
+			// (`user:alice`). See canonical_store.py:5216 and the spec's
+			// Open Question #6. We replicate exactly: strip the
+			// `user:` prefix from `principal` before comparing.
+			subjectID := principal
+			if len(subjectID) > 5 && subjectID[:5] == "user:" {
+				subjectID = subjectID[5:]
+			}
+			if v, ok := payload[subjectField]; ok && v == subjectID {
+				isSubject = true
+			}
+		}
+		if !(isOwner || isSubject) {
+			continue
+		}
+
+		out.Nodes = append(out.Nodes, TenantExportNode{
+			TenantID:   tenantID,
+			NodeID:     nodeID,
+			TypeID:     typeID,
+			Payload:    payload,
+			CreatedAt:  createdAt,
+			UpdatedAt:  updatedAt,
+			OwnerActor: owner,
+			DataPolicy: string(policy),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return out, fmt.Errorf("store: ExportUserData rows: %w", err)
+	}
+	return out, nil
 }
 
 // isUniqueViolation reports whether err is a SQLite UNIQUE-constraint


### PR DESCRIPTION
## Summary

W2 — `ExportUserData` RPC (EPIC #407). GDPR Article 20 portability:
emit every node a user owns or is the subject of across every tenant
they're a member of, as a single JSON bundle.

- `internal/api/export_user_data.go` — handler with trusted-actor
  self-or-admin gate (shared `isSelfOrAdmin` from the DeleteUser
  pipeline per spec), cross-tenant walk via `globalstore.GetUserTenants`,
  per-tenant exception swallow, real `status.Errorf` aborts (Go-port
  delta vs Python's try/except envelope).
- `internal/store/nodes.go` — `ExportUserData` per-tenant collector.
  Filters by owner-match or subject-field-match, drops AUDIT-policy
  types, preserves field-id-keyed payload (CLAUDE.md invariant #6).
- `internal/api/export_user_data_test.go` — four arms per spec
  contract pins: self happy / admin happy / no-data empty bundle /
  non-self-non-admin → PERMISSION_DENIED.

**Streaming deferred** to Phase 2 (spec open question #1). Bundles are
built in-memory and returned inline as `export_json`. A user with 10M
nodes across 100 tenants will hit the gRPC max-message-size today —
matches the current Python pathology rather than silently changing the
wire shape. Tracked for follow-up.

### Drive-by build fix

The post-merge state of `main` had three identifier collisions from
concurrent W2 PRs landing within seconds: `userToProto`,
`lookupMemberRole`, and `withTrustedUser`. Local `go vet` failed before
this PR. Deduped here so CI can run; rules of resolution:

- `userToProto` → kept `list_users.go` (nil-safe; PR #437 landed first).
- `lookupMemberRole` → kept `add_tenant_member.go` (PR #434 landed first).
- `withTrustedUser` → consolidated into `helpers_external_test.go`
  (same pattern as PR #429 used for `newGlobalStore`).

Did NOT modify `_go_parity.py` or `server.go` per task instructions.
The canary probe over `ExecuteAtomic` in `server_test.go` is preserved.

Refs #407

## Test plan

- [x] `go vet ./...` clean (server/go).
- [x] `go test ./...` clean (server/go) — 14 packages, all pass.
- [x] `go test ./...` clean (sdk/go/entdb) — 4 packages, all pass.
- [x] `python -m pytest tests/python/unit tests/python/integration -q` — 2529 passed.
- [x] `uvx ruff@0.15.7 check .` — all checks passed.
- [x] `uvx ruff@0.15.7 format --check .` — 220 files already formatted.