### PR TITLE
fix(go-rewrite): dedupe parallel-PR helper redeclarations

### DIFF
--- a/server/go/internal/api/add_tenant_member.go
+++ b/server/go/internal/api/add_tenant_member.go
@@ -162,21 +162,3 @@ func (s *Server) AddTenantMember(
 
 	return &pb.TenantMemberResponse{Success: true}, nil
 }
-
-// lookupMemberRole returns the role string for (tenantID, userID), or
-// "" if no membership exists. O(N) in the tenant's member count to
-// stay in lock-step with the Python _get_member_role implementation
-// (grpc_server.py:2290-2296). A dedicated MemberRole helper in
-// globalstore is tracked as a follow-up in the port spec.
-func (s *Server) lookupMemberRole(ctx context.Context, tenantID, userID string) (string, error) {
-	members, err := s.global.GetTenantMembers(ctx, tenantID)
-	if err != nil {
-		return "", err
-	}
-	for _, m := range members {
-		if m.UserID == userID {
-			return m.Role, nil
-		}
-	}
-	return "", nil
-}

--- a/server/go/internal/api/change_member_role.go
+++ b/server/go/internal/api/change_member_role.go
@@ -93,7 +93,7 @@ func (s *Server) ChangeMemberRole(
 		callerRole, err := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
 		if err != nil {
 			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
-			return nil, err
+			return nil, errs.Errorf(codes.Internal, "list tenant members: %v", err)
 		}
 		if callerRole != "owner" && callerRole != "admin" {
 			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
@@ -143,24 +143,4 @@ func (s *Server) ChangeMemberRole(
 
 	metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "ok", time.Since(start))
 	return &pb.ChangeMemberRoleResponse{Success: true}, nil
-}
-
-// lookupMemberRole returns the trusted caller's role within tenantID, or
-// the empty string if no membership row exists. Errors from the
-// globalstore are surfaced as codes.Internal — mirrors how the Python
-// handler lets a SQLite error bubble through the unconditional catch.
-func (s *Server) lookupMemberRole(ctx context.Context, tenantID, userID string) (string, error) {
-	if userID == "" {
-		return "", nil
-	}
-	members, err := s.global.GetTenantMembers(ctx, tenantID)
-	if err != nil {
-		return "", errs.Errorf(codes.Internal, "list tenant members: %v", err)
-	}
-	for _, m := range members {
-		if m.UserID == userID {
-			return m.Role, nil
-		}
-	}
-	return "", nil
 }

--- a/server/go/internal/api/get_tenant_quota_test.go
+++ b/server/go/internal/api/get_tenant_quota_test.go
@@ -21,21 +21,10 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
-
-// withTrustedUser returns a ctx that carries the given subject as the
-// trusted user identity, mirroring what the auth interceptor sets on
-// every authenticated request.
-func withTrustedUser(ctx context.Context, subject string) context.Context {
-	return auth.WithIdentity(ctx, auth.Identity{
-		Method:  auth.MethodSession,
-		Subject: subject,
-	})
-}
 
 // TestGetTenantQuota_Member_HappyPath: a tenant member with role=member
 // can read the quota dashboard; configured cfg + usage round-trip into

--- a/server/go/internal/api/get_user.go
+++ b/server/go/internal/api/get_user.go
@@ -43,7 +43,6 @@ import (
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
@@ -110,20 +109,4 @@ func (s *Server) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.GetUs
 		Found: true,
 		User:  userToProto(user),
 	}, nil
-}
-
-// userToProto mirrors `_user_dict_to_proto` in the Python handler
-// (server/python/entdb_server/api/grpc_server.py:2088-...). NULL columns
-// land as Go zero values via globalstore.User's plain-string fields,
-// which marshal to the proto's empty-string defaults -- the same shape
-// Python emits when it stringifies a None.
-func userToProto(u *globalstore.User) *pb.UserInfo {
-	return &pb.UserInfo{
-		UserId:    u.UserID,
-		Email:     u.Email,
-		Name:      u.Name,
-		Status:    u.Status,
-		CreatedAt: u.CreatedAt,
-		UpdatedAt: u.UpdatedAt,
-	}
 }

--- a/server/go/internal/api/helpers.go
+++ b/server/go/internal/api/helpers.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Shared helpers for the api package. These were previously duplicated
+// across the per-RPC handler files (e.g. get_user.go, list_users.go,
+// add_tenant_member.go, change_member_role.go) by parallel Wave 2
+// PRs that landed on main without seeing each other. Consolidating
+// them here keeps `go vet ./internal/api/...` clean and ensures every
+// caller sees identical semantics.
+//
+// Conventions:
+//   - Helpers that are pure Server methods (need s.global, s.sharding,
+//     etc.) live as methods on *Server.
+//   - Helpers that are pure wire-shape transforms live as free
+//     functions, mirror their Python counterparts in
+//     server/python/entdb_server/api/grpc_server.py, and are nil-safe
+//     where the Python equivalent is.
+
+package api
+
+import (
+	"context"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// userToProto maps a globalstore.User row to its proto wire form,
+// mirroring `_user_dict_to_proto` in the Python handler
+// (server/python/entdb_server/api/grpc_server.py:2088-2097). NULL
+// columns land as Go zero values via globalstore.User's plain-string
+// fields, which marshal to the proto's empty-string defaults -- the
+// same shape Python emits when it stringifies a None. A nil row
+// yields a zero-value UserInfo so callers never panic on missing data
+// (preserves the list_users.go pre-merge behaviour).
+func userToProto(u *globalstore.User) *pb.UserInfo {
+	if u == nil {
+		return &pb.UserInfo{}
+	}
+	return &pb.UserInfo{
+		UserId:    u.UserID,
+		Email:     u.Email,
+		Name:      u.Name,
+		Status:    u.Status,
+		CreatedAt: u.CreatedAt,
+		UpdatedAt: u.UpdatedAt,
+	}
+}
+
+// lookupMemberRole returns the role string for (tenantID, userID) or
+// "" if no membership row exists. Empty userID short-circuits to ""
+// so callers don't have to guard. O(N) in the tenant's member count
+// to stay in lock-step with the Python _get_member_role implementation
+// (grpc_server.py:2290-2296); a dedicated MemberRole helper in
+// globalstore is tracked as a follow-up in the port spec.
+//
+// Errors from the globalstore are returned raw — call sites decide
+// how to wrap them (e.g. as codes.Internal). This matches the
+// add_tenant_member.go pre-merge contract; change_member_role.go's
+// call site wraps explicitly.
+func (s *Server) lookupMemberRole(ctx context.Context, tenantID, userID string) (string, error) {
+	if userID == "" {
+		return "", nil
+	}
+	members, err := s.global.GetTenantMembers(ctx, tenantID)
+	if err != nil {
+		return "", err
+	}
+	for _, m := range members {
+		if m.UserID == userID {
+			return m.Role, nil
+		}
+	}
+	return "", nil
+}

--- a/server/go/internal/api/helpers_external_test.go
+++ b/server/go/internal/api/helpers_external_test.go
@@ -3,8 +3,10 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 )
 
@@ -16,4 +18,16 @@ func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
 	}
 	t.Cleanup(func() { _ = gs.Close() })
 	return gs
+}
+
+// withTrustedUser returns a ctx that carries the given subject as the
+// trusted user identity, mirroring what the auth interceptor sets on
+// every authenticated request. Method is arbitrary for handler-level
+// tests because auth.Authoritative only consults Subject for the
+// trusted path; MethodSession is used here as a neutral default.
+func withTrustedUser(ctx context.Context, subject string) context.Context {
+	return auth.WithIdentity(ctx, auth.Identity{
+		Method:  auth.MethodSession,
+		Subject: subject,
+	})
 }

--- a/server/go/internal/api/list_users.go
+++ b/server/go/internal/api/list_users.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
@@ -96,21 +95,4 @@ func (s *Server) ListUsers(
 		out = append(out, userToProto(r))
 	}
 	return &pb.ListUsersResponse{Users: out}, nil
-}
-
-// userToProto maps a globalstore.User row to its proto wire form,
-// mirroring _user_dict_to_proto at grpc_server.py:2088-2097. A nil row
-// yields a zero-value UserInfo so callers never panic on missing data.
-func userToProto(u *globalstore.User) *pb.UserInfo {
-	if u == nil {
-		return &pb.UserInfo{}
-	}
-	return &pb.UserInfo{
-		UserId:    u.UserID,
-		Email:     u.Email,
-		Name:      u.Name,
-		Status:    u.Status,
-		CreatedAt: u.CreatedAt,
-		UpdatedAt: u.UpdatedAt,
-	}
 }

--- a/server/go/internal/api/update_user_test.go
+++ b/server/go/internal/api/update_user_test.go
@@ -14,19 +14,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
-
-// withTrustedUser stamps a verified user identity onto ctx so the
-// handler's auth.Authoritative call returns the trusted Actor — the
-// only way a unit test can drive the post-#168 trusted-actor pattern.
-func withTrustedUser(ctx context.Context, subject string) context.Context {
-	return auth.WithIdentity(ctx, auth.Identity{
-		Method:  auth.MethodOAuth,
-		Subject: subject,
-	})
-}
 
 // TestUpdateUser_Self_HappyPath: alice updates her own row (only
 // `name` set; truthy-only gating means `email` and `status` are not


### PR DESCRIPTION
## Summary

- Wave 2 round-2 PRs (CreateUser, GetUser, ListUsers, AddTenantMember, ChangeMemberRole, UpdateUser, GetTenantQuota, ...) each independently added the same helpers. After they all merged onto `main`, `go vet ./internal/api/...` started failing with `userToProto redeclared` and `Server.lookupMemberRole already declared`. This blocks every Wave 2 round-3 agent's local CI.
- Consolidate the duplicated helpers into a single home in `package api` so the build is clean again:
  - `userToProto(*globalstore.User) *pb.UserInfo` and `(*Server).lookupMemberRole(ctx, tenantID, userID)` → `server/go/internal/api/helpers.go` (new).
  - `withTrustedUser(ctx, subject)` → appended to the existing `server/go/internal/api/helpers_external_test.go` (already housed `newGlobalStore`).
- Adjust the two call sites/test files that were previously importing things they no longer need (drop unused `globalstore` and `auth` imports).
- One small behavior reconciliation: `change_member_role.go`'s pre-merge `lookupMemberRole` wrapped globalstore errors as `codes.Internal`; `add_tenant_member.go`'s returned them raw. The consolidated helper returns raw errors (matching add_tenant_member, which already wraps explicitly at the call site) and `change_member_role.go` now wraps its own error in the same `codes.Internal, "list tenant members: %v"` shape it had before — net zero behavior change at both call sites.

The `userToProto` versions were semantically identical for non-nil inputs; `list_users.go`'s pre-merge variant additionally guarded `u == nil` and returned `&pb.UserInfo{}`. The consolidated helper preserves that nil-safety so neither caller regresses.

The two `withTrustedUser` test helpers differed only in `auth.Method` (`MethodOAuth` vs `MethodSession`); `auth.Authoritative` does not consult `Method` on the trusted-identity path (verified via grep across `internal/auth/`), so the consolidated helper picks `MethodSession` as a neutral default and both test suites pass unchanged.

## Test plan

- [x] `cd server/go && go vet ./...` clean (was failing before).
- [x] `cd server/go && go test ./...` all packages pass.
- [x] `cd server/go && go test -race ./internal/api/...` passes.
- [x] All previously-affected tests pass when run by name (`ChangeMemberRole*`, `AddTenantMember*`, `GetUser*`, `ListUsers*`, `GetTenantQuota*`, `UpdateUser*`).
- [x] `uvx ruff@0.15.7 check .` clean.
- [x] `uvx ruff@0.15.7 format --check .` clean.

Refs #407