### PR TITLE
feat(go-rewrite): wire --seed-tenant for cross-impl harness — Wave 4

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -21,7 +21,9 @@ import (
 	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/testseed"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
 
@@ -31,6 +33,11 @@ func main() {
 	walBackend := flag.String("wal-backend", "memory", "WAL backend: memory (only one supported in Wave 1)")
 	walTopic := flag.String("wal-topic", "entdb-wal", "WAL topic name")
 	walGroup := flag.String("wal-group", "entdb-applier", "WAL consumer group id")
+	// --seed-tenant is a test-only flag honoured by the cross-impl
+	// contract harness (docs/go-port/shared/test-harness.md). When set,
+	// the binary pre-creates a tenant + alice/bob users + the seed node
+	// the contract suite expects to find. Empty disables seeding.
+	seedTenant := flag.String("seed-tenant", "", "test-only: pre-create this tenant + contract-fixture state before serving")
 	flag.Parse()
 
 	lis, err := net.Listen("tcp", *addr)
@@ -39,6 +46,21 @@ func main() {
 	}
 
 	srvOpts := []api.Option{}
+
+	// Schema registry. Populated below when --seed-tenant is set so the
+	// contract suite's GetSchema/ExecuteAtomic asserts hold; left empty
+	// otherwise (production wiring lands in a later wave once the loader
+	// hook is connected to a config source).
+	registry := schema.NewRegistry()
+	if *seedTenant != "" {
+		if err := testseed.RegisterContractSchema(registry); err != nil {
+			log.Fatalf("entdb-server: register contract schema: %v", err)
+		}
+	}
+	if _, err := registry.Freeze(); err != nil {
+		log.Fatalf("entdb-server: freeze registry: %v", err)
+	}
+	srvOpts = append(srvOpts, api.WithSchemaRegistry(registry))
 
 	// Per-tenant canonical store (optional in Wave-1; if data-dir is
 	// unset, RPCs will be served as Unimplemented anyway and the
@@ -49,7 +71,7 @@ func main() {
 		applier   *apply.Applier
 	)
 	if *dataDir != "" {
-		canonical, err = store.New(store.Options{RootDir: *dataDir, WALMode: true})
+		canonical, err = store.New(store.Options{RootDir: *dataDir, WALMode: true, Registry: registry})
 		if err != nil {
 			log.Fatalf("entdb-server: open canonical store: %v", err)
 		}
@@ -99,6 +121,20 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Test-only seed: contract harness boots the binary with
+	// --seed-tenant <id> and expects the tenant + contract fixture state
+	// to be queryable before the first RPC arrives. Skipped silently
+	// when the flag is empty.
+	if *seedTenant != "" {
+		if canonical == nil || global == nil {
+			log.Fatalf("entdb-server: --seed-tenant requires --data-dir")
+		}
+		if err := testseed.SeedTenant(ctx, global, canonical, *seedTenant); err != nil {
+			log.Fatalf("entdb-server: seed tenant %q: %v", *seedTenant, err)
+		}
+		log.Printf("entdb-server: seeded tenant %q (alice=owner, bob=member, seed node + receipt)", *seedTenant)
+	}
 
 	// Run the applier in a background goroutine. Halt-on-poison errors
 	// surface here; the supervisor (this loop) logs and shuts down.

--- a/server/go/internal/testseed/seed.go
+++ b/server/go/internal/testseed/seed.go
@@ -1,0 +1,172 @@
+// Package testseed wires the deterministic test-only fixture the
+// cross-implementation contract suite (tests/python/integration/
+// test_grpc_contract.py) expects to find on a freshly-booted server.
+//
+// The harness contract is documented in docs/go-port/shared/test-harness.md
+// (the `--seed-tenant` row). The Python in-process fixture lives at
+// tests/python/integration/conftest.py:275-348 and seeds the same shape
+// via direct globalstore/canonicalstore writes + a follow-up ExecuteAtomic
+// call. This package reproduces that state for the Go subprocess harness.
+//
+// CLAUDE.md invariant #1 says all writes go through the WAL. This
+// package is the documented exception: it is a test-only seed for
+// the contract harness, gated by `--seed-tenant`, and never reachable
+// from a production code path. The seed writes the same applied_events
+// + applied_offsets rows the applier would have written had the seed
+// run through ExecuteAtomic, so post-seed reads behave identically.
+package testseed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"google.golang.org/grpc/codes"
+)
+
+// Fixture constants — keep in lock-step with
+// tests/python/integration/conftest.py (TENANT, ALICE, SEED_NODE_ID)
+// and tests/python/integration/test_grpc_contract.py.
+const (
+	AliceUserID  = "alice"
+	BobUserID    = "bob"
+	AliceActor   = "user:alice"
+	SeedNodeID   = "seeded-node"
+	SeedReceipt  = "seed-1"
+	SeedTopic    = "entdb-wal"
+	UserTypeID   = 1
+	TaskTypeID   = 2
+	AssignedToID = 100
+)
+
+// RegisterContractSchema populates reg with the User/Task/AssignedTo
+// types the contract suite asserts against. Mirrors
+// tests/python/integration/conftest.py:_build_python_registry.
+//
+// Idempotent on a fresh registry; a second call against an already-
+// populated registry returns ErrDuplicateRegistration.
+func RegisterContractSchema(reg *schema.Registry) error {
+	if reg == nil {
+		return errors.New("testseed: nil registry")
+	}
+	user := &schema.NodeTypeDef{
+		TypeID: UserTypeID,
+		Name:   "User",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "email", Kind: schema.KindString},
+			{FieldID: 2, Name: "name", Kind: schema.KindString},
+		},
+	}
+	if err := reg.RegisterNode(user); err != nil {
+		return fmt.Errorf("testseed: register User: %w", err)
+	}
+	task := &schema.NodeTypeDef{
+		TypeID: TaskTypeID,
+		Name:   "Task",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "title", Kind: schema.KindString},
+			{FieldID: 2, Name: "description", Kind: schema.KindString},
+		},
+	}
+	if err := reg.RegisterNode(task); err != nil {
+		return fmt.Errorf("testseed: register Task: %w", err)
+	}
+	edge := &schema.EdgeTypeDef{
+		EdgeID:     AssignedToID,
+		Name:       "AssignedTo",
+		FromTypeID: TaskTypeID,
+		ToTypeID:   UserTypeID,
+	}
+	if err := reg.RegisterEdge(edge); err != nil {
+		return fmt.Errorf("testseed: register AssignedTo: %w", err)
+	}
+	return nil
+}
+
+// SeedTenant applies the contract-fixture seed for tenantID. Order
+// mirrors the Python conftest:
+//
+//  1. tenant_registry row (tenantID, "Acme Corp", region default).
+//  2. user_registry rows: alice + bob.
+//  3. tenant_members: alice=owner, bob=member.
+//  4. canonical store: OpenTenant + seeded-node + seed-1 receipt +
+//     applied_offsets row.
+//
+// All steps are best-effort idempotent: an already-existing row is
+// treated as success so repeated harness boots against the same
+// data-dir don't fail.
+func SeedTenant(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, tenantID string) error {
+	if g == nil {
+		return errors.New("testseed: nil globalstore")
+	}
+	if s == nil {
+		return errors.New("testseed: nil canonical store")
+	}
+	if tenantID == "" {
+		return errors.New("testseed: empty tenantID")
+	}
+
+	if _, err := g.CreateTenant(ctx, tenantID, "Acme Corp", ""); err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("testseed: create tenant: %w", err)
+	}
+	if _, err := g.CreateUser(ctx, AliceUserID, "alice@example.com", "Alice"); err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("testseed: create user alice: %w", err)
+	}
+	if _, err := g.CreateUser(ctx, BobUserID, "bob@example.com", "Bob"); err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("testseed: create user bob: %w", err)
+	}
+	if err := g.AddTenantMember(ctx, tenantID, AliceUserID, "owner"); err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("testseed: add alice as owner: %w", err)
+	}
+	if err := g.AddTenantMember(ctx, tenantID, BobUserID, "member"); err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("testseed: add bob as member: %w", err)
+	}
+
+	if err := s.OpenTenant(ctx, tenantID); err != nil {
+		return fmt.Errorf("testseed: open tenant: %w", err)
+	}
+
+	// Seed node — payload is field-id-keyed (CLAUDE.md invariant #6).
+	// Field 1 = email, Field 2 = name (per RegisterContractSchema).
+	if _, err := s.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:     SeedNodeID,
+		TypeID:     UserTypeID,
+		Payload:    map[string]any{"1": "seeded@example.com", "2": "Seeded"},
+		OwnerActor: AliceActor,
+	}); err != nil && !isUniqueOrAlreadyExists(err) {
+		return fmt.Errorf("testseed: create seed node: %w", err)
+	}
+
+	// seed-1 receipt so GetReceiptStatus(seed-1) returns APPLIED.
+	if err := s.RecordIdempotency(ctx, tenantID, SeedReceipt, "entdb-wal:0:0"); err != nil && !isIdempotencyViolation(err) {
+		return fmt.Errorf("testseed: record receipt seed-1: %w", err)
+	}
+
+	// applied_offsets: mark partition 0 of entdb-wal as having processed
+	// offset 1 (one event — the seed node). WaitForOffset(target=0)
+	// returns immediately because the in-memory map now has tenantID >= 0.
+	if err := s.UpdateAppliedOffset(ctx, tenantID, SeedTopic, 0, 1); err != nil {
+		return fmt.Errorf("testseed: update applied offset: %w", err)
+	}
+
+	return nil
+}
+
+func isAlreadyExists(err error) bool {
+	return errs.Code(err) == codes.AlreadyExists
+}
+
+func isUniqueOrAlreadyExists(err error) bool {
+	if isAlreadyExists(err) {
+		return true
+	}
+	return errors.Is(err, store.ErrUniqueConstraint)
+}
+
+func isIdempotencyViolation(err error) bool {
+	return errors.Is(err, store.ErrIdempotencyViolation)
+}

--- a/server/go/internal/testseed/seed_test.go
+++ b/server/go/internal/testseed/seed_test.go
@@ -1,0 +1,130 @@
+package testseed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+func newStores(t *testing.T) (*globalstore.GlobalStore, *store.CanonicalStore, *schema.Registry) {
+	t.Helper()
+	dir := t.TempDir()
+	g, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: false})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = g.Close() })
+
+	reg := schema.NewRegistry()
+	if err := RegisterContractSchema(reg); err != nil {
+		t.Fatalf("RegisterContractSchema: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+
+	s, err := store.New(store.Options{RootDir: dir, WALMode: false, Registry: reg})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	return g, s, reg
+}
+
+func TestSeedTenant_PopulatesContractFixture(t *testing.T) {
+	ctx := context.Background()
+	g, s, _ := newStores(t)
+
+	if err := SeedTenant(ctx, g, s, "acme"); err != nil {
+		t.Fatalf("SeedTenant: %v", err)
+	}
+
+	// Tenant present.
+	tn, err := g.GetTenant(ctx, "acme")
+	if err != nil || tn == nil {
+		t.Fatalf("GetTenant: %v, tenant=%v", err, tn)
+	}
+	if tn.Status != "active" {
+		t.Fatalf("tenant status = %q, want active", tn.Status)
+	}
+
+	// Users present.
+	for _, uid := range []string{"alice", "bob"} {
+		u, err := g.GetUser(ctx, uid)
+		if err != nil || u == nil {
+			t.Fatalf("GetUser %q: %v, user=%v", uid, err, u)
+		}
+	}
+
+	// Memberships: alice=owner, bob=member.
+	members, err := g.GetTenantMembers(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	roles := map[string]string{}
+	for _, m := range members {
+		roles[m.UserID] = m.Role
+	}
+	if roles["alice"] != "owner" {
+		t.Fatalf("alice role = %q, want owner", roles["alice"])
+	}
+	if roles["bob"] != "member" {
+		t.Fatalf("bob role = %q, want member", roles["bob"])
+	}
+
+	// Seed node present.
+	n, err := s.GetNode(ctx, "acme", SeedNodeID)
+	if err != nil || n == nil {
+		t.Fatalf("GetNode seeded-node: %v, node=%v", err, n)
+	}
+	if n.OwnerActor != AliceActor {
+		t.Fatalf("seed node owner = %q, want %q", n.OwnerActor, AliceActor)
+	}
+
+	// Receipt applied.
+	applied, err := s.CheckIdempotency(ctx, "acme", SeedReceipt)
+	if err != nil {
+		t.Fatalf("CheckIdempotency: %v", err)
+	}
+	if !applied {
+		t.Fatalf("CheckIdempotency seed-1 = false, want true")
+	}
+
+	// WaitForOffset returns immediately for target=0 since the applied
+	// offset map is populated.
+	if err := s.WaitForOffset(ctx, "acme", 0); err != nil {
+		t.Fatalf("WaitForOffset(0): %v", err)
+	}
+}
+
+func TestSeedTenant_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	g, s, _ := newStores(t)
+
+	if err := SeedTenant(ctx, g, s, "acme"); err != nil {
+		t.Fatalf("first SeedTenant: %v", err)
+	}
+	if err := SeedTenant(ctx, g, s, "acme"); err != nil {
+		t.Fatalf("second SeedTenant (should be idempotent): %v", err)
+	}
+}
+
+func TestRegisterContractSchema_DefinesExpectedTypes(t *testing.T) {
+	reg := schema.NewRegistry()
+	if err := RegisterContractSchema(reg); err != nil {
+		t.Fatalf("RegisterContractSchema: %v", err)
+	}
+	if nt := reg.NodeType("User"); nt == nil || nt.TypeID != UserTypeID {
+		t.Fatalf("User type missing or wrong id: %+v", nt)
+	}
+	if nt := reg.NodeType("Task"); nt == nil || nt.TypeID != TaskTypeID {
+		t.Fatalf("Task type missing or wrong id: %+v", nt)
+	}
+	if et := reg.EdgeType("AssignedTo"); et == nil || et.EdgeID != AssignedToID {
+		t.Fatalf("AssignedTo edge missing or wrong id: %+v", et)
+	}
+}

--- a/tests/python/integration/conftest.py
+++ b/tests/python/integration/conftest.py
@@ -374,6 +374,8 @@ async def _start_go_server(tmp_path_factory) -> AsyncIterator[int]:
             str(data_dir),
             "--wal-backend",
             "memory",
+            "--seed-tenant",
+            TENANT,
         ]
         log_fh = open(log_path, "ab", buffering=0)  # noqa: SIM115 - lifetime tied to subprocess
         proc = subprocess.Popen(


### PR DESCRIPTION
## Summary

Wires the `--seed-tenant <id>` flag the cross-impl contract harness spec (`docs/go-port/shared/test-harness.md` L96-117) requires. The Python in-process fixture seeds tenant `acme` + users alice/bob + schema (User/Task/AssignedTo) + seed node + `seed-1` receipt before yielding the port; the Go subprocess fixture never did. Every cross-impl contract failure (39 of them per Wave 4 triage) was downstream of empty stores — not Go behavior bugs.

Triage: [.claude/triage/wave4-divergence-fix-plan.md](../blob/main/.claude/triage/wave4-divergence-fix-plan.md) (not committed; lives in local triage workspace).

## What changed

- New `server/go/internal/testseed/` package:
  - `RegisterContractSchema(reg)` — mirrors `_build_python_registry` in conftest (User=1, Task=2, AssignedTo=100).
  - `SeedTenant(ctx, g, s, tenantID)` — applies the deterministic fixture: tenant row, alice (owner) + bob (member), `OpenTenant`, `seeded-node` of type 1 with payload `{1:"seeded@example.com", 2:"Seeded"}` owned by `user:alice`, `seed-1` receipt in `applied_events`, `applied_offsets` row at offset 1 so `WaitForOffset(target=0)` returns immediately.
  - Idempotent: re-running the seed against an existing fixture succeeds.
- `server/go/cmd/entdb-server/main.go`:
  - Adds `--seed-tenant <id>` flag. When set, registers the contract schema, freezes the registry, opens the stores, and runs `testseed.SeedTenant` before `srv.Serve` accepts traffic.
  - Wires the schema registry through `api.WithSchemaRegistry` and `store.Options.Registry` (was previously absent from the binary; needed for `GetSchema`/index hooks under seed).
- `tests/python/integration/conftest.py`:
  - Appends `--seed-tenant acme` to the Go subprocess `cmd` in `_start_go_server`.

## Test results

Under `ENTDB_SERVER_TARGET=go`:

```
============== 1 failed, 69 passed, 1 skipped in 81.25s (0:01:21) ==============
```

**69/70 passing, 1 skipped (Python-only).** Residual failure (real Go behavior bug, not seed-related, deferred to its own PR):

- `GetTenantQuota-happy` — aborts with `PERMISSION_DENIED: "GetTenantQuota: no trusted identity"`. The Go handler requires a trusted identity from the auth context, but the harness runs with `--auth-disabled` semantics (no auth interceptor). Python's `GetTenantQuota` accepts the request when no auth interceptor is wired; Go's handler does not. Fix is in the Go `GetTenantQuota` handler, not the seed.

Under default (Python target): **71/71 passing** (no regressions).

Full Python suite: **2529 passed in 61.74s** (no regressions).

`cd server/go && go vet ./... && go test ./...`: all packages pass, including 3 new tests in `testseed/`.

Lint/format: `uvx ruff@0.15.7 check .` and `uvx ruff@0.15.7 format --check .` both pass.

Refs #407

## Test plan

- [x] Go unit tests: `go test ./internal/testseed/...` — 3/3 pass (PopulatesContractFixture, Idempotent, DefinesExpectedTypes).
- [x] Go full suite: `cd server/go && go vet ./... && go test ./...` — all packages pass.
- [x] Cross-impl contract suite: `ENTDB_SERVER_TARGET=go python -m pytest tests/python/integration/test_grpc_contract.py -v` — 69/70 pass + 1 Python-only skip.
- [x] Python target unchanged: `python -m pytest tests/python/integration/test_grpc_contract.py -v` — 71/71 pass.
- [x] Full Python suite: `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 pass, 0 regressions.
- [x] Lint: `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` — clean.