### PR TITLE
feat(go-rewrite): TransferOwnership RPC — Wave 2 (WAL-first restoration)

### DIFF
--- a/server/go/internal/api/transfer_ownership.go
+++ b/server/go/internal/api/transfer_ownership.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// TransferOwnership implements entdb.v1.EntDBService/TransferOwnership.
+//
+// Source-of-truth Python: server/python/entdb_server/api/grpc_server.py:2030-2049.
+// Port spec: docs/go-port/rpcs/TransferOwnership.md.
+//
+// # WAL-first restoration (CLAUDE.md §1)
+//
+// The Python handler bypasses the WAL and writes nodes.owner_actor
+// directly via canonical_store._sync_transfer_ownership — a long-
+// standing violation of "every mutation goes through the WAL"
+// (CLAUDE.md invariant #1, called out in PLAN.md §6.1).
+//
+// The Go port restores the invariant: the handler appends a
+// `transfer_ownership` op to the per-tenant WAL via the shared
+// wal.Producer, then synchronously materialises the change in the
+// per-tenant SQLite via store.TransferOwnership. The applier already
+// dispatches the same op on replay (see internal/apply/ops_transfer_ownership.go),
+// so a future rebuild from the WAL will reproduce the transfer
+// exactly. Idempotency-key based de-dupe in the applier keeps the
+// in-flight + replay paths from double-applying.
+//
+// # Auth model — trusted-actor, current-owner-only
+//
+//  1. Authentication is required (handler is NOT in
+//     AuthInterceptor.UNAUTHENTICATED_METHODS).
+//  2. The wire-claimed `context.actor` field is UNTRUSTED — the
+//     handler rebinds to the interceptor-attested identity via
+//     auth.Authoritative on entry. Privilege-escalation regression
+//     pinned by commit fece3fb ("Fix privilege escalation: ignore
+//     client-claimed actor in gRPC handlers").
+//  3. Tenant gate: s.checkTenant verifies the tenant exists and is
+//     owned by this node (sharding) and is in the served region.
+//  4. Owner-only authorization: the trusted actor MUST equal the
+//     node's current owner_actor. Non-owner callers — even those who
+//     hold an ADMIN ACL grant on the node — are rejected with
+//     PERMISSION_DENIED. This is a Go-side hardening over the Python
+//     handler, which performs no authorization beyond _check_tenant.
+//
+// # Side effects
+//
+//   - WAL append: one TransactionEvent containing a single
+//     `transfer_ownership` op (node_id, new_owner). Idempotency key
+//     is derived per-call via a UUID.
+//   - SQLite: nodes.owner_actor flipped to new_owner; node_visibility
+//     refreshed so the new owner can see the node and the old owner
+//     loses implicit access (explicit ACL grants survive — by design,
+//     spec §"ACL changes").
+//   - No globalstore writes. No mailbox notification.
+//
+// # Error contract
+//
+//	INVALID_ARGUMENT      empty node_id / new_owner / context.tenant_id
+//	                      OR new_owner is not a kind:id-prefixed actor
+//	                      string (user:/group:/system:).
+//	NOT_FOUND             tenant does not exist (from checkTenant) OR
+//	                      node does not exist in the tenant.
+//	UNAVAILABLE           tenant pinned to another node.
+//	PERMISSION_DENIED     trusted actor is not the current owner.
+//	OK + found=true       transfer applied.
+//
+// Note: the Python wire contract returns (found=false, error="") for a
+// missing node (no gRPC status). The Go port hardens this to NOT_FOUND
+// because:
+//   - It is consistent with the rest of the Wave-2 surface (every
+//     "row missing" path uses codes.NotFound), AND
+//   - The contract test that pinned the soft-fail behaviour
+//     (test_acl_v2.py:534-536) is being retired alongside the Python
+//     server in EPIC #407. Existing Python tests targeting
+//     TransferOwnership are pinned via the parity harness, not via this
+//     wire shape.
+//
+// Metrics: emits entdb_grpc_requests_total{method="TransferOwnership",
+// status="ok"|"error"} via the shared chokepoint.
+
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const grpcMethodTransferOwnership = "TransferOwnership"
+
+// transferOwnershipTopic is the WAL topic the handler appends to. Mirrors
+// the per-tenant Kafka topic naming in the Python wal/kafka.py module —
+// each tenant key partitions onto its own slot so total order is
+// preserved per-tenant. The applier consumes from the same topic name.
+const transferOwnershipTopic = "entdb-wal"
+
+// TransferOwnership reassigns nodes.owner_actor and refreshes node_visibility.
+// See package-level doc for the WAL-first restoration model and auth contract.
+func (s *Server) TransferOwnership(
+	ctx context.Context,
+	req *pb.TransferOwnershipRequest,
+) (*pb.TransferOwnershipResponse, error) {
+	start := time.Now()
+	statusLabel := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(grpcMethodTransferOwnership, statusLabel, time.Since(start))
+	}()
+
+	// 1. Validation. Mirror the Python required-arg checks plus the
+	//    Go-side hardening called out in spec §"Wire contract".
+	if req.GetContext() == nil || req.GetContext().GetTenantId() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetNodeId() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "node_id is required")
+	}
+	if req.GetNewOwner() == "" {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "new_owner is required")
+	}
+	if !isValidActorString(req.GetNewOwner()) {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.InvalidArgument,
+			"new_owner must be a kind:id actor string (user:..., group:..., system:...)")
+	}
+
+	tenantID := req.GetContext().GetTenantId()
+
+	// 2. Tenant gate — verify the tenant exists, is owned by this node,
+	//    and matches the served region. Returns NotFound / Unavailable
+	//    with the redirect trailer pre-set on sharding mismatch.
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		statusLabel = "error"
+		return nil, err
+	}
+
+	// 3. Trusted-actor rebind. From this point on, req.Context.Actor is
+	//    strictly informational; every authorization branch consults
+	//    `trusted`. Privilege-escalation regression fix in commit fece3fb.
+	claimed := auth.ParseActor(req.GetContext().GetActor())
+	trusted := auth.Authoritative(ctx, claimed)
+
+	if s.store == nil {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "canonical store not configured")
+	}
+
+	// 4. Read the node to a) confirm existence (NotFound otherwise) and
+	//    b) check current ownership for the auth gate.
+	current, err := s.store.GetNode(ctx, tenantID, req.GetNodeId())
+	if err != nil {
+		if errors.Is(err, store.ErrNodeNotFound) {
+			statusLabel = "error"
+			return nil, errs.Errorf(codes.NotFound, "node %q not found", req.GetNodeId())
+		}
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.Internal, "read node: %v", err)
+	}
+
+	// 5. Current-owner-only authorization. The trusted actor's full
+	//    "kind:id" form must match the stored owner_actor verbatim.
+	//    system: callers are NOT bypassed here — TransferOwnership is a
+	//    user-initiated handoff, not an admin override (the Python
+	//    bulk-reassign handler `TransferUserContent` covers the admin
+	//    path). Group ownership is technically representable on disk
+	//    but a group cannot be a caller, so it cannot pass this gate.
+	if trusted.IsZero() || trusted.String() != current.OwnerActor {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.PermissionDenied,
+			"only the current owner of node %q can transfer ownership", req.GetNodeId())
+	}
+
+	// 6. WAL append. Encodes the same op shape the applier dispatches in
+	//    internal/apply/ops_transfer_ownership.go.
+	idempKey, err := newIdempotencyKey()
+	if err != nil {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.Internal, "generate idempotency key: %v", err)
+	}
+	evt := wal.Event{
+		TenantID:       tenantID,
+		Actor:          trusted.String(),
+		IdempotencyKey: idempKey,
+		Ops: []map[string]any{
+			{
+				"op":        string(apply.OpTransferOwnership),
+				"node_id":   req.GetNodeId(),
+				"new_owner": req.GetNewOwner(),
+			},
+		},
+	}
+	if s.producer != nil {
+		value, encErr := evt.Encode()
+		if encErr != nil {
+			statusLabel = "error"
+			return nil, errs.Errorf(codes.Internal, "encode wal event: %v", encErr)
+		}
+		headers := map[string][]byte{
+			wal.HeaderIdempotencyKey: []byte(idempKey),
+		}
+		if _, appendErr := s.producer.Append(ctx, transferOwnershipTopic, tenantID, value, headers); appendErr != nil {
+			statusLabel = "error"
+			return nil, errs.Errorf(codes.Internal, "wal append: %v", appendErr)
+		}
+	}
+
+	// 7. Synchronous apply. The applier will re-dispatch the same op on
+	//    replay; CheckIdempotency in applier.applyEvent dedupes via the
+	//    applied_events table so the rebuild stays correct.
+	if err := s.store.TransferOwnership(ctx, tenantID, req.GetNodeId(), req.GetNewOwner()); err != nil {
+		if errors.Is(err, store.ErrNodeNotFound) {
+			// Race window: node was deleted between GetNode and the
+			// apply. Surface as NotFound for symmetry with step 4.
+			statusLabel = "error"
+			return nil, errs.Errorf(codes.NotFound, "node %q not found", req.GetNodeId())
+		}
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.Internal, "apply transfer_ownership: %v", err)
+	}
+
+	return &pb.TransferOwnershipResponse{Found: true}, nil
+}
+
+// isValidActorString reports whether s is a kind:id-prefixed actor string
+// the spec accepts for `new_owner`. Mirrors auth.ParseActor's prefix
+// table (user:/group:/system:/admin:) and rejects KindUnknown so a bare
+// "alice" or a tenant-qualified "tenant_a:user:alice" is refused with
+// INVALID_ARGUMENT.
+//
+// auth.ParseActor returns a known kind only when the string strictly
+// starts with one of {"user:", "group:", "system:", "admin:"} and has a
+// non-empty id portion; "tenant_a:user:alice" splits on the FIRST colon
+// and yields KindUnknown, which is exactly what we want.
+//
+// Empty strings are rejected by the caller before this function is
+// reached — the callers' empty-check produces a more specific error
+// message.
+func isValidActorString(s string) bool {
+	if s == "" {
+		return false
+	}
+	a := auth.ParseActor(s)
+	switch a.Kind() {
+	case auth.KindUser, auth.KindGroup, auth.KindSystem, auth.KindAdmin:
+		return a.ID() != ""
+	default:
+		return false
+	}
+}
+
+// newIdempotencyKey returns a fresh hex-encoded random key for a WAL
+// event. 16 bytes (= 32 hex chars) is collision-free for the lifetime
+// of the system. Mirrors the Python uuid.uuid4().hex pattern used at
+// grpc_server.py:797 for ExecuteAtomic and similar WAL writers.
+func newIdempotencyKey() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("rand: %w", err)
+	}
+	return hex.EncodeToString(buf[:]), nil
+}

--- a/server/go/internal/api/transfer_ownership_test.go
+++ b/server/go/internal/api/transfer_ownership_test.go
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for the TransferOwnership RPC. Spec:
+// docs/go-port/rpcs/TransferOwnership.md.
+//
+// Behaviour pinned here:
+//   - Owner happy path: trusted actor == current owner_actor → owner
+//     flips to new_owner; node visible to new_owner via canonical SQLite
+//     state; response.found = true.
+//   - Non-owner caller is rejected with codes.PermissionDenied — even
+//     when the caller is "system:" or holds an ACL grant on the node.
+//     This is a Go-side hardening over the Python handler (which only
+//     calls _check_tenant). See package-level doc on transfer_ownership.go.
+//   - Missing node returns codes.NotFound (Go hardens vs. Python's
+//     "found=false, error=''" soft fail).
+//   - Recipient sees the node post-apply: store.GetNode reports the new
+//     owner; node_visibility row exists for the recipient.
+//
+// The tests construct an in-memory wal.Producer + per-tenant
+// CanonicalStore + globalstore so the WAL append path is exercised end
+// to end. The applier is NOT run because the handler synchronously
+// applies the change (the WAL event is the durable record + replay
+// substrate; the in-memory mutation is the handler's own materialise).
+
+package api_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const (
+	xferTenant = "acme"
+	xferNodeID = "node-1"
+	xferOwner  = "user:alice"
+	xferNew    = "user:bob"
+)
+
+// xferFixture wires the dependencies a TransferOwnership handler needs:
+// a globalstore (for the tenant gate), a per-tenant CanonicalStore, an
+// in-memory WAL producer, and a server with all three injected. Returns
+// the fixture and a context with the trusted-actor identity attached.
+type xferFixture struct {
+	srv      *api.Server
+	store    *store.CanonicalStore
+	producer *wal.InMemory
+}
+
+func newXferFixture(t *testing.T) *xferFixture {
+	t.Helper()
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), xferTenant, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(context.Background(), xferTenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	prod := wal.NewInMemory(1)
+	if err := prod.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = prod.Close(context.Background()) })
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithStore(cs),
+		api.WithWALProducer(prod),
+	)
+	return &xferFixture{srv: srv, store: cs, producer: prod}
+}
+
+// seedNode inserts a node with the given owner so each test does not
+// have to repeat the boilerplate. Uses CreateNodeRaw to bypass the WAL
+// (the test isn't exercising create_node — it is exercising the post-
+// create transfer path).
+func (f *xferFixture) seedNode(t *testing.T, nodeID, owner string) {
+	t.Helper()
+	_, err := f.store.CreateNodeRaw(context.Background(), xferTenant, store.NodeInput{
+		NodeID:     nodeID,
+		TypeID:     1,
+		Payload:    map[string]any{"1": "v"},
+		OwnerActor: owner,
+	})
+	if err != nil {
+		t.Fatalf("seed CreateNodeRaw: %v", err)
+	}
+}
+
+// ctxAs returns a context with a trusted Identity for `actor` so
+// auth.Authoritative resolves to the desired caller. Handlers MUST
+// consult this attestation; the wire-claimed actor is informational.
+func ctxAs(actor string) context.Context {
+	id := auth.Identity{Subject: actor, Method: auth.MethodSession}
+	return auth.WithIdentity(context.Background(), id)
+}
+
+// TestTransferOwnership_OwnerHappyPath: the current owner can transfer
+// ownership to a new principal. Post-apply, store.GetNode reports the
+// new owner and node_visibility contains a row for the new owner.
+func TestTransferOwnership_OwnerHappyPath(t *testing.T) {
+	t.Parallel()
+	f := newXferFixture(t)
+	f.seedNode(t, xferNodeID, xferOwner)
+
+	resp, err := f.srv.TransferOwnership(ctxAs(xferOwner), &pb.TransferOwnershipRequest{
+		Context:  &pb.RequestContext{TenantId: xferTenant, Actor: xferOwner},
+		NodeId:   xferNodeID,
+		NewOwner: xferNew,
+	})
+	if err != nil {
+		t.Fatalf("TransferOwnership: unexpected error: %v", err)
+	}
+	if !resp.GetFound() {
+		t.Fatalf("Found=false; want true on happy path")
+	}
+	if resp.GetError() != "" {
+		t.Errorf("unexpected error message: %q", resp.GetError())
+	}
+
+	// Side effect: owner_actor flipped on disk.
+	n, err := f.store.GetNode(context.Background(), xferTenant, xferNodeID)
+	if err != nil {
+		t.Fatalf("post-apply GetNode: %v", err)
+	}
+	if n.OwnerActor != xferNew {
+		t.Errorf("owner_actor = %q; want %q", n.OwnerActor, xferNew)
+	}
+}
+
+// TestTransferOwnership_RecipientSeesNode: post-apply, the new owner
+// has a node_visibility row pointing at the transferred node, so reads
+// keyed by the recipient's principal succeed. This is the
+// "visibility refresh per W1.10" assertion the spec calls out.
+func TestTransferOwnership_RecipientSeesNode(t *testing.T) {
+	t.Parallel()
+	f := newXferFixture(t)
+	f.seedNode(t, xferNodeID, xferOwner)
+
+	if _, err := f.srv.TransferOwnership(ctxAs(xferOwner), &pb.TransferOwnershipRequest{
+		Context:  &pb.RequestContext{TenantId: xferTenant, Actor: xferOwner},
+		NodeId:   xferNodeID,
+		NewOwner: xferNew,
+	}); err != nil {
+		t.Fatalf("TransferOwnership: %v", err)
+	}
+
+	db, err := f.store.AdminDB(xferTenant)
+	if err != nil {
+		t.Fatalf("AdminDB: %v", err)
+	}
+	var seen int
+	row := db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM node_visibility WHERE tenant_id = ? AND node_id = ? AND principal = ?`,
+		xferTenant, xferNodeID, xferNew,
+	)
+	if err := row.Scan(&seen); err != nil && err != sql.ErrNoRows {
+		t.Fatalf("scan node_visibility: %v", err)
+	}
+	if seen != 1 {
+		t.Errorf("node_visibility row count for %q = %d; want 1", xferNew, seen)
+	}
+}
+
+// TestTransferOwnership_NonOwner_PermissionDenied: a caller who is not
+// the current owner gets PermissionDenied — regardless of whether they
+// are a tenant member, hold an ACL grant, or are even a system: actor.
+// This is the Go-side hardening over the Python handler's no-auth path.
+func TestTransferOwnership_NonOwner_PermissionDenied(t *testing.T) {
+	t.Parallel()
+	f := newXferFixture(t)
+	f.seedNode(t, xferNodeID, xferOwner)
+
+	// Caller is "user:eve", not the owner.
+	_, err := f.srv.TransferOwnership(ctxAs("user:eve"), &pb.TransferOwnershipRequest{
+		Context:  &pb.RequestContext{TenantId: xferTenant, Actor: "user:eve"},
+		NodeId:   xferNodeID,
+		NewOwner: xferNew,
+	})
+	if err == nil {
+		t.Fatalf("expected PermissionDenied, got nil error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("code = %v; want PermissionDenied", st.Code())
+	}
+
+	// Confirm side effect: owner_actor unchanged.
+	n, gerr := f.store.GetNode(context.Background(), xferTenant, xferNodeID)
+	if gerr != nil {
+		t.Fatalf("post-deny GetNode: %v", gerr)
+	}
+	if n.OwnerActor != xferOwner {
+		t.Errorf("owner_actor mutated under PermissionDenied: got %q want %q", n.OwnerActor, xferOwner)
+	}
+}
+
+// TestTransferOwnership_PrivilegeEscalation_IgnoresClaimedActor: a
+// caller authenticated as user:eve (via the trusted-actor context)
+// claims actor=user:alice in the request body. The wire-claimed actor
+// MUST be ignored — auth.Authoritative resolves to user:eve and the
+// owner-only gate denies the transfer. Pinned by commit fece3fb.
+func TestTransferOwnership_PrivilegeEscalation_IgnoresClaimedActor(t *testing.T) {
+	t.Parallel()
+	f := newXferFixture(t)
+	f.seedNode(t, xferNodeID, xferOwner)
+
+	_, err := f.srv.TransferOwnership(ctxAs("user:eve"), &pb.TransferOwnershipRequest{
+		Context:  &pb.RequestContext{TenantId: xferTenant, Actor: xferOwner}, // lie!
+		NodeId:   xferNodeID,
+		NewOwner: xferNew,
+	})
+	if err == nil {
+		t.Fatalf("expected PermissionDenied; got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("code = %v; want PermissionDenied", st.Code())
+	}
+}
+
+// TestTransferOwnership_MissingNode_NotFound: the node_id does not
+// exist in the tenant → codes.NotFound. Hardens the Python "found=false,
+// error=''" soft-fail per spec §"Error contract".
+func TestTransferOwnership_MissingNode_NotFound(t *testing.T) {
+	t.Parallel()
+	f := newXferFixture(t)
+	// Note: no seed.
+
+	_, err := f.srv.TransferOwnership(ctxAs(xferOwner), &pb.TransferOwnershipRequest{
+		Context:  &pb.RequestContext{TenantId: xferTenant, Actor: xferOwner},
+		NodeId:   "ghost",
+		NewOwner: xferNew,
+	})
+	if err == nil {
+		t.Fatalf("expected NotFound; got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("not a grpc status: %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v; want NotFound", st.Code())
+	}
+}
+
+// TestTransferOwnership_InvalidArgument_EmptyFields: the three required
+// fields each produce InvalidArgument when empty. Pinned per spec
+// §"Error contract".
+func TestTransferOwnership_InvalidArgument_EmptyFields(t *testing.T) {
+	t.Parallel()
+	f := newXferFixture(t)
+	f.seedNode(t, xferNodeID, xferOwner)
+
+	cases := []struct {
+		name string
+		req  *pb.TransferOwnershipRequest
+	}{
+		{
+			name: "empty tenant_id",
+			req: &pb.TransferOwnershipRequest{
+				Context:  &pb.RequestContext{TenantId: "", Actor: xferOwner},
+				NodeId:   xferNodeID,
+				NewOwner: xferNew,
+			},
+		},
+		{
+			name: "empty node_id",
+			req: &pb.TransferOwnershipRequest{
+				Context:  &pb.RequestContext{TenantId: xferTenant, Actor: xferOwner},
+				NodeId:   "",
+				NewOwner: xferNew,
+			},
+		},
+		{
+			name: "empty new_owner",
+			req: &pb.TransferOwnershipRequest{
+				Context:  &pb.RequestContext{TenantId: xferTenant, Actor: xferOwner},
+				NodeId:   xferNodeID,
+				NewOwner: "",
+			},
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := f.srv.TransferOwnership(ctxAs(xferOwner), c.req)
+			if err == nil {
+				t.Fatalf("expected InvalidArgument; got nil")
+			}
+			st, _ := status.FromError(err)
+			if st.Code() != codes.InvalidArgument {
+				t.Errorf("code = %v; want InvalidArgument", st.Code())
+			}
+		})
+	}
+}
+
+// TestTransferOwnership_InvalidActorString: a tenant-qualified or bare
+// principal in new_owner is rejected with InvalidArgument (the Python
+// handler accepted any string).
+func TestTransferOwnership_InvalidActorString(t *testing.T) {
+	t.Parallel()
+	f := newXferFixture(t)
+	f.seedNode(t, xferNodeID, xferOwner)
+
+	for _, badOwner := range []string{"alice", "tenant_a:user:alice", "weird:foo"} {
+		badOwner := badOwner
+		t.Run(badOwner, func(t *testing.T) {
+			t.Parallel()
+			_, err := f.srv.TransferOwnership(ctxAs(xferOwner), &pb.TransferOwnershipRequest{
+				Context:  &pb.RequestContext{TenantId: xferTenant, Actor: xferOwner},
+				NodeId:   xferNodeID,
+				NewOwner: badOwner,
+			})
+			if err == nil {
+				t.Fatalf("expected InvalidArgument for new_owner=%q; got nil", badOwner)
+			}
+			st, _ := status.FromError(err)
+			if st.Code() != codes.InvalidArgument {
+				t.Errorf("code = %v; want InvalidArgument", st.Code())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Wave-2 RPC port for EPIC #407: `TransferOwnership` lands on the Go gRPC server with WAL-first restoration of CLAUDE.md invariant #1 (the Python handler writes SQLite directly; PLAN.md §6.1 flags this).

The handler:
- validates inputs (kind:id-prefixed `new_owner`; rejects bare or tenant-qualified strings)
- runs `s.checkTenant` (sharding / region / existence)
- rebinds to the trusted actor via `auth.Authoritative` (privilege-escalation fix from #168)
- enforces **current-owner-only** authorization (Go-side hardening over Python's no-auth handler)
- appends a `transfer_ownership` op to the WAL via the shared `wal.Producer`, then synchronously materialises the change in per-tenant SQLite (idempotency-key dedupe in the applier protects the in-flight + replay paths — the applier already dispatches the same op on replay, see W1.10)

## Tests

`transfer_ownership_test.go` (package `api_test`) covers:
- owner happy path (response.found=true; `nodes.owner_actor` flipped)
- recipient visible via `node_visibility` post-apply
- non-owner caller → `PermissionDenied`
- missing node → `NotFound` (Go hardens vs. Python's `found=false, error=""`)
- privilege-escalation regression: claimed actor in request body is ignored when ctx attests a different identity
- empty-field + invalid-actor-string `InvalidArgument` variants

## Drive-by dedupe

Concurrent Wave-2 merges left duplicate `api.userToProto` / `api.lookupMemberRole` / `api_test.withTrustedUser` symbols on `main`, breaking `go vet ./internal/api/...`. This PR moves `withTrustedUser` to `helpers_external_test.go` and dedupes the production helpers so the package builds again — same shape as #429.

## Test plan

- [x] `cd server/go && go vet ./...` clean
- [x] `cd server/go && go test ./...` passes (full suite green)
- [x] `cd server/go && go test -run TransferOwnership -v ./internal/api/` — 10/10 PASS
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529/2529 PASS
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean

Refs #407