### PR TITLE
fix(go-rewrite): dedupe round-3 helper redeclarations

### DIFF
--- a/server/go/internal/api/get_connected_nodes.go
+++ b/server/go/internal/api/get_connected_nodes.go
@@ -45,13 +45,11 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/payload"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 )
@@ -158,7 +156,7 @@ func (s *Server) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNode
 
 	out := make([]*pb.Node, 0, len(collected))
 	for _, n := range collected {
-		pn, perr := storeNodeToProto(s.registry, n)
+		pn, perr := s.storeNodeToProto("", n)
 		if perr != nil {
 			// A single bad row collapses the whole response to empty —
 			// matches Python's broad except. Recording as error so the
@@ -317,145 +315,8 @@ func sortNodesByCreatedAtDesc(nodes []*store.Node) {
 	}
 }
 
-// authActorToACLActor bridges the auth.Actor (caller identity admitted
-// by the interceptor) and the acl.Actor (ACL grant subject). user/system
-// translate directly; admin maps to system because admins bypass ACL on
-// the read path (matches Python's "admin can read everything" handler-
-// level convention).
-func authActorToACLActor(a auth.Actor) acl.Actor {
-	if a.IsZero() {
-		return acl.Actor{}
-	}
-	switch a.Kind() {
-	case auth.KindUser:
-		return acl.User(a.ID())
-	case auth.KindSystem:
-		return acl.System(a.ID())
-	case auth.KindAdmin:
-		// Admins bypass ACL for read on the Python side; expressing them
-		// as system: actors here picks up the same bypass in
-		// acl.Filter.FilterReadable.
-		return acl.System(a.ID())
-	default:
-		// Service / unknown — fall through to user: form so the filter
-		// has a non-system, non-empty actor.
-		return acl.User(a.ID())
-	}
-}
-
-// storeVisibilityAdapter satisfies acl.VisibilityReader by forwarding to
-// CanonicalStore.GetVisibleNodeIDs. Mirrors the same adapter used in
-// acl/integration_test.go.
-type storeVisibilityAdapter struct {
-	s *store.CanonicalStore
-}
-
-func (a storeVisibilityAdapter) VisibleNodeIDs(ctx context.Context, tenantID string, actorIDs []string, nodeIDs []string) (map[string]struct{}, error) {
-	return a.s.GetVisibleNodeIDs(ctx, tenantID, actorIDs, nodeIDs)
-}
-
-// storeNodeToProto converts a store.Node to a wire pb.Node. Payload
-// stays field-id-keyed per CLAUDE.md invariant #6 — the SDK names the
-// fields client-side. Mirrors Python's _node_to_proto at
-// grpc_server.py:1693-1710.
-//
-// The schema registry is currently unused on egress (the wire stays
-// id-keyed and structpb encodes scalars without help). It is accepted as
-// a parameter so a future kind-aware encoding can be plumbed in without
-// changing call sites.
-func storeNodeToProto(_ interface{}, n *store.Node) (*pb.Node, error) {
-	idPayload, err := decodeIDKeyedPayload(n.PayloadJSON)
-	if err != nil {
-		return nil, err
-	}
-	pStruct, err := payload.PayloadToStruct(nil, "", idPayload)
-	if err != nil {
-		return nil, err
-	}
-	aclEntries, err := decodeACLEntries(n.ACLJSON)
-	if err != nil {
-		return nil, err
-	}
-	return &pb.Node{
-		TenantId:   n.TenantID,
-		NodeId:     n.NodeID,
-		TypeId:     n.TypeID,
-		CreatedAt:  n.CreatedAt,
-		UpdatedAt:  n.UpdatedAt,
-		OwnerActor: n.OwnerActor,
-		Payload:    pStruct,
-		Acl:        aclEntries,
-	}, nil
-}
-
-// decodeIDKeyedPayload parses a raw JSON object whose keys are
-// stringified field_ids ({"1": ...}) into the uint32-keyed map the
-// payload package consumes. Empty / null JSON yields an empty map.
-func decodeIDKeyedPayload(raw string) (map[uint32]any, error) {
-	out := map[uint32]any{}
-	if raw == "" || raw == "null" {
-		return out, nil
-	}
-	tmp := map[string]any{}
-	if err := json.Unmarshal([]byte(raw), &tmp); err != nil {
-		return nil, err
-	}
-	for k, v := range tmp {
-		id, ok := parsePositiveDigits(k)
-		if !ok {
-			// A non-digit key on disk would violate invariant #6. We
-			// drop silently (the read path can't fix old rows; the
-			// applier-side guard prevents new ones).
-			continue
-		}
-		out[id] = v
-	}
-	return out, nil
-}
-
-// decodeACLEntries parses the on-disk acl_blob ([{principal, permission}])
-// into the wire pb.AclEntry slice. Empty / null yields nil.
-func decodeACLEntries(raw string) ([]*pb.AclEntry, error) {
-	if raw == "" || raw == "null" {
-		return nil, nil
-	}
-	var tmp []store.ACLEntry
-	if err := json.Unmarshal([]byte(raw), &tmp); err != nil {
-		return nil, err
-	}
-	if len(tmp) == 0 {
-		return nil, nil
-	}
-	out := make([]*pb.AclEntry, 0, len(tmp))
-	for _, e := range tmp {
-		out = append(out, &pb.AclEntry{
-			Grantee:    e.Principal,
-			Permission: e.Permission,
-		})
-	}
-	return out, nil
-}
-
-// parsePositiveDigits parses a non-empty digit-only string into a
-// uint32 in [1, 65535]. Mirrors payload.parseFieldID (unexported there).
-func parsePositiveDigits(s string) (uint32, bool) {
-	if s == "" {
-		return 0, false
-	}
-	var n uint32
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, false
-		}
-		d := uint32(c - '0')
-		next := n*10 + d
-		if next < n {
-			return 0, false
-		}
-		n = next
-	}
-	if n == 0 || n > 65535 {
-		return 0, false
-	}
-	return n, true
-}
+// authActorToACLActor / storeVisibilityAdapter /
+// (*Server).storeNodeToProto / decodeIDKeyedPayload / decodeACLEntries
+// /parsePayloadFieldID — consolidated in helpers.go (round-3 Wave-2
+// dedupe). The shared method form takes typeName (passed "" here
+// because GetConnectedNodes operates on heterogeneous node sets).

--- a/server/go/internal/api/get_edges_from.go
+++ b/server/go/internal/api/get_edges_from.go
@@ -45,15 +45,11 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"time"
-
-	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 )
 
 const grpcMethodGetEdgesFrom = "GetEdgesFrom"
@@ -122,34 +118,6 @@ func (s *Server) GetEdgesFrom(ctx context.Context, req *pb.GetEdgesRequest) (*pb
 	return &pb.GetEdgesResponse{Edges: out, HasMore: hasMore}, nil
 }
 
-// edgeToProto translates a store.Edge into its wire shape. PropsJSON is
-// stored as a JSON-encoded map keyed by field IDs (CLAUDE.md invariant
-// 6); we round-trip through map[string]any -> structpb.NewStruct so the
-// wire `props` mirrors Python's `_dict_to_struct` output. On any
-// translation error, props is left nil (parity with Python's defensive
-// fall-through at grpc_server.py:1408).
-func edgeToProto(e *store.Edge) *pb.Edge {
-	out := &pb.Edge{
-		TenantId:   e.TenantID,
-		EdgeTypeId: e.EdgeTypeID,
-		FromNodeId: e.FromNodeID,
-		ToNodeId:   e.ToNodeID,
-		CreatedAt:  e.CreatedAt,
-	}
-	if e.PropsJSON == "" {
-		return out
-	}
-	var m map[string]any
-	if err := json.Unmarshal([]byte(e.PropsJSON), &m); err != nil {
-		return out
-	}
-	if m == nil {
-		return out
-	}
-	s, err := structpb.NewStruct(m)
-	if err != nil {
-		return out
-	}
-	out.Props = s
-	return out
-}
+// edgeToProto is shared with GetEdgesTo and lives in helpers.go (after
+// the round-3 Wave-2 dedupe). The defensive empty-Struct shape is
+// preserved there; behaviour is otherwise identical.

--- a/server/go/internal/api/get_edges_from_test.go
+++ b/server/go/internal/api/get_edges_from_test.go
@@ -71,7 +71,7 @@ func newEdgesServer(t *testing.T, tenantID string) (*api.Server, *store.Canonica
 	return srv, cs
 }
 
-func edgesReq(tenantID, nodeID string) *pb.GetEdgesRequest {
+func edgesFromReq(tenantID, nodeID string) *pb.GetEdgesRequest {
 	return &pb.GetEdgesRequest{
 		Context: &pb.RequestContext{TenantId: tenantID},
 		NodeId:  nodeID,
@@ -84,7 +84,7 @@ func TestGetEdgesFrom_EmptyTenantReturnsNoEdges(t *testing.T) {
 	t.Parallel()
 	srv, _ := newEdgesServer(t, "tenant-empty")
 
-	resp, err := srv.GetEdgesFrom(context.Background(), edgesReq("tenant-empty", "src"))
+	resp, err := srv.GetEdgesFrom(context.Background(), edgesFromReq("tenant-empty", "src"))
 	if err != nil {
 		t.Fatalf("GetEdgesFrom: unexpected error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestGetEdgesFrom_SingleEdgeRoundTrip(t *testing.T) {
 		t.Fatalf("CreateEdge: %v", err)
 	}
 
-	resp, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-single", "src"))
+	resp, err := srv.GetEdgesFrom(ctx, edgesFromReq("tenant-single", "src"))
 	if err != nil {
 		t.Fatalf("GetEdgesFrom: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestGetEdgesFrom_MultipleEdgesAllReturned(t *testing.T) {
 		}
 	}
 
-	resp, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-multi", "src"))
+	resp, err := srv.GetEdgesFrom(ctx, edgesFromReq("tenant-multi", "src"))
 	if err != nil {
 		t.Fatalf("GetEdgesFrom: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestGetEdgesFrom_MissingSourceReturnsEmpty(t *testing.T) {
 		t.Fatalf("CreateEdge: %v", err)
 	}
 
-	resp, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-miss", "ghost"))
+	resp, err := srv.GetEdgesFrom(ctx, edgesFromReq("tenant-miss", "ghost"))
 	if err != nil {
 		t.Fatalf("GetEdgesFrom: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestGetEdgesFrom_EdgeTypeFilter(t *testing.T) {
 	}
 
 	// edge_type_id == 0 -> no filter, returns both.
-	respAll, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-filter", "src"))
+	respAll, err := srv.GetEdgesFrom(ctx, edgesFromReq("tenant-filter", "src"))
 	if err != nil {
 		t.Fatalf("GetEdgesFrom (all): %v", err)
 	}
@@ -265,7 +265,7 @@ func TestGetEdgesFrom_StoreErrorSwallowedToEmpty(t *testing.T) {
 		api.WithSharding(&tenant.Sharding{NodeID: "node-a"}),
 	)
 
-	resp, err := srv.GetEdgesFrom(ctx, edgesReq("tenant-broken", "src"))
+	resp, err := srv.GetEdgesFrom(ctx, edgesFromReq("tenant-broken", "src"))
 	if err != nil {
 		t.Fatalf("GetEdgesFrom: must swallow store err to OK + empty resp, got %v", err)
 	}

--- a/server/go/internal/api/get_edges_to.go
+++ b/server/go/internal/api/get_edges_to.go
@@ -39,15 +39,11 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"time"
-
-	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
-	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 )
 
 const grpcMethodGetEdgesTo = "GetEdgesTo"
@@ -129,48 +125,7 @@ func (s *Server) GetEdgesTo(
 	return &pb.GetEdgesResponse{Edges: out, HasMore: hasMore}, nil
 }
 
-// edgeToProto lowers a store.Edge into the wire shape. props_json is
-// parsed into a typed google.protobuf.Struct so SDK clients can read
-// `props` directly (Python parity: the handler passes the parsed dict
-// to `_dict_to_struct` at grpc_server.py:166 before assembling the
-// Edge proto). A non-JSON or non-object props_json column is treated
-// as an empty struct — matching `_dict_to_struct`'s defensive shape
-// when an unexpected legacy row is replayed.
-//
-// Kept package-private so a future GetEdgesFrom port can share it via
-// a single chokepoint without the conversion shape diverging between
-// the from / to handlers (see spec "Shared Go package deps").
-func edgeToProto(e *store.Edge) *pb.Edge {
-	out := &pb.Edge{
-		TenantId:   e.TenantID,
-		EdgeTypeId: e.EdgeTypeID,
-		FromNodeId: e.FromNodeID,
-		ToNodeId:   e.ToNodeID,
-		CreatedAt:  e.CreatedAt,
-	}
-	out.Props = edgePropsToStruct(e.PropsJSON)
-	return out
-}
-
-// edgePropsToStruct parses a stored props_json column into a typed
-// Struct. Empty / invalid input lowers to an empty Struct, never nil:
-// the Python wire shape always emits the field (zero-value
-// google.protobuf.Struct{}) so SDK consumers can rely on
-// `edge.props.fields` being addressable without a nil check.
-func edgePropsToStruct(propsJSON string) *structpb.Struct {
-	if propsJSON == "" {
-		s, _ := structpb.NewStruct(map[string]any{})
-		return s
-	}
-	var m map[string]any
-	if err := json.Unmarshal([]byte(propsJSON), &m); err != nil || m == nil {
-		s, _ := structpb.NewStruct(map[string]any{})
-		return s
-	}
-	s, err := structpb.NewStruct(m)
-	if err != nil {
-		s, _ = structpb.NewStruct(map[string]any{})
-		return s
-	}
-	return s
-}
+// edgeToProto and edgePropsToStruct live in helpers.go (consolidated
+// in the round-3 Wave-2 dedupe). The defensive empty-Struct semantics
+// — never nil for `props` even on malformed legacy rows — are
+// preserved there.

--- a/server/go/internal/api/get_edges_to_test.go
+++ b/server/go/internal/api/get_edges_to_test.go
@@ -40,8 +40,8 @@ func newEdgeStore(t *testing.T, tenantID string) *store.CanonicalStore {
 	return cs
 }
 
-// edgesReq is a small builder so each case reads as the wire payload.
-func edgesReq(tenantID, nodeID string, edgeTypeID, limit int32) *pb.GetEdgesRequest {
+// edgesToReq is a small builder so each case reads as the wire payload.
+func edgesToReq(tenantID, nodeID string, edgeTypeID, limit int32) *pb.GetEdgesRequest {
 	return &pb.GetEdgesRequest{
 		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
 		NodeId:     nodeID,
@@ -59,7 +59,7 @@ func TestGetEdgesTo_EmptyReturnsNoEdges(t *testing.T) {
 	cs := newEdgeStore(t, tenantID)
 
 	srv := api.New(api.WithStore(cs))
-	resp, err := srv.GetEdgesTo(context.Background(), edgesReq(tenantID, "n-target", 0, 0))
+	resp, err := srv.GetEdgesTo(context.Background(), edgesToReq(tenantID, "n-target", 0, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo: unexpected error: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestGetEdgesTo_SingleEdgeRoundtrip(t *testing.T) {
 	}
 
 	srv := api.New(api.WithStore(cs))
-	resp, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 0, 0))
+	resp, err := srv.GetEdgesTo(ctx, edgesToReq(tenantID, target, 0, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo: unexpected error: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestGetEdgesTo_MultipleEdgesFanIn(t *testing.T) {
 	}
 
 	srv := api.New(api.WithStore(cs))
-	resp, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 0, 0))
+	resp, err := srv.GetEdgesTo(ctx, edgesToReq(tenantID, target, 0, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo: unexpected error: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestGetEdgesTo_MissingDstReturnsEmpty(t *testing.T) {
 	}
 
 	srv := api.New(api.WithStore(cs))
-	resp, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, "ghost", 0, 0))
+	resp, err := srv.GetEdgesTo(ctx, edgesToReq(tenantID, "ghost", 0, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo: unexpected error: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestGetEdgesTo_EdgeTypeFilter(t *testing.T) {
 	srv := api.New(api.WithStore(cs))
 
 	// edge_type_id=1 ⇒ only the two upvotes.
-	resp, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 1, 0))
+	resp, err := srv.GetEdgesTo(ctx, edgesToReq(tenantID, target, 1, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo type=1: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestGetEdgesTo_EdgeTypeFilter(t *testing.T) {
 	}
 
 	// edge_type_id=2 ⇒ only the single reply.
-	resp2, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 2, 0))
+	resp2, err := srv.GetEdgesTo(ctx, edgesToReq(tenantID, target, 2, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo type=2: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestGetEdgesTo_EdgeTypeFilter(t *testing.T) {
 	}
 
 	// edge_type_id=0 ⇒ unfiltered, all three rows.
-	respAll, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 0, 0))
+	respAll, err := srv.GetEdgesTo(ctx, edgesToReq(tenantID, target, 0, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo type=0: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestGetEdgesTo_EdgeTypeFilter(t *testing.T) {
 	}
 
 	// edge_type_id=99 (unknown) ⇒ empty.
-	respMiss, err := srv.GetEdgesTo(ctx, edgesReq(tenantID, target, 99, 0))
+	respMiss, err := srv.GetEdgesTo(ctx, edgesToReq(tenantID, target, 99, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo type=99: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestGetEdgesTo_StoreErrorReturnsEmpty(t *testing.T) {
 	// error and the handler must collapse that to edges=[].
 
 	srv := api.New(api.WithStore(cs))
-	resp, err := srv.GetEdgesTo(ctx, edgesReq("tenant-unopened", "n", 0, 0))
+	resp, err := srv.GetEdgesTo(ctx, edgesToReq("tenant-unopened", "n", 0, 0))
 	if err != nil {
 		t.Fatalf("GetEdgesTo: must return OK + empty body, not gRPC error: %v", err)
 	}

--- a/server/go/internal/api/get_node.go
+++ b/server/go/internal/api/get_node.go
@@ -82,25 +82,9 @@ import (
 
 const getNodeMethod = "GetNode"
 
-// readRole captures the outcome of the cross-tenant read-membership
-// check. Mirrors the Python sentinels at `_check_cross_tenant_read`
-// (server/python/entdb_server/api/grpc_server.py:561-618).
-type readRole int
-
-const (
-	// roleLocal is the back-compat path when no global_store is wired.
-	// Skips all membership checks; matches Python's
-	// `if self.global_store is None: return "local"` (`:570-571`).
-	roleLocal readRole = iota
-	// roleMember means the caller is either a tenant member or a
-	// system / admin actor. Same as Python `"member"` (`:582-589`).
-	roleMember
-	// roleCrossTenant means the caller is not a member but has at
-	// least one node_access row in the tenant. The handler must then
-	// re-check the specific node_id post-lookup. Same as Python
-	// `"cross_tenant"` (`:597-617`).
-	roleCrossTenant
-)
+// readRole / roleLocal / roleMember / roleCrossTenant — shared with
+// the other read RPCs (GetNodes, QueryNodes, GetConnectedNodes) and
+// declared in helpers.go (consolidated in the round-3 Wave-2 dedupe).
 
 // GetNode implements entdb.v1.EntDBService/GetNode. See file header
 // for the full contract.
@@ -208,82 +192,12 @@ func (s *Server) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNo
 	return &pb.GetNodeResponse{Found: true, Node: wire}, nil
 }
 
-// checkCrossTenantRead returns the caller's read role within tenantID.
-// Mirrors Python `_check_cross_tenant_read` at
-// server/python/entdb_server/api/grpc_server.py:561-618.
-//
-// Resolution order:
-//
-//  1. global_store == nil => roleLocal (back-compat path). Skips
-//     membership entirely.
-//  2. system / admin actors => roleMember (system bypass).
-//  3. IsMember(tenant, user_id) => roleMember.
-//  4. Any node_access row in the tenant for this actor =>
-//     roleCrossTenant.
-//  5. Otherwise => PERMISSION_DENIED.
-func (s *Server) checkCrossTenantRead(ctx context.Context, tenantID string, a auth.Actor) (readRole, error) {
-	if s.global == nil {
-		return roleLocal, nil
-	}
-	if a.IsSystem() || a.IsAdmin() {
-		return roleMember, nil
-	}
-	if a.IsZero() {
-		return 0, errs.Errorf(codes.PermissionDenied,
-			"GetNode: actor lacks access to tenant %q", tenantID)
-	}
-
-	// Membership check. global_store stores user_ids by their bare
-	// SDK identifier (e.g. "alice"), so we strip the "user:" prefix
-	// before consulting it.
-	if a.IsUser() {
-		ok, err := s.global.IsMember(ctx, tenantID, a.ID())
-		if err != nil {
-			return 0, fmt.Errorf("GetNode: IsMember: %w", err)
-		}
-		if ok {
-			return roleMember, nil
-		}
-	}
-
-	// Cross-tenant: any node_access grant in this tenant for the
-	// canonical actor string is enough to upgrade to "cross_tenant".
-	any, err := s.hasAnyNodeAccess(ctx, tenantID, a.String())
-	if err != nil {
-		return 0, err
-	}
-	if any {
-		return roleCrossTenant, nil
-	}
-	return 0, errs.Errorf(codes.PermissionDenied,
-		"GetNode: actor lacks access to tenant %q", tenantID)
-}
-
-// hasAnyNodeAccess returns true if there is at least one non-deny,
-// non-expired node_access row in tenantID granted to actorID. Mirrors
-// the Python "has_node_access" probe inside
-// `_check_cross_tenant_read` (`grpc_server.py:610-617`).
-func (s *Server) hasAnyNodeAccess(ctx context.Context, tenantID, actorID string) (bool, error) {
-	db, err := s.store.AdminDB(tenantID)
-	if err != nil {
-		return false, fmt.Errorf("GetNode: admin db: %w", err)
-	}
-	now := time.Now().UnixMilli()
-	var one int
-	err = db.QueryRowContext(ctx, `
-		SELECT 1 FROM node_access
-		WHERE actor_id = ?
-		  AND permission != 'deny'
-		  AND (expires_at IS NULL OR expires_at > ?)
-		LIMIT 1`, actorID, now).Scan(&one)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return false, nil
-		}
-		return false, fmt.Errorf("GetNode: query node_access: %w", err)
-	}
-	return true, nil
-}
+// checkCrossTenantRead lives in helpers.go (consolidated in the
+// round-3 Wave-2 dedupe). It now uses store.ResolveActorGroups +
+// store.HasNodeAccess for group-aware grant resolution rather than the
+// per-handler hasAnyNodeAccess shortcut — the per-node hasNodeAccess
+// below is still consulted by step 7 of GetNode for the specific
+// node_id post-lookup ACL re-check.
 
 // hasNodeAccess returns true if actorID has a non-deny, non-expired
 // node_access grant on (tenantID, nodeID). Mirrors a slim slice of

--- a/server/go/internal/api/get_node_by_key_test.go
+++ b/server/go/internal/api/get_node_by_key_test.go
@@ -69,9 +69,9 @@ func newCanonicalStore(t *testing.T, tenantID string) *store.CanonicalStore {
 	return cs
 }
 
-// seedNode writes a node row keyed by field_id (CLAUDE.md invariant
+// seedNodeByKey writes a node row keyed by field_id (CLAUDE.md invariant
 // #6) so the unique-index SELECT lights it up.
-func seedNode(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, ownerActor string, payload map[string]any, acl []store.ACLEntry) {
+func seedNodeByKey(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, ownerActor string, payload map[string]any, acl []store.ACLEntry) {
 	t.Helper()
 	if _, err := cs.CreateNodeRaw(context.Background(), tenantID, store.NodeInput{
 		NodeID:     nodeID,
@@ -107,7 +107,7 @@ func TestGetNodeByKey_HappyRoundTrip(t *testing.T) {
 	}
 
 	cs := newCanonicalStore(t, gnbkTenant)
-	seedNode(t, cs, gnbkTenant, gnbkNodeID, "user:alice",
+	seedNodeByKey(t, cs, gnbkTenant, gnbkNodeID, "user:alice",
 		map[string]any{"1": "alice@example.com"}, nil)
 
 	srv := api.New(
@@ -208,7 +208,7 @@ func TestGetNodeByKey_ACLDenied(t *testing.T) {
 	}
 	cs := newCanonicalStore(t, gnbkTenant)
 
-	seedNode(t, cs, gnbkTenant, gnbkNodeID, "user:alice",
+	seedNodeByKey(t, cs, gnbkTenant, gnbkNodeID, "user:alice",
 		map[string]any{"1": "alice@example.com"},
 		[]store.ACLEntry{{Principal: "user:bob", Permission: "deny"}},
 	)
@@ -250,7 +250,7 @@ func TestGetNodeByCompositeKey_StoreLevel(t *testing.T) {
 
 	// Seed a Task node with a (owner_id=alice, title="finish go port")
 	// composite tuple. Field ids 2 and 1 (Python sample).
-	seedNode(t, cs, gnbkTenant, "task-1", "user:alice",
+	seedNodeByKey(t, cs, gnbkTenant, "task-1", "user:alice",
 		map[string]any{
 			"1": "finish go port",
 			"2": "alice",

--- a/server/go/internal/api/get_node_test.go
+++ b/server/go/internal/api/get_node_test.go
@@ -53,9 +53,9 @@ func newGetNodeStore(t *testing.T) *store.CanonicalStore {
 	return cs
 }
 
-// seedNode is a small builder that opens the tenant + creates a node.
+// seedNodeForGet is a small builder that opens the tenant + creates a node.
 // Returns the created node so tests can pin created_at / updated_at.
-func seedNode(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner string, payload map[string]any) *store.Node {
+func seedNodeForGet(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner string, payload map[string]any) *store.Node {
 	t.Helper()
 	ctx := context.Background()
 	if err := cs.OpenTenant(ctx, tenantID); err != nil {
@@ -89,7 +89,7 @@ func TestGetNode_HappyRoundTrip(t *testing.T) {
 	const tenantID = "tenant-a"
 	const nodeID = "node-1"
 
-	created := seedNode(t, cs, tenantID, nodeID, "user:alice", map[string]any{
+	created := seedNodeForGet(t, cs, tenantID, nodeID, "user:alice", map[string]any{
 		"1": "alice@example.com",
 		"2": "hashed-password-blob",
 	})
@@ -189,7 +189,7 @@ func TestGetNode_NoPermission(t *testing.T) {
 	if err := gs.AddTenantMember(ctx, tenantID, "alice", "owner"); err != nil {
 		t.Fatalf("AddTenantMember: %v", err)
 	}
-	seedNode(t, cs, tenantID, nodeID, "user:alice", nil)
+	seedNodeForGet(t, cs, tenantID, nodeID, "user:alice", nil)
 
 	srv := api.New(api.WithStore(cs), api.WithGlobalStore(gs))
 	_, err := srv.GetNode(ctx, &pb.GetNodeRequest{
@@ -229,7 +229,7 @@ func TestGetNode_PayloadIsIDKeyedOnWire(t *testing.T) {
 	const tenantID = "tenant-a"
 	const nodeID = "node-1"
 
-	seedNode(t, cs, tenantID, nodeID, "user:alice", map[string]any{
+	seedNodeForGet(t, cs, tenantID, nodeID, "user:alice", map[string]any{
 		"1": "alice@example.com",
 		"2": "hashed-password",
 	})

--- a/server/go/internal/api/get_nodes.go
+++ b/server/go/internal/api/get_nodes.go
@@ -51,12 +51,10 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
@@ -230,7 +228,7 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 			missing = append(missing, id)
 			continue
 		}
-		pn, perr := storeNodeToProto(s, results[i])
+		pn, perr := s.storeNodeToProto("", results[i])
 		if perr != nil {
 			// Conversion failure on a single row -- fold into
 			// missing_ids rather than failing the whole batch
@@ -247,112 +245,8 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 	}, nil
 }
 
-// crossTenantRole is the result of checkCrossTenantRead. Mirrors the
-// "local" / "member" / "cross_tenant" string return of the Python
-// helper at grpc_server.py:561-618.
-type crossTenantRole int
-
-const (
-	roleLocal       crossTenantRole = iota // no global_store wired
-	roleMember                             // tenant member or system actor
-	roleCrossTenant                        // non-member with node_access grants
-)
-
-// checkCrossTenantRead is the Go port of
-// server/python/entdb_server/api/grpc_server.py:_check_cross_tenant_read
-// (561-618). Returns roleLocal / roleMember / roleCrossTenant on
-// success, or a PERMISSION_DENIED status error on rejection.
-//
-// Inlined here (rather than in a shared helper) because GetNodes is
-// the first read RPC to need it; subsequent read handlers (QueryNodes,
-// GetEdgesFrom, …) will refactor this into internal/tenant once the
-// surface stabilises.
-func (s *Server) checkCrossTenantRead(ctx context.Context, tenantID string, actor auth.Actor) (crossTenantRole, error) {
-	// No global_store wired -> "local" (backward-compat with bring-up
-	// configs and unit tests; mirrors grpc_server.py:590-591).
-	if s.global == nil {
-		return roleLocal, nil
-	}
-	// System actors bypass all checks (grpc_server.py:594-595).
-	if actor.IsSystem() {
-		return roleMember, nil
-	}
-	// Tenant membership: resolve actor -> user_id and consult
-	// globalstore.IsMember. Only user-kind actors can ever be members
-	// (admins / unknown kinds are not in tenant_members rows; for
-	// parity with Python we still try IsMember which falls through to
-	// false for them).
-	userID := actor.ID()
-	if !actor.IsUser() {
-		userID = actor.String()
-	}
-	if userID != "" {
-		isMember, err := s.global.IsMember(ctx, tenantID, userID)
-		if err == nil && isMember {
-			return roleMember, nil
-		}
-	}
-	// Not a member -- check for cross-tenant node_access grants.
-	if s.store != nil {
-		actorIDs, err := s.store.ResolveActorGroups(ctx, tenantID, actor.String())
-		if err == nil && len(actorIDs) > 0 {
-			has, herr := s.store.HasNodeAccess(ctx, tenantID, actorIDs)
-			if herr == nil && has {
-				return roleCrossTenant, nil
-			}
-		}
-	}
-	return 0, errs.Errorf(codes.PermissionDenied,
-		"Actor is not a member of this tenant")
-}
-
-// storeNodeToProto converts a *store.Node (id-keyed payload JSON,
-// raw ACL JSON) into a *pb.Node. Mirrors the inline conversion in
-// Python's grpc_server.py:1273-1284.
-//
-// Schema-aware kind coercion: when the schema registry is wired, we
-// look up the node type by type_id and feed payload.PayloadToStruct
-// the type's name so BYTES / TIMESTAMP / INTEGER values are encoded
-// correctly. Without a registry (unit tests), we fall through to the
-// schema-less passthrough.
-func storeNodeToProto(s *Server, n *store.Node) (*pb.Node, error) {
-	// Parse payload (string-keyed by field_id) into map[string]any.
-	var rawPayload map[string]any
-	if n.PayloadJSON != "" {
-		if err := json.Unmarshal([]byte(n.PayloadJSON), &rawPayload); err != nil {
-			return nil, err
-		}
-	}
-	// Build a *structpb.Struct with the same string keys. The wire
-	// stays id-keyed per CLAUDE.md invariant #6.
-	st, err := structpb.NewStruct(rawPayload)
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse ACL JSON into proto entries.
-	var aclList []store.ACLEntry
-	if n.ACLJSON != "" {
-		if err := json.Unmarshal([]byte(n.ACLJSON), &aclList); err != nil {
-			return nil, err
-		}
-	}
-	aclProto := make([]*pb.AclEntry, 0, len(aclList))
-	for _, e := range aclList {
-		aclProto = append(aclProto, &pb.AclEntry{
-			Principal:  e.Principal,
-			Permission: e.Permission,
-		})
-	}
-
-	return &pb.Node{
-		TenantId:   n.TenantID,
-		NodeId:     n.NodeID,
-		TypeId:     n.TypeID,
-		CreatedAt:  n.CreatedAt,
-		UpdatedAt:  n.UpdatedAt,
-		OwnerActor: n.OwnerActor,
-		Payload:    st,
-		Acl:        aclProto,
-	}, nil
-}
+// crossTenantRole / checkCrossTenantRead / storeNodeToProto — shared
+// with the other read RPCs and declared in helpers.go (consolidated in
+// the round-3 Wave-2 dedupe). The shared type is named `readRole`
+// there; the constants (roleLocal / roleMember / roleCrossTenant) are
+// untouched, so existing callers in this file still compile.

--- a/server/go/internal/api/get_nodes_test.go
+++ b/server/go/internal/api/get_nodes_test.go
@@ -49,10 +49,10 @@ func newStoreWithTenant(t *testing.T, tenantID string) *store.CanonicalStore {
 	return cs
 }
 
-// seedNode is a tiny helper to put one node into the store with a
+// seedNodeForGetNodes is a tiny helper to put one node into the store with a
 // deterministic owner so the cross-tenant filter tests can vary by
 // whether the actor matches owner_actor.
-func seedNode(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner string) {
+func seedNodeForGetNodes(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner string) {
 	t.Helper()
 	_, err := cs.CreateNodeRaw(context.Background(), tenantID, store.NodeInput{
 		NodeID:     nodeID,
@@ -61,7 +61,7 @@ func seedNode(t *testing.T, cs *store.CanonicalStore, tenantID, nodeID, owner st
 		OwnerActor: owner,
 	})
 	if err != nil {
-		t.Fatalf("seedNode %s: %v", nodeID, err)
+		t.Fatalf("seedNodeForGetNodes %s: %v", nodeID, err)
 	}
 }
 
@@ -110,7 +110,7 @@ func TestGetNodes_SingleHit(t *testing.T) {
 		t.Fatalf("AddTenantMember: %v", err)
 	}
 	cs := newStoreWithTenant(t, tenantID)
-	seedNode(t, cs, tenantID, "n1", "user:alice")
+	seedNodeForGetNodes(t, cs, tenantID, "n1", "user:alice")
 
 	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
 	resp, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
@@ -180,9 +180,9 @@ func TestGetNodes_MultiPreservesOrderAndDuplicates(t *testing.T) {
 		t.Fatalf("AddTenantMember: %v", err)
 	}
 	cs := newStoreWithTenant(t, tenantID)
-	seedNode(t, cs, tenantID, "n1", "user:alice")
-	seedNode(t, cs, tenantID, "n2", "user:alice")
-	seedNode(t, cs, tenantID, "n3", "user:alice")
+	seedNodeForGetNodes(t, cs, tenantID, "n1", "user:alice")
+	seedNodeForGetNodes(t, cs, tenantID, "n2", "user:alice")
+	seedNodeForGetNodes(t, cs, tenantID, "n3", "user:alice")
 
 	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
 	resp, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
@@ -231,8 +231,8 @@ func TestGetNodes_MissingAndDeniedMergedIntoMissingIds(t *testing.T) {
 		t.Fatalf("AddTenantMember: %v", err)
 	}
 	cs := newStoreWithTenant(t, tenantID)
-	seedNode(t, cs, tenantID, "n1", "user:alice")
-	seedNode(t, cs, tenantID, "n2", "user:alice")
+	seedNodeForGetNodes(t, cs, tenantID, "n1", "user:alice")
+	seedNodeForGetNodes(t, cs, tenantID, "n2", "user:alice")
 
 	// Grant mallory READ access to n1 only — this is the
 	// `node_access` row that flips _check_cross_tenant_read from
@@ -360,15 +360,7 @@ func TestGetNodes_UnknownTenantNotFound(t *testing.T) {
 	}
 }
 
-// nodeIDs flattens a []*pb.Node to its node_id slice, preserving
-// order. Used by the order-and-duplicates assertion.
-func nodeIDs(ns []*pb.Node) []string {
-	out := make([]string, 0, len(ns))
-	for _, n := range ns {
-		out = append(out, n.GetNodeId())
-	}
-	return out
-}
+// nodeIDs lives in helpers_external_test.go.
 
 func equalSlice(a, b []string) bool {
 	if len(a) != len(b) {

--- a/server/go/internal/api/helpers.go
+++ b/server/go/internal/api/helpers.go
@@ -19,9 +19,22 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/payload"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 )
 
 // userToProto maps a globalstore.User row to its proto wire form,
@@ -71,4 +84,301 @@ func (s *Server) lookupMemberRole(ctx context.Context, tenantID, userID string) 
 		}
 	}
 	return "", nil
+}
+
+// readRole captures the outcome of the cross-tenant read-membership
+// check. Mirrors the Python sentinels at `_check_cross_tenant_read`
+// (server/python/entdb_server/api/grpc_server.py:561-618).
+//
+// Consolidated from per-handler duplicates (get_node.go's readRole and
+// get_nodes.go's crossTenantRole — same semantics, different names).
+type readRole int
+
+const (
+	// roleLocal is the back-compat path when no global_store is wired.
+	// Skips all membership checks; matches Python's
+	// `if self.global_store is None: return "local"` (`:570-571`).
+	roleLocal readRole = iota
+	// roleMember means the caller is either a tenant member or a
+	// system / admin actor. Same as Python `"member"` (`:582-589`).
+	roleMember
+	// roleCrossTenant means the caller is not a member but has at
+	// least one node_access row in the tenant. The handler must then
+	// re-check the specific node_id post-lookup. Same as Python
+	// `"cross_tenant"` (`:597-617`).
+	roleCrossTenant
+)
+
+// checkCrossTenantRead returns the caller's read role within tenantID.
+// Mirrors Python `_check_cross_tenant_read` at
+// server/python/entdb_server/api/grpc_server.py:561-618.
+//
+// Resolution order:
+//
+//  1. global_store == nil  => roleLocal (back-compat path).
+//  2. system / admin actor => roleMember (bypass).
+//  3. zero actor           => PERMISSION_DENIED (defensive).
+//  4. user IsMember        => roleMember.
+//  5. any non-deny, non-expired node_access grant (group-aware via
+//     ResolveActorGroups) => roleCrossTenant.
+//  6. otherwise            => PERMISSION_DENIED.
+//
+// Consolidated from get_node.go (admin/zero handling) and get_nodes.go
+// (group-aware grant resolution). Picks the union: broader scope on
+// the grant check, defensive on the actor side.
+func (s *Server) checkCrossTenantRead(ctx context.Context, tenantID string, a auth.Actor) (readRole, error) {
+	if s.global == nil {
+		return roleLocal, nil
+	}
+	if a.IsSystem() || a.IsAdmin() {
+		return roleMember, nil
+	}
+	if a.IsZero() {
+		return 0, errs.Errorf(codes.PermissionDenied,
+			"actor lacks access to tenant %q", tenantID)
+	}
+
+	// Membership check. global_store stores user_ids by their bare
+	// SDK identifier (e.g. "alice"), so user-kind actors consult
+	// IsMember with the bare id. Non-user kinds (already filtered by
+	// the admin/system branch above) fall through to the grant check.
+	if a.IsUser() {
+		ok, err := s.global.IsMember(ctx, tenantID, a.ID())
+		if err != nil {
+			return 0, fmt.Errorf("checkCrossTenantRead: IsMember: %w", err)
+		}
+		if ok {
+			return roleMember, nil
+		}
+	}
+
+	// Cross-tenant grant probe. Group-aware: ResolveActorGroups expands
+	// the actor into the set of actor_ids (self + groups) that could
+	// hold a node_access row; HasNodeAccess filters by non-deny / non-
+	// expired in the per-tenant SQLite.
+	if s.store != nil {
+		actorIDs, err := s.store.ResolveActorGroups(ctx, tenantID, a.String())
+		if err == nil && len(actorIDs) > 0 {
+			has, herr := s.store.HasNodeAccess(ctx, tenantID, actorIDs)
+			if herr == nil && has {
+				return roleCrossTenant, nil
+			}
+		}
+	}
+	return 0, errs.Errorf(codes.PermissionDenied,
+		"actor lacks access to tenant %q", tenantID)
+}
+
+// edgeToProto translates a store.Edge into its wire shape. PropsJSON
+// is stored as a JSON-encoded map keyed by field IDs (CLAUDE.md
+// invariant 6); we round-trip through map[string]any -> structpb so
+// the wire `props` mirrors Python's `_dict_to_struct` output.
+//
+// Defensive shape: an empty / invalid props_json lowers to an empty
+// Struct (never nil) so SDK consumers can rely on `edge.props.fields`
+// being addressable without a nil check. Matches Python's
+// `_dict_to_struct` zero-value behaviour at grpc_server.py:166.
+func edgeToProto(e *store.Edge) *pb.Edge {
+	return &pb.Edge{
+		TenantId:   e.TenantID,
+		EdgeTypeId: e.EdgeTypeID,
+		FromNodeId: e.FromNodeID,
+		ToNodeId:   e.ToNodeID,
+		CreatedAt:  e.CreatedAt,
+		Props:      edgePropsToStruct(e.PropsJSON),
+	}
+}
+
+// edgePropsToStruct parses a stored props_json column into a typed
+// Struct. Empty / invalid input lowers to an empty Struct, never nil:
+// the Python wire shape always emits the field so SDK consumers can
+// rely on `edge.props.fields` being addressable without a nil check.
+func edgePropsToStruct(propsJSON string) *structpb.Struct {
+	if propsJSON == "" {
+		s, _ := structpb.NewStruct(map[string]any{})
+		return s
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(propsJSON), &m); err != nil || m == nil {
+		s, _ := structpb.NewStruct(map[string]any{})
+		return s
+	}
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		s, _ = structpb.NewStruct(map[string]any{})
+		return s
+	}
+	return s
+}
+
+// storeNodeToProto translates a store.Node into the wire pb.Node.
+// Payload stays id-keyed on the wire per CLAUDE.md invariant #6; the
+// SDK names the fields client-side. ACL JSON is unmarshalled to
+// repeated AclEntry.
+//
+// typeName is consumed only by payload.PayloadToStruct for kind-aware
+// coercion (BYTES -> base64, TIMESTAMP/INTEGER -> float64). Callers
+// that have already resolved the type (QueryNodes) pass it directly;
+// callers that operate on heterogeneous node sets (GetNodes,
+// GetConnectedNodes) pass "" and accept the schema-less passthrough.
+//
+// Consolidated from three Wave-2 duplicates (get_nodes.go,
+// get_connected_nodes.go, query_nodes.go). Picks the method form +
+// payload.PayloadToStruct path so the schema-aware QueryNodes call
+// site is preserved.
+func (s *Server) storeNodeToProto(typeName string, n *store.Node) (*pb.Node, error) {
+	idPayload, err := decodeIDKeyedPayload(n.PayloadJSON)
+	if err != nil {
+		return nil, errs.Errorf(codes.Internal,
+			"parse payload for %s: %v", n.NodeID, err)
+	}
+	pStruct, err := payload.PayloadToStruct(s.registry, typeName, idPayload)
+	if err != nil {
+		return nil, err
+	}
+	aclEntries, err := decodeACLEntries(n.ACLJSON)
+	if err != nil {
+		return nil, errs.Errorf(codes.Internal,
+			"parse acl for %s: %v", n.NodeID, err)
+	}
+	return &pb.Node{
+		TenantId:   n.TenantID,
+		NodeId:     n.NodeID,
+		TypeId:     n.TypeID,
+		CreatedAt:  n.CreatedAt,
+		UpdatedAt:  n.UpdatedAt,
+		OwnerActor: n.OwnerActor,
+		Payload:    pStruct,
+		Acl:        aclEntries,
+	}, nil
+}
+
+// decodeIDKeyedPayload parses a raw JSON object whose keys are
+// stringified field_ids ({"1": ...}) into the uint32-keyed map the
+// payload package consumes. Empty / null JSON yields an empty map.
+// Non-digit keys are dropped silently (CLAUDE.md invariant #6 — the
+// applier-side guard prevents new ones; we can't fix legacy rows on
+// read).
+func decodeIDKeyedPayload(raw string) (map[uint32]any, error) {
+	out := map[uint32]any{}
+	if raw == "" || raw == "null" {
+		return out, nil
+	}
+	tmp := map[string]any{}
+	if err := json.Unmarshal([]byte(raw), &tmp); err != nil {
+		return nil, err
+	}
+	for k, v := range tmp {
+		id, ok := parsePayloadFieldID(k)
+		if !ok {
+			continue
+		}
+		out[id] = v
+	}
+	return out, nil
+}
+
+// decodeACLEntries parses the on-disk acl_blob
+// ([{principal, permission}]) into the wire pb.AclEntry slice. Empty /
+// null yields nil. Grantee mirrors Principal (the proto field was
+// added for clarity; the SDK reads either).
+func decodeACLEntries(raw string) ([]*pb.AclEntry, error) {
+	if raw == "" || raw == "null" {
+		return nil, nil
+	}
+	var list []store.ACLEntry
+	if err := json.Unmarshal([]byte(raw), &list); err != nil {
+		return nil, err
+	}
+	out := make([]*pb.AclEntry, 0, len(list))
+	for _, e := range list {
+		out = append(out, &pb.AclEntry{
+			Principal:  e.Principal,
+			Permission: e.Permission,
+			Grantee:    e.Principal,
+		})
+	}
+	return out, nil
+}
+
+// parsePayloadFieldID parses a digit-only string into a uint32 in the
+// FieldDef bound (1-65535). Mirrors payload.parseFieldID — duplicated
+// here because that helper is unexported.
+func parsePayloadFieldID(s string) (uint32, bool) {
+	if s == "" {
+		return 0, false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil || n == 0 || n > 65535 {
+		return 0, false
+	}
+	return uint32(n), true
+}
+
+// authActorToACLActor bridges the auth.Actor (caller identity admitted
+// by the interceptor) and the acl.Actor (ACL grant subject). user /
+// system translate directly; admin maps to system because admins
+// bypass ACL on the read path (matches Python's "admin can read
+// everything" handler-level convention — expressing admin as system:
+// here picks up the same bypass in acl.Filter.FilterReadable).
+//
+// Consolidated from query_nodes.go and get_connected_nodes.go. Picks
+// the defensive form: IsZero short-circuits, admin -> system to
+// preserve the read-path bypass.
+func authActorToACLActor(a auth.Actor) acl.Actor {
+	if a.IsZero() {
+		return acl.Actor{}
+	}
+	switch a.Kind() {
+	case auth.KindUser:
+		return acl.User(a.ID())
+	case auth.KindSystem:
+		return acl.System(a.ID())
+	case auth.KindAdmin:
+		return acl.System(a.ID())
+	default:
+		// Service / unknown — fall through to user: form so the
+		// filter has a non-system, non-empty actor.
+		return acl.User(a.ID())
+	}
+}
+
+// storeVisibilityAdapter satisfies acl.VisibilityReader by forwarding
+// to CanonicalStore.GetVisibleNodeIDs. The store method is named
+// GetVisibleNodeIDs (renamed from the Python _get_visible_nodes); the
+// acl interface uses the unprefixed name. Both signatures are
+// otherwise identical.
+type storeVisibilityAdapter struct {
+	s *store.CanonicalStore
+}
+
+// VisibleNodeIDs satisfies acl.VisibilityReader.
+func (a storeVisibilityAdapter) VisibleNodeIDs(ctx context.Context, tenantID string, actorIDs []string, nodeIDs []string) (map[string]struct{}, error) {
+	return a.s.GetVisibleNodeIDs(ctx, tenantID, actorIDs, nodeIDs)
+}
+
+// newIdempotencyKey returns a 128-bit hex-encoded random idempotency
+// key for a WAL Append. The producer's dedupe identity is
+// (topic, key, idempotency_key); a fresh key per RPC means every
+// distinct WAL-writing invocation lands a distinct record even when
+// the natural (topic, key) pair repeats. Mirrors the
+// uuid.uuid4().hex pattern Python uses at grpc_server.py:797 and
+// elsewhere — only uniqueness is contractually pinned.
+//
+// Consolidated from three Wave-2 duplicates
+// (remove_group_member.go, set_legal_hold.go, transfer_ownership.go).
+// Picks the (string, error) signature; set_legal_hold's call site
+// (previously string-only with a time-based fallback) now propagates
+// the error along its best-effort WAL-append branch.
+func newIdempotencyKey() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("idempotency key: %w", err)
+	}
+	return hex.EncodeToString(buf[:]), nil
 }

--- a/server/go/internal/api/helpers_external_test.go
+++ b/server/go/internal/api/helpers_external_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
 
 func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
@@ -30,4 +31,16 @@ func withTrustedUser(ctx context.Context, subject string) context.Context {
 		Method:  auth.MethodSession,
 		Subject: subject,
 	})
+}
+
+// nodeIDs flattens a []*pb.Node to its node_id slice, preserving
+// order. Shared diagnostic helper used by the get_nodes and
+// search_nodes assertion blocks (consolidated in the round-3 Wave-2
+// dedupe — the two parallel PRs each declared a private copy).
+func nodeIDs(ns []*pb.Node) []string {
+	out := make([]string, 0, len(ns))
+	for _, n := range ns {
+		out = append(out, n.GetNodeId())
+	}
+	return out
 }

--- a/server/go/internal/api/query_nodes.go
+++ b/server/go/internal/api/query_nodes.go
@@ -42,8 +42,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
-	"strconv"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -277,106 +275,9 @@ func (s *Server) applyQueryACLFilter(ctx context.Context, tenantID string, a aut
 	return out, nil
 }
 
-// authActorToACLActor coerces an auth.Actor into an acl.Actor.
-func authActorToACLActor(a auth.Actor) acl.Actor {
-	switch a.Kind() {
-	case auth.KindUser:
-		return acl.User(a.ID())
-	case auth.KindSystem:
-		return acl.System(a.ID())
-	case auth.KindAdmin:
-		// admin: actors are not ACL grant subjects; map to user: so
-		// owner-by-actor checks still resolve cleanly.
-		return acl.User(a.ID())
-	default:
-		return acl.Actor{}
-	}
-}
-
-// storeNodeToProto translates a store.Node into the wire pb.Node.
-// Payload stays id-keyed on the wire; ACL is the JSON-stored shape
-// unmarshalled to repeated AclEntry.
-func (s *Server) storeNodeToProto(typeName string, n *store.Node) (*pb.Node, error) {
-	rawPayload := map[string]any{}
-	if n.PayloadJSON != "" {
-		if err := json.Unmarshal([]byte(n.PayloadJSON), &rawPayload); err != nil {
-			return nil, errs.Errorf(codes.Internal,
-				"QueryNodes: parse payload for %s: %v", n.NodeID, err)
-		}
-	}
-	idPayload := make(map[uint32]any, len(rawPayload))
-	for k, v := range rawPayload {
-		fid, ok := parsePayloadFieldID(k)
-		if !ok {
-			// Non-digit keys can't appear in on-disk payloads (the
-			// applier writes id-keyed JSON only); drop silently to
-			// avoid blowing up egress on legacy data.
-			continue
-		}
-		idPayload[fid] = v
-	}
-
-	pStruct, err := payload.PayloadToStruct(s.registry, typeName, idPayload)
-	if err != nil {
-		return nil, err
-	}
-
-	var aclList []store.ACLEntry
-	if n.ACLJSON != "" && n.ACLJSON != "null" {
-		if err := json.Unmarshal([]byte(n.ACLJSON), &aclList); err != nil {
-			return nil, errs.Errorf(codes.Internal,
-				"QueryNodes: parse acl for %s: %v", n.NodeID, err)
-		}
-	}
-	protoACL := make([]*pb.AclEntry, 0, len(aclList))
-	for _, e := range aclList {
-		protoACL = append(protoACL, &pb.AclEntry{
-			Principal:  e.Principal,
-			Permission: e.Permission,
-			Grantee:    e.Principal,
-		})
-	}
-
-	return &pb.Node{
-		TenantId:   n.TenantID,
-		NodeId:     n.NodeID,
-		TypeId:     n.TypeID,
-		CreatedAt:  n.CreatedAt,
-		UpdatedAt:  n.UpdatedAt,
-		OwnerActor: n.OwnerActor,
-		Payload:    pStruct,
-		Acl:        protoACL,
-	}, nil
-}
-
-// storeVisibilityAdapter adapts *store.CanonicalStore to the
-// acl.VisibilityReader interface. The store method is GetVisibleNodeIDs
-// (renamed from the Python _get_visible_nodes); the acl interface uses
-// the unprefixed name. Both signatures are otherwise identical.
-type storeVisibilityAdapter struct {
-	store *store.CanonicalStore
-}
-
-// VisibleNodeIDs satisfies acl.VisibilityReader.
-func (a storeVisibilityAdapter) VisibleNodeIDs(ctx context.Context, tenantID string, actorIDs []string, nodeIDs []string) (map[string]struct{}, error) {
-	return a.store.GetVisibleNodeIDs(ctx, tenantID, actorIDs, nodeIDs)
-}
-
-// parsePayloadFieldID parses a digit-only string into a uint32 in the
-// FieldDef bound (1-65535). Mirrors payload.parseFieldID — duplicated
-// here because that helper is unexported.
-func parsePayloadFieldID(s string) (uint32, bool) {
-	if s == "" {
-		return 0, false
-	}
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, false
-		}
-	}
-	n, err := strconv.ParseUint(s, 10, 32)
-	if err != nil || n == 0 || n > 65535 {
-		return 0, false
-	}
-	return uint32(n), true
-}
+// authActorToACLActor / (*Server).storeNodeToProto /
+// storeVisibilityAdapter / parsePayloadFieldID — consolidated in
+// helpers.go (round-3 Wave-2 dedupe). The shared authActorToACLActor
+// maps admin -> system (defensive: picks up the read-path bypass in
+// acl.Filter.FilterReadable). The shared storeNodeToProto preserves
+// the typeName-aware payload.PayloadToStruct path used here.

--- a/server/go/internal/api/remove_group_member.go
+++ b/server/go/internal/api/remove_group_member.go
@@ -59,8 +59,6 @@ package api
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"time"
@@ -242,15 +240,5 @@ func (s *Server) RemoveGroupMember(
 	return &pb.GroupMemberResponse{Success: found}, nil
 }
 
-// newIdempotencyKey returns a 128-bit hex-encoded random idempotency
-// key for the WAL Append. The producer's dedupe identity is
-// (topic, key, idempotency_key); a fresh key per RPC means every
-// distinct RemoveGroupMember invocation lands a distinct WAL record
-// even when the (group, member) pair repeats.
-func newIdempotencyKey() (string, error) {
-	var buf [16]byte
-	if _, err := rand.Read(buf[:]); err != nil {
-		return "", fmt.Errorf("RemoveGroupMember: idempotency key: %w", err)
-	}
-	return hex.EncodeToString(buf[:]), nil
-}
+// newIdempotencyKey lives in helpers.go (consolidated in the round-3
+// Wave-2 dedupe).

--- a/server/go/internal/api/search_nodes_test.go
+++ b/server/go/internal/api/search_nodes_test.go
@@ -401,14 +401,7 @@ func TestSearchNodes_TypeWithNoSearchableFields(t *testing.T) {
 	}
 }
 
-// nodeIDs is a tiny diagnostic helper for assertion messages.
-func nodeIDs(ns []*pb.Node) []string {
-	out := make([]string, 0, len(ns))
-	for _, n := range ns {
-		out = append(out, n.GetNodeId())
-	}
-	return out
-}
+// nodeIDs lives in helpers_external_test.go.
 
 // codeOf extracts a grpc code from err for compact assertions.
 func codeOf(err error) codes.Code {

--- a/server/go/internal/api/set_legal_hold.go
+++ b/server/go/internal/api/set_legal_hold.go
@@ -50,8 +50,6 @@ package api
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -188,21 +186,27 @@ func (s *Server) SetLegalHold(
 		if req.GetEnabled() {
 			op["reason"] = "SetLegalHold RPC"
 		}
-		ev := wal.Event{
-			TenantID:       req.GetTenantId(),
-			Actor:          trusted.String(),
-			IdempotencyKey: newIdempotencyKey(),
-			TsMs:           time.Now().UnixMilli(),
-			Ops:            []map[string]any{op},
-		}
-		value, encErr := ev.Encode()
-		if encErr == nil {
-			headers := map[string][]byte{
-				wal.HeaderIdempotencyKey: []byte(ev.IdempotencyKey),
+		// Best-effort WAL audit row. Failures here are not surfaced
+		// to the client — the synchronous SetTenantStatus above is the
+		// authoritative side effect. An idempotency-key alloc failure
+		// (crypto/rand error, vanishingly rare) skips the append; the
+		// status flip still stands.
+		if idempKey, keyErr := newIdempotencyKey(); keyErr == nil {
+			ev := wal.Event{
+				TenantID:       req.GetTenantId(),
+				Actor:          trusted.String(),
+				IdempotencyKey: idempKey,
+				TsMs:           time.Now().UnixMilli(),
+				Ops:            []map[string]any{op},
 			}
-			// Best-effort: failures are not surfaced to the client.
-			// Audit row in WAL is the immutable record (CLAUDE.md §2).
-			_, _ = s.producer.Append(ctx, setLegalHoldWALTopic, req.GetTenantId(), value, headers)
+			value, encErr := ev.Encode()
+			if encErr == nil {
+				headers := map[string][]byte{
+					wal.HeaderIdempotencyKey: []byte(ev.IdempotencyKey),
+				}
+				// Audit row in WAL is the immutable record (CLAUDE.md §2).
+				_, _ = s.producer.Append(ctx, setLegalHoldWALTopic, req.GetTenantId(), value, headers)
+			}
 		}
 	}
 
@@ -212,17 +216,8 @@ func (s *Server) SetLegalHold(
 	}, nil
 }
 
-// newIdempotencyKey produces a random hex string suitable for use as
-// the WAL idempotency-key header. Mirrors the uuid4-hex shape Python
-// uses; uniqueness is the only contract.
-func newIdempotencyKey() string {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		// Fall back to a time-based key if crypto/rand is unavailable
-		// (extremely rare; the kernel CSPRNG is always seeded by the
-		// time userland code runs). The applier dedupes on the key,
-		// not on its randomness, so this is acceptable.
-		return time.Now().Format("20060102T150405.000000000")
-	}
-	return hex.EncodeToString(b[:])
-}
+// newIdempotencyKey lives in helpers.go (consolidated in the round-3
+// Wave-2 dedupe). Its signature is now (string, error); the
+// time-based fallback this file previously used has been dropped — a
+// crypto/rand failure is vanishingly rare and the best-effort WAL
+// append above simply skips the audit row in that case.

--- a/server/go/internal/api/transfer_ownership.go
+++ b/server/go/internal/api/transfer_ownership.go
@@ -78,10 +78,7 @@ package api
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
-	"fmt"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -259,14 +256,5 @@ func isValidActorString(s string) bool {
 	}
 }
 
-// newIdempotencyKey returns a fresh hex-encoded random key for a WAL
-// event. 16 bytes (= 32 hex chars) is collision-free for the lifetime
-// of the system. Mirrors the Python uuid.uuid4().hex pattern used at
-// grpc_server.py:797 for ExecuteAtomic and similar WAL writers.
-func newIdempotencyKey() (string, error) {
-	var buf [16]byte
-	if _, err := rand.Read(buf[:]); err != nil {
-		return "", fmt.Errorf("rand: %w", err)
-	}
-	return hex.EncodeToString(buf[:]), nil
-}
+// newIdempotencyKey lives in helpers.go (consolidated in the round-3
+// Wave-2 dedupe).


### PR DESCRIPTION
## Summary

`origin/main` was broken: Wave-2 round-3 PRs (`GetEdges{From,To}`, `Get{Node,Nodes}`, `SearchNodes`, `QueryNodes`, sharing/ACL ports, `RemoveGroupMember`, `SetLegalHold`, `TransferOwnership`) each independently re-declared the same helpers. Once all merged onto main, `go vet ./internal/api/...` failed with redeclarations and tests couldn't compile.

Consolidated everything into `helpers.go` / `helpers_external_test.go` — same pattern as the earlier fix in #460.

### Production helpers moved to `server/go/internal/api/helpers.go`

- `edgeToProto` / `edgePropsToStruct` — kept the defensive empty-Struct shape from get_edges_to.go (never nil, even on malformed legacy rows).
- `readRole` + `roleLocal` / `roleMember` / `roleCrossTenant` — single shared type (the get_nodes.go copy named it `crossTenantRole`; constants were identical).
- `(*Server).checkCrossTenantRead` — union of the two versions: admin/IsZero handling from get_node.go + group-aware grant resolution (`ResolveActorGroups` + `HasNodeAccess`) from get_nodes.go.
- `(*Server).storeNodeToProto(typeName, n)` — picked the method form from query_nodes.go (schema-aware payload egress via `payload.PayloadToStruct`). Callers in get_nodes.go and get_connected_nodes.go now pass `""` for the schema-less passthrough they were doing anyway.
- `decodeIDKeyedPayload` / `decodeACLEntries` / `parsePayloadFieldID` — supporting helpers, deduped.
- `authActorToACLActor` — kept the defensive form from get_connected_nodes.go (IsZero short-circuit, admin → system: to pick up `acl.Filter.FilterReadable` bypass).
- `storeVisibilityAdapter` + `VisibleNodeIDs` — single canonical type (field `s`); positional struct literals at both call sites still compile.
- `newIdempotencyKey() (string, error)` — kept the `(string, error)` signature used by remove_group_member.go and transfer_ownership.go. `set_legal_hold.go`'s previous `() string` (with time-based fallback) is rewritten to handle the error along the best-effort WAL-append branch.

### Test helpers consolidated in `helpers_external_test.go`

- `nodeIDs([]*pb.Node)` — duplicated identically by `get_nodes_test.go` and `search_nodes_test.go`.
- `seedNode` (three different signatures!) and `edgesReq` (two different signatures) — renamed per-file rather than merged, since the signatures aren't reconcilable without rewriting tests.

## Test plan

- [x] `cd server/go && go vet ./...` — clean.
- [x] `cd server/go && go test ./...` — all pass.
- [x] `cd server/go && go test -race ./internal/api/...` — clean.
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` — clean.
- [x] `python -m pytest tests/python/unit/ -q` — 1712 passed.

Refs #407