### PR TITLE
fix(go-rewrite): align GetTenantQuota auth posture — Wave 4

### DIFF
--- a/server/go/internal/api/get_tenant_quota.go
+++ b/server/go/internal/api/get_tenant_quota.go
@@ -11,11 +11,16 @@
 //     out of globalstore (tenant_quotas + tenant_usage); both fall back to
 //     zero-valued defaults when the row is absent.
 //   - Auth: trusted-actor. The proto `actor` field is a hint only and is
-//     deliberately ignored for authorization (see commit fece3fb,
-//     "Fix privilege escalation"). Authoritative actor is taken from the
-//     interceptor-populated Identity on ctx.
-//   - Authorization gate: caller must be a member of the tenant
-//     (any role, including admin/owner). Non-members → PERMISSION_DENIED.
+//     deliberately ignored for authorization when an interceptor-attested
+//     Identity is on ctx (commit fece3fb, "Fix privilege escalation").
+//     When no Identity is present (unit tests, no-auth deployments) we
+//     fall through to the claimed actor — the documented Authoritative
+//     contract. Mirrors get_authoritative_actor in
+//     server/python/entdb_server/auth/auth_interceptor.py:92-115.
+//   - Authorization gate: matches Python `_require_admin_or_owner`
+//     (grpc_server.py:2656-2690). The trusted actor passes if it is
+//     system:/admin:, or if it is a user: whose tenant role is "owner"
+//     or "admin". Plain members and non-members → PERMISSION_DENIED.
 //     Empty tenant_id → INVALID_ARGUMENT.
 //   - period_end_ms is computed locally from time.Now(), never read from
 //     the DB — keeps dashboards correct for tenants with no writes this
@@ -63,38 +68,39 @@ func (s *Server) GetTenantQuota(
 		return nil, err
 	}
 
-	// Trusted actor: proto `actor` is ignored. The interceptor places
-	// the verified Identity on ctx; auth.Authoritative normalises it to
-	// an Actor. If the test/server is wired without an auth interceptor,
-	// Authoritative falls through to the claimed actor — but we then
-	// drop it on the floor and require a real trusted identity below.
-	id, ok := auth.IdentityFromContext(ctx)
-	if !ok {
-		outcome = "error"
-		return nil, errs.Errorf(codes.PermissionDenied,
-			"GetTenantQuota: no trusted identity")
-	}
-	trusted := auth.Authoritative(ctx, auth.User(id.Subject))
+	// Trusted-actor rebind. When the auth interceptor has populated an
+	// Identity on ctx, Authoritative returns that identity and the
+	// claimed actor is ignored — this is the privilege-escalation guard
+	// (commit fece3fb). When no interceptor ran (unit tests, contract
+	// harness without auth), Authoritative falls through to the claimed
+	// actor, matching Python's get_authoritative_actor fallback at
+	// auth_interceptor.py:108-115.
+	claimed := auth.ParseActor(req.GetActor())
+	trusted := auth.Authoritative(ctx, claimed)
 
-	// Membership gate: any member (including admin/owner) may read the
-	// tenant's quota dashboard. Non-members are rejected. Mirrors
-	// "_require_admin_or_owner" semantics relaxed to member-or-admin
-	// per the W2 task spec for parity dashboards.
 	if s.global == nil {
 		outcome = "error"
 		return nil, errs.Errorf(codes.Unimplemented,
 			"GetTenantQuota: quota registry not configured")
 	}
-	member, err := s.global.IsMember(ctx, tenantID, trusted.ID())
-	if err != nil {
-		outcome = "error"
-		return nil, errs.Errorf(codes.Internal,
-			"GetTenantQuota: membership probe: %v", err)
-	}
-	if !member {
-		outcome = "error"
-		return nil, errs.Errorf(codes.PermissionDenied,
-			"GetTenantQuota: caller is not a member of %q", tenantID)
+
+	// Admin/owner gate. Mirrors `_require_admin_or_owner` at
+	// grpc_server.py:2671-2690:
+	//   - system:/admin: actors bypass the membership check.
+	//   - user: actors must have role "owner" or "admin" on the tenant.
+	// Plain members and non-members are rejected.
+	if !(trusted.IsSystem() || trusted.IsAdmin()) {
+		role, err := s.lookupMemberRole(ctx, tenantID, trusted.ID())
+		if err != nil {
+			outcome = "error"
+			return nil, errs.Errorf(codes.Internal,
+				"GetTenantQuota: lookup member role: %v", err)
+		}
+		if role != "owner" && role != "admin" {
+			outcome = "error"
+			return nil, errs.Errorf(codes.PermissionDenied,
+				"GetTenantQuota requires admin or owner role")
+		}
 	}
 
 	cfg, err := s.global.GetTenantQuota(ctx, tenantID)

--- a/server/go/internal/api/get_tenant_quota_test.go
+++ b/server/go/internal/api/get_tenant_quota_test.go
@@ -1,12 +1,21 @@
 // Tests for GetTenantQuota (Wave 2 / EPIC #407). Behavioural pins:
 //
-//  1. Member happy path — tenant member sees configured quota + usage.
-//  2. Admin happy path — admin role works the same as member.
-//  3. Non-member → PERMISSION_DENIED, even with claimed actor on the wire.
-//  4. Quota not configured → defaults (zero-valued cfg fields) but
+//  1. Owner happy path — a user with role=owner sees configured quota +
+//     usage. Matches Python `_require_admin_or_owner` at
+//     grpc_server.py:2685.
+//  2. Admin-role happy path — a tenant user with role=admin succeeds.
+//  3. Plain member → PERMISSION_DENIED. The handler is admin/owner-only;
+//     tenant role=member is NOT enough (matches Python contract test
+//     test_grpc_contract.py:483-486).
+//  4. Non-member → PERMISSION_DENIED, even with claimed actor on the
+//     wire (privilege-escalation pin).
+//  5. Quota not configured → defaults (zero-valued cfg fields) but
 //     period_end_ms is still computed and writes_used / period_start_ms
 //     come from the synthesized usage row.
-//  5. Empty tenant_id → INVALID_ARGUMENT (gate runs before tenant check).
+//  6. Empty tenant_id → INVALID_ARGUMENT (gate runs before tenant check).
+//  7. No-trusted-identity fallback — when no auth interceptor is wired,
+//     the handler falls through to the claimed actor (cross-impl
+//     contract harness behaviour after #473).
 //
 // Spec: docs/go-port/rpcs/GetTenantQuota.md.
 // Privilege-escalation pin: claim-on-wire is ignored, trusted Identity wins.
@@ -26,10 +35,10 @@ import (
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
 
-// TestGetTenantQuota_Member_HappyPath: a tenant member with role=member
+// TestGetTenantQuota_Owner_HappyPath: a tenant user with role=owner
 // can read the quota dashboard; configured cfg + usage round-trip into
 // the response and period_end_ms is in the future.
-func TestGetTenantQuota_Member_HappyPath(t *testing.T) {
+func TestGetTenantQuota_Owner_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	gs := newGlobalStore(t)
@@ -38,7 +47,7 @@ func TestGetTenantQuota_Member_HappyPath(t *testing.T) {
 	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
 		t.Fatalf("CreateTenant: %v", err)
 	}
-	if err := gs.AddTenantMember(ctx, "acme", "alice", "member"); err != nil {
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "owner"); err != nil {
 		t.Fatalf("AddTenantMember: %v", err)
 	}
 	if _, err := gs.SetTenantQuota(ctx, globalstore.QuotaConfig{
@@ -95,9 +104,9 @@ func TestGetTenantQuota_Member_HappyPath(t *testing.T) {
 	}
 }
 
-// TestGetTenantQuota_Admin_HappyPath: an admin role is treated identically
-// to a member for read access (per W2 spec — read is gated by membership,
-// admin is just one specific role).
+// TestGetTenantQuota_Admin_HappyPath: a tenant user with role=admin
+// succeeds, parity with role=owner. Matches the `role in ("owner",
+// "admin")` check at grpc_server.py:2685.
 func TestGetTenantQuota_Admin_HappyPath(t *testing.T) {
 	t.Parallel()
 
@@ -170,7 +179,7 @@ func TestGetTenantQuota_NoQuotaConfigured_ReturnsDefaults(t *testing.T) {
 	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
 		t.Fatalf("CreateTenant: %v", err)
 	}
-	if err := gs.AddTenantMember(ctx, "acme", "alice", "member"); err != nil {
+	if err := gs.AddTenantMember(ctx, "acme", "alice", "owner"); err != nil {
 		t.Fatalf("AddTenantMember: %v", err)
 	}
 
@@ -217,5 +226,65 @@ func TestGetTenantQuota_EmptyTenantID_InvalidArgument(t *testing.T) {
 	}
 	if got := errs.Code(err); got != codes.InvalidArgument {
 		t.Fatalf("GetTenantQuota: code = %v, want InvalidArgument (err=%v)", got, err)
+	}
+}
+
+// TestGetTenantQuota_PlainMember_PermissionDenied: a tenant user whose
+// role is "member" (not owner / not admin) is rejected. Pins the
+// Python contract test row at test_grpc_contract.py:483-486
+// (actor=user:bob, role=member → permission_denied).
+func TestGetTenantQuota_PlainMember_PermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(ctx, "acme", "bob", "member"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	ctx = withTrustedUser(ctx, "bob")
+
+	_, err := srv.GetTenantQuota(ctx, &pb.GetTenantQuotaRequest{TenantId: "acme"})
+	if err == nil {
+		t.Fatalf("GetTenantQuota: expected PermissionDenied, got nil")
+	}
+	if got := errs.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("GetTenantQuota: code = %v, want PermissionDenied (err=%v)", got, err)
+	}
+}
+
+// TestGetTenantQuota_NoTrustedIdentity_FallsBackToClaimed: when no auth
+// interceptor populated an Identity on ctx (cross-impl contract harness,
+// no-auth deployments), the handler falls through to the claimed actor
+// per auth.Authoritative's documented contract. A system: actor on the
+// wire then bypasses the membership gate. This is the divergence the
+// Wave-4 parity fix closes — previously the handler hard-rejected.
+func TestGetTenantQuota_NoTrustedIdentity_FallsBackToClaimed(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+	// No withTrustedUser — auth interceptor disabled. Mirrors the
+	// contract harness path against the Go subprocess.
+	resp, err := srv.GetTenantQuota(ctx, &pb.GetTenantQuotaRequest{
+		TenantId: "acme",
+		Actor:    "system:admin",
+	})
+	if err != nil {
+		t.Fatalf("GetTenantQuota: unexpected error: %v", err)
+	}
+	if resp.GetTenantId() != "acme" {
+		t.Errorf("TenantId = %q, want %q", resp.GetTenantId(), "acme")
 	}
 }


### PR DESCRIPTION
## Summary

- Final Wave-2 cross-impl parity divergence. The Go `GetTenantQuota` handler hard-rejected callers with no trusted identity on ctx (`PERMISSION_DENIED: "GetTenantQuota: no trusted identity"`). Python's `_require_admin_or_owner` falls back to the claimed actor when no auth interceptor populated an Identity, per the documented `auth.Authoritative` contract.
- Replaces the hard-reject with the canonical `auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))` pattern used by every other admin RPC.
- Tightens the gate to match Python exactly (`grpc_server.py:2671-2690`): trusted actor passes if it is `system:`/`admin:`, OR if it is a `user:` whose tenant role is `owner`/`admin`. Plain members and non-members are rejected. This brings the row at `test_grpc_contract.py:483-486` (actor=user:bob, role=member → PERMISSION_DENIED) into agreement.
- Updates Go unit tests: renames `Member_HappyPath` → `Owner_HappyPath`, adds `PlainMember_PermissionDenied` (pins the Python contract row) and `NoTrustedIdentity_FallsBackToClaimed` (pins the harness-without-auth path).

With this change, `ENTDB_SERVER_TARGET=go python -m pytest tests/python/integration/test_grpc_contract.py` is **70 passed, 1 skipped (Python-only)** — full parity with the Python reference server.

Refs #407.

## Test plan

- [x] `cd server/go && go vet ./... && go test ./...` — all packages green.
- [x] `cd server/go && go test ./internal/api/ -run GetTenantQuota -v` — 7/7 pass.
- [x] `ENTDB_SERVER_TARGET=go python -m pytest tests/python/integration/test_grpc_contract.py -v -k GetTenantQuota` — 3/3 pass (happy, invalid_argument, permission_denied).
- [x] `ENTDB_SERVER_TARGET=go python -m pytest tests/python/integration/test_grpc_contract.py -v` — 70 passed, 1 skipped (Python-only).
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed.
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` — clean.