### PR TITLE
feat(go-rewrite): activate cross-impl tests for all 44 Go RPCs — Wave 2

### DIFF
--- a/tests/python/integration/_go_parity.py
+++ b/tests/python/integration/_go_parity.py
@@ -23,10 +23,58 @@ from __future__ import annotations
 # contract case for that RPC runs against the Go subprocess; non-
 # membership means it is skipped (not failed) when target=go.
 #
-# The registry is intentionally empty at Wave 2 start. Each subsequent
-# Wave 2 / Wave 3 PR lands one or more RPC names here together with
-# the Go handler.
-GO_IMPLEMENTED: set[str] = set()
+# Wave 2 consolidation: all 44 EntDBService RPCs now have Go-side
+# handlers merged on main. Membership here flips the contract suite
+# to exercise the Go binary for every RPC when ENTDB_SERVER_TARGET=go.
+# Wire-shape parity is best-effort at this point; any behavioural
+# divergences from the Python reference implementation become visible
+# as test failures and are tracked as follow-ups (see EPIC #407).
+GO_IMPLEMENTED: set[str] = {
+    "AddGroupMember",
+    "AddTenantMember",
+    "ArchiveTenant",
+    "CancelUserDeletion",
+    "ChangeMemberRole",
+    "CreateTenant",
+    "CreateUser",
+    "DelegateAccess",
+    "DeleteUser",
+    "ExecuteAtomic",
+    "ExportUserData",
+    "FreezeUser",
+    "GetConnectedNodes",
+    "GetEdgesFrom",
+    "GetEdgesTo",
+    "GetMailbox",
+    "GetNode",
+    "GetNodeByKey",
+    "GetNodes",
+    "GetReceiptStatus",
+    "GetSchema",
+    "GetTenant",
+    "GetTenantMembers",
+    "GetTenantQuota",
+    "GetUser",
+    "GetUserTenants",
+    "Health",
+    "ListMailboxUsers",
+    "ListSharedWithMe",
+    "ListTenants",
+    "ListUsers",
+    "QueryNodes",
+    "RemoveGroupMember",
+    "RemoveTenantMember",
+    "RevokeAccess",
+    "RevokeAllUserAccess",
+    "SearchMailbox",
+    "SearchNodes",
+    "SetLegalHold",
+    "ShareNode",
+    "TransferOwnership",
+    "TransferUserContent",
+    "UpdateUser",
+    "WaitForOffset",
+}
 
 
 def is_go_implemented(rpc_name: str) -> bool:


### PR DESCRIPTION
## Summary

Wave 2 final consolidation: every method on `entdb.v1.EntDBService` now has a Go-side handler merged, so this PR registers all 44 RPC names in `tests/python/integration/_go_parity.py::GO_IMPLEMENTED`. With this in place the `conftest.live_server` fixture (#428) routes every cross-implementation contract case through the Go subprocess when `ENTDB_SERVER_TARGET=go`.

Per-RPC gating is now effectively a no-op: the contract suite runs end-to-end against the Go binary. Wire-shape parity is best-effort at Wave 2 — divergences from the Python reference become visible here and are tracked as follow-ups (this PR does **not** fix Go behaviour). The `Go Server Contract` CI job remains `continue-on-error: true`; flipping that is a separate PR (Wave 3).

Refs #407.

## Local verification

- `python -m pytest tests/python/integration/ -q` (default target=python): **817 passed**.
- `ENTDB_SERVER_TARGET=go python -m pytest tests/python/integration/ -q`: **31 passed, 39 failed, 747 skipped** (skipped = Python-only suites; failures = behavioural divergences listed below).
- `uvx ruff@0.15.7 check .` — clean.
- `uvx ruff@0.15.7 format --check .` — clean.

## Contract cases that PASS under `ENTDB_SERVER_TARGET=go`

```
Health-happy
GetSchema-happy
ListTenants-permission_denied
GetUser-not_found
GetUser-invalid_argument0
GetUser-invalid_argument1
ListUsers-invalid_argument
CreateUser-happy
CreateUser-permission_denied
CreateUser-invalid_argument
UpdateUser-permission_denied
GetTenant-not_found
GetTenant-invalid_argument
CreateTenant-happy
CreateTenant-invalid_argument
GetTenantMembers-invalid_argument
GetUserTenants-invalid_argument
AddTenantMember-invalid_argument
AddTenantMember-permission_denied
ChangeMemberRole-invalid_argument
RemoveTenantMember-invalid_argument
TransferUserContent-invalid_argument
SetLegalHold-invalid_argument
RevokeAllUserAccess-invalid_argument
GetTenantQuota-invalid_argument
ExportUserData-happy
ExportUserData-permission_denied
FreezeUser-happy1
DeleteUser-permission_denied
CancelUserDeletion-happy
ArchiveTenant-invalid_argument
```

## Contract cases that FAIL under `ENTDB_SERVER_TARGET=go` (Wave 2 follow-ups)

These are behavioural divergences between the Go and Python servers — Go either returns an unexpected gRPC error (most cases) or a wire-shape mismatch on the happy path. They are **not** fixed in this PR.

```
GetNode-happy
GetNode-not_found
GetNodes-happy
QueryNodes-happy
GetEdgesFrom-happy
GetEdgesTo-happy
GetConnectedNodes-happy
SearchMailbox-happy
GetMailbox-happy
ListMailboxUsers-happy
WaitForOffset-happy
GetReceiptStatus-happy0
GetReceiptStatus-happy1
ShareNode-happy
ListSharedWithMe-happy
RevokeAccess-happy
AddGroupMember-happy
RemoveGroupMember-happy
TransferOwnership-happy
GetUser-happy
ListUsers-happy
UpdateUser-happy           (Go returns "User not found")
GetTenant-happy
GetTenantMembers-happy
GetUserTenants-happy
AddTenantMember-happy
ChangeMemberRole-happy
RemoveTenantMember-happy
TransferUserContent-happy
SetLegalHold-happy
RevokeAllUserAccess-happy
GetTenantQuota-happy
GetTenantQuota-permission_denied
GetNodeByKey-not_found
SearchNodes-invalid_argument
SearchNodes-happy
FreezeUser-happy0
DeleteUser-happy
ArchiveTenant-happy
```

Reviewers should not block this PR on the failures — they were invisible to CI until now, and the whole point of this consolidation is to surface them. Each will be tracked as a Wave 3 follow-up under EPIC #407.

## Test plan

- [x] `python -m pytest tests/python/integration/ -q` passes (target=python).
- [x] `ENTDB_SERVER_TARGET=go python -m pytest tests/python/integration/ -q` runs end-to-end (failures enumerated above; no longer silently skipped).
- [x] `uvx ruff@0.15.7 check .` and `uvx ruff@0.15.7 format --check .` clean.
- [ ] `Go Server Contract` CI job continues to run with `continue-on-error: true` until Wave 3 PR flips it.