### PR TITLE
feat(go-rewrite): Go server Docker image + E2E cross-impl coverage — Wave 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,10 +272,21 @@ jobs:
           target: server
 
   e2e-tests:
-    name: E2E Tests
+    name: E2E Tests (${{ matrix.server }})
     runs-on: ubuntu-latest
     needs: [changes, docker-build]
-    if: needs.changes.outputs.docker == 'true' || needs.changes.outputs.python == 'true'
+    if: needs.changes.outputs.docker == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.go == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        server: [python, go]
+    # Wave-5 (EPIC #407): the Go leg is intentionally allowed to fail
+    # while the test fixture (proto schema vs --seed-tenant contract
+    # schema) and the WAL backend gap are closed in Wave 6. Flip to the
+    # default (no continue-on-error) once the Go target reaches parity.
+    continue-on-error: ${{ matrix.server == 'go' }}
+    env:
+      ENTDB_SERVER_TARGET: ${{ matrix.server }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3

--- a/Dockerfile.go
+++ b/Dockerfile.go
@@ -1,0 +1,84 @@
+# EntDB Server (Go) Dockerfile
+#
+# Multi-stage build that compiles server/go/cmd/entdb-server into a
+# minimal distroless runtime image. Uses modernc.org/sqlite (pure-Go
+# SQLite) so CGO_ENABLED=0 and the binary lands in a "static" distroless
+# base — no glibc, no shell, no package manager.
+#
+# Wave 5 (EPIC #407) ships this image alongside the existing Python
+# server image (see ../Dockerfile) so the E2E suite can target either
+# implementation by switching ENTDB_SERVER_TARGET={python,go}.
+#
+# Build:
+#   docker build -f Dockerfile.go -t entdb-server-go:test .
+#
+# Run (server picks up flags, NOT env vars — the Python server uses env;
+# the Go binary takes -addr / -data-dir / -wal-backend / -seed-tenant):
+#   docker run --rm -p 50051:50051 entdb-server-go:test \
+#       -addr=:50051 -data-dir=/var/lib/entdb -wal-backend=memory
+#
+# Inspect flags:
+#   docker run --rm entdb-server-go:test -help
+
+# =============================================================================
+# Builder stage — compile the binary with CGO disabled
+# =============================================================================
+FROM golang:1.25-bookworm AS builder
+
+WORKDIR /src
+
+# Cache modules layer separately from source. The Go server module lives
+# at server/go (separate go.mod from the SDK).
+COPY server/go/go.mod server/go/go.sum ./server/go/
+RUN cd server/go && go mod download
+
+# Bring in the rest of the Go server source.
+COPY server/go/ ./server/go/
+
+# CGO disabled so the resulting binary is statically linked and runs on
+# `gcr.io/distroless/static-debian12`. modernc.org/sqlite is pure Go, so
+# this works for the persistence layer too.
+RUN cd server/go && \
+    CGO_ENABLED=0 GOOS=linux go build \
+        -trimpath -ldflags="-s -w" \
+        -o /entdb-server \
+        ./cmd/entdb-server
+
+# Pre-create the data directory with the right ownership for the
+# nonroot distroless user (uid/gid 65532). distroless/static has no
+# shell, so we cannot mkdir at runtime — the directory has to be
+# baked into the final image with the right ownership.
+RUN mkdir -p /staging/var/lib/entdb && chown -R 65532:65532 /staging
+
+# =============================================================================
+# Runtime stage — distroless static, just the binary
+# =============================================================================
+FROM gcr.io/distroless/static-debian12:nonroot AS server
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+
+LABEL org.opencontainers.image.title="EntDB Server (Go)" \
+      org.opencontainers.image.description="Go reimplementation of the EntDB tenant-sharded graph gRPC server" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${COMMIT}" \
+      org.opencontainers.image.source="https://github.com/elloloop/tenant-shard-db" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.vendor="elloloop"
+
+COPY --from=builder /entdb-server /entdb-server
+COPY --from=builder --chown=65532:65532 /staging/var/lib/entdb /var/lib/entdb
+
+# Default port. The Go binary accepts -addr=host:port; docker-compose /
+# the E2E harness override the flag explicitly when needed.
+EXPOSE 50051
+
+USER nonroot:nonroot
+
+# distroless/static has no shell, so we must use the exec form. The
+# default flags wire up an in-memory WAL (the only backend the Go server
+# supports today — Kafka/etc land in a later wave) and point the data
+# directory at /var/lib/entdb. Override the full command at `docker run`
+# / `docker compose run` time to pass --seed-tenant or other test flags.
+ENTRYPOINT ["/entdb-server"]
+CMD ["-addr=:50051", "-data-dir=/var/lib/entdb", "-wal-backend=memory"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,38 @@ services:
       start_period: 10s
 
   # ==========================================================================
+  # EntDB Server (Go) — Wave-5 reimplementation (EPIC #407).
+  #
+  # Opt-in via the "go-server" profile so the default `docker compose up`
+  # still launches the Python server. Bring up explicitly with:
+  #
+  #   docker compose --profile go-server up entdb-server-go
+  #
+  # The Go binary today only supports the in-memory WAL backend (no
+  # Kafka/S3 wiring yet), so this service has no infra dependencies and
+  # binds to host port 50052 to avoid colliding with the Python server.
+  # Test fixture: --seed-tenant pre-creates the contract-suite tenant so
+  # clients can issue RPCs against `playground` without an out-of-band
+  # bootstrap.
+  # ==========================================================================
+  entdb-server-go:
+    profiles: ["go-server"]
+    build:
+      context: .
+      dockerfile: Dockerfile.go
+      target: server
+    image: entdb-server-go:test
+    ports:
+      - "50052:50051"
+    command:
+      - "-addr=:50051"
+      - "-data-dir=/var/lib/entdb"
+      - "-wal-backend=memory"
+      - "-seed-tenant=playground"
+    volumes:
+      - entdb-go-data:/var/lib/entdb
+
+  # ==========================================================================
   # Redpanda (Kafka-compatible)
   # ==========================================================================
   redpanda:
@@ -200,6 +232,8 @@ volumes:
   redpanda-data:
     driver: local
   minio-data:
+    driver: local
+  entdb-go-data:
     driver: local
 
 networks:

--- a/tests/python/e2e/docker-compose.e2e.go.yml
+++ b/tests/python/e2e/docker-compose.e2e.go.yml
@@ -1,0 +1,65 @@
+version: "3.8"
+
+# =============================================================================
+# EntDB E2E Test Environment — Go server target
+# =============================================================================
+#
+# Parallel compose file to docker-compose.e2e.yml, but the server is the
+# Go reimplementation (Dockerfile.go). The Go server today only supports
+# the in-memory WAL backend (no Kafka/S3 wiring yet), so this stack is
+# infra-free — just the server + the test runner.
+#
+# Wave 5 (EPIC #407): this enables ENTDB_SERVER_TARGET=go in
+# tests/python/e2e/run-e2e.sh. Behavioural divergences vs the Python
+# server are EXPECTED in this PR — see the Wave-5 PR body for the
+# enumerated pass/fail breakdown. Closing those divergences is Wave 6.
+#
+# Usage:
+#   ENTDB_SERVER_TARGET=go tests/python/e2e/run-e2e.sh --logs
+#
+# =============================================================================
+
+services:
+  # ==========================================================================
+  # EntDB Server (Go binary)
+  #
+  # `--seed-tenant=e2e-test` pre-creates the tenant + alice/bob users +
+  # seed node so RPCs can target it without an out-of-band bootstrap
+  # (matches what the cross-impl contract harness does for the Python
+  # in-process fixture — see tests/python/integration/conftest.py).
+  # ==========================================================================
+  server:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile.go
+      target: server
+    image: entdb-server-go:test
+    command:
+      - "-addr=:50051"
+      - "-data-dir=/var/lib/entdb"
+      - "-wal-backend=memory"
+      - "-seed-tenant=e2e-test"
+    # No HEALTHCHECK in the distroless image (no shell, no grpc probe
+    # binary baked in). The test runner retries its own connect with
+    # MAX_RETRIES so a TCP-ready server is sufficient.
+
+  # ==========================================================================
+  # E2E Test Runner — identical to the Python-target stack.
+  # ==========================================================================
+  e2e-tests:
+    build:
+      context: ../../..
+      dockerfile: tests/python/e2e/Dockerfile.e2e
+    environment:
+      - ENTDB_HOST=server
+      - ENTDB_PORT=50051
+      - ENTDB_TENANT=e2e-test
+      - ENTDB_SERVER_TARGET=go
+    depends_on:
+      - server
+    volumes:
+      - ../../tests/e2e:/app/tests/e2e:ro
+
+networks:
+  default:
+    name: entdb-e2e-go-network

--- a/tests/python/e2e/run-e2e.sh
+++ b/tests/python/e2e/run-e2e.sh
@@ -6,12 +6,19 @@
 # This script runs the end-to-end test suite in Docker.
 #
 # Usage:
-#   ./tests/e2e/run-e2e.sh
+#   ./tests/python/e2e/run-e2e.sh                            # Python server (default)
+#   ENTDB_SERVER_TARGET=go ./tests/python/e2e/run-e2e.sh     # Go server (Wave-5)
 #
 # Options:
 #   --no-cache    Rebuild containers without cache
 #   --keep        Keep containers running after tests
 #   --logs        Show server logs on failure
+#
+# Environment:
+#   ENTDB_SERVER_TARGET   "python" (default) or "go". Selects which
+#                         server compose file is used. The Go target
+#                         uses Dockerfile.go (CGO-free distroless) and
+#                         the in-memory WAL — no Redpanda/MinIO.
 #
 # =============================================================================
 
@@ -19,7 +26,21 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-COMPOSE_FILE="$SCRIPT_DIR/docker-compose.e2e.yml"
+
+ENTDB_SERVER_TARGET="${ENTDB_SERVER_TARGET:-python}"
+
+case "$ENTDB_SERVER_TARGET" in
+    python)
+        COMPOSE_FILE="$SCRIPT_DIR/docker-compose.e2e.yml"
+        ;;
+    go)
+        COMPOSE_FILE="$SCRIPT_DIR/docker-compose.e2e.go.yml"
+        ;;
+    *)
+        echo "ERROR: ENTDB_SERVER_TARGET must be 'python' or 'go' (got '$ENTDB_SERVER_TARGET')"
+        exit 2
+        ;;
+esac
 
 # Parse arguments
 NO_CACHE=""
@@ -41,7 +62,7 @@ for arg in "$@"; do
 done
 
 echo "=============================================="
-echo "EntDB E2E Test Suite"
+echo "EntDB E2E Test Suite (target=$ENTDB_SERVER_TARGET)"
 echo "=============================================="
 echo ""
 
@@ -54,12 +75,22 @@ docker compose -f "$COMPOSE_FILE" build $NO_CACHE
 
 echo ""
 echo "[2/3] Starting infrastructure..."
-docker compose -f "$COMPOSE_FILE" up -d redpanda minio
-docker compose -f "$COMPOSE_FILE" up -d minio-init
-docker compose -f "$COMPOSE_FILE" up -d server
 
-echo "Waiting for server to be healthy..."
-docker compose -f "$COMPOSE_FILE" up -d --wait server
+if [ "$ENTDB_SERVER_TARGET" = "go" ]; then
+    # Go server has no Kafka/S3 dependencies (in-memory WAL only) and
+    # the distroless image carries no healthcheck binary; the test
+    # runner retries its own connect, so plain `up -d` is enough.
+    docker compose -f "$COMPOSE_FILE" up -d server
+    echo "Waiting briefly for Go server to bind its listener..."
+    sleep 3
+else
+    docker compose -f "$COMPOSE_FILE" up -d redpanda minio
+    docker compose -f "$COMPOSE_FILE" up -d minio-init
+    docker compose -f "$COMPOSE_FILE" up -d server
+
+    echo "Waiting for server to be healthy..."
+    docker compose -f "$COMPOSE_FILE" up -d --wait server
+fi
 
 echo ""
 echo "[3/4] Running e2e tests..."


### PR DESCRIPTION
## Summary

Wave 5 of EPIC #407 (Python → Go server port). Waves 1–4 brought the
Go server to **70/70 cross-impl contract parity** in the integration
suite, but the E2E suite still only exercised the Python image. This
PR adds Docker + compose plumbing so the same E2E test cases run
against either implementation, gated by `ENTDB_SERVER_TARGET`.

Refs #407 · spec: `docs/go-port/shared/test-harness.md`

### What landed

- **`Dockerfile.go`** — multi-stage build of `server/go/cmd/entdb-server`.
  CGO disabled (`modernc.org/sqlite` is pure Go) so the runtime image
  is `gcr.io/distroless/static-debian12:nonroot`. Data dir is
  pre-created in the builder and `COPY --chown=65532` into the runtime
  layer (no shell available for runtime `mkdir`). Final image is
  static + minimal.
- **`docker-compose.yml`** — opt-in `go-server` profile + new
  `entdb-server-go` service on host port `50052`. Wired with
  `--seed-tenant=playground` so the Console sandbox tab can target the
  Go server without an out-of-band bootstrap. No infra dependencies
  (Go server is memory-WAL only today — Kafka/S3 land in a later wave).
- **`tests/python/e2e/docker-compose.e2e.go.yml`** + updates to
  **`run-e2e.sh`** — `ENTDB_SERVER_TARGET={python,go}` switches
  compose files. Go variant skips Redpanda/MinIO and relies on the
  test runner's own connect retry loop (distroless image has no
  shell-based healthcheck binary).
- **`.github/workflows/ci.yml`** — `e2e-tests` job becomes a matrix
  `{python, go}`. Go leg is `continue-on-error: true` until Wave 6
  closes the divergences enumerated below.

### Local verification

```
docker build -f Dockerfile.go -t entdb-server-go:test .          # ✓
docker run --rm entdb-server-go:test -help                       # ✓ shows flags
cd server/go && go vet ./... && go test ./...                    # ✓ all green
uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .      # ✓ clean
python -m pytest tests/python/integration/test_grpc_contract.py  # ✓ 71/71
python -m pytest tests/python/unit/ tests/python/integration/    # ✓ 2529/2529
```

### E2E pass counts

| Target  | Passed | Failed | Total |
|---------|--------|--------|-------|
| python  | 12     | 0      | 12    |
| go      | 0      | 12     | 12    |

The Go failures are NOT bugs in the RPC handlers — they're fixture
gaps that I'm intentionally leaving for Wave 6 (per the agent
instructions). All 12 failures fall into two clean buckets:

1. **`PERMISSION_DENIED — actor "user:e2e-runner" is not a member
   of tenant "e2e-test"`** (8 tests). `--seed-tenant` adds alice/bob
   only; the e2e runner uses `user:e2e-runner`. Fix: extend the seed
   to add the e2e actor as a tenant member, or parameterise the seed.
2. **`INVALID_ARGUMENT — unknown type_id 8001`** etc. (4 tests).
   `--seed-tenant` registers the contract-suite schema
   (User/Task/AssignedTo, IDs `1000/1100/2000`), not the e2e schema
   (User/Product/Order/Purchased/…, IDs `8001/8002/8003/8101/…`).
   Fix: support `--seed-schema=<name>` or load the e2e schema from
   the test fixture before serving.

Both are server-side fixture work, not handler bugs — confirmed by
the fact that the cross-impl contract suite (which uses the same Go
binary + a Python-side schema fixture) still passes 71/71. Filing as
Wave-6 follow-ups; not in scope for this PR.

## Test plan

- [x] `docker build -f Dockerfile.go -t entdb-server-go:test .` succeeds
- [x] `docker run --rm entdb-server-go:test -help` prints flag set
- [x] `docker run` with default CMD binds `:50051` and starts the applier
- [x] `ENTDB_SERVER_TARGET=python bash tests/python/e2e/run-e2e.sh` → 12/12
- [x] `ENTDB_SERVER_TARGET=go bash tests/python/e2e/run-e2e.sh --logs` → 0/12 (divergences enumerated above)
- [x] `cd server/go && go vet ./... && go test ./...` — all packages pass
- [x] `python -m pytest tests/python/integration/test_grpc_contract.py` — 71/71 cross-impl parity preserved
- [x] `python -m pytest tests/python/unit tests/python/integration` — 2529/2529 pass
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` — clean