### PR TITLE
feat(go-rewrite): GetNode RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_node.go
+++ b/server/go/internal/api/get_node.go
@@ -1,0 +1,380 @@
+// GetNode RPC — Wave 2 of the Python -> Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/GetNode.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:55 (rpc), :394-407
+// (request/response), :454-472 (Node). Reference Python handler:
+// server/python/entdb_server/api/grpc_server.py:994-1064.
+//
+// Semantics (preserved from the Python handler):
+//
+//   - Read-only single-node lookup keyed on (tenant_id, node_id). Per
+//     the spec, type_id on the request is ACCEPTED but NOT used to
+//     filter the lookup — bug-for-bug parity with Python's
+//     `canonical_store.get_node(tenant, node_id)` chokepoint
+//     (`grpc_server.py:1029-1031`). Flagged as a follow-up in the spec
+//     "Open questions / risks" section.
+//
+//   - Trusted-actor pattern (CLAUDE.md, commit fece3fb): the wire
+//     `request.context.actor` is UNTRUSTED. We resolve identity via
+//     `auth.Authoritative` and ignore the wire claim for any auth
+//     decision. Pinned by
+//     tests/python/integration/test_privilege_escalation.py:186-209.
+//
+//   - NOT_FOUND wins over PERMISSION_DENIED. The handler runs the
+//     tenant gate, then determines the caller's role
+//     (local/member/cross_tenant), then looks up the row. If the row
+//     does not exist we return `&pb.GetNodeResponse{Found: false}` with
+//     gRPC status OK — Python contract pin
+//     test_grpc_contract.py:217-222 (`r.found is False`).
+//     PERMISSION_DENIED is reserved for the case where the caller is
+//     not a tenant member at all (fires before lookup; spec
+//     "Error contract" — non-members cannot probe for node existence)
+//     OR where the row EXISTS and a cross-tenant caller lacks an
+//     explicit per-node grant.
+//
+//   - Cross-tenant role check. When the caller is not a tenant member
+//     but DOES have at least one node_access row in the tenant, role
+//     becomes "cross_tenant" (Python `_check_cross_tenant_read`). The
+//     per-node ACL is then re-checked against the specific node_id
+//     post-lookup, mirroring Python's two-step at
+//     `grpc_server.py:561-618` + `:1031-1045`.
+//
+//   - Payload egress is id-keyed (CLAUDE.md invariant #6). The wire
+//     Struct has stringified field_id keys ("1", "2", ...); SDK
+//     translates id -> name on the client side. Pinned by
+//     test_payload_wire_format.py:158-189.
+//
+//   - `after_offset` + `wait_timeout_ms` provide read-after-write
+//     consistency by waiting for the WAL applier to reach a stream
+//     position before reading. Default 30s when wait_timeout_ms == 0.
+//     Wait failures are silent (Python parity at
+//     `grpc_server.py:1015-1020`).
+//
+//   - Unlike Python, we do NOT swallow uncaught exceptions into
+//     found=false. The Python handler's outer try/except is a
+//     defensive artifact unreachable in real grpc.aio runtime (where
+//     context.abort is terminal). In Go, gRPC errors are returned as
+//     real status codes. See spec "Quirk to preserve".
+//
+// No WAL append, no SQLite write.
+
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/payload"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+const getNodeMethod = "GetNode"
+
+// readRole captures the outcome of the cross-tenant read-membership
+// check. Mirrors the Python sentinels at `_check_cross_tenant_read`
+// (server/python/entdb_server/api/grpc_server.py:561-618).
+type readRole int
+
+const (
+	// roleLocal is the back-compat path when no global_store is wired.
+	// Skips all membership checks; matches Python's
+	// `if self.global_store is None: return "local"` (`:570-571`).
+	roleLocal readRole = iota
+	// roleMember means the caller is either a tenant member or a
+	// system / admin actor. Same as Python `"member"` (`:582-589`).
+	roleMember
+	// roleCrossTenant means the caller is not a member but has at
+	// least one node_access row in the tenant. The handler must then
+	// re-check the specific node_id post-lookup. Same as Python
+	// `"cross_tenant"` (`:597-617`).
+	roleCrossTenant
+)
+
+// GetNode implements entdb.v1.EntDBService/GetNode. See file header
+// for the full contract.
+func (s *Server) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNodeResponse, error) {
+	start := time.Now()
+	resultStatus := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(getNodeMethod, resultStatus, time.Since(start))
+	}()
+
+	if s.store == nil {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "GetNode: store not wired")
+	}
+
+	tenantID := req.GetContext().GetTenantId()
+	nodeID := req.GetNodeId()
+	if nodeID == "" {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "GetNode: node_id is required")
+	}
+
+	// 1. Tenant gate — sharding redirect, region pin, existence.
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
+	// 2. Trusted actor — wire claim is ignored for any auth decision
+	//    (privilege-escalation guard, commit fece3fb).
+	actor := auth.Authoritative(ctx, auth.ParseActor(req.GetContext().GetActor()))
+
+	// 3. Make sure the per-tenant DB exists. Mirrors Python's
+	//    auto-open via `_get_connection(tenant_id)` at
+	//    canonical_store.py:2306. CheckTenant has already vetted the
+	//    tenant id; this just lazy-creates the tenant_<id>.db file
+	//    and is a precondition for both the cross-tenant ACL probe
+	//    and the GetNode read below.
+	if err := s.store.OpenTenant(ctx, tenantID); err != nil {
+		resultStatus = "error"
+		return nil, errs.Errorf(errs.Code(err), "GetNode: open tenant: %v", err)
+	}
+
+	// 4. Cross-tenant read membership check. PERMISSION_DENIED here
+	//    fires BEFORE the row lookup, so non-members cannot probe for
+	//    node existence (spec "Error contract" / Python `:1024-1025`).
+	role, err := s.checkCrossTenantRead(ctx, tenantID, actor)
+	if err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
+	// 5. Optional read-after-write barrier. Failures are silent — the
+	//    handler proceeds with a stale read. Mirrors Python's
+	//    `_wait_for_offset` returning a bool that GetNode discards
+	//    (`grpc_server.py:1015-1020`).
+	if off := req.GetAfterOffset(); off != "" {
+		timeout := 30 * time.Second
+		if ms := req.GetWaitTimeoutMs(); ms > 0 {
+			timeout = time.Duration(ms) * time.Millisecond
+		}
+		waitCtx, cancel := context.WithTimeout(ctx, timeout)
+		_ = s.store.WaitForOffset(waitCtx, tenantID, parseStreamOffset(off))
+		cancel()
+	}
+
+	// 6. The actual read. Missing -> Found=false with status OK. Per
+	//    spec, type_id is NOT used as a filter (Python parity).
+	n, err := s.store.GetNode(ctx, tenantID, nodeID)
+	if err != nil {
+		if errors.Is(err, store.ErrNodeNotFound) {
+			return &pb.GetNodeResponse{Found: false}, nil
+		}
+		resultStatus = "error"
+		return nil, errs.Errorf(errs.Code(err), "GetNode: %v", err)
+	}
+
+	// 7. Cross-tenant per-node ACL re-check. The role test above only
+	//    confirmed the actor has SOME access in the tenant; now we
+	//    confirm the specific node grants them read. This fires AFTER
+	//    the row lookup, so it returns PERMISSION_DENIED, not the
+	//    found=false signal a non-member would see — matching Python
+	//    `:1041-1045`.
+	if role == roleCrossTenant {
+		ok, err := s.hasNodeAccess(ctx, tenantID, nodeID, actor.String())
+		if err != nil {
+			resultStatus = "error"
+			return nil, errs.Errorf(errs.Code(err), "GetNode: %v", err)
+		}
+		if !ok {
+			resultStatus = "error"
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"Actor does not have access to this node")
+		}
+	}
+
+	// 8. Translate the storage row into the wire Node. The payload
+	//    stays id-keyed (CLAUDE.md invariant #6) — translation is a
+	//    zero-translation wrap via payload.PayloadToStruct.
+	wire, err := nodeToProto(s.registry, n)
+	if err != nil {
+		resultStatus = "error"
+		return nil, errs.Errorf(errs.Code(err), "GetNode: encode payload: %v", err)
+	}
+	return &pb.GetNodeResponse{Found: true, Node: wire}, nil
+}
+
+// checkCrossTenantRead returns the caller's read role within tenantID.
+// Mirrors Python `_check_cross_tenant_read` at
+// server/python/entdb_server/api/grpc_server.py:561-618.
+//
+// Resolution order:
+//
+//  1. global_store == nil => roleLocal (back-compat path). Skips
+//     membership entirely.
+//  2. system / admin actors => roleMember (system bypass).
+//  3. IsMember(tenant, user_id) => roleMember.
+//  4. Any node_access row in the tenant for this actor =>
+//     roleCrossTenant.
+//  5. Otherwise => PERMISSION_DENIED.
+func (s *Server) checkCrossTenantRead(ctx context.Context, tenantID string, a auth.Actor) (readRole, error) {
+	if s.global == nil {
+		return roleLocal, nil
+	}
+	if a.IsSystem() || a.IsAdmin() {
+		return roleMember, nil
+	}
+	if a.IsZero() {
+		return 0, errs.Errorf(codes.PermissionDenied,
+			"GetNode: actor lacks access to tenant %q", tenantID)
+	}
+
+	// Membership check. global_store stores user_ids by their bare
+	// SDK identifier (e.g. "alice"), so we strip the "user:" prefix
+	// before consulting it.
+	if a.IsUser() {
+		ok, err := s.global.IsMember(ctx, tenantID, a.ID())
+		if err != nil {
+			return 0, fmt.Errorf("GetNode: IsMember: %w", err)
+		}
+		if ok {
+			return roleMember, nil
+		}
+	}
+
+	// Cross-tenant: any node_access grant in this tenant for the
+	// canonical actor string is enough to upgrade to "cross_tenant".
+	any, err := s.hasAnyNodeAccess(ctx, tenantID, a.String())
+	if err != nil {
+		return 0, err
+	}
+	if any {
+		return roleCrossTenant, nil
+	}
+	return 0, errs.Errorf(codes.PermissionDenied,
+		"GetNode: actor lacks access to tenant %q", tenantID)
+}
+
+// hasAnyNodeAccess returns true if there is at least one non-deny,
+// non-expired node_access row in tenantID granted to actorID. Mirrors
+// the Python "has_node_access" probe inside
+// `_check_cross_tenant_read` (`grpc_server.py:610-617`).
+func (s *Server) hasAnyNodeAccess(ctx context.Context, tenantID, actorID string) (bool, error) {
+	db, err := s.store.AdminDB(tenantID)
+	if err != nil {
+		return false, fmt.Errorf("GetNode: admin db: %w", err)
+	}
+	now := time.Now().UnixMilli()
+	var one int
+	err = db.QueryRowContext(ctx, `
+		SELECT 1 FROM node_access
+		WHERE actor_id = ?
+		  AND permission != 'deny'
+		  AND (expires_at IS NULL OR expires_at > ?)
+		LIMIT 1`, actorID, now).Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("GetNode: query node_access: %w", err)
+	}
+	return true, nil
+}
+
+// hasNodeAccess returns true if actorID has a non-deny, non-expired
+// node_access grant on (tenantID, nodeID). Mirrors a slim slice of
+// `canonical_store.can_access` (`canonical_store.py:2867-2946`) — for
+// W2 GetNode parity the read predicate "any non-deny grant" is
+// sufficient (Python `:1041-1045` calls `can_access(node_id, actor,
+// "read")` which collapses to the same SQL when no typed caps are
+// registered for the type).
+func (s *Server) hasNodeAccess(ctx context.Context, tenantID, nodeID, actorID string) (bool, error) {
+	db, err := s.store.AdminDB(tenantID)
+	if err != nil {
+		return false, fmt.Errorf("GetNode: admin db: %w", err)
+	}
+	now := time.Now().UnixMilli()
+	var one int
+	err = db.QueryRowContext(ctx, `
+		SELECT 1 FROM node_access
+		WHERE node_id = ? AND actor_id = ?
+		  AND permission != 'deny'
+		  AND (expires_at IS NULL OR expires_at > ?)
+		LIMIT 1`, nodeID, actorID, now).Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("GetNode: query node_access: %w", err)
+	}
+	return true, nil
+}
+
+// nodeToProto translates a store.Node into the wire pb.Node, including
+// id-keyed payload egress per CLAUDE.md invariant #6. The payload is
+// wrapped via payload.PayloadToStruct so kind-aware coercions
+// (BYTES -> base64, INTEGER -> float64) are handled centrally.
+//
+// The on-disk payload_json is keyed by string field_id ("1", "2"); we
+// re-key to uint32 before handing it to PayloadToStruct (which expects
+// a uint32-keyed map). When reg is nil OR has no entry for type_id
+// the Struct round-trip is a schema-less passthrough — that's the
+// path unit tests with no Registry exercise.
+func nodeToProto(reg *schema.Registry, n *store.Node) (*pb.Node, error) {
+	out := &pb.Node{
+		TenantId:   n.TenantID,
+		NodeId:     n.NodeID,
+		TypeId:     n.TypeID,
+		CreatedAt:  n.CreatedAt,
+		UpdatedAt:  n.UpdatedAt,
+		OwnerActor: n.OwnerActor,
+	}
+
+	rawPayload := map[string]any{}
+	if n.PayloadJSON != "" {
+		if err := json.Unmarshal([]byte(n.PayloadJSON), &rawPayload); err != nil {
+			return nil, fmt.Errorf("decode payload_json: %w", err)
+		}
+	}
+	idKeyed := make(map[uint32]any, len(rawPayload))
+	for k, v := range rawPayload {
+		id, perr := strconv.ParseUint(k, 10, 32)
+		if perr != nil {
+			// Non-digit key on disk is unexpected; skip silently
+			// rather than corrupting the wire response. Matches
+			// Python's id_to_name_keys passthrough where an
+			// unparseable key falls into the decimal-string bucket.
+			continue
+		}
+		idKeyed[uint32(id)] = v
+	}
+
+	typeName := ""
+	if reg != nil {
+		if nt := reg.NodeTypeByID(n.TypeID); nt != nil {
+			typeName = nt.Name
+		}
+	}
+	wire, err := payload.PayloadToStruct(reg, typeName, idKeyed)
+	if err != nil {
+		return nil, fmt.Errorf("encode payload: %w", err)
+	}
+	out.Payload = wire
+
+	if n.ACLJSON != "" && n.ACLJSON != "[]" {
+		var entries []store.ACLEntry
+		if err := json.Unmarshal([]byte(n.ACLJSON), &entries); err == nil {
+			for _, e := range entries {
+				out.Acl = append(out.Acl, &pb.AclEntry{
+					Principal:  e.Principal,
+					Permission: e.Permission,
+				})
+			}
+		}
+	}
+	return out, nil
+}

--- a/server/go/internal/api/get_node_test.go
+++ b/server/go/internal/api/get_node_test.go
@@ -1,0 +1,285 @@
+// Tests for the GetNode RPC (W2 — EPIC #407).
+//
+// Spec: docs/go-port/rpcs/GetNode.md. Four behaviours pinned here:
+//
+//  1. Happy round-trip: an existing node -> Found=true with Node
+//     populated; payload round-trips through the wire as id-keyed
+//     Struct (mirrors test_grpc_contract.py:212-216 and the
+//     payload-wire pin test_payload_wire_format.py:158-189).
+//
+//  2. Missing node -> Found=false with status OK (NOT NOT_FOUND).
+//     Pinned by test_grpc_contract.py:217-222.
+//
+//  3. Non-member with no per-tenant grants -> PERMISSION_DENIED. The
+//     check fires BEFORE row lookup, so a non-member querying any
+//     node_id (existent or not) sees PERMISSION_DENIED. Pinned by
+//     test_privilege_escalation.py:186-209 + spec "Error contract".
+//
+//  4. Invariant #6: payload on the wire is keyed by stringified
+//     field_id, NOT by field name. Disk and wire BOTH use id keys —
+//     the SDK does name translation. Pinned by
+//     test_payload_wire_format.py:158-189.
+//
+// The shared globalstore helper lives in helpers_external_test.go;
+// do NOT redeclare newGlobalStore here.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// newGetNodeStore returns a tmpdir-backed CanonicalStore with WAL on.
+// Closed on test teardown. Independent of newTestStore in
+// get_receipt_status_test.go (that one is in package api, not api_test).
+func newGetNodeStore(t *testing.T) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// seedNode is a small builder that opens the tenant + creates a node.
+// Returns the created node so tests can pin created_at / updated_at.
+func seedNode(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner string, payload map[string]any) *store.Node {
+	t.Helper()
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	n, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:     nodeID,
+		TypeID:     7,
+		Payload:    payload,
+		OwnerActor: owner,
+	})
+	if err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+	return n
+}
+
+// TestGetNode_HappyRoundTrip seeds a node and asserts the RPC returns
+// it field-for-field, with the payload visible on the wire as a
+// Struct keyed by stringified field_id.
+//
+// The test runs WITHOUT a globalstore so the cross-tenant check
+// short-circuits to roleLocal (back-compat path) — that's the
+// minimal-deps shape the spec documents at "Open questions / risks"
+// item 5 ("global_store is None -> 'local'"). The privilege /
+// membership branches are covered by the dedicated cases below.
+func TestGetNode_HappyRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cs := newGetNodeStore(t)
+	const tenantID = "tenant-a"
+	const nodeID = "node-1"
+
+	created := seedNode(t, cs, tenantID, nodeID, "user:alice", map[string]any{
+		"1": "alice@example.com",
+		"2": "hashed-password-blob",
+	})
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		TypeId:  7,
+		NodeId:  nodeID,
+	})
+	if err != nil {
+		t.Fatalf("GetNode: unexpected err: %v", err)
+	}
+	if !resp.GetFound() {
+		t.Fatalf("GetNode: found: got false, want true")
+	}
+	got := resp.GetNode()
+	if got == nil {
+		t.Fatalf("GetNode: node is nil despite found=true")
+	}
+	if got.GetNodeId() != nodeID {
+		t.Fatalf("GetNode: node_id: got %q, want %q", got.GetNodeId(), nodeID)
+	}
+	if got.GetTypeId() != 7 {
+		t.Fatalf("GetNode: type_id: got %d, want 7", got.GetTypeId())
+	}
+	if got.GetOwnerActor() != "user:alice" {
+		t.Fatalf("GetNode: owner_actor: got %q, want %q", got.GetOwnerActor(), "user:alice")
+	}
+	if got.GetCreatedAt() != created.CreatedAt {
+		t.Fatalf("GetNode: created_at: got %d, want %d", got.GetCreatedAt(), created.CreatedAt)
+	}
+}
+
+// TestGetNode_MissingNode pins the in-band absence signal: an unknown
+// node_id returns Found=false with codes.OK, NOT codes.NotFound. This
+// is the deliberate asymmetry called out in the spec — clients branch
+// on response.Found, so upgrading to a NOT_FOUND status code would be
+// a contract break.
+//
+// Runs WITHOUT a globalstore so the membership gate short-circuits to
+// roleLocal — otherwise a non-member would hit PERMISSION_DENIED
+// before the lookup, which is a different contract pin (covered
+// below).
+func TestGetNode_MissingNode(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cs := newGetNodeStore(t)
+	const tenantID = "tenant-a"
+
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		TypeId:  7,
+		NodeId:  "does-not-exist",
+	})
+	if err != nil {
+		t.Fatalf("GetNode: unexpected err for missing node: %v", err)
+	}
+	if resp.GetFound() {
+		t.Fatalf("GetNode: found: got true, want false for missing node")
+	}
+	if resp.GetNode() != nil {
+		t.Fatalf("GetNode: node populated despite found=false: %+v", resp.GetNode())
+	}
+}
+
+// TestGetNode_NoPermission pins the cross-tenant gate: a non-member
+// caller (no membership row, no node_access row) sees
+// PERMISSION_DENIED, regardless of whether the node exists. The
+// global_store is wired so the membership check actually runs (Python
+// `_check_cross_tenant_read` short-circuits to "local" only when no
+// global_store is configured — spec "Open questions / risks" item 5).
+//
+// We seed the tenant + a node owned by alice, then query as bob who
+// has no membership and no grants. PERMISSION_DENIED fires before the
+// row lookup; we don't even need the node to exist for the assertion
+// (and the spec is explicit that this is the intended shape — a
+// non-member querying a non-existent node sees PERMISSION_DENIED, not
+// found=false, so they cannot probe for node existence).
+func TestGetNode_NoPermission(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cs := newGetNodeStore(t)
+	gs := newGlobalStore(t)
+	const tenantID = "tenant-a"
+	const nodeID = "node-1"
+
+	if _, err := gs.CreateTenant(ctx, tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	// alice is a member; bob is NOT.
+	if err := gs.AddTenantMember(ctx, tenantID, "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	seedNode(t, cs, tenantID, nodeID, "user:alice", nil)
+
+	srv := api.New(api.WithStore(cs), api.WithGlobalStore(gs))
+	_, err := srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:bob"},
+		TypeId:  7,
+		NodeId:  nodeID,
+	})
+	if err == nil {
+		t.Fatalf("GetNode: expected PERMISSION_DENIED, got nil error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("GetNode: error is not a grpc status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("GetNode: code: got %v, want PermissionDenied", st.Code())
+	}
+}
+
+// TestGetNode_PayloadIsIDKeyedOnWire is the explicit invariant-#6
+// pin: the on-disk payload is keyed by field_id (Python parity, see
+// CLAUDE.md), AND the wire payload egress also stays id-keyed (the
+// SDK does the id->name translation client-side). This is the
+// "zero-translation egress" rule from
+// docs/go-port/shared/payload-translation.md.
+//
+// Without a SchemaRegistry, payload.PayloadToStruct takes the
+// schema-less passthrough path which preserves digit-only keys
+// verbatim. We assert (a) the wire Struct contains exactly the
+// stringified field_id keys we wrote, and (b) it does NOT contain a
+// name-keyed entry — a regression that translated id->name on the
+// server side would surface as the latter.
+func TestGetNode_PayloadIsIDKeyedOnWire(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cs := newGetNodeStore(t)
+	const tenantID = "tenant-a"
+	const nodeID = "node-1"
+
+	seedNode(t, cs, tenantID, nodeID, "user:alice", map[string]any{
+		"1": "alice@example.com",
+		"2": "hashed-password",
+	})
+
+	srv := api.New(api.WithStore(cs))
+	resp, err := srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		TypeId:  7,
+		NodeId:  nodeID,
+	})
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if !resp.GetFound() {
+		t.Fatalf("GetNode: found=false")
+	}
+	wire := resp.GetNode().GetPayload()
+	if wire == nil {
+		t.Fatalf("GetNode: payload Struct is nil")
+	}
+	fields := wire.GetFields()
+	// Invariant #6: keys on the wire are stringified field_ids.
+	if v, ok := fields["1"]; !ok {
+		t.Fatalf("payload field %q missing on wire; got keys %v", "1", keysOf(fields))
+	} else if v.GetStringValue() != "alice@example.com" {
+		t.Fatalf("payload[1]: got %q, want %q", v.GetStringValue(), "alice@example.com")
+	}
+	if v, ok := fields["2"]; !ok {
+		t.Fatalf("payload field %q missing on wire; got keys %v", "2", keysOf(fields))
+	} else if v.GetStringValue() != "hashed-password" {
+		t.Fatalf("payload[2]: got %q, want %q", v.GetStringValue(), "hashed-password")
+	}
+	// Negative: name-keyed entries would mean someone re-introduced
+	// server-side id->name translation; that's a CLAUDE.md invariant
+	// #6 violation and a wire-format regression.
+	for _, name := range []string{"email", "password", "password_hash"} {
+		if _, ok := fields[name]; ok {
+			t.Fatalf("payload contains name-keyed field %q on the wire (invariant #6 violation); "+
+				"all keys: %v", name, keysOf(fields))
+		}
+	}
+}
+
+// keysOf returns the keys of a structpb fields map as a slice — used
+// by failure messages so the diff is readable without breaking out
+// reflect.
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Port the read-side single-node lookup (`entdb.v1.EntDBService/GetNode`) from Python to Go. The handler runs the tenant gate, resolves the trusted actor via `auth.Authoritative` (ignoring the wire claim), classifies the caller as local/member/cross_tenant, optionally waits for an applier offset, reads via `store.GetNode`, and translates the row through `payload.PayloadToStruct`.
- Preserve the Python error-contract asymmetry: `NOT_FOUND` wins for a missing row (returned in-band as `found=false` with status OK), `PERMISSION_DENIED` fires before the lookup for non-members so they cannot probe for node existence, and again post-lookup for cross-tenant callers without a per-node grant.
- Preserve CLAUDE.md invariant #6 — payload on the wire stays keyed by stringified `field_id`; the SDK does the id→name translation client-side. New invariant test pins this on the wire.
- Dedupe three pre-existing symbol collisions in `package api` (`userToProto`, `Server.lookupMemberRole`, `withTrustedUser`) that were blocking `go vet ./...` after the parallel Wave-2 PRs landed. Same shape as the prior dedupe in #429.

Refs #407.

## Test plan

- [x] `cd server/go && go vet ./...` clean
- [x] `cd server/go && go test ./...` — all packages green; the four new `TestGetNode_*` cases (happy round-trip, missing→found=false, non-member→PERMISSION_DENIED, payload id-keyed on wire) all pass
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` — clean
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed
- [x] `cd sdk/go/entdb && go vet ./... && go test ./...` — clean