### PR TITLE
ci(go-rewrite): require Go server contract tests to pass — Wave 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,16 +142,15 @@ jobs:
 
   # Cross-implementation contract suite — same Python tests, but the
   # gRPC server is the Go ``entdb-server`` subprocess. Each Wave-2 PR
-  # adds one RPC to ``tests/python/integration/_go_parity.py`` and
-  # the matching contract case starts running here. Until then the
-  # leg is informational (``continue-on-error: true``); Wave-3 flips
-  # it to required once ``GO_IMPLEMENTED`` covers every RPC.
+  # added one RPC to ``tests/python/integration/_go_parity.py`` and
+  # the matching contract case started running here. Wave-3 flipped
+  # this job to required now that ``GO_IMPLEMENTED`` covers every
+  # RPC — Go-server failures gate merges.
   go-server-contract:
     name: Go Server Contract
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.go == 'true'
-    continue-on-error: true
     env:
       ENTDB_SERVER_TARGET: go
     steps:
@@ -304,7 +303,7 @@ jobs:
     name: All Checks Passed
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint, type-check, unit-tests, integration-tests, schema-compat, go-server-build, go-server-proto-drift, docker-build, e2e-tests, security-scan]
+    needs: [lint, type-check, unit-tests, integration-tests, go-server-contract, schema-compat, go-server-build, go-server-proto-drift, docker-build, e2e-tests, security-scan]
     steps:
       - name: Verify required checks
         env:


### PR DESCRIPTION
## Summary

- Wave 2 of EPIC #407 landed all 44 `entdb.v1.EntDBService` RPCs in the Go server, and `GO_IMPLEMENTED` in `tests/python/integration/_go_parity.py` now routes the full Python integration suite through the Go `entdb-server` subprocess.
- This PR is the matrix-flip moment: drop `continue-on-error: true` from the `go-server-contract` job in `.github/workflows/ci.yml` so cross-impl divergences actually gate merges, and wire the job into the `all-checks` aggregator's `needs:` list for branch protection.
- Updated the inline comment above the job to reflect that the leg is now required rather than informational.

Refs #407.

Heads up: this PR's own CI may go red on the `go-server-contract` leg if the Go server still diverges from Python on any contract test. That's the expected first read of the new signal — we'll iterate from there.

## Test plan

- [ ] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes locally (done).
- [ ] CI runs on the PR — `go-server-contract` reports as a required check, and `All Checks Passed` aggregates it.
- [ ] If `go-server-contract` fails, open follow-up issues against the divergent RPCs rather than reverting.