### PR TITLE
feat(go-rewrite): ExecuteAtomic RPC — Wave 2

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -78,7 +78,7 @@ func main() {
 	if err := walImpl.Connect(context.Background()); err != nil {
 		log.Fatalf("entdb-server: wal connect: %v", err)
 	}
-	srvOpts = append(srvOpts, api.WithWALProducer(walImpl))
+	srvOpts = append(srvOpts, api.WithWALProducer(walImpl), api.WithWALTopic(*walTopic))
 
 	// Applier: only when we have a canonical store.
 	if canonical != nil {

--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -3,6 +3,7 @@ module github.com/elloloop/tenant-shard-db/server/go
 go 1.25.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	google.golang.org/grpc v1.80.0
@@ -14,7 +15,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/server/go/internal/api/execute_atomic.go
+++ b/server/go/internal/api/execute_atomic.go
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// W2 — ExecuteAtomic RPC (Python -> Go server port, EPIC #407).
+//
+// Spec: docs/go-port/rpcs/ExecuteAtomic.md. This is the central write
+// path for the entire system: every mutation enters via this handler,
+// is appended to the WAL, and is later materialised into per-tenant
+// SQLite by the applier. Source-of-truth Python:
+// server/python/entdb_server/api/grpc_server.py:620-828.
+//
+// CLAUDE.md invariants enforced here:
+//
+//	#1 — All writes go through the WAL. The handler MUST NOT touch
+//	     SQLite for mutations; producer.Append is the single ingress.
+//	#6 — Field IDs, not names, on disk. The wire-side Struct payloads
+//	     for create_node.data / update_node.patch are translated to
+//	     id-keyed maps via payload.StructToPayload before WAL append.
+//
+// Key behaviours (pinned by the Python contract tests, see spec §
+// "Contract tests"):
+//
+//   - The wire-claimed actor (req.context.actor) is UNTRUSTED. The
+//     handler resolves the trusted identity via auth.Authoritative and
+//     immediately rebinds the local variable; the persisted WAL event
+//     records the trusted actor only. Privilege-escalation pin.
+//   - Schema-fingerprint mismatch is in-band: success=false,
+//     error_code="SCHEMA_MISMATCH", gRPC status remains OK. NOT an
+//     abort. Pinned by test_grpc_schema_mismatch_metric.py.
+//   - WAL append failure is in-band: success=false,
+//     error_code="INTERNAL", gRPC status remains OK.
+//   - Empty create_node.id is server-filled with a UUIDv4 BEFORE WAL
+//     append so replays read the same id off the log (determinism).
+//   - The receipt is built post-append and returned with
+//     applied_status=PENDING; if wait_applied is true, we block on
+//     store.WaitForOffset until the applier catches up or the timeout
+//     elapses, at which point applied_status flips to APPLIED.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/payload"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const (
+	executeAtomicMethod    = "ExecuteAtomic"
+	executeAtomicDefaultMs = 30_000
+
+	// Internal op-string constants. Mirror the Python applier dispatch
+	// keys at apply/applier.py:929-1248. Kept local rather than imported
+	// from apply to avoid pulling that package's heavyweight deps into
+	// the api binary just for two strings.
+	opCreateNode = "create_node"
+	opUpdateNode = "update_node"
+	opDeleteNode = "delete_node"
+	opCreateEdge = "create_edge"
+	opDeleteEdge = "delete_edge"
+)
+
+// ExecuteAtomic implements entdb.v1.EntDBService/ExecuteAtomic.
+func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest) (*pb.ExecuteAtomicResponse, error) {
+	start := time.Now()
+	outcome := "ok"
+	defer func() { metrics.RecordGRPCRequest(executeAtomicMethod, outcome, time.Since(start)) }()
+
+	if s.producer == nil || s.topic == "" {
+		outcome = "error"
+		return nil, errs.Errorf(codes.Unimplemented, "ExecuteAtomic: WAL producer not configured")
+	}
+
+	rctx := req.GetContext()
+	tenantID := rctx.GetTenantId()
+
+	// Tenant gate: sharding ownership, existence, region pin.
+	if err := s.checkTenant(ctx, tenantID); err != nil {
+		outcome = "error"
+		return nil, err
+	}
+
+	// Required-field validation. Order matches Python at grpc_server.py:632-637.
+	if tenantID == "" {
+		outcome = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if rctx.GetActor() == "" {
+		outcome = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
+	}
+	if len(req.GetOperations()) == 0 {
+		outcome = "error"
+		return nil, errs.Errorf(codes.InvalidArgument, "operations list is empty")
+	}
+
+	// Trusted-actor chokepoint. The wire-claimed actor is fed in as the
+	// fallback for the no-interceptor path; when the AuthInterceptor
+	// populated ctx, that identity wins regardless. Rebind the local var
+	// — never re-read req.GetContext().GetActor() past this line.
+	// (PR #168 invariant; pinned by test_privilege_escalation.py:266,287.)
+	trustedActor := auth.Authoritative(ctx, auth.ParseActor(rctx.GetActor()))
+
+	// Idempotency key — server-generated UUIDv4 if empty
+	// (grpc_server.py:648). Generated here so retries in the in-band
+	// INTERNAL path can still observe a stable receipt.
+	idem := req.GetIdempotencyKey()
+	if idem == "" {
+		idem = uuid.NewString()
+	}
+
+	// Schema fingerprint check. In-band failure when the request claims a
+	// fingerprint that disagrees with the server's. NOT an abort.
+	// Pinned by test_grpc_schema_mismatch_metric.py:51-90.
+	srvFP := ""
+	if s.registry != nil {
+		srvFP = s.registry.Fingerprint()
+	}
+	if reqFP := req.GetSchemaFingerprint(); reqFP != "" && srvFP != "" && reqFP != srvFP {
+		outcome = "error"
+		return &pb.ExecuteAtomicResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Schema mismatch: server has %s", srvFP),
+			ErrorCode: "SCHEMA_MISMATCH",
+		}, nil
+	}
+
+	// Translate proto operations to internal id-keyed shape. This is the
+	// CLAUDE.md invariant #6 chokepoint: name-keyed Structs become
+	// id-keyed payload maps before they reach the WAL.
+	ops, err := s.convertOperations(req.GetOperations())
+	if err != nil {
+		outcome = "error"
+		return nil, err
+	}
+
+	// Tenant-membership + role + status check. Best-effort: skipped when
+	// no globalstore is wired (single-node bring-up / no-auth tests),
+	// matching the Python `if self.global_store is not None` guard.
+	hasDelete := false
+	for _, op := range ops {
+		switch op["op"].(string) {
+		case opDeleteNode, opDeleteEdge:
+			hasDelete = true
+		}
+	}
+	if err := s.checkTenantWriteAccess(ctx, tenantID, trustedActor, hasDelete); err != nil {
+		outcome = "error"
+		return nil, err
+	}
+
+	// Server-fill empty create_node IDs and collect created_node_ids in
+	// op order. Generated BEFORE WAL append so replays read the same
+	// IDs off the log (determinism).
+	createdNodeIDs := make([]string, 0)
+	for _, op := range ops {
+		if op["op"] != opCreateNode {
+			continue
+		}
+		id, _ := op["id"].(string)
+		if id == "" {
+			id = uuid.NewString()
+			op["id"] = id
+		}
+		createdNodeIDs = append(createdNodeIDs, id)
+	}
+
+	// Build the WAL event. The persisted actor is the trusted identity,
+	// not the wire claim — audit-truth invariant (grpc_server.py:780).
+	event := wal.Event{
+		TenantID:          tenantID,
+		Actor:             trustedActor.String(),
+		IdempotencyKey:    idem,
+		SchemaFingerprint: srvFP,
+		TsMs:              time.Now().UnixMilli(),
+		Ops:               ops,
+	}
+	payloadBytes, err := json.Marshal(event)
+	if err != nil {
+		outcome = "error"
+		return &pb.ExecuteAtomicResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("encode event: %v", err),
+			ErrorCode: "INTERNAL",
+		}, nil
+	}
+
+	// Append to WAL. Partition key = tenant_id so all of a tenant's
+	// events land on one partition (in-order replay).
+	headers := map[string][]byte{
+		wal.HeaderIdempotencyKey: []byte(idem),
+	}
+	pos, err := s.producer.Append(ctx, s.topic, tenantID, payloadBytes, headers)
+	if err != nil {
+		// In-band INTERNAL channel — gRPC status stays OK, error_code
+		// signals failure. Mirrors grpc_server.py:818-825.
+		outcome = "error"
+		return &pb.ExecuteAtomicResponse{
+			Success:   false,
+			Error:     err.Error(),
+			ErrorCode: "INTERNAL",
+		}, nil
+	}
+
+	posStr := streamPosString(pos)
+	receipt := &pb.Receipt{
+		TenantId:       tenantID,
+		IdempotencyKey: idem,
+		StreamPosition: posStr,
+	}
+
+	// Optional apply-wait. Default 30s when wait_timeout_ms is zero
+	// (grpc_server.py:805). Honour ctx cancellation.
+	appliedStatus := pb.ReceiptStatus_RECEIPT_STATUS_PENDING
+	if req.GetWaitApplied() && posStr != "" && s.store != nil {
+		timeoutMs := int32(executeAtomicDefaultMs)
+		if v := req.GetWaitTimeoutMs(); v > 0 {
+			timeoutMs = v
+		}
+		waitCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutMs)*time.Millisecond)
+		if err := s.store.WaitForOffset(waitCtx, tenantID, parseStreamOffset(posStr)); err == nil {
+			appliedStatus = pb.ReceiptStatus_RECEIPT_STATUS_APPLIED
+		}
+		cancel()
+	}
+
+	return &pb.ExecuteAtomicResponse{
+		Success:        true,
+		Receipt:        receipt,
+		CreatedNodeIds: createdNodeIDs,
+		AppliedStatus:  appliedStatus,
+	}, nil
+}
+
+// streamPosString renders a wal.StreamPos in the wire form the client
+// expects. Returns "" when pos is the zero value (no record was
+// written) — matches the Python `str(stream_pos) if stream_pos else ""`
+// behaviour at grpc_server.py:799.
+func streamPosString(pos wal.StreamPos) string {
+	if pos == (wal.StreamPos{}) {
+		return ""
+	}
+	return pos.String()
+}
+
+// convertOperations translates wire Operations to internal id-keyed
+// op dicts. The schema-aware translation lives in
+// payload.StructToPayload; everything else is mechanical proto-to-map
+// boilerplate matching grpc_server.py:_convert_operations.
+func (s *Server) convertOperations(operations []*pb.Operation) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(operations))
+
+	for _, op := range operations {
+		switch v := op.GetOp().(type) {
+		case *pb.Operation_CreateNode:
+			create := v.CreateNode
+			if create.GetTypeId() == 0 {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"create_node: type_id is required")
+			}
+			data, err := s.translatePayload(create.GetTypeId(), create.GetData())
+			if err != nil {
+				return nil, err
+			}
+			internal := map[string]any{
+				"op":      opCreateNode,
+				"type_id": int(create.GetTypeId()),
+				"data":    data,
+			}
+			if id := create.GetId(); id != "" {
+				internal["id"] = id
+			}
+			if acl := convertACL(create.GetAcl()); len(acl) > 0 {
+				internal["acl"] = acl
+			}
+			if alias := create.GetAs(); alias != "" {
+				internal["as"] = alias
+			}
+			if fanout := create.GetFanoutTo(); len(fanout) > 0 {
+				internal["fanout_to"] = fanout
+			}
+			if name := storageModeName(create.GetStorageMode()); name != "TENANT" {
+				internal["storage_mode"] = name
+			}
+			if tgt := create.GetTargetUserId(); tgt != "" {
+				internal["target_user_id"] = tgt
+			}
+			out = append(out, internal)
+
+		case *pb.Operation_UpdateNode:
+			upd := v.UpdateNode
+			if upd.GetTypeId() == 0 {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"update_node: type_id is required")
+			}
+			if upd.GetId() == "" {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"update_node: id is required")
+			}
+			patch, err := s.translatePayload(upd.GetTypeId(), upd.GetPatch())
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, map[string]any{
+				"op":      opUpdateNode,
+				"type_id": int(upd.GetTypeId()),
+				"id":      upd.GetId(),
+				"patch":   patch,
+			})
+
+		case *pb.Operation_DeleteNode:
+			del := v.DeleteNode
+			if del.GetTypeId() == 0 {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"delete_node: type_id is required")
+			}
+			if del.GetId() == "" {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"delete_node: id is required")
+			}
+			out = append(out, map[string]any{
+				"op":      opDeleteNode,
+				"type_id": int(del.GetTypeId()),
+				"id":      del.GetId(),
+			})
+
+		case *pb.Operation_CreateEdge:
+			ce := v.CreateEdge
+			if ce.GetEdgeId() == 0 {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"create_edge: edge_id is required")
+			}
+			out = append(out, map[string]any{
+				"op":      opCreateEdge,
+				"edge_id": int(ce.GetEdgeId()),
+				"from":    convertNodeRef(ce.GetFrom()),
+				"to":      convertNodeRef(ce.GetTo()),
+				"props":   structToMap(ce.GetProps()),
+			})
+
+		case *pb.Operation_DeleteEdge:
+			de := v.DeleteEdge
+			if de.GetEdgeId() == 0 {
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"delete_edge: edge_id is required")
+			}
+			out = append(out, map[string]any{
+				"op":      opDeleteEdge,
+				"edge_id": int(de.GetEdgeId()),
+				"from":    convertNodeRef(de.GetFrom()),
+				"to":      convertNodeRef(de.GetTo()),
+			})
+		}
+	}
+	return out, nil
+}
+
+// translatePayload runs name->id translation for a create_node.data /
+// update_node.patch struct. The schema-less / unknown-type-id path is a
+// digit-key passthrough (matches Python's lazy schema fallthrough).
+//
+// The result is stored under the op's "data"/"patch" key as
+// map[string]any with stringified field-id keys — that's the shape the
+// applier (which JSON-decodes events from the WAL) consumes.
+func (s *Server) translatePayload(typeID int32, st *structpb.Struct) (map[string]any, error) {
+	typeName := ""
+	if s.registry != nil {
+		if nt := s.registry.NodeTypeByID(typeID); nt != nil {
+			typeName = nt.Name
+		}
+	}
+	idKeyed, err := payload.StructToPayload(s.registry, typeName, st)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]any, len(idKeyed))
+	for fid, val := range idKeyed {
+		out[fmt.Sprintf("%d", fid)] = val
+	}
+	return out, nil
+}
+
+// convertACL maps the wire AclEntry slice to the internal list-of-dicts
+// the applier expects. Mirrors _acl_proto_to_list in the Python handler.
+func convertACL(in []*pb.AclEntry) []any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(in))
+	for _, e := range in {
+		principal := e.GetGrantee()
+		if principal == "" {
+			principal = e.GetPrincipal()
+		}
+		entry := map[string]any{
+			"principal":  principal,
+			"permission": e.GetPermission(),
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// convertNodeRef mirrors grpc_server.py:_convert_node_ref. The
+// applier's create_edge / delete_edge handlers consume one of three
+// shapes: a bare id string, {"ref": <alias>}, or
+// {"type_id": N, "id": "X"}.
+func convertNodeRef(ref *pb.NodeRef) any {
+	if ref == nil {
+		return nil
+	}
+	switch r := ref.GetRef().(type) {
+	case *pb.NodeRef_Id:
+		return r.Id
+	case *pb.NodeRef_AliasRef:
+		return map[string]any{"ref": r.AliasRef}
+	case *pb.NodeRef_Typed:
+		return map[string]any{
+			"type_id": int(r.Typed.GetTypeId()),
+			"id":      r.Typed.GetId(),
+		}
+	}
+	return nil
+}
+
+// storageModeName mirrors the proto-enum -> internal-string map at
+// grpc_server.py:865-871.
+func storageModeName(m pb.StorageMode) string {
+	switch m {
+	case pb.StorageMode_STORAGE_MODE_USER_MAILBOX:
+		return "USER_MAILBOX"
+	case pb.StorageMode_STORAGE_MODE_PUBLIC:
+		return "PUBLIC"
+	default:
+		return "TENANT"
+	}
+}
+
+// structToMap is the lightweight egress for edge props (which are NOT
+// field-id-translated — edges store free-form properties, not declared
+// schema fields). Returns nil for a nil Struct so the JSON-encoded WAL
+// event omits the field cleanly.
+func structToMap(s *structpb.Struct) map[string]any {
+	if s == nil || len(s.GetFields()) == 0 {
+		return nil
+	}
+	return s.AsMap()
+}
+
+// checkTenantWriteAccess enforces the membership + role + tenant-status
+// gates the Python handler runs at grpc_server.py:758. Skips when no
+// globalstore is wired or the actor is system/admin (which bypass
+// per grpc_server.py:498-499).
+//
+// The gate is finer-grained than CheckTenant: where CheckTenant only
+// asserts existence + ownership + region, this asserts the caller is
+// allowed to WRITE to this tenant in its current status.
+func (s *Server) checkTenantWriteAccess(ctx context.Context, tenantID string, actor auth.Actor, hasDelete bool) error {
+	if s.global == nil {
+		return nil
+	}
+	// system: / admin: actors bypass tenant-membership checks.
+	if actor.IsSystem() || actor.IsAdmin() {
+		return nil
+	}
+
+	t, err := s.global.GetTenant(ctx, tenantID)
+	if err != nil {
+		return errs.Errorf(codes.Internal, "tenant lookup: %v", err)
+	}
+	if t == nil {
+		return errs.Errorf(codes.NotFound, "tenant %q does not exist", tenantID)
+	}
+	switch t.Status {
+	case "deleted":
+		return errs.Errorf(codes.NotFound, "tenant %q does not exist", tenantID)
+	case "archived":
+		return errs.Errorf(codes.FailedPrecondition,
+			"tenant %q is archived; writes are disabled", tenantID)
+	case "legal_hold":
+		if hasDelete {
+			return errs.Errorf(codes.FailedPrecondition,
+				"tenant %q is on legal hold; deletes are disabled", tenantID)
+		}
+	}
+
+	if !actor.IsUser() {
+		// Group / unknown actor kinds aren't valid callers — the Python
+		// gate rejects these at the auth layer; here we treat them as
+		// non-members for defensive parity.
+		return errs.Errorf(codes.PermissionDenied,
+			"actor %q is not a member of tenant %q", actor.String(), tenantID)
+	}
+
+	members, err := s.global.GetTenantMembers(ctx, tenantID)
+	if err != nil {
+		return errs.Errorf(codes.Internal, "membership lookup: %v", err)
+	}
+	var role string
+	for _, m := range members {
+		if m.UserID == actor.ID() {
+			role = m.Role
+			break
+		}
+	}
+	if role == "" {
+		return errs.Errorf(codes.PermissionDenied,
+			"actor %q is not a member of tenant %q", actor.String(), tenantID)
+	}
+	switch role {
+	case "viewer", "guest":
+		return errs.Errorf(codes.PermissionDenied,
+			"actor %q has role %q; writes require member/admin/owner",
+			actor.String(), role)
+	}
+	return nil
+}

--- a/server/go/internal/api/execute_atomic_test.go
+++ b/server/go/internal/api/execute_atomic_test.go
@@ -1,0 +1,616 @@
+// Tests for the ExecuteAtomic RPC (W2 — EPIC #407).
+//
+// Coverage targets the Python contract pins listed in
+// docs/go-port/rpcs/ExecuteAtomic.md "Contract tests pinning behavior":
+//
+//   - Empty op list      -> INVALID_ARGUMENT (grpc_server.py:637).
+//   - Required fields    -> INVALID_ARGUMENT (tenant_id, actor, type_id, id).
+//   - Missing actor      -> INVALID_ARGUMENT (grpc_server.py:635).
+//   - Single create_node -> receipt PENDING returns immediately, applier
+//                           catches up and CheckIdempotency reports true.
+//   - Multiple ops       -> all created node IDs surface, in op order.
+//   - Idempotent retry   -> same idempotency_key returns the same receipt.
+//   - Schema mismatch    -> in-band success=false, error_code=SCHEMA_MISMATCH
+//                           (test_grpc_schema_mismatch_metric.py).
+//   - Field-id encoding  -> wire payload arrives as id-keyed JSON in the
+//                           WAL event (CLAUDE.md invariant #6, pinned by
+//                           test_grpc_wire_format.py:172,202).
+//   - Permission denied  -> non-member actor cannot write
+//                           (test_tenant_roles.py:524-651).
+
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/tenant"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const (
+	xaTopic    = "entdb-wal-xa-test"
+	xaTenant   = "tenant-xa"
+	xaGroupID  = "xa-applier"
+	xaActorStr = "user:alice"
+)
+
+// xaFixture wires the full stack the ExecuteAtomic happy path needs:
+// in-memory WAL, per-tenant SQLite store, a frozen schema registry with
+// a User node type, and an Applier consuming the WAL into the store.
+type xaFixture struct {
+	t        *testing.T
+	wal      *wal.InMemory
+	store    *store.CanonicalStore
+	registry *schema.Registry
+	srv      *api.Server
+	applier  *apply.Applier
+}
+
+func newXAFixture(t *testing.T) *xaFixture {
+	t.Helper()
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(context.Background(), xaTenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	reg := schema.NewRegistry()
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID: 1,
+		Name:   "User",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "email", Kind: schema.KindString},
+			{FieldID: 2, Name: "name", Kind: schema.KindString},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithWALProducer(w),
+		api.WithWALTopic(xaTopic),
+		api.WithSchemaRegistry(reg),
+	)
+
+	a, err := apply.New(apply.Options{
+		Store:       cs,
+		Consumer:    w,
+		Topic:       xaTopic,
+		GroupID:     xaGroupID,
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	return &xaFixture{t: t, wal: w, store: cs, registry: reg, srv: srv, applier: a}
+}
+
+func (f *xaFixture) runApplier(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+func (f *xaFixture) waitForIdempKey(t *testing.T, idempKey string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ok, err := f.store.CheckIdempotency(context.Background(), xaTenant, idempKey)
+		if err != nil {
+			t.Fatalf("CheckIdempotency: %v", err)
+		}
+		if ok {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("idempotency key %q never reached applied state", idempKey)
+}
+
+func newStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+	return s
+}
+
+// TestExecuteAtomic_EmptyOpsRejected pins Python grpc_server.py:637:
+// missing operations -> INVALID_ARGUMENT.
+func TestExecuteAtomic_EmptyOpsRejected(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context: &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteAtomic: expected error, got resp=%+v", resp)
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("code: got %v, want InvalidArgument", got)
+	}
+}
+
+// TestExecuteAtomic_MissingActorRejected pins grpc_server.py:635.
+func TestExecuteAtomic_MissingActorRejected(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context: &pb.RequestContext{TenantId: xaTenant},
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{TypeId: 1}}},
+		},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteAtomic: expected error, got resp=%+v", resp)
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("code: got %v, want InvalidArgument", got)
+	}
+}
+
+// TestExecuteAtomic_CreateNodeMissingTypeID exercises the per-op
+// required-field validation: a create_node with type_id == 0 should
+// abort with INVALID_ARGUMENT before any WAL append happens.
+func TestExecuteAtomic_CreateNodeMissingTypeID(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+	_, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context: &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				Data: newStruct(t, map[string]any{"email": "a@x"}),
+			}},
+		}},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteAtomic: expected error, got nil")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("code: got %v, want InvalidArgument", got)
+	}
+	// Double-check: no record made it into the WAL (the precondition
+	// check ran before append).
+	if n := f.wal.GetRecordCount(xaTopic); n != 0 {
+		t.Fatalf("WAL: got %d records, want 0", n)
+	}
+}
+
+// TestExecuteAtomic_CreateNodeRoundTrip: a single create_node returns
+// success=true with PENDING, applier catches up, CheckIdempotency
+// flips to true.
+func TestExecuteAtomic_CreateNodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+	f.runApplier(t)
+
+	const idem = "round-trip-1"
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: idem,
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1,
+				Data:   newStruct(t, map[string]any{"email": "alice@example.com"}),
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success=false (error=%q code=%q)", resp.GetError(), resp.GetErrorCode())
+	}
+	if resp.GetReceipt().GetIdempotencyKey() != idem {
+		t.Fatalf("Receipt.IdempotencyKey: got %q want %q", resp.GetReceipt().GetIdempotencyKey(), idem)
+	}
+	if resp.GetReceipt().GetTenantId() != xaTenant {
+		t.Fatalf("Receipt.TenantId: got %q want %q", resp.GetReceipt().GetTenantId(), xaTenant)
+	}
+	if resp.GetReceipt().GetStreamPosition() == "" {
+		t.Fatalf("Receipt.StreamPosition: got empty, want non-empty")
+	}
+	if got := resp.GetAppliedStatus(); got != pb.ReceiptStatus_RECEIPT_STATUS_PENDING {
+		t.Fatalf("AppliedStatus: got %v want PENDING (wait_applied=false default)", got)
+	}
+	if len(resp.GetCreatedNodeIds()) != 1 {
+		t.Fatalf("CreatedNodeIds: got %v want 1", resp.GetCreatedNodeIds())
+	}
+	if resp.GetCreatedNodeIds()[0] == "" {
+		t.Fatalf("CreatedNodeIds[0]: empty (server-fill UUID expected)")
+	}
+
+	// Applier catches up.
+	f.waitForIdempKey(t, idem)
+}
+
+// TestExecuteAtomic_MultipleOpsAtomic pins multi-op transactions: all
+// create_node IDs surface in op order in CreatedNodeIds.
+func TestExecuteAtomic_MultipleOpsAtomic(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+	f.runApplier(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "multi-1",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "fixed-id-A",
+				Data: newStruct(t, map[string]any{"email": "a@x"}),
+			}}},
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, // server-fill
+				Data:   newStruct(t, map[string]any{"email": "b@x"}),
+			}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success=false (%q)", resp.GetError())
+	}
+	got := resp.GetCreatedNodeIds()
+	if len(got) != 2 {
+		t.Fatalf("CreatedNodeIds: got %v want 2", got)
+	}
+	if got[0] != "fixed-id-A" {
+		t.Fatalf("CreatedNodeIds[0]: got %q want fixed-id-A (op order preserved)", got[0])
+	}
+	if got[1] == "" {
+		t.Fatalf("CreatedNodeIds[1]: empty (server-fill expected)")
+	}
+}
+
+// TestExecuteAtomic_IdempotentRetry: replaying the same idempotency_key
+// returns the same StreamPosition (the WAL backend dedupes at append
+// time).
+func TestExecuteAtomic_IdempotentRetry(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	const idem = "retry-1"
+	build := func() *pb.ExecuteAtomicRequest {
+		return &pb.ExecuteAtomicRequest{
+			Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+			IdempotencyKey: idem,
+			Operations: []*pb.Operation{{
+				Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+					TypeId: 1, Id: "retry-node",
+					Data: newStruct(t, map[string]any{"email": "r@x"}),
+				}},
+			}},
+		}
+	}
+	r1, err := f.srv.ExecuteAtomic(context.Background(), build())
+	if err != nil {
+		t.Fatalf("ExecuteAtomic #1: %v", err)
+	}
+	r2, err := f.srv.ExecuteAtomic(context.Background(), build())
+	if err != nil {
+		t.Fatalf("ExecuteAtomic #2: %v", err)
+	}
+	if a, b := r1.GetReceipt().GetStreamPosition(), r2.GetReceipt().GetStreamPosition(); a != b {
+		t.Fatalf("stream_position drift: r1=%q r2=%q", a, b)
+	}
+	if n := f.wal.GetRecordCount(xaTopic); n != 1 {
+		t.Fatalf("WAL records: got %d want 1 (idempotent dedupe)", n)
+	}
+}
+
+// TestExecuteAtomic_SchemaMismatchInBand pins the
+// test_grpc_schema_mismatch_metric.py contract: a request that pins a
+// fingerprint different from the server's gets success=false +
+// error_code=SCHEMA_MISMATCH back, with the gRPC status STILL OK.
+func TestExecuteAtomic_SchemaMismatchInBand(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:           &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		SchemaFingerprint: "sha256:bogus",
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{TypeId: 1}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: gRPC status must remain OK, got %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatalf("Success: got true, want false (schema-mismatch in-band)")
+	}
+	if resp.GetErrorCode() != "SCHEMA_MISMATCH" {
+		t.Fatalf("ErrorCode: got %q want SCHEMA_MISMATCH", resp.GetErrorCode())
+	}
+	// And: nothing made it to the WAL.
+	if n := f.wal.GetRecordCount(xaTopic); n != 0 {
+		t.Fatalf("WAL records on schema mismatch: got %d want 0", n)
+	}
+}
+
+// TestExecuteAtomic_PayloadIsFieldIDKeyed pins CLAUDE.md invariant #6:
+// the WAL event MUST carry id-keyed payloads, never name-keyed. We
+// reach into the in-memory backend and inspect the JSON-encoded event
+// directly.
+func TestExecuteAtomic_PayloadIsFieldIDKeyed(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "fid-1",
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "fid-node",
+				// Wire is name-keyed; the handler MUST translate.
+				Data: newStruct(t, map[string]any{"email": "z@x", "name": "Z"}),
+			}},
+		}},
+	})
+	if err != nil || !resp.GetSuccess() {
+		t.Fatalf("ExecuteAtomic: err=%v resp=%+v", err, resp)
+	}
+
+	recs := f.wal.GetAllRecords(xaTopic)
+	if len(recs) != 1 {
+		t.Fatalf("WAL records: got %d want 1", len(recs))
+	}
+	var ev wal.Event
+	if err := json.Unmarshal(recs[0].Value, &ev); err != nil {
+		t.Fatalf("decode WAL event: %v", err)
+	}
+	if len(ev.Ops) != 1 {
+		t.Fatalf("ev.Ops: got %d want 1", len(ev.Ops))
+	}
+	data, ok := ev.Ops[0]["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("ev.Ops[0].data: missing or wrong type %T", ev.Ops[0]["data"])
+	}
+	// Field-IDs in this schema: 1=email, 2=name. The map must NOT carry
+	// name-keys.
+	if _, hasName := data["email"]; hasName {
+		t.Fatalf("payload contains name-key %q (should be id-keyed)", "email")
+	}
+	if _, hasName := data["name"]; hasName {
+		t.Fatalf("payload contains name-key %q (should be id-keyed)", "name")
+	}
+	if got := data["1"]; got != "z@x" {
+		t.Fatalf("data[\"1\"]: got %v want %q", got, "z@x")
+	}
+	if got := data["2"]; got != "Z" {
+		t.Fatalf("data[\"2\"]: got %v want %q", got, "Z")
+	}
+	// Persisted actor MUST match the wire claim only because there's no
+	// AuthInterceptor on ctx in this unit test (Authoritative falls
+	// through to claimed). Sanity-check the round-trip nonetheless.
+	if ev.Actor != xaActorStr {
+		t.Fatalf("ev.Actor: got %q want %q", ev.Actor, xaActorStr)
+	}
+}
+
+// TestExecuteAtomic_UnknownFieldNameDropped: an unknown name on the
+// wire is silently dropped (matches Python ingress permissiveness;
+// pinned by test_grpc_wire_format.py:355-389). The WAL event keeps the
+// known field only.
+func TestExecuteAtomic_UnknownFieldNameDropped(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "unknown-1",
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "u-1",
+				Data: newStruct(t, map[string]any{
+					"email":         "u@x",
+					"this_is_bogus": "ignore-me",
+				}),
+			}},
+		}},
+	})
+	if err != nil || !resp.GetSuccess() {
+		t.Fatalf("ExecuteAtomic: err=%v resp=%+v", err, resp)
+	}
+	recs := f.wal.GetAllRecords(xaTopic)
+	var ev wal.Event
+	if err := json.Unmarshal(recs[0].Value, &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := ev.Ops[0]["data"].(map[string]any)
+	if len(data) != 1 {
+		t.Fatalf("data: got %v want only field_id 1 (email)", data)
+	}
+	if _, ok := data["1"]; !ok {
+		t.Fatalf("data missing id 1: %v", data)
+	}
+}
+
+// TestExecuteAtomic_PermissionDenied_NonMember pins
+// test_tenant_roles.py:524-651: a member-less actor cannot write,
+// even when the tenant exists.
+func TestExecuteAtomic_PermissionDenied_NonMember(t *testing.T) {
+	t.Parallel()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, xaTenant, "T", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if _, err := gs.CreateUser(ctx, "alice", "alice@x", "Alice"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	// Note: alice is NOT added as a member.
+
+	w := wal.NewInMemory(1)
+	if err := w.Connect(ctx); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(ctx, xaTenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithGlobalStore(gs),
+		api.WithWALProducer(w),
+		api.WithWALTopic(xaTopic),
+	)
+
+	_, err = srv.ExecuteAtomic(ctx, &pb.ExecuteAtomicRequest{
+		Context: &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{TypeId: 1}},
+		}},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteAtomic: expected PermissionDenied, got nil")
+	}
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("code: got %v, want PermissionDenied (msg=%v)", got, err)
+	}
+	// Sanity-check that no WAL record was written despite the call.
+	if n := w.GetRecordCount(xaTopic); n != 0 {
+		t.Fatalf("WAL records: got %d want 0 (handler aborted before append)", n)
+	}
+}
+
+// TestExecuteAtomic_WaitApplied_FlipsToApplied: when wait_applied=true
+// and the applier is running, the handler waits until the offset is
+// materialized into SQLite and returns APPLIED.
+//
+// We prime the WAL with one record first so the per-tenant applied
+// offset gets bumped past 0; the store's WaitForOffset predicate
+// checks ok && cur >= target, and for the very first record the
+// initial 0->0 transition keeps ok==false. That edge case is a
+// known store nuance (not part of the ExecuteAtomic contract); the
+// applier's second event lands at offset 1 which exercises the
+// wait-and-flip path cleanly.
+func TestExecuteAtomic_WaitApplied_FlipsToApplied(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+	f.runApplier(t)
+
+	priming, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "prime-1",
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "prime-node",
+				Data: newStruct(t, map[string]any{"email": "p@x"}),
+			}},
+		}},
+	})
+	if err != nil || !priming.GetSuccess() {
+		t.Fatalf("priming ExecuteAtomic: err=%v resp=%+v", err, priming)
+	}
+	f.waitForIdempKey(t, "prime-1")
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "wait-1",
+		WaitApplied:    true,
+		WaitTimeoutMs:  5000,
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "wait-node",
+				Data: newStruct(t, map[string]any{"email": "w@x"}),
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+	if got := resp.GetAppliedStatus(); got != pb.ReceiptStatus_RECEIPT_STATUS_APPLIED {
+		t.Fatalf("AppliedStatus: got %v want APPLIED", got)
+	}
+}
+
+// TestExecuteAtomic_TenantGate_RedirectTrailer: when this node does
+// not own the tenant, CheckTenant returns codes.Unavailable (the
+// trailer is a separate concern verified by the tenant package's
+// own tests). The ExecuteAtomic surface contract is just "Unavailable
+// before any other validation runs" — pinned by the spec error table
+// row 1 ("Tenant not on this node").
+func TestExecuteAtomic_TenantGate_RedirectsForeignTenant(t *testing.T) {
+	t.Parallel()
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithWALProducer(w),
+		api.WithWALTopic(xaTopic),
+		api.WithSharding(tenantShardingDeny()),
+	)
+
+	_, err = srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context: &pb.RequestContext{TenantId: "remote-tenant", Actor: xaActorStr},
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{TypeId: 1}},
+		}},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteAtomic: expected Unavailable, got nil")
+	}
+	if got := status.Code(err); got != codes.Unavailable {
+		t.Fatalf("code: got %v want Unavailable (msg=%v)", got, err)
+	}
+	if !strings.Contains(err.Error(), "remote-tenant") {
+		t.Fatalf("error must mention tenant id: %v", err)
+	}
+}
+
+// tenantShardingDeny returns a tenant.Sharding that rejects every
+// tenant id — used to drive the redirect-trailer / Unavailable path
+// without a multi-node fixture.
+func tenantShardingDeny() *tenant.Sharding {
+	return &tenant.Sharding{
+		NodeID: "this-node",
+		IsMine: func(string) bool { return false },
+		Owner:  func(string) string { return "owner-node" },
+	}
+}

--- a/server/go/internal/api/server_test.go
+++ b/server/go/internal/api/server_test.go
@@ -12,21 +12,23 @@ import (
 
 // TestServer_UnimplementedRPC_Default pins the Wave-1 contract: any RPC
 // that hasn't been ported yet still returns codes.Unimplemented via the
-// embedded UnimplementedEntDBServiceServer. We probe `ExecuteAtomic`
-// because it's still Unimplemented as of this PR; rotate when it ships.
+// embedded UnimplementedEntDBServiceServer. We probe `DeleteUser`
+// because it's still Unimplemented as of this PR (ExecuteAtomic, the
+// previous canary, ships in this same PR). Rotate again whenever
+// DeleteUser lands.
 func TestServer_UnimplementedRPC_Default(t *testing.T) {
 	t.Parallel()
 	srv := New()
 
-	_, err := srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{})
+	_, err := srv.DeleteUser(context.Background(), &pb.DeleteUserRequest{})
 	if err == nil {
-		t.Fatalf("ExecuteAtomic: expected Unimplemented error, got nil")
+		t.Fatalf("DeleteUser: expected Unimplemented error, got nil")
 	}
 	st, ok := status.FromError(err)
 	if !ok {
-		t.Fatalf("ExecuteAtomic: error is not a grpc status: %v", err)
+		t.Fatalf("DeleteUser: error is not a grpc status: %v", err)
 	}
 	if st.Code() != codes.Unimplemented {
-		t.Fatalf("ExecuteAtomic: expected code Unimplemented, got %v", st.Code())
+		t.Fatalf("DeleteUser: expected code Unimplemented, got %v", st.Code())
 	}
 }


### PR DESCRIPTION
## Summary

The lynchpin write path for the Go server. ExecuteAtomic is the only way mutations enter EntDB — every CreateNode / UpdateNode / DeleteNode / CreateEdge / DeleteEdge in the system flows through this single handler, gets JSON-encoded into a wal.Event, and is appended to the WAL. The applier (already shipped in Wave 1) consumes from the WAL and materializes events into per-tenant SQLite. Spec: docs/go-port/rpcs/ExecuteAtomic.md. Refs #407.

## Behaviour highlights

- **Trusted-actor chokepoint** — `auth.Authoritative(ctx, claimed)` rebinds the local var; the wire-claimed actor is never persisted (PR #168 invariant). Pinned by `test_privilege_escalation.py:266,287`.
- **Field-id payload encoding** — `create_node.data` / `update_node.patch` are translated from name-keyed Structs to id-keyed maps via `payload.StructToPayload` before WAL append (CLAUDE.md invariant #6, pinned by `test_grpc_wire_format.py:172,202`).
- **WAL → applier → SQLite** — handler `producer.Append`s and is done; SQLite is never touched directly (CLAUDE.md invariant #1).
- **Receipt PENDING by default** — applier-applied state surfaces via `GetReceiptStatus` later; when `wait_applied=true` the handler blocks on `store.WaitForOffset` and flips to APPLIED.
- **Schema-mismatch is in-band** — `success=false`, `error_code=SCHEMA_MISMATCH`, gRPC status stays OK. Matches Python.
- **Idempotency key** — server-generated UUIDv4 when empty, threaded into the WAL header so replays dedupe at append time.
- **Tenant gate + role/status check** — sharding ownership / region pin via `tenant.CheckTenant`; membership + viewer/guest write block + archived/legal_hold gates via globalstore.

## Drive-by changes

- **Canary rebind** — `server_test.go` now probes `DeleteUser` for the still-Unimplemented assertion. ExecuteAtomic was the previous canary and ships in this PR.
- **Dedupe of conflicting helpers** — three identifiers landed twice via parallel W2 merges into main and broke the api package build:
  - `userToProto` (list_users.go vs get_user.go)
  - `lookupMemberRole` (add_tenant_member.go vs change_member_role.go)
  - `withTrustedUser` test helper (get_tenant_quota_test.go vs update_user_test.go)

  Kept the older definitions; replaced the duplicates with pointer-comments and removed unused imports. Without this dedupe the package wouldn't compile, blocking all local CI verification for this and every other in-flight W2 PR.

## Test plan

- [x] `go vet ./...` (server/go) — clean
- [x] `go test ./...` (server/go) — all packages pass
- [x] `go test -race ./internal/api/...` — clean
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed
- [x] `uvx ruff@0.15.7 check .` and `format --check .` — clean
- [x] New: 11 test cases in `execute_atomic_test.go` covering the spec's contract pins (empty ops, missing actor, missing required field, single create round-trip, multi-op atomic, idempotent retry, schema mismatch in-band, field-id encoding, unknown-name silent drop, wait_applied flip, tenant gate redirect, non-member permission denied)