### PR TITLE
feat(go-rewrite): ShareNode RPC — Wave 2 (WAL-first restoration)

### DIFF
--- a/server/go/internal/api/share_node.go
+++ b/server/go/internal/api/share_node.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// ShareNode RPC — Wave 2 of the Python → Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/ShareNode.md.
+// Reference Python: server/python/entdb_server/api/grpc_server.py:1746-1826.
+// Applier branch (W1.10): server/go/internal/apply/ops_share_node.go.
+//
+// # WAL-first restoration (PLAN.md §6)
+//
+// The Python ShareNode handler bypasses the WAL (CLAUDE.md invariant
+// #1). It writes directly to canonical_store.share_node(...) at
+// grpc_server.py:1794, which means a materialized-view rebuild from
+// the WAL silently drops every share grant. The Go port restores
+// the invariant: handler appends a `share_node` op to the WAL, the
+// applier (already wired in W1.10 — ops_share_node.go) consumes it
+// and writes node_access. There is no direct CanonicalStore.ShareNode
+// call from this handler.
+//
+// # Auth model — trusted-actor / owner-only
+//
+//  1. checkTenant: sharding ownership + region pinning. Errors from
+//     the gate (UNAVAILABLE w/ redirect, FAILED_PRECONDITION on region
+//     mismatch, NOT_FOUND on missing tenant) propagate unchanged.
+//  2. Trusted-actor rebind: the wire-claimed actor is UNTRUSTED — we
+//     rebind to the interceptor-bound identity via auth.Authoritative.
+//     Privilege-escalation regression pinned by commit fece3fb.
+//  3. ACL pre-check: system: / admin: actors short-circuit allow.
+//     For a user: actor, the caller MUST own the target node. The
+//     full Python flow (_check_capability with CoreCapability.ADMIN
+//     and the share-grant fall-through) is deferred to a follow-up
+//     once the acl.Checker is wired into Server — until then, this
+//     handler enforces the strictly-narrower owner-only branch.
+//     Non-owner / unknown node → soft-fail (OK + success=false).
+//
+// # Error contract (matches Python soft-fail shape)
+//
+// ShareNodeResponse is { success bool, error string } — NOT a
+// google.rpc.Status. The handler returns success=false on
+// PermissionError / unknown-node / WAL append errors instead of
+// aborting with a status code. The ONLY hard-error paths are:
+//
+//	UNIMPLEMENTED           WAL producer / canonical store not wired.
+//	UNAVAILABLE             Tenant not served by this node (gate).
+//	FAILED_PRECONDITION     Region mismatch / tenant archived (gate).
+//	NOT_FOUND               Tenant marked deleted (gate).
+//
+// All other failures route through OK + success=false. This is a
+// deliberate contract pin — flipping to status.Errorf is a wire-
+// contract break (spec §"Error contract").
+//
+// # Side effects
+//
+// On success: a single record is appended to the WAL. The applier
+// then writes one row to node_access (and, for cross-tenant grants,
+// one row to GlobalStore.shared_index via SharedAdded result). NO
+// mailbox fanout — Python doesn't either (spec §"Side effects",
+// open question 2). NO direct SQLite write from this handler.
+//
+// Idempotency: until the proto carries an idempotency_key, retries
+// generate distinct WAL records that collapse at the applier via
+// INSERT OR REPLACE on (node_id, actor_id). Acceptable but noisy;
+// flagged in the spec for the receipt-tracking follow-up.
+//
+// Metrics: emits entdb_grpc_requests_total{method="ShareNode",
+// status="ok"|"denied"|"error"} via the shared chokepoint.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// shareNodeMethod is the RPC label for metrics.
+const shareNodeMethod = "ShareNode"
+
+// shareNodeWALTopic is the topic this handler appends to. Must match
+// the topic the applier subscribes to (cmd/entdb-server/main.go:32
+// default — "entdb-wal"). When Server gains a typed WAL-topic option
+// in a follow-up, swap this constant for s.walTopic.
+const shareNodeWALTopic = "entdb-wal"
+
+// ShareNode appends a share_node op to the WAL. The applier
+// (apply/ops_share_node.go) materialises it into node_access. See
+// the package-level doc for the full contract.
+func (s *Server) ShareNode(
+	ctx context.Context,
+	req *pb.ShareNodeRequest,
+) (*pb.ShareNodeResponse, error) {
+	start := time.Now()
+	status := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(shareNodeMethod, status, time.Since(start))
+	}()
+
+	// Optional-deps guard. The WAL producer is mandatory for ShareNode
+	// because the entire point of this RPC is the WAL append.
+	if s.producer == nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "WAL producer not configured")
+	}
+	// CanonicalStore is needed for the owner pre-check; without it we
+	// cannot enforce auth and refuse to write to the WAL.
+	if s.store == nil {
+		status = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "Canonical store not configured")
+	}
+
+	tenantID := req.GetContext().GetTenantId()
+
+	// 1. Tenant gate (sharding ownership + region pinning). Errors here
+	//    are gRPC status codes; we surface them unchanged.
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		status = "error"
+		return nil, err
+	}
+
+	// 2. Trusted-actor rebind. The wire claim is UNTRUSTED.
+	claimedActor := req.GetContext().GetActor()
+	trusted := auth.Authoritative(ctx, auth.ParseActor(claimedActor))
+	if trusted.IsZero() {
+		status = "denied"
+		return &pb.ShareNodeResponse{Success: false, Error: "actor is required"}, nil
+	}
+
+	// 3. Required-arg validation. Python (grpc_server.py:1746-1826)
+	//    does not pre-validate node_id / actor_id shape — soft-fail
+	//    parity preserved.
+	nodeID := req.GetNodeId()
+	actorID := normalizeActorID(req.GetActorId())
+	if nodeID == "" || actorID == "" {
+		status = "denied"
+		return &pb.ShareNodeResponse{
+			Success: false,
+			Error:   "node_id and actor_id are required",
+		}, nil
+	}
+
+	// 4. ACL pre-check. system: / admin: actors short-circuit allow,
+	//    matching Python's _is_admin_or_system bypass at
+	//    grpc_server.py:498-499 / 341-347. Otherwise, the trusted
+	//    actor MUST own the node. NOT_FOUND on the underlying GetNode
+	//    surfaces as success=false (parity with Python's
+	//    PermissionError-via-missing-node behaviour at spec §Wire-
+	//    contract.NodeId — "existence is not pre-validated, the auth
+	//    check carries the existence signal").
+	if !(trusted.IsSystem() || trusted.IsAdmin()) {
+		node, err := s.store.GetNode(ctx, tenantID, nodeID)
+		if err != nil {
+			if errors.Is(err, errs.ErrNotFound) {
+				// Spec §Wire-contract.NodeId pins this as PERMISSION_DENIED-
+				// shaped (not NOT_FOUND); the Python handler returns
+				// success=false on PermissionError. We follow the soft-
+				// fail contract — a missing node is indistinguishable
+				// from "no grant" to the caller.
+				status = "denied"
+				return &pb.ShareNodeResponse{
+					Success: false,
+					Error:   "permission denied: missing-or-no-grant on node",
+				}, nil
+			}
+			status = "error"
+			return &pb.ShareNodeResponse{Success: false, Error: err.Error()}, nil
+		}
+		if node.OwnerActor != trusted.String() {
+			// Wave-2 narrowing: only owner / system / admin may share.
+			// The full share-grant-grants-share path (a node admin who
+			// is not the owner can re-share) is deferred to the follow-
+			// up that wires acl.Checker into Server.
+			status = "denied"
+			return &pb.ShareNodeResponse{
+				Success: false,
+				Error:   "permission denied: only the node owner can share",
+			}, nil
+		}
+	}
+
+	// 5. Build the WAL op envelope. Mirror the Python applier's
+	//    op shape (apply/ops_share_node.go:18-31). Field defaults:
+	//    actor_type → "user", permission → "read" (spec §Wire-contract).
+	actorType := req.GetActorType()
+	if actorType == "" {
+		actorType = "user"
+	}
+	permission := req.GetPermission()
+	if permission == "" {
+		permission = "read"
+	}
+	coreCaps := make([]int32, 0, len(req.GetCoreCaps()))
+	for _, c := range req.GetCoreCaps() {
+		coreCaps = append(coreCaps, int32(c))
+	}
+	extCaps := append([]int32(nil), req.GetExtCapIds()...)
+
+	// Cross-tenant fan-out hint for the applier's SharedAdded result.
+	// When actor_id is "tenant:<X>" or contains "@tenant:<Y>", record
+	// the recipient + source_tenant so the applier post-commit hook
+	// can write the GlobalStore.shared_index row that ListSharedWithMe
+	// reads (spec §Side-effects.4 / cross-tenant pin
+	// test_cross_tenant_read.py:75-105).
+	userID, sourceTenant := crossTenantHint(actorID, tenantID)
+
+	op := map[string]any{
+		"op":          "share_node",
+		"node_id":     nodeID,
+		"actor_id":    actorID,
+		"actor_type":  actorType,
+		"permission":  permission,
+		"expires_at":  req.GetExpiresAt(),
+		"type_id":     req.GetTypeId(),
+		"core_caps":   coreCaps,
+		"ext_cap_ids": extCaps,
+		"granted_by":  trusted.String(),
+	}
+	if userID != "" {
+		op["user_id"] = userID
+	}
+	if sourceTenant != "" {
+		op["source_tenant"] = sourceTenant
+	}
+
+	idemKey := newShareNodeIdempotencyKey(tenantID, trusted.String(), nodeID, actorID)
+	ev := wal.Event{
+		TenantID:       tenantID,
+		Actor:          trusted.String(),
+		IdempotencyKey: idemKey,
+		Ops:            []map[string]any{op},
+	}
+	value, err := ev.Encode()
+	if err != nil {
+		status = "error"
+		return &pb.ShareNodeResponse{Success: false, Error: err.Error()}, nil
+	}
+
+	headers := map[string][]byte{
+		wal.HeaderIdempotencyKey: []byte(idemKey),
+	}
+	if _, err := s.producer.Append(ctx, shareNodeWALTopic, tenantID, value, headers); err != nil {
+		status = "error"
+		return &pb.ShareNodeResponse{Success: false, Error: err.Error()}, nil
+	}
+
+	return &pb.ShareNodeResponse{Success: true}, nil
+}
+
+// normalizeActorID rewrites a bare "<id>" form to "user:<id>". Mirrors
+// the Python normalisation at grpc_server.py:1772-1778 and the proto
+// comment at entdb.proto:723-725. Already-prefixed ids
+// (user:/group:/system:/admin:/service:/tenant:) pass through
+// unchanged.
+func normalizeActorID(s string) string {
+	if s == "" {
+		return ""
+	}
+	for _, prefix := range []string{
+		"user:", "group:", "system:", "admin:", "service:", "tenant:",
+	} {
+		if strings.HasPrefix(s, prefix) {
+			return s
+		}
+	}
+	return "user:" + s
+}
+
+// crossTenantHint extracts (userID, sourceTenant) from an actor_id
+// when it represents a cross-tenant grantee. Returns ("", "") for
+// same-tenant grants. The applier consumes these via op["user_id"] /
+// op["source_tenant"] to populate GlobalStore.shared_index
+// (apply/ops_share_node.go:74-83).
+//
+// Today: only tenant:<id> recipients are surfaced (the
+// "user:<id>@tenant:<Y>" form is not part of the proto contract yet).
+// The applier post-commit hook does the per-member group expansion.
+func crossTenantHint(actorID, sourceTenant string) (userID, src string) {
+	if strings.HasPrefix(actorID, "tenant:") {
+		return strings.TrimPrefix(actorID, "tenant:"), sourceTenant
+	}
+	if strings.HasPrefix(actorID, "user:") {
+		// Same-tenant user: grants do NOT need shared_index — the
+		// recipient discovers the grant via node_access in their own
+		// tenant. Return zero values.
+		return "", ""
+	}
+	return "", ""
+}
+
+// newShareNodeIdempotencyKey builds a deterministic dedupe key from
+// the (tenant, granter, node, recipient) tuple plus a wall-clock
+// nanosecond suffix. The suffix is what makes retries de-duplicate
+// (the applier collapses via INSERT OR REPLACE) but distinct user-
+// driven re-shares still land. Mirrors spec §Side-effects: "Re-issuing
+// the same ShareNode produces an INSERT OR REPLACE that updates
+// granted_at." When the proto gains an idempotency_key field
+// (#407 follow-up), prefer the caller-supplied value over this
+// derived form.
+func newShareNodeIdempotencyKey(tenantID, granter, nodeID, recipient string) string {
+	return strings.Join([]string{
+		"share_node",
+		tenantID,
+		granter,
+		nodeID,
+		recipient,
+		time.Now().UTC().Format(time.RFC3339Nano),
+	}, "|")
+}

--- a/server/go/internal/api/share_node_test.go
+++ b/server/go/internal/api/share_node_test.go
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for the ShareNode RPC. Spec: docs/go-port/rpcs/ShareNode.md.
+// Behavioural pins (mirror Python contract suite):
+//
+//   - Owner-as-trusted-actor happy path (test_grpc_contract.py:327-338).
+//   - Non-owner / non-admin → soft-fail success=false, error contains
+//     "permission denied" (Python: PermissionError → success=false at
+//     grpc_server.py:1791-1793).
+//   - Unknown node id → soft-fail success=false (spec §Wire-contract.NodeId
+//     "auth check carries the existence signal").
+//   - Idempotent re-share: two ShareNode calls with the same shape both
+//     succeed; the WAL records two events but the applier collapses
+//     them via INSERT OR REPLACE (canonical_store.py:2989).
+//   - Cross-tenant recipient (tenant:<id>) lands a user_id /
+//     source_tenant hint into the WAL op so the applier can populate
+//     GlobalStore.shared_index (spec §Side-effects.4 / cross-tenant pin
+//     test_cross_tenant_read.py:75-105). This is the closest analogue
+//     to a "recipient mailbox flag" — ShareNode does NOT fan a
+//     notification into the recipient's mailbox today (spec §Side-
+//     effects "Mailbox fanout: ShareNode does NOT currently fan a
+//     notification into the recipient's mailbox SQLite").
+
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// shareNodeFixture wires a Server with a CanonicalStore + GlobalStore +
+// in-memory WAL producer, opens one tenant, and seeds one node owned by
+// "user:alice". Returns (server, producer, ctx) so tests can assert
+// against the WAL contents directly.
+func shareNodeFixture(t *testing.T) (*api.Server, *wal.InMemory, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	if err := cs.OpenTenant(ctx, "acme"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if _, err := cs.CreateNodeRaw(ctx, "acme", store.NodeInput{
+		NodeID:     "doc-1",
+		TypeID:     7,
+		Payload:    map[string]any{"1": "hello"},
+		OwnerActor: "user:alice",
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	producer := wal.NewInMemory(0)
+	if err := producer.Connect(ctx); err != nil {
+		t.Fatalf("producer.Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = producer.Close(ctx) })
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithGlobalStore(gs),
+		api.WithWALProducer(producer),
+	)
+	return srv, producer, ctx
+}
+
+// shareNodeOps reads every record on the WAL "entdb-wal" topic, decodes
+// the events, and returns their op slices in order. Used to assert the
+// shape of what the handler appended.
+func shareNodeOps(t *testing.T, p *wal.InMemory) [][]map[string]any {
+	t.Helper()
+	recs, err := p.PollBatch(context.Background(), "entdb-wal", "test-reader", 64, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("PollBatch: %v", err)
+	}
+	out := make([][]map[string]any, 0, len(recs))
+	for _, r := range recs {
+		ev, err := wal.DecodeEvent(r.Value)
+		if err != nil {
+			t.Fatalf("DecodeEvent: %v", err)
+		}
+		out = append(out, ev.Ops)
+	}
+	return out
+}
+
+// TestShareNode_OwnerHappyPath: alice (the node owner) shares doc-1
+// with user:bob. Response is success=true; one record lands on the WAL
+// with op="share_node" and the expected fields. Mirrors
+// test_grpc_contract.py:327-338.
+func TestShareNode_OwnerHappyPath(t *testing.T) {
+	t.Parallel()
+
+	srv, producer, ctx := shareNodeFixture(t)
+
+	resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+		Context: &pb.RequestContext{
+			TenantId: "acme",
+			Actor:    "user:alice",
+		},
+		NodeId:     "doc-1",
+		ActorId:    "user:bob",
+		Permission: "read",
+	})
+	if err != nil {
+		t.Fatalf("ShareNode: unexpected gRPC error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("ShareNode: success=false, error=%q; want success=true", resp.GetError())
+	}
+	if resp.GetError() != "" {
+		t.Errorf("ShareNode: unexpected error message %q", resp.GetError())
+	}
+
+	ops := shareNodeOps(t, producer)
+	if len(ops) != 1 {
+		t.Fatalf("WAL records: got %d, want 1", len(ops))
+	}
+	if len(ops[0]) != 1 {
+		t.Fatalf("ops in record 0: got %d, want 1", len(ops[0]))
+	}
+	op := ops[0][0]
+	if op["op"] != "share_node" {
+		t.Errorf("op type = %q; want %q", op["op"], "share_node")
+	}
+	if op["node_id"] != "doc-1" {
+		t.Errorf("op.node_id = %q; want %q", op["node_id"], "doc-1")
+	}
+	if op["actor_id"] != "user:bob" {
+		t.Errorf("op.actor_id = %q; want %q", op["actor_id"], "user:bob")
+	}
+	if op["actor_type"] != "user" {
+		t.Errorf("op.actor_type = %q; want %q", op["actor_type"], "user")
+	}
+	if op["permission"] != "read" {
+		t.Errorf("op.permission = %q; want %q", op["permission"], "read")
+	}
+	if op["granted_by"] != "user:alice" {
+		t.Errorf("op.granted_by = %q; want %q", op["granted_by"], "user:alice")
+	}
+}
+
+// TestShareNode_BareActorIDNormalized: a bare "<id>" recipient is
+// rewritten to "user:<id>" before the WAL append, mirroring
+// entdb.proto:723-725 and grpc_server.py:1772-1778.
+func TestShareNode_BareActorIDNormalized(t *testing.T) {
+	t.Parallel()
+
+	srv, producer, ctx := shareNodeFixture(t)
+
+	resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+		Context: &pb.RequestContext{TenantId: "acme", Actor: "user:alice"},
+		NodeId:  "doc-1",
+		ActorId: "bob", // bare form
+	})
+	if err != nil {
+		t.Fatalf("ShareNode: unexpected gRPC error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("ShareNode: success=false, error=%q", resp.GetError())
+	}
+
+	ops := shareNodeOps(t, producer)
+	if len(ops) != 1 {
+		t.Fatalf("WAL records: got %d, want 1", len(ops))
+	}
+	if got := ops[0][0]["actor_id"]; got != "user:bob" {
+		t.Errorf("normalised actor_id = %q; want %q", got, "user:bob")
+	}
+}
+
+// TestShareNode_NonOwnerSoftFail: a user: actor that does NOT own the
+// node receives success=false with a "permission denied" error, NOT a
+// gRPC PERMISSION_DENIED status. Mirrors the soft-fail shape pinned by
+// spec §Error-contract.
+func TestShareNode_NonOwnerSoftFail(t *testing.T) {
+	t.Parallel()
+
+	srv, producer, ctx := shareNodeFixture(t)
+
+	resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+		Context: &pb.RequestContext{TenantId: "acme", Actor: "user:carol"},
+		NodeId:  "doc-1",
+		ActorId: "user:bob",
+	})
+	if err != nil {
+		t.Fatalf("ShareNode: unexpected gRPC error: %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatalf("ShareNode (non-owner): success=true; want false")
+	}
+	if !strings.Contains(resp.GetError(), "permission denied") {
+		t.Errorf("error = %q; want substring %q", resp.GetError(), "permission denied")
+	}
+
+	// No record should have been appended on the deny path.
+	if ops := shareNodeOps(t, producer); len(ops) != 0 {
+		t.Errorf("WAL: %d records appended on deny; want 0", len(ops))
+	}
+}
+
+// TestShareNode_UnknownNodeSoftFail: sharing a node that does not exist
+// returns success=false (no PermissionError leaks; spec
+// §Wire-contract.NodeId "auth check carries the existence signal").
+// Crucially, NO record is appended to the WAL — the handler must not
+// pollute the log with un-applicable events.
+func TestShareNode_UnknownNodeSoftFail(t *testing.T) {
+	t.Parallel()
+
+	srv, producer, ctx := shareNodeFixture(t)
+
+	resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+		Context: &pb.RequestContext{TenantId: "acme", Actor: "user:alice"},
+		NodeId:  "ghost",
+		ActorId: "user:bob",
+	})
+	if err != nil {
+		t.Fatalf("ShareNode: unexpected gRPC error: %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Errorf("ShareNode (unknown node): success=true; want false")
+	}
+	if resp.GetError() == "" {
+		t.Errorf("ShareNode (unknown node): empty error message; want a permission/missing-grant note")
+	}
+	if ops := shareNodeOps(t, producer); len(ops) != 0 {
+		t.Errorf("WAL: %d records appended on unknown-node deny; want 0", len(ops))
+	}
+}
+
+// TestShareNode_AdminBypass: an admin: actor may share any node it does
+// not own. Mirrors the system/admin short-circuit at
+// grpc_server.py:498-499 / 341-347.
+func TestShareNode_AdminBypass(t *testing.T) {
+	t.Parallel()
+
+	srv, _, ctx := shareNodeFixture(t)
+
+	resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+		Context: &pb.RequestContext{TenantId: "acme", Actor: "admin:root"},
+		NodeId:  "doc-1",
+		ActorId: "user:bob",
+	})
+	if err != nil {
+		t.Fatalf("ShareNode (admin): unexpected gRPC error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("ShareNode (admin): success=false, error=%q", resp.GetError())
+	}
+}
+
+// TestShareNode_IdempotentReshare: re-sharing the same (node, recipient)
+// tuple twice each returns success=true. The applier collapses the two
+// records via INSERT OR REPLACE — pinned at the handler level by simply
+// not failing on the second call. Spec §Side-effects: "Re-issuing the
+// same ShareNode produces an INSERT OR REPLACE that updates
+// granted_at."
+func TestShareNode_IdempotentReshare(t *testing.T) {
+	t.Parallel()
+
+	srv, producer, ctx := shareNodeFixture(t)
+
+	for i, perm := range []string{"read", "write"} {
+		resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+			Context:    &pb.RequestContext{TenantId: "acme", Actor: "user:alice"},
+			NodeId:     "doc-1",
+			ActorId:    "user:bob",
+			Permission: perm,
+		})
+		if err != nil {
+			t.Fatalf("iter %d: ShareNode: %v", i, err)
+		}
+		if !resp.GetSuccess() {
+			t.Fatalf("iter %d: success=false, error=%q", i, resp.GetError())
+		}
+	}
+
+	// Both records should appear on the WAL — the handler appends one
+	// per call. Applier-side dedupe is applier_test territory.
+	ops := shareNodeOps(t, producer)
+	if len(ops) != 2 {
+		t.Fatalf("WAL records: got %d, want 2 (handler does not dedupe; applier does)", len(ops))
+	}
+	if ops[0][0]["permission"] != "read" || ops[1][0]["permission"] != "write" {
+		t.Errorf("permissions in order: %q,%q; want read,write",
+			ops[0][0]["permission"], ops[1][0]["permission"])
+	}
+}
+
+// TestShareNode_CrossTenantRecipient: sharing with a "tenant:<X>"
+// recipient surfaces user_id + source_tenant hints in the op so the
+// applier can populate GlobalStore.shared_index. This is the closest
+// proxy for "recipient mailbox flag" — ShareNode does NOT fan a true
+// mailbox notification (spec §Side-effects "Mailbox fanout: ShareNode
+// does NOT currently fan a notification into the recipient's mailbox
+// SQLite"); the WAL hint is what makes ListSharedWithMe see the share.
+// Cross-tenant pin: test_cross_tenant_read.py:75-105.
+func TestShareNode_CrossTenantRecipient(t *testing.T) {
+	t.Parallel()
+
+	srv, producer, ctx := shareNodeFixture(t)
+
+	resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+		Context: &pb.RequestContext{TenantId: "acme", Actor: "user:alice"},
+		NodeId:  "doc-1",
+		ActorId: "tenant:globex",
+	})
+	if err != nil {
+		t.Fatalf("ShareNode: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("ShareNode (cross-tenant): success=false, error=%q", resp.GetError())
+	}
+
+	ops := shareNodeOps(t, producer)
+	if len(ops) != 1 {
+		t.Fatalf("WAL records: got %d, want 1", len(ops))
+	}
+	op := ops[0][0]
+	if op["actor_id"] != "tenant:globex" {
+		t.Errorf("op.actor_id = %q; want %q", op["actor_id"], "tenant:globex")
+	}
+	if op["user_id"] != "globex" {
+		t.Errorf("op.user_id (cross-tenant hint) = %q; want %q", op["user_id"], "globex")
+	}
+	if op["source_tenant"] != "acme" {
+		t.Errorf("op.source_tenant (cross-tenant hint) = %q; want %q", op["source_tenant"], "acme")
+	}
+}
+
+// TestShareNode_TypedCapsPersistedVerbatim: when CoreCaps and ExtCapIds
+// are populated on the request, they must reach the WAL op verbatim
+// (spec contract pin test_acl_capabilities.py:60-82). Numeric values
+// arrive as JSON numbers (float64) on the consumer side — the test
+// asserts the encoded form rather than the typed slice.
+func TestShareNode_TypedCapsPersistedVerbatim(t *testing.T) {
+	t.Parallel()
+
+	srv, producer, ctx := shareNodeFixture(t)
+
+	resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+		Context: &pb.RequestContext{TenantId: "acme", Actor: "user:alice"},
+		NodeId:  "doc-1",
+		ActorId: "user:bob",
+		CoreCaps: []pb.CoreCapability{
+			pb.CoreCapability_CORE_CAP_READ,
+			pb.CoreCapability_CORE_CAP_EDIT,
+		},
+		ExtCapIds: []int32{42, 99},
+	})
+	if err != nil {
+		t.Fatalf("ShareNode: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("ShareNode: success=false, error=%q", resp.GetError())
+	}
+
+	ops := shareNodeOps(t, producer)
+	if len(ops) != 1 {
+		t.Fatalf("WAL records: got %d, want 1", len(ops))
+	}
+	core, _ := json.Marshal(ops[0][0]["core_caps"])
+	ext, _ := json.Marshal(ops[0][0]["ext_cap_ids"])
+	// JSON numbers → float64, so we compare the encoded form.
+	if string(core) != "[1,3]" {
+		t.Errorf("op.core_caps JSON = %s; want [1,3]", core)
+	}
+	if string(ext) != "[42,99]" {
+		t.Errorf("op.ext_cap_ids JSON = %s; want [42,99]", ext)
+	}
+}
+
+// TestShareNode_NoProducerUnimplemented: when the WAL producer is not
+// wired, the handler aborts with UNIMPLEMENTED (spec §Implementation —
+// the handler refuses to bypass the WAL).
+func TestShareNode_NoProducerUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New() // no WithWALProducer / WithStore
+
+	_, err := srv.ShareNode(context.Background(), &pb.ShareNodeRequest{
+		Context: &pb.RequestContext{TenantId: "acme", Actor: "user:alice"},
+		NodeId:  "doc-1",
+		ActorId: "user:bob",
+	})
+	if err == nil {
+		t.Fatalf("ShareNode: expected UNIMPLEMENTED, got nil")
+	}
+	if got := errs.Code(err); got != codes.Unimplemented {
+		t.Fatalf("ShareNode: code = %v; want Unimplemented (err=%v)", got, err)
+	}
+}
+
+// TestShareNode_EmptyNodeOrActorSoftFail: empty node_id or actor_id
+// surface as soft-fail success=false rather than INVALID_ARGUMENT —
+// matches Python's "no shape validation" behaviour (spec §Error-
+// contract: "Python doesn't validate node_id/actor_id shape today").
+func TestShareNode_EmptyNodeOrActorSoftFail(t *testing.T) {
+	t.Parallel()
+
+	srv, _, ctx := shareNodeFixture(t)
+
+	for _, tc := range []struct {
+		name    string
+		nodeID  string
+		actorID string
+	}{
+		{"empty-node", "", "user:bob"},
+		{"empty-actor", "doc-1", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+				Context: &pb.RequestContext{TenantId: "acme", Actor: "user:alice"},
+				NodeId:  tc.nodeID,
+				ActorId: tc.actorID,
+			})
+			if err != nil {
+				t.Fatalf("ShareNode: unexpected gRPC error: %v", err)
+			}
+			if resp.GetSuccess() {
+				t.Fatalf("ShareNode: success=true; want false")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `entdb.v1.EntDBService/ShareNode` in the Go server port (EPIC #407).
- Restores CLAUDE.md invariant #1 (all writes through the WAL): the Python handler at `grpc_server.py:1794` writes `node_access` directly, silently losing share grants on a materialized-view rebuild. The Go handler now appends a `share_node` op to the WAL; the applier branch added in W1.10 (`server/go/internal/apply/ops_share_node.go`) materialises it.
- Auth model: trusted-actor with admin/system bypass + owner-only for user actors. Full `acl.Checker`-driven share-grant-grants-share fall-through is deferred until `acl.Checker` is wired into `Server` (follow-up).
- Soft-fail wire shape preserved (success=false, error=...) per spec — denials, unknown nodes, and WAL append errors do NOT abort with a gRPC status code.
- Cross-tenant `tenant:<X>` recipients surface user_id + source_tenant hints into the WAL op so the applier can write `GlobalStore.shared_index` post-commit (preserves `test_cross_tenant_read.py:75-105`).

Spec: [docs/go-port/rpcs/ShareNode.md](../blob/main/docs/go-port/rpcs/ShareNode.md)
Plan: [docs/go-port/PLAN.md §6](../blob/main/docs/go-port/PLAN.md) (WAL-first restorations)
Refs: #407

### Build-unblock side effect

Three accidental redeclarations landed on `origin/main` from concurrent W2 PRs and broke the `api`-package build for every subsequent W2 worktree. This PR dedupes them in the same diff so it can compile + test cleanly:

- `userToProto` (get_user.go vs list_users.go) — kept the nil-safe copy.
- `(*Server).lookupMemberRole` (add_tenant_member.go vs change_member_role.go) — kept the simpler copy.
- `withTrustedUser` (get_tenant_quota_test.go vs update_user_test.go) — kept the session-method copy (auth.Authoritative ignores Method).

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test ./...` passes (16/16 packages).
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed.
- [x] `uvx ruff@0.15.7 check .` clean.
- [x] `uvx ruff@0.15.7 format --check .` clean.
- [x] New tests cover: owner happy path, bare-actor normalisation, non-owner soft-fail (no WAL pollution), unknown-node soft-fail (no WAL pollution), admin bypass, idempotent re-share, cross-tenant recipient hint, typed CoreCaps + ExtCapIds round-trip, missing-producer UNIMPLEMENTED, empty node/actor soft-fail.
- [x] No changes to `_go_parity.py` or `server.go` — the `ExecuteAtomic` Unimplemented canary in `server_test.go` still passes.