### PR TITLE
fix(go-rewrite): dedupe newCanonicalStore test helper

### DIFF
--- a/server/go/internal/api/export_user_data_test.go
+++ b/server/go/internal/api/export_user_data_test.go
@@ -29,19 +29,6 @@ import (
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 )
 
-// newCanonicalStore returns a tmpdir-backed *store.CanonicalStore. Used
-// by the cross-tenant ExportUserData tests so each one gets a fresh
-// per-tenant SQLite tree on disk.
-func newCanonicalStore(t *testing.T) *store.CanonicalStore {
-	t.Helper()
-	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
-	if err != nil {
-		t.Fatalf("store.New: %v", err)
-	}
-	t.Cleanup(func() { _ = cs.Close() })
-	return cs
-}
-
 // seedAliceNode creates a single owner-matching node in `tenant` with
 // owner_actor=user:alice. Returns the node id so callers can assert on
 // the bundle contents.

--- a/server/go/internal/api/get_node_by_key_test.go
+++ b/server/go/internal/api/get_node_by_key_test.go
@@ -48,12 +48,12 @@ const (
 	gnbkField  = int32(1)
 )
 
-// newCanonicalStore opens a tmpdir-backed store + opens one tenant. We
+// newCanonicalStoreForTenant opens a tmpdir-backed store + opens one tenant. We
 // don't reach for a Registry — GetNodeByKey relies on the unique
 // expression index lazily created by the applier, but the SELECT works
 // without it (degrades to a scan); pure read tests don't need the
 // index for correctness.
-func newCanonicalStore(t *testing.T, tenantID string) *store.CanonicalStore {
+func newCanonicalStoreForTenant(t *testing.T, tenantID string) *store.CanonicalStore {
 	t.Helper()
 	cs, err := store.New(store.Options{
 		RootDir: t.TempDir(),
@@ -106,7 +106,7 @@ func TestGetNodeByKey_HappyRoundTrip(t *testing.T) {
 		t.Fatalf("CreateTenant: %v", err)
 	}
 
-	cs := newCanonicalStore(t, gnbkTenant)
+	cs := newCanonicalStoreForTenant(t, gnbkTenant)
 	seedNodeByKey(t, cs, gnbkTenant, gnbkNodeID, "user:alice",
 		map[string]any{"1": "alice@example.com"}, nil)
 
@@ -166,7 +166,7 @@ func TestGetNodeByKey_MissingKey(t *testing.T) {
 	if _, err := gs.CreateTenant(ctx, gnbkTenant, "Acme", gnbkRegion); err != nil {
 		t.Fatalf("CreateTenant: %v", err)
 	}
-	cs := newCanonicalStore(t, gnbkTenant)
+	cs := newCanonicalStoreForTenant(t, gnbkTenant)
 
 	srv := api.New(
 		api.WithGlobalStore(gs),
@@ -206,7 +206,7 @@ func TestGetNodeByKey_ACLDenied(t *testing.T) {
 	if _, err := gs.CreateTenant(ctx, gnbkTenant, "Acme", gnbkRegion); err != nil {
 		t.Fatalf("CreateTenant: %v", err)
 	}
-	cs := newCanonicalStore(t, gnbkTenant)
+	cs := newCanonicalStoreForTenant(t, gnbkTenant)
 
 	seedNodeByKey(t, cs, gnbkTenant, gnbkNodeID, "user:alice",
 		map[string]any{"1": "alice@example.com"},
@@ -245,7 +245,7 @@ func TestGetNodeByKey_ACLDenied(t *testing.T) {
 // non-matching value misses with (nil, nil).
 func TestGetNodeByCompositeKey_StoreLevel(t *testing.T) {
 	t.Parallel()
-	cs := newCanonicalStore(t, gnbkTenant)
+	cs := newCanonicalStoreForTenant(t, gnbkTenant)
 	ctx := context.Background()
 
 	// Seed a Task node with a (owner_id=alice, title="finish go port")

--- a/server/go/internal/api/helpers_external_test.go
+++ b/server/go/internal/api/helpers_external_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 )
 
 func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
@@ -19,6 +20,19 @@ func newGlobalStore(t *testing.T) *globalstore.GlobalStore {
 	}
 	t.Cleanup(func() { _ = gs.Close() })
 	return gs
+}
+
+// newCanonicalStore returns a tmpdir-backed *store.CanonicalStore. Used
+// by the cross-tenant ExportUserData tests so each one gets a fresh
+// per-tenant SQLite tree on disk.
+func newCanonicalStore(t *testing.T) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
 }
 
 // withTrustedUser returns a ctx that carries the given subject as the


### PR DESCRIPTION
## Summary

Two test files in `server/go/internal/api` (package `api_test`) independently declared a `newCanonicalStore` test helper with conflicting signatures (1-arg vs 2-arg), causing a duplicate-declaration compile error.

- Removed the local 1-arg `newCanonicalStore` helper from `export_user_data_test.go`.
- Added the canonical 1-arg `newCanonicalStore(t *testing.T) *store.CanonicalStore` helper to `helpers_external_test.go` so all sibling test files share it.
- Renamed the 2-arg variant in `get_node_by_key_test.go` to `newCanonicalStoreForTenant(t *testing.T, tenantID string)` and updated its call sites. Body/behaviour unchanged.

Refs #407.

## Test plan

- [x] `cd server/go && go vet ./...`
- [x] `cd server/go && go test ./...`
- [x] `cd server/go && go test -race ./internal/api/...`
- [x] `uvx ruff@0.15.7 check .`
- [x] `uvx ruff@0.15.7 format --check .`