### PR TITLE
feat(go-rewrite): GetNodes RPC — Wave 2

### DIFF
--- a/server/go/internal/api/get_nodes.go
+++ b/server/go/internal/api/get_nodes.go
@@ -1,0 +1,358 @@
+// GetNodes RPC — Wave 2 of the Python -> Go server port (EPIC #407).
+// Spec: docs/go-port/rpcs/GetNodes.md.
+//
+// Wire contract: proto/entdb/v1/entdb.proto:58 (rpc), :409-422 (request/
+// response). Reference Python handler:
+// server/python/entdb_server/api/grpc_server.py:1215-1291.
+//
+// Semantics (preserved from the Python handler):
+//
+//   - Tenant gate first via Server.checkTenant (NOT_FOUND /
+//     UNAVAILABLE / FAILED_PRECONDITION on miss).
+//   - Trusted-actor rebinding (auth.Authoritative). The wire actor is
+//     UNTRUSTED for any auth decision -- the trusted identity from the
+//     gRPC interceptor wins. Pinned by
+//     tests/python/integration/test_privilege_escalation.py:213-228.
+//   - Cross-tenant role check is BATCH-LEVEL: if the actor is neither a
+//     tenant member nor a system actor and has no node_access grants,
+//     the whole call aborts PERMISSION_DENIED. There is NO per-id
+//     PERMISSION_DENIED on the wire.
+//   - Per-id missing OR cross-tenant denied are MERGED into
+//     missing_ids -- a deliberate information-leak guard so a foreign
+//     actor cannot probe whether a node exists vs whether they lack
+//     access (spec "Auth", Python grpc_server.py:1262-1271).
+//   - The proto's `type_id` field is silently ignored (Python iterates
+//     the ids and trusts whatever type_id is on disk; preserved for
+//     parity, spec "Wire contract" #2).
+//   - Duplicate node_ids are NOT deduped; each lookup runs
+//     independently. Order of `nodes` follows request order minus
+//     missing/denied (gaps closed, indexes are NOT parallel to
+//     `node_ids`).
+//   - `after_offset` fences the read against the applier (default
+//     30s). Python's bare-except swallows a fence timeout as
+//     "everything missing"; we preserve that behaviour for v1
+//     parity (spec "Open Questions" #1).
+//   - Bare-except in Python masks any internal error (SQLite, panic)
+//     as nodes=[], missing_ids=<all input> with status OK. Preserved
+//     verbatim: this masks data-loss bugs but is the documented
+//     contract.
+//
+// Hardening delta vs Python (flagged in PR body for #407 owner):
+//
+//   - Batch-size cap: Python has no upper bound; a 100k-id payload
+//     happily melts the SQLite pool and blows past gRPC's 4 MiB
+//     default response size. The Go port aborts
+//     RESOURCE_EXHAUSTED at len(node_ids) > maxBatchNodeIDs (1000)
+//     BEFORE doing any I/O. Spec "Notes on performance & limits".
+//
+// No WAL append, no SQLite write, no audit row. Pure read.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+const (
+	getNodesMethod = "GetNodes"
+
+	// maxBatchNodeIDs is the server-side guardrail for a single
+	// GetNodes request. Above this we reject before doing any I/O
+	// with codes.RESOURCE_EXHAUSTED. Python has no such cap; this is
+	// a Go-port hardening delta for issue #407.
+	maxBatchNodeIDs = 1000
+
+	// getNodesFanout is the bounded concurrency for per-id store
+	// lookups. Caps in-flight SQLite reads at a small constant so a
+	// 1000-id batch doesn't starve the pool. Behaviour-preserving
+	// with respect to Python (which is serial); only a perf knob.
+	getNodesFanout = 32
+
+	// getNodesAfterOffsetDefault matches Python's 30s default fence
+	// (grpc_server.py:1236-1240).
+	getNodesAfterOffsetDefault = 30 * time.Second
+)
+
+// GetNodes implements entdb.v1.EntDBService/GetNodes. See file header
+// for the full contract.
+func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.GetNodesResponse, error) {
+	start := time.Now()
+	resultStatus := "ok"
+	defer func() {
+		metrics.RecordGRPCRequest(getNodesMethod, resultStatus, time.Since(start))
+	}()
+
+	tenantID := req.GetContext().GetTenantId()
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
+	// Trusted-actor: ignore req.Context.Actor for any auth decision.
+	// The interceptor (when wired) populates ctx with the trusted
+	// identity; without it, we fall through to the claimed actor
+	// (documented unit-test / no-auth fallback).
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetContext().GetActor()))
+
+	// Batch-size cap. Reject BEFORE any I/O so a hostile / buggy
+	// caller cannot cause work to start. Python parity gap; flagged
+	// in PR body.
+	if len(req.GetNodeIds()) > maxBatchNodeIDs {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.ResourceExhausted,
+			"GetNodes: batch size %d exceeds limit %d",
+			len(req.GetNodeIds()), maxBatchNodeIDs)
+	}
+
+	// Empty node_ids -> empty response. Python returns the same shape
+	// (the for-loop simply doesn't run).
+	if len(req.GetNodeIds()) == 0 {
+		return &pb.GetNodesResponse{
+			Nodes:      []*pb.Node{},
+			MissingIds: []string{},
+		}, nil
+	}
+
+	// Cross-tenant role check (BATCH-LEVEL). Mirrors Python
+	// _check_cross_tenant_read at grpc_server.py:561-618. The shared
+	// helper isn't yet ported; we inline a parity-faithful version
+	// here. Returns one of: roleLocal (no global), roleMember
+	// (member or system actor), roleCrossTenant (non-member with
+	// node_access grants), or PERMISSION_DENIED (non-member, no
+	// grants).
+	role, err := s.checkCrossTenantRead(ctx, tenantID, trusted)
+	if err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
+	// after_offset fence. Python wraps the call with a swallowing
+	// try/except so a timeout is observed as "all missing". We
+	// preserve that for v1 (spec "Open Questions" #1): a fence
+	// failure is intentionally NOT a hard error here.
+	if req.GetAfterOffset() != "" && s.store != nil {
+		timeout := getNodesAfterOffsetDefault
+		if ms := req.GetWaitTimeoutMs(); ms > 0 {
+			timeout = time.Duration(ms) * time.Millisecond
+		}
+		waitCtx, cancel := context.WithTimeout(ctx, timeout)
+		target := parseStreamOffset(req.GetAfterOffset())
+		_ = s.store.WaitForOffset(waitCtx, tenantID, target)
+		cancel()
+	}
+
+	// Resolve actor groups once for cross-tenant per-node ACL
+	// filtering. Members + local skip this entirely.
+	var actorIDs []string
+	if role == roleCrossTenant && s.store != nil {
+		actorIDs, _ = s.store.ResolveActorGroups(ctx, tenantID, trusted.String())
+	}
+
+	if s.store == nil {
+		// No per-tenant store wired -- preserve Python's bare-except
+		// behaviour: everything missing, status OK, metric=error so
+		// the swallow doesn't inflate the ok counter.
+		resultStatus = "error"
+		return &pb.GetNodesResponse{
+			Nodes:      []*pb.Node{},
+			MissingIds: append([]string{}, req.GetNodeIds()...),
+		}, nil
+	}
+
+	ids := req.GetNodeIds()
+	results := make([]*store.Node, len(ids))
+	denied := make([]bool, len(ids))
+	hadFatal := false
+	var fatalMu sync.Mutex
+
+	sem := make(chan struct{}, getNodesFanout)
+	var wg sync.WaitGroup
+	for i, id := range ids {
+		i, id := i, id
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer func() {
+				<-sem
+				wg.Done()
+				if r := recover(); r != nil {
+					// Per-id panic -- treat as "missing", consistent
+					// with Python's outer bare-except.
+					fatalMu.Lock()
+					hadFatal = true
+					fatalMu.Unlock()
+				}
+			}()
+			n, gerr := s.store.GetNode(ctx, tenantID, id)
+			if gerr != nil || n == nil {
+				return // miss -> nil entry -> missing_ids
+			}
+			if actorIDs != nil {
+				ok, aerr := s.store.CanAccess(ctx, tenantID, id, actorIDs)
+				if aerr != nil || !ok {
+					denied[i] = true
+					return
+				}
+			}
+			results[i] = n
+		}()
+	}
+	wg.Wait()
+
+	if hadFatal {
+		// At least one panic during the fan-out. Python's bare-except
+		// returns "all missing"; the safest parity move when we can't
+		// trust partial state is to do the same and flag the metric
+		// as error.
+		resultStatus = "error"
+		return &pb.GetNodesResponse{
+			Nodes:      []*pb.Node{},
+			MissingIds: append([]string{}, ids...),
+		}, nil
+	}
+
+	nodes := make([]*pb.Node, 0, len(ids))
+	missing := make([]string, 0)
+	for i, id := range ids {
+		if results[i] == nil || denied[i] {
+			missing = append(missing, id)
+			continue
+		}
+		pn, perr := storeNodeToProto(s, results[i])
+		if perr != nil {
+			// Conversion failure on a single row -- fold into
+			// missing_ids rather than failing the whole batch
+			// (matches Python's "swallow and degrade" stance).
+			missing = append(missing, id)
+			continue
+		}
+		nodes = append(nodes, pn)
+	}
+
+	return &pb.GetNodesResponse{
+		Nodes:      nodes,
+		MissingIds: missing,
+	}, nil
+}
+
+// crossTenantRole is the result of checkCrossTenantRead. Mirrors the
+// "local" / "member" / "cross_tenant" string return of the Python
+// helper at grpc_server.py:561-618.
+type crossTenantRole int
+
+const (
+	roleLocal       crossTenantRole = iota // no global_store wired
+	roleMember                             // tenant member or system actor
+	roleCrossTenant                        // non-member with node_access grants
+)
+
+// checkCrossTenantRead is the Go port of
+// server/python/entdb_server/api/grpc_server.py:_check_cross_tenant_read
+// (561-618). Returns roleLocal / roleMember / roleCrossTenant on
+// success, or a PERMISSION_DENIED status error on rejection.
+//
+// Inlined here (rather than in a shared helper) because GetNodes is
+// the first read RPC to need it; subsequent read handlers (QueryNodes,
+// GetEdgesFrom, …) will refactor this into internal/tenant once the
+// surface stabilises.
+func (s *Server) checkCrossTenantRead(ctx context.Context, tenantID string, actor auth.Actor) (crossTenantRole, error) {
+	// No global_store wired -> "local" (backward-compat with bring-up
+	// configs and unit tests; mirrors grpc_server.py:590-591).
+	if s.global == nil {
+		return roleLocal, nil
+	}
+	// System actors bypass all checks (grpc_server.py:594-595).
+	if actor.IsSystem() {
+		return roleMember, nil
+	}
+	// Tenant membership: resolve actor -> user_id and consult
+	// globalstore.IsMember. Only user-kind actors can ever be members
+	// (admins / unknown kinds are not in tenant_members rows; for
+	// parity with Python we still try IsMember which falls through to
+	// false for them).
+	userID := actor.ID()
+	if !actor.IsUser() {
+		userID = actor.String()
+	}
+	if userID != "" {
+		isMember, err := s.global.IsMember(ctx, tenantID, userID)
+		if err == nil && isMember {
+			return roleMember, nil
+		}
+	}
+	// Not a member -- check for cross-tenant node_access grants.
+	if s.store != nil {
+		actorIDs, err := s.store.ResolveActorGroups(ctx, tenantID, actor.String())
+		if err == nil && len(actorIDs) > 0 {
+			has, herr := s.store.HasNodeAccess(ctx, tenantID, actorIDs)
+			if herr == nil && has {
+				return roleCrossTenant, nil
+			}
+		}
+	}
+	return 0, errs.Errorf(codes.PermissionDenied,
+		"Actor is not a member of this tenant")
+}
+
+// storeNodeToProto converts a *store.Node (id-keyed payload JSON,
+// raw ACL JSON) into a *pb.Node. Mirrors the inline conversion in
+// Python's grpc_server.py:1273-1284.
+//
+// Schema-aware kind coercion: when the schema registry is wired, we
+// look up the node type by type_id and feed payload.PayloadToStruct
+// the type's name so BYTES / TIMESTAMP / INTEGER values are encoded
+// correctly. Without a registry (unit tests), we fall through to the
+// schema-less passthrough.
+func storeNodeToProto(s *Server, n *store.Node) (*pb.Node, error) {
+	// Parse payload (string-keyed by field_id) into map[string]any.
+	var rawPayload map[string]any
+	if n.PayloadJSON != "" {
+		if err := json.Unmarshal([]byte(n.PayloadJSON), &rawPayload); err != nil {
+			return nil, err
+		}
+	}
+	// Build a *structpb.Struct with the same string keys. The wire
+	// stays id-keyed per CLAUDE.md invariant #6.
+	st, err := structpb.NewStruct(rawPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse ACL JSON into proto entries.
+	var aclList []store.ACLEntry
+	if n.ACLJSON != "" {
+		if err := json.Unmarshal([]byte(n.ACLJSON), &aclList); err != nil {
+			return nil, err
+		}
+	}
+	aclProto := make([]*pb.AclEntry, 0, len(aclList))
+	for _, e := range aclList {
+		aclProto = append(aclProto, &pb.AclEntry{
+			Principal:  e.Principal,
+			Permission: e.Permission,
+		})
+	}
+
+	return &pb.Node{
+		TenantId:   n.TenantID,
+		NodeId:     n.NodeID,
+		TypeId:     n.TypeID,
+		CreatedAt:  n.CreatedAt,
+		UpdatedAt:  n.UpdatedAt,
+		OwnerActor: n.OwnerActor,
+		Payload:    st,
+		Acl:        aclProto,
+	}, nil
+}

--- a/server/go/internal/api/get_nodes_test.go
+++ b/server/go/internal/api/get_nodes_test.go
@@ -1,0 +1,420 @@
+// Tests for the GetNodes RPC (W2 — EPIC #407).
+//
+// Spec: docs/go-port/rpcs/GetNodes.md. Coverage targets the contract
+// pins enumerated there:
+//
+//   - Empty node_ids -> nodes=[] missing_ids=[] OK (Python parity).
+//   - Single id round-trip: existing id surfaces as a Node; unknown id
+//     surfaces in missing_ids.
+//   - Multi-id round-trip: multiple existing ids preserve request order
+//     (gaps closed); duplicates are NOT deduped.
+//   - Mixed missing + visible + denied: missing-or-denied are merged
+//     into missing_ids; the cross-tenant denied case must NOT be
+//     distinguishable from not-found
+//     (test_cross_tenant_read.py:254-407 + spec "Auth").
+//   - Oversize batch (> maxBatchNodeIDs) -> RESOURCE_EXHAUSTED before
+//     any I/O. Hardening delta vs Python (no Python equivalent).
+//   - Unknown tenant -> NOT_FOUND from the tenant gate
+//     (CheckTenant / globalstore.GetTenant).
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// newStoreWithTenant builds a fresh CanonicalStore rooted at t.TempDir()
+// and pre-opens tenantID. Closed automatically on test teardown.
+func newStoreWithTenant(t *testing.T, tenantID string) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{
+		RootDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(context.Background(), tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	return cs
+}
+
+// seedNode is a tiny helper to put one node into the store with a
+// deterministic owner so the cross-tenant filter tests can vary by
+// whether the actor matches owner_actor.
+func seedNode(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner string) {
+	t.Helper()
+	_, err := cs.CreateNodeRaw(context.Background(), tenantID, store.NodeInput{
+		NodeID:     nodeID,
+		TypeID:     1,
+		Payload:    map[string]any{"1": nodeID + "-payload"},
+		OwnerActor: owner,
+	})
+	if err != nil {
+		t.Fatalf("seedNode %s: %v", nodeID, err)
+	}
+}
+
+// TestGetNodes_EmptyList pins the trivial "no work" branch:
+// nodes=[] missing_ids=[] OK. No store I/O — but tenant gate +
+// cross-tenant role check still run.
+func TestGetNodes_EmptyList(t *testing.T) {
+	t.Parallel()
+	const tenantID = "acme"
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(context.Background(), tenantID, "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	cs := newStoreWithTenant(t, tenantID)
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+	resp, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+	})
+	if err != nil {
+		t.Fatalf("GetNodes: %v", err)
+	}
+	if len(resp.GetNodes()) != 0 {
+		t.Fatalf("nodes: got %d, want 0", len(resp.GetNodes()))
+	}
+	if len(resp.GetMissingIds()) != 0 {
+		t.Fatalf("missing_ids: got %d, want 0", len(resp.GetMissingIds()))
+	}
+}
+
+// TestGetNodes_SingleHit pins the single-id round-trip path:
+// existing -> nodes has one entry, missing_ids is empty.
+func TestGetNodes_SingleHit(t *testing.T) {
+	t.Parallel()
+	const tenantID = "acme"
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(context.Background(), tenantID, "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	cs := newStoreWithTenant(t, tenantID)
+	seedNode(t, cs, tenantID, "n1", "user:alice")
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+	resp, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		NodeIds: []string{"n1"},
+	})
+	if err != nil {
+		t.Fatalf("GetNodes: %v", err)
+	}
+	if len(resp.GetNodes()) != 1 {
+		t.Fatalf("nodes: got %d, want 1", len(resp.GetNodes()))
+	}
+	if got := resp.GetNodes()[0].GetNodeId(); got != "n1" {
+		t.Fatalf("node_id: got %q, want n1", got)
+	}
+	if len(resp.GetMissingIds()) != 0 {
+		t.Fatalf("missing_ids: got %v, want []", resp.GetMissingIds())
+	}
+}
+
+// TestGetNodes_SingleMiss pins that an unknown id surfaces in
+// missing_ids with status OK — NOT a NOT_FOUND batch error.
+func TestGetNodes_SingleMiss(t *testing.T) {
+	t.Parallel()
+	const tenantID = "acme"
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(context.Background(), tenantID, "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	cs := newStoreWithTenant(t, tenantID)
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+	resp, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		NodeIds: []string{"ghost"},
+	})
+	if err != nil {
+		t.Fatalf("GetNodes: %v", err)
+	}
+	if len(resp.GetNodes()) != 0 {
+		t.Fatalf("nodes: got %d, want 0", len(resp.GetNodes()))
+	}
+	if got := resp.GetMissingIds(); len(got) != 1 || got[0] != "ghost" {
+		t.Fatalf("missing_ids: got %v, want [ghost]", got)
+	}
+}
+
+// TestGetNodes_MultiPreservesOrderAndDuplicates pins two contract
+// invariants in one test:
+//   - Order: nodes in request order, gaps closed (denied/missing
+//     are absent, not nil-padded).
+//   - Duplicates: requesting the same id twice yields the node twice
+//     (Python iterates verbatim — spec "Batch semantics" #5).
+func TestGetNodes_MultiPreservesOrderAndDuplicates(t *testing.T) {
+	t.Parallel()
+	const tenantID = "acme"
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(context.Background(), tenantID, "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	cs := newStoreWithTenant(t, tenantID)
+	seedNode(t, cs, tenantID, "n1", "user:alice")
+	seedNode(t, cs, tenantID, "n2", "user:alice")
+	seedNode(t, cs, tenantID, "n3", "user:alice")
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+	resp, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		// Request order: n3, missing-x, n1, n1 (duplicate), n2.
+		NodeIds: []string{"n3", "missing-x", "n1", "n1", "n2"},
+	})
+	if err != nil {
+		t.Fatalf("GetNodes: %v", err)
+	}
+	want := []string{"n3", "n1", "n1", "n2"}
+	if got := nodeIDs(resp.GetNodes()); !equalSlice(got, want) {
+		t.Fatalf("nodes order: got %v, want %v", got, want)
+	}
+	if got := resp.GetMissingIds(); len(got) != 1 || got[0] != "missing-x" {
+		t.Fatalf("missing_ids: got %v, want [missing-x]", got)
+	}
+}
+
+// TestGetNodes_MissingAndDeniedMergedIntoMissingIds is the
+// information-leak guard: a cross-tenant non-member with at least one
+// node_access grant on tenantID can read SOME nodes but not others.
+// Per the spec, the wire MUST NOT distinguish "you don't have access"
+// from "the node doesn't exist" — both cases land in missing_ids.
+//
+// Setup: alice owns three nodes in acme. mallory is not a member of
+// acme but has a node_access grant on n1 (so can_access(n1) is true)
+// and no grant on n2. Probing mallory through GetNodes should yield:
+//
+//   - n1 in nodes (visible cross-tenant).
+//   - n2 in missing_ids (cross-tenant denied — no per-id error).
+//   - ghost in missing_ids (truly absent).
+//
+// The two missing reasons are intentionally indistinguishable on the
+// wire.
+func TestGetNodes_MissingAndDeniedMergedIntoMissingIds(t *testing.T) {
+	t.Parallel()
+	const tenantID = "acme"
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	// alice IS a member of acme; mallory is NOT.
+	if err := gs.AddTenantMember(context.Background(), tenantID, "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	cs := newStoreWithTenant(t, tenantID)
+	seedNode(t, cs, tenantID, "n1", "user:alice")
+	seedNode(t, cs, tenantID, "n2", "user:alice")
+
+	// Grant mallory READ access to n1 only — this is the
+	// `node_access` row that flips _check_cross_tenant_read from
+	// PERMISSION_DENIED to "cross_tenant" + per-id filtering.
+	if err := cs.ShareNode(context.Background(), tenantID, store.ShareNodeInput{
+		NodeID:     "n1",
+		ActorID:    "user:mallory",
+		ActorType:  "user",
+		Permission: "read",
+		GrantedBy:  "user:alice",
+	}); err != nil {
+		t.Fatalf("ShareNode n1: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+	resp, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:mallory"},
+		NodeIds: []string{"n1", "n2", "ghost"},
+	})
+	if err != nil {
+		t.Fatalf("GetNodes: unexpected gRPC error: %v", err)
+	}
+	// n1 is the only visible node.
+	if got := nodeIDs(resp.GetNodes()); len(got) != 1 || got[0] != "n1" {
+		t.Fatalf("nodes: got %v, want [n1]", got)
+	}
+	// Both n2 (denied) and ghost (missing) land in missing_ids —
+	// indistinguishable.
+	missing := resp.GetMissingIds()
+	if !containsAll(missing, []string{"n2", "ghost"}) || len(missing) != 2 {
+		t.Fatalf("missing_ids: got %v, want exactly [n2, ghost] in some order", missing)
+	}
+}
+
+// TestGetNodes_OversizeBatchRejected pins the Go-port hardening
+// delta: above maxBatchNodeIDs (1000) the handler aborts
+// RESOURCE_EXHAUSTED before any tenant / store I/O. Python has no
+// such cap; the cap is documented in the spec "Open Questions" #4.
+func TestGetNodes_OversizeBatchRejected(t *testing.T) {
+	t.Parallel()
+	const tenantID = "acme"
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	cs := newStoreWithTenant(t, tenantID)
+
+	ids := make([]string, 1001) // > 1000 cap
+	for i := range ids {
+		ids[i] = "id-" + itoa(i)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+	_, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		NodeIds: ids,
+	})
+	if err == nil {
+		t.Fatalf("expected RESOURCE_EXHAUSTED, got nil")
+	}
+	if got := status.Code(err); got != codes.ResourceExhausted {
+		t.Fatalf("got code %v, want ResourceExhausted", got)
+	}
+}
+
+// TestGetNodes_OversizeBatchExactlyAtCapAccepted is the boundary
+// counterpart: a batch of exactly maxBatchNodeIDs (1000) is
+// accepted (cap is EXCLUSIVE-of-greater, INCLUSIVE-of-cap).
+func TestGetNodes_OversizeBatchExactlyAtCapAccepted(t *testing.T) {
+	t.Parallel()
+	const tenantID = "acme"
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(context.Background(), tenantID, "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	cs := newStoreWithTenant(t, tenantID)
+
+	ids := make([]string, 1000) // exactly at cap
+	for i := range ids {
+		ids[i] = "id-" + itoa(i)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+	resp, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		NodeIds: ids,
+	})
+	if err != nil {
+		t.Fatalf("GetNodes at cap: %v", err)
+	}
+	// All 1000 ids miss (none seeded) -> all in missing_ids.
+	if got := len(resp.GetMissingIds()); got != 1000 {
+		t.Fatalf("missing_ids: got %d, want 1000", got)
+	}
+	if len(resp.GetNodes()) != 0 {
+		t.Fatalf("nodes: got %d, want 0", len(resp.GetNodes()))
+	}
+}
+
+// TestGetNodes_UnknownTenantNotFound pins the tenant-gate behaviour:
+// an unknown tenant_id results in codes.NotFound from CheckTenant
+// before any read work runs. Mirrors the Python NOT_FOUND from
+// _check_tenant (grpc_server.py:362-401).
+func TestGetNodes_UnknownTenantNotFound(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	cs := newStoreWithTenant(t, "acme") // open a different tenant
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+
+	_, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: "ghost-tenant", Actor: "user:alice"},
+		NodeIds: []string{"n1"},
+	})
+	if err == nil {
+		t.Fatalf("expected NOT_FOUND, got nil")
+	}
+	if got := status.Code(err); got != codes.NotFound {
+		t.Fatalf("got code %v, want NotFound", got)
+	}
+}
+
+// nodeIDs flattens a []*pb.Node to its node_id slice, preserving
+// order. Used by the order-and-duplicates assertion.
+func nodeIDs(ns []*pb.Node) []string {
+	out := make([]string, 0, len(ns))
+	for _, n := range ns {
+		out = append(out, n.GetNodeId())
+	}
+	return out
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsAll(haystack, needles []string) bool {
+	set := make(map[string]struct{}, len(haystack))
+	for _, h := range haystack {
+		set[h] = struct{}{}
+	}
+	for _, n := range needles {
+		if _, ok := set[n]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// itoa is a tiny strconv-free integer formatter so the
+// oversize-batch tests don't drag in an import for one call site.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/server/go/internal/store/access.go
+++ b/server/go/internal/store/access.go
@@ -1,0 +1,240 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// systemActor is the bootstrap/replay identity used by the applier.
+// It bypasses every ACL check (mirrors canonical_store.py:2825 +
+// :2883). Never appears on the wire.
+const systemActor = "__system__"
+
+// aclMaxDepth bounds recursive group-membership / acl_inherit
+// expansion. Mirrors canonical_store.py:_ACL_MAX_DEPTH = 10.
+const aclMaxDepth = 10
+
+// ResolveActorGroups expands an actor into the flat list
+// [actor, group_1, group_2, ...] by recursively walking the
+// group_users table. Mirrors canonical_store.py:_sync_resolve_actor_groups
+// (2828-2853).
+//
+// Cycle-safe: the SQL CTE bounds depth at aclMaxDepth.
+//
+// Used by read handlers in two places:
+//
+//  1. GetNodes / QueryNodes: the cross-tenant role gate calls this once
+//     per request when the caller is non-member, then feeds the
+//     expansion into HasNodeAccess + CanAccess.
+//  2. ACL post-filter on visibility queries (GetVisibleNodeIDs,
+//     ListSharedWithMe).
+//
+// The actor argument is the canonical "kind:id" form (e.g.
+// "user:alice"). The returned slice always contains actor as its
+// first element so callers can treat the empty-groups case as
+// "self-only" without a special case.
+func (s *CanonicalStore) ResolveActorGroups(ctx context.Context, tenantID, actor string) ([]string, error) {
+	if actor == "" {
+		return nil, nil
+	}
+	db, err := s.db(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	q := fmt.Sprintf(`
+		WITH RECURSIVE membership(gid, depth) AS (
+			SELECT group_id, 0 FROM group_users
+			WHERE member_actor_id = ?
+			UNION ALL
+			SELECT gu.group_id, m.depth + 1
+			FROM group_users gu
+			JOIN membership m ON gu.member_actor_id = m.gid
+			WHERE m.depth < %d
+		)
+		SELECT DISTINCT gid FROM membership`, aclMaxDepth,
+	)
+	rows, err := db.QueryContext(ctx, q, actor)
+	if err != nil {
+		return nil, fmt.Errorf("store: ResolveActorGroups: %w", err)
+	}
+	defer rows.Close()
+	out := []string{actor}
+	for rows.Next() {
+		var gid string
+		if err := rows.Scan(&gid); err != nil {
+			return nil, fmt.Errorf("store: ResolveActorGroups scan: %w", err)
+		}
+		out = append(out, gid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: ResolveActorGroups rows: %w", err)
+	}
+	return out, nil
+}
+
+// HasNodeAccess reports whether at least one of actorIDs has a
+// non-deny, non-expired node_access grant in the tenant. Mirrors
+// canonical_store.py:_sync_has_node_access (3956-3974).
+//
+// Used by the cross-tenant role gate in GetNodes / QueryNodes to
+// decide whether a non-member caller has any reason to be reading
+// from this tenant at all (vs. an outright PERMISSION_DENIED).
+func (s *CanonicalStore) HasNodeAccess(ctx context.Context, tenantID string, actorIDs []string) (bool, error) {
+	if len(actorIDs) == 0 {
+		return false, nil
+	}
+	db, err := s.db(tenantID)
+	if err != nil {
+		return false, err
+	}
+	ph := strings.Repeat("?,", len(actorIDs))
+	ph = ph[:len(ph)-1]
+	q := fmt.Sprintf(`
+		SELECT 1 FROM node_access
+		WHERE actor_id IN (%s)
+		  AND permission != 'deny'
+		  AND (expires_at IS NULL OR expires_at > ?)
+		LIMIT 1`, ph,
+	)
+	args := make([]any, 0, len(actorIDs)+1)
+	for _, a := range actorIDs {
+		args = append(args, a)
+	}
+	args = append(args, s.now())
+	var one int
+	row := db.QueryRowContext(ctx, q, args...)
+	switch err := row.Scan(&one); err {
+	case nil:
+		return true, nil
+	default:
+		// sql.ErrNoRows -> false, no error. Other errors propagate.
+		if isNoRows(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("store: HasNodeAccess: %w", err)
+	}
+}
+
+// CanAccess reports whether any of actorIDs can read nodeID per the
+// owner / visibility / node_access / acl_inherit rules. Mirrors
+// canonical_store.py:_sync_can_access (2867-2946).
+//
+// Order:
+//  1. The "__system__" actor short-circuits to true.
+//  2. An explicit deny on the target node by any actor in actorIDs
+//     wins -- returns false even if a sibling allow exists.
+//  3. Otherwise walk the acl_inherit chain (depth-bounded) and at
+//     each ancestor accept on owner-match, visibility-match (incl.
+//     "tenant:*" wildcard), or non-deny non-expired node_access.
+//
+// Returns false if no path matches.
+func (s *CanonicalStore) CanAccess(ctx context.Context, tenantID, nodeID string, actorIDs []string) (bool, error) {
+	if len(actorIDs) == 0 {
+		return false, nil
+	}
+	for _, a := range actorIDs {
+		if a == systemActor {
+			return true, nil
+		}
+	}
+	db, err := s.db(tenantID)
+	if err != nil {
+		return false, err
+	}
+
+	actorPh := strings.Repeat("?,", len(actorIDs))
+	actorPh = actorPh[:len(actorPh)-1]
+
+	// Step 1: explicit deny check on the target node.
+	denyQ := fmt.Sprintf(`
+		SELECT 1 FROM node_access
+		WHERE node_id = ? AND actor_id IN (%s)
+		  AND permission = 'deny'
+		LIMIT 1`, actorPh,
+	)
+	denyArgs := make([]any, 0, 1+len(actorIDs))
+	denyArgs = append(denyArgs, nodeID)
+	for _, a := range actorIDs {
+		denyArgs = append(denyArgs, a)
+	}
+	var one int
+	row := db.QueryRowContext(ctx, denyQ, denyArgs...)
+	switch err := row.Scan(&one); err {
+	case nil:
+		return false, nil // explicit deny
+	default:
+		if !isNoRows(err) {
+			return false, fmt.Errorf("store: CanAccess deny probe: %w", err)
+		}
+	}
+
+	// Step 2: ancestry walk + owner / visibility / node_access checks.
+	visIDs := make([]string, 0, len(actorIDs)+1)
+	visIDs = append(visIDs, actorIDs...)
+	visIDs = append(visIDs, "tenant:*")
+	visPh := strings.Repeat("?,", len(visIDs))
+	visPh = visPh[:len(visPh)-1]
+
+	walkQ := fmt.Sprintf(`
+		WITH RECURSIVE ancestry(nid, depth) AS (
+			SELECT ?, 0
+			UNION ALL
+			SELECT ai.inherit_from, a.depth + 1
+			FROM acl_inherit ai
+			JOIN ancestry a ON ai.node_id = a.nid
+			WHERE a.depth < %d
+		)
+		SELECT 1 FROM ancestry anc
+		JOIN nodes n ON n.node_id = anc.nid AND n.tenant_id = ?
+		WHERE (
+			n.owner_actor IN (%s)
+			OR EXISTS (
+				SELECT 1 FROM node_visibility nv
+				WHERE nv.tenant_id = ? AND nv.node_id = anc.nid
+				  AND nv.principal IN (%s)
+			)
+			OR EXISTS (
+				SELECT 1 FROM node_access na
+				WHERE na.node_id = anc.nid
+				  AND na.actor_id IN (%s)
+				  AND na.permission != 'deny'
+				  AND (na.expires_at IS NULL OR na.expires_at > ?)
+			)
+		)
+		LIMIT 1`,
+		aclMaxDepth, actorPh, visPh, actorPh,
+	)
+	walkArgs := make([]any, 0, 4+3*len(actorIDs)+len(visIDs))
+	walkArgs = append(walkArgs, nodeID, tenantID)
+	for _, a := range actorIDs {
+		walkArgs = append(walkArgs, a)
+	}
+	walkArgs = append(walkArgs, tenantID)
+	for _, v := range visIDs {
+		walkArgs = append(walkArgs, v)
+	}
+	for _, a := range actorIDs {
+		walkArgs = append(walkArgs, a)
+	}
+	walkArgs = append(walkArgs, s.now())
+
+	row = db.QueryRowContext(ctx, walkQ, walkArgs...)
+	switch err := row.Scan(&one); err {
+	case nil:
+		return true, nil
+	default:
+		if isNoRows(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("store: CanAccess walk: %w", err)
+	}
+}
+
+// isNoRows wraps errors.Is(err, sql.ErrNoRows) so callers don't need
+// to import database/sql.
+func isNoRows(err error) bool {
+	return errors.Is(err, sql.ErrNoRows)
+}


### PR DESCRIPTION
## Summary

Ports the batch-read **GetNodes** handler to the Go rewrite (refs #407, Wave 2). Spec: `docs/go-port/rpcs/GetNodes.md`. Reference Python: `server/python/entdb_server/api/grpc_server.py:1215-1291`.

### Parity preserved

- Tenant gate first; `PERMISSION_DENIED` is **batch-level only** — no per-id non-OK status.
- Trusted-actor rebinding via `auth.Authoritative` ignores any wire-claimed actor for auth decisions (privilege-escalation guard from #168).
- Cross-tenant non-members with at least one `node_access` grant fall through to per-id ACL filtering; **nodes the actor cannot read are MERGED into `missing_ids`** alongside truly-absent ids. This is a deliberate information-leak guard: foreign actors cannot probe existence vs access.
- Order is request order with gaps closed; duplicate `node_ids` are **NOT** deduped (each lookup runs independently — Python iterates verbatim).
- The proto's `type_id` field is silently ignored (Python iterates the ids and trusts whatever `type_id` is on disk).
- `after_offset` fence honours `wait_timeout_ms` (default 30s); a fence timeout is swallowed into "all missing" with status OK to match Python's bare-except (flagged for v2 tightening in the spec's open questions).

### Hardening delta vs Python (refs #407)

**Batch-size cap.** Python has none; a 100k-id payload melts the SQLite pool and blows past gRPC's 4 MiB default response size. The Go port aborts `RESOURCE_EXHAUSTED` at `len(node_ids) > 1000` **before any I/O**. The cap matches the spec's "Notes on performance & limits" recommendation; please confirm 1000 is the right number for the EPIC owner.

### Implementation notes

- Bounded concurrency (32-way fan-out) over per-id `store.GetNode` reads. Behaviour-preserving wrt Python (which is serial); only a perf knob.
- Cross-tenant role check is inlined in `get_nodes.go` for now; subsequent read RPCs (QueryNodes, GetEdgesFrom, …) will refactor it into `internal/tenant` once the surface stabilises.
- Adds three minimal helpers to `store`: `ResolveActorGroups`, `HasNodeAccess`, `CanAccess` — direct SQL ports of `canonical_store.py:_sync_resolve_actor_groups`, `_sync_has_node_access`, `_sync_can_access`.

### Drive-by build-break fixes

`origin/main` was failing `go vet` because three symbols landed twice from independent parallel Wave-2 PRs. This branch dedupes them so the package compiles:

- `userToProto` — kept in `list_users.go` (#437); removed from `get_user.go` (#444).
- `lookupMemberRole` — kept in `change_member_role.go` (#442); removed from `add_tenant_member.go` (#434).
- `withTrustedUser` — kept in `get_tenant_quota_test.go` (#438); removed from `update_user_test.go` (#443).

The `ExecuteAtomic` Unimplemented canary is left untouched.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` clean (all packages)
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed
- [x] `uvx ruff@0.15.7 check .` clean
- [x] `uvx ruff@0.15.7 format --check .` clean
- [x] New tests cover: empty / single-hit / single-miss / multi-with-duplicates, mixed missing+visible+denied folded into `missing_ids`, oversize batch (1001) -> `RESOURCE_EXHAUSTED`, boundary at-cap (1000) accepted, unknown tenant -> `NOT_FOUND`.