### PR TITLE
feat(go-rewrite): seed-profile flag for cross-impl E2E parity — Wave 6

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -35,9 +35,20 @@ func main() {
 	walGroup := flag.String("wal-group", "entdb-applier", "WAL consumer group id")
 	// --seed-tenant is a test-only flag honoured by the cross-impl
 	// contract harness (docs/go-port/shared/test-harness.md). When set,
-	// the binary pre-creates a tenant + alice/bob users + the seed node
-	// the contract suite expects to find. Empty disables seeding.
-	seedTenant := flag.String("seed-tenant", "", "test-only: pre-create this tenant + contract-fixture state before serving")
+	// the binary pre-creates a tenant + the actors / nodes the chosen
+	// --seed-profile expects to find. Empty disables seeding.
+	seedTenant := flag.String("seed-tenant", "", "test-only: pre-create this tenant before serving (paired with --seed-profile)")
+	// --seed-profile selects the fixture shape applied to --seed-tenant.
+	//   - "none" (default): no seeding (legacy --seed-tenant without
+	//     --seed-profile defaults to "contract" for backwards
+	//     compatibility with the Wave-4 harness).
+	//   - "contract": User/Task/AssignedTo schema + alice/bob users +
+	//     seed node + seed-1 receipt. Matches the cross-impl contract
+	//     suite (tests/python/integration/test_grpc_contract.py).
+	//   - "e2e": User/Product/Order schema (typeIDs 8001/8002/8003) +
+	//     Purchased/PlacedOrder/OrderContains edges + e2e-runner user
+	//     as tenant owner. Matches tests/python/e2e/.
+	seedProfile := flag.String("seed-profile", "", "test-only: seed profile {none, contract, e2e}; default 'contract' when --seed-tenant is set")
 	flag.Parse()
 
 	lis, err := net.Listen("tcp", *addr)
@@ -45,16 +56,39 @@ func main() {
 		log.Fatalf("entdb-server: listen %s: %v", *addr, err)
 	}
 
+	// Resolve --seed-profile. Empty profile + non-empty --seed-tenant
+	// defaults to "contract" so the pre-Wave-6 harness invocation
+	// (--seed-tenant=acme without --seed-profile) keeps working.
+	profile := *seedProfile
+	if profile == "" {
+		if *seedTenant != "" {
+			profile = "contract"
+		} else {
+			profile = "none"
+		}
+	}
+	switch profile {
+	case "none", "contract", "e2e":
+		// ok
+	default:
+		log.Fatalf("entdb-server: invalid --seed-profile %q (want none|contract|e2e)", profile)
+	}
+
 	srvOpts := []api.Option{}
 
-	// Schema registry. Populated below when --seed-tenant is set so the
-	// contract suite's GetSchema/ExecuteAtomic asserts hold; left empty
-	// otherwise (production wiring lands in a later wave once the loader
-	// hook is connected to a config source).
+	// Schema registry. Populated below when a seed profile selects one
+	// so the cross-impl suites' GetSchema/ExecuteAtomic asserts hold;
+	// left empty for profile=none (production wiring lands in a later
+	// wave once the loader hook is connected to a config source).
 	registry := schema.NewRegistry()
-	if *seedTenant != "" {
+	switch profile {
+	case "contract":
 		if err := testseed.RegisterContractSchema(registry); err != nil {
 			log.Fatalf("entdb-server: register contract schema: %v", err)
+		}
+	case "e2e":
+		if err := testseed.RegisterE2ESchema(registry); err != nil {
+			log.Fatalf("entdb-server: register e2e schema: %v", err)
 		}
 	}
 	if _, err := registry.Freeze(); err != nil {
@@ -122,18 +156,29 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Test-only seed: contract harness boots the binary with
-	// --seed-tenant <id> and expects the tenant + contract fixture state
-	// to be queryable before the first RPC arrives. Skipped silently
-	// when the flag is empty.
-	if *seedTenant != "" {
+	// Test-only seed: the cross-impl harnesses boot the binary with
+	// --seed-tenant <id> --seed-profile <name> and expect the tenant +
+	// fixture state to be queryable before the first RPC arrives.
+	// Skipped silently when profile=none.
+	if profile != "none" {
+		if *seedTenant == "" {
+			log.Fatalf("entdb-server: --seed-profile=%s requires --seed-tenant", profile)
+		}
 		if canonical == nil || global == nil {
-			log.Fatalf("entdb-server: --seed-tenant requires --data-dir")
+			log.Fatalf("entdb-server: --seed-profile=%s requires --data-dir", profile)
 		}
-		if err := testseed.SeedTenant(ctx, global, canonical, *seedTenant); err != nil {
-			log.Fatalf("entdb-server: seed tenant %q: %v", *seedTenant, err)
+		switch profile {
+		case "contract":
+			if err := testseed.SeedTenantContract(ctx, global, canonical, *seedTenant); err != nil {
+				log.Fatalf("entdb-server: seed tenant %q (contract): %v", *seedTenant, err)
+			}
+			log.Printf("entdb-server: seeded tenant %q with contract profile (alice=owner, bob=member, seed node + receipt)", *seedTenant)
+		case "e2e":
+			if err := testseed.SeedTenantE2E(ctx, global, canonical, *seedTenant); err != nil {
+				log.Fatalf("entdb-server: seed tenant %q (e2e): %v", *seedTenant, err)
+			}
+			log.Printf("entdb-server: seeded tenant %q with e2e profile (e2e-runner=owner, User/Product/Order schema)", *seedTenant)
 		}
-		log.Printf("entdb-server: seeded tenant %q (alice=owner, bob=member, seed node + receipt)", *seedTenant)
 	}
 
 	// Run the applier in a background goroutine. Halt-on-poison errors

--- a/server/go/internal/testseed/seed.go
+++ b/server/go/internal/testseed/seed.go
@@ -1,19 +1,29 @@
-// Package testseed wires the deterministic test-only fixture the
-// cross-implementation contract suite (tests/python/integration/
-// test_grpc_contract.py) expects to find on a freshly-booted server.
+// Package testseed wires the deterministic test-only fixtures the
+// cross-implementation suites (tests/python/integration/test_grpc_contract.py
+// and tests/python/e2e/) expect to find on a freshly-booted server.
 //
 // The harness contract is documented in docs/go-port/shared/test-harness.md
-// (the `--seed-tenant` row). The Python in-process fixture lives at
-// tests/python/integration/conftest.py:275-348 and seeds the same shape
-// via direct globalstore/canonicalstore writes + a follow-up ExecuteAtomic
-// call. This package reproduces that state for the Go subprocess harness.
+// (the `--seed-tenant` and `--seed-profile` rows). The Python in-process
+// fixture for the contract suite lives at tests/python/integration/conftest.py
+// and seeds the same shape via direct globalstore/canonicalstore writes +
+// a follow-up ExecuteAtomic call. This package reproduces that state for
+// the Go subprocess harness.
+//
+// Profiles:
+//   - "contract": User/Task/AssignedTo schema + alice/bob users +
+//     seed node + seed-1 receipt. Mirrors the Python contract fixture.
+//   - "e2e": User/Product/Order schema (typeIDs 8001/8002/8003) + edge
+//     types (Purchased/PlacedOrder/OrderContains, 8101/8102/8103) +
+//     a single `e2e-runner` user as tenant owner. No seed node — the
+//     e2e suite creates all its own state.
 //
 // CLAUDE.md invariant #1 says all writes go through the WAL. This
 // package is the documented exception: it is a test-only seed for
-// the contract harness, gated by `--seed-tenant`, and never reachable
-// from a production code path. The seed writes the same applied_events
-// + applied_offsets rows the applier would have written had the seed
-// run through ExecuteAtomic, so post-seed reads behave identically.
+// the cross-impl harnesses, gated by `--seed-profile`, and never
+// reachable from a production code path. The seed writes the same
+// applied_events + applied_offsets rows the applier would have written
+// had the seed run through ExecuteAtomic, so post-seed reads behave
+// identically.
 package testseed
 
 import (
@@ -28,7 +38,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// Fixture constants — keep in lock-step with
+// Contract-suite fixture constants — keep in lock-step with
 // tests/python/integration/conftest.py (TENANT, ALICE, SEED_NODE_ID)
 // and tests/python/integration/test_grpc_contract.py.
 const (
@@ -41,6 +51,21 @@ const (
 	UserTypeID   = 1
 	TaskTypeID   = 2
 	AssignedToID = 100
+)
+
+// E2E-suite fixture constants — keep in lock-step with
+// tests/python/e2e/e2e_schema.proto and tests/python/e2e/test_e2e.py.
+const (
+	E2ERunnerUserID = "e2e-runner"
+	E2ERunnerActor  = "user:e2e-runner"
+
+	E2EUserTypeID    = 8001
+	E2EProductTypeID = 8002
+	E2EOrderTypeID   = 8003
+
+	E2EPurchasedEdgeID     = 8101
+	E2EPlacedOrderEdgeID   = 8102
+	E2EOrderContainsEdgeID = 8103
 )
 
 // RegisterContractSchema populates reg with the User/Task/AssignedTo
@@ -87,8 +112,106 @@ func RegisterContractSchema(reg *schema.Registry) error {
 	return nil
 }
 
-// SeedTenant applies the contract-fixture seed for tenantID. Order
-// mirrors the Python conftest:
+// RegisterE2ESchema populates reg with the User/Product/Order types +
+// Purchased/PlacedOrder/OrderContains edges the e2e suite asserts
+// against. Type IDs (8001/8002/8003) and edge IDs (8101/8102/8103)
+// must match tests/python/e2e/e2e_schema.proto verbatim — the e2e
+// SDK loads its registry from the proto descriptor at runtime and
+// the wire payloads will fail to route otherwise.
+//
+// Field IDs are derived from the proto field numbers (CLAUDE.md
+// invariant #6 — field IDs, not names, are the storage key).
+func RegisterE2ESchema(reg *schema.Registry) error {
+	if reg == nil {
+		return errors.New("testseed: nil registry")
+	}
+
+	user := &schema.NodeTypeDef{
+		TypeID: E2EUserTypeID,
+		Name:   "User",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "email", Kind: schema.KindString, Required: true, Indexed: true},
+			{FieldID: 2, Name: "name", Kind: schema.KindString, Required: true, Searchable: true},
+			{FieldID: 3, Name: "age", Kind: schema.KindInteger},
+			{FieldID: 4, Name: "active", Kind: schema.KindBoolean},
+			{FieldID: 5, Name: "created_at", Kind: schema.KindInteger},
+		},
+	}
+	if err := reg.RegisterNode(user); err != nil {
+		return fmt.Errorf("testseed: register E2E User: %w", err)
+	}
+
+	product := &schema.NodeTypeDef{
+		TypeID: E2EProductTypeID,
+		Name:   "Product",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "sku", Kind: schema.KindString, Required: true, Indexed: true, Unique: true},
+			{FieldID: 2, Name: "name", Kind: schema.KindString, Required: true, Searchable: true},
+			{FieldID: 3, Name: "price", Kind: schema.KindFloat, Required: true},
+			{FieldID: 4, Name: "category", Kind: schema.KindEnum, EnumValues: []string{"electronics", "clothing", "food", "other"}},
+			{FieldID: 5, Name: "in_stock", Kind: schema.KindBoolean},
+		},
+	}
+	if err := reg.RegisterNode(product); err != nil {
+		return fmt.Errorf("testseed: register E2E Product: %w", err)
+	}
+
+	order := &schema.NodeTypeDef{
+		TypeID: E2EOrderTypeID,
+		Name:   "Order",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "order_number", Kind: schema.KindString, Required: true, Indexed: true, Unique: true},
+			{FieldID: 2, Name: "total", Kind: schema.KindFloat, Required: true},
+			{FieldID: 3, Name: "status", Kind: schema.KindEnum, EnumValues: []string{"pending", "paid", "shipped", "delivered", "cancelled"}},
+			{FieldID: 4, Name: "created_at", Kind: schema.KindInteger},
+		},
+	}
+	if err := reg.RegisterNode(order); err != nil {
+		return fmt.Errorf("testseed: register E2E Order: %w", err)
+	}
+
+	purchased := &schema.EdgeTypeDef{
+		EdgeID:     E2EPurchasedEdgeID,
+		Name:       "purchased",
+		FromTypeID: E2EUserTypeID,
+		ToTypeID:   E2EProductTypeID,
+		Props: []schema.FieldDef{
+			{FieldID: 1, Name: "quantity", Kind: schema.KindInteger, Required: true},
+			{FieldID: 2, Name: "price_paid", Kind: schema.KindFloat},
+		},
+	}
+	if err := reg.RegisterEdge(purchased); err != nil {
+		return fmt.Errorf("testseed: register E2E purchased: %w", err)
+	}
+
+	placedOrder := &schema.EdgeTypeDef{
+		EdgeID:     E2EPlacedOrderEdgeID,
+		Name:       "placed_order",
+		FromTypeID: E2EUserTypeID,
+		ToTypeID:   E2EOrderTypeID,
+	}
+	if err := reg.RegisterEdge(placedOrder); err != nil {
+		return fmt.Errorf("testseed: register E2E placed_order: %w", err)
+	}
+
+	orderContains := &schema.EdgeTypeDef{
+		EdgeID:     E2EOrderContainsEdgeID,
+		Name:       "contains",
+		FromTypeID: E2EOrderTypeID,
+		ToTypeID:   E2EProductTypeID,
+		Props: []schema.FieldDef{
+			{FieldID: 1, Name: "quantity", Kind: schema.KindInteger, Required: true},
+		},
+	}
+	if err := reg.RegisterEdge(orderContains); err != nil {
+		return fmt.Errorf("testseed: register E2E contains: %w", err)
+	}
+
+	return nil
+}
+
+// SeedTenantContract applies the contract-fixture seed for tenantID.
+// Order mirrors the Python conftest:
 //
 //  1. tenant_registry row (tenantID, "Acme Corp", region default).
 //  2. user_registry rows: alice + bob.
@@ -99,7 +222,7 @@ func RegisterContractSchema(reg *schema.Registry) error {
 // All steps are best-effort idempotent: an already-existing row is
 // treated as success so repeated harness boots against the same
 // data-dir don't fail.
-func SeedTenant(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, tenantID string) error {
+func SeedTenantContract(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, tenantID string) error {
 	if g == nil {
 		return errors.New("testseed: nil globalstore")
 	}
@@ -151,6 +274,56 @@ func SeedTenant(ctx context.Context, g *globalstore.GlobalStore, s *store.Canoni
 	// returns immediately because the in-memory map now has tenantID >= 0.
 	if err := s.UpdateAppliedOffset(ctx, tenantID, SeedTopic, 0, 1); err != nil {
 		return fmt.Errorf("testseed: update applied offset: %w", err)
+	}
+
+	return nil
+}
+
+// SeedTenant is a deprecated alias for SeedTenantContract kept until
+// every caller has been migrated. New callers MUST use the explicit
+// profile-aware variant.
+//
+// Deprecated: use SeedTenantContract.
+func SeedTenant(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, tenantID string) error {
+	return SeedTenantContract(ctx, g, s, tenantID)
+}
+
+// SeedTenantE2E applies the e2e-fixture seed for tenantID. Order:
+//
+//  1. tenant_registry row (tenantID, "E2E Test Tenant", region default).
+//  2. user_registry row: e2e-runner.
+//  3. tenant_members: e2e-runner=owner.
+//  4. canonical store: OpenTenant (so the per-tenant SQLite file exists).
+//
+// No seed node — the e2e suite creates and asserts every node itself.
+// All steps are best-effort idempotent (matches SeedTenantContract).
+//
+// The schema registration is the caller's responsibility (typically
+// via RegisterE2ESchema before Freeze) so the registry can be frozen
+// once before the canonical store is opened.
+func SeedTenantE2E(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, tenantID string) error {
+	if g == nil {
+		return errors.New("testseed: nil globalstore")
+	}
+	if s == nil {
+		return errors.New("testseed: nil canonical store")
+	}
+	if tenantID == "" {
+		return errors.New("testseed: empty tenantID")
+	}
+
+	if _, err := g.CreateTenant(ctx, tenantID, "E2E Test Tenant", ""); err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("testseed: create tenant: %w", err)
+	}
+	if _, err := g.CreateUser(ctx, E2ERunnerUserID, "e2e-runner@example.com", "E2E Runner"); err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("testseed: create user e2e-runner: %w", err)
+	}
+	if err := g.AddTenantMember(ctx, tenantID, E2ERunnerUserID, "owner"); err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("testseed: add e2e-runner as owner: %w", err)
+	}
+
+	if err := s.OpenTenant(ctx, tenantID); err != nil {
+		return fmt.Errorf("testseed: open tenant: %w", err)
 	}
 
 	return nil

--- a/server/go/internal/testseed/seed_test.go
+++ b/server/go/internal/testseed/seed_test.go
@@ -113,6 +113,105 @@ func TestSeedTenant_Idempotent(t *testing.T) {
 	}
 }
 
+func newE2EStores(t *testing.T) (*globalstore.GlobalStore, *store.CanonicalStore, *schema.Registry) {
+	t.Helper()
+	dir := t.TempDir()
+	g, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: false})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = g.Close() })
+
+	reg := schema.NewRegistry()
+	if err := RegisterE2ESchema(reg); err != nil {
+		t.Fatalf("RegisterE2ESchema: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+
+	s, err := store.New(store.Options{RootDir: dir, WALMode: false, Registry: reg})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	return g, s, reg
+}
+
+func TestSeedTenantE2E_PopulatesE2EFixture(t *testing.T) {
+	ctx := context.Background()
+	g, s, _ := newE2EStores(t)
+
+	if err := SeedTenantE2E(ctx, g, s, "e2e-test"); err != nil {
+		t.Fatalf("SeedTenantE2E: %v", err)
+	}
+
+	// Tenant present.
+	tn, err := g.GetTenant(ctx, "e2e-test")
+	if err != nil || tn == nil {
+		t.Fatalf("GetTenant: %v, tenant=%v", err, tn)
+	}
+
+	// e2e-runner user present.
+	u, err := g.GetUser(ctx, E2ERunnerUserID)
+	if err != nil || u == nil {
+		t.Fatalf("GetUser %q: %v, user=%v", E2ERunnerUserID, err, u)
+	}
+
+	// e2e-runner is owner of the tenant.
+	members, err := g.GetTenantMembers(ctx, "e2e-test")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	var role string
+	for _, m := range members {
+		if m.UserID == E2ERunnerUserID {
+			role = m.Role
+		}
+	}
+	if role != "owner" {
+		t.Fatalf("e2e-runner role = %q, want owner", role)
+	}
+}
+
+func TestSeedTenantE2E_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	g, s, _ := newE2EStores(t)
+
+	if err := SeedTenantE2E(ctx, g, s, "e2e-test"); err != nil {
+		t.Fatalf("first SeedTenantE2E: %v", err)
+	}
+	if err := SeedTenantE2E(ctx, g, s, "e2e-test"); err != nil {
+		t.Fatalf("second SeedTenantE2E (should be idempotent): %v", err)
+	}
+}
+
+func TestRegisterE2ESchema_DefinesExpectedTypes(t *testing.T) {
+	reg := schema.NewRegistry()
+	if err := RegisterE2ESchema(reg); err != nil {
+		t.Fatalf("RegisterE2ESchema: %v", err)
+	}
+	if nt := reg.NodeType("User"); nt == nil || nt.TypeID != E2EUserTypeID {
+		t.Fatalf("User type missing or wrong id: %+v", nt)
+	}
+	if nt := reg.NodeType("Product"); nt == nil || nt.TypeID != E2EProductTypeID {
+		t.Fatalf("Product type missing or wrong id: %+v", nt)
+	}
+	if nt := reg.NodeType("Order"); nt == nil || nt.TypeID != E2EOrderTypeID {
+		t.Fatalf("Order type missing or wrong id: %+v", nt)
+	}
+	if et := reg.EdgeType("purchased"); et == nil || et.EdgeID != E2EPurchasedEdgeID {
+		t.Fatalf("purchased edge missing or wrong id: %+v", et)
+	}
+	if et := reg.EdgeType("placed_order"); et == nil || et.EdgeID != E2EPlacedOrderEdgeID {
+		t.Fatalf("placed_order edge missing or wrong id: %+v", et)
+	}
+	if et := reg.EdgeType("contains"); et == nil || et.EdgeID != E2EOrderContainsEdgeID {
+		t.Fatalf("contains edge missing or wrong id: %+v", et)
+	}
+}
+
 func TestRegisterContractSchema_DefinesExpectedTypes(t *testing.T) {
 	reg := schema.NewRegistry()
 	if err := RegisterContractSchema(reg); err != nil {

--- a/tests/python/e2e/docker-compose.e2e.go.yml
+++ b/tests/python/e2e/docker-compose.e2e.go.yml
@@ -23,10 +23,11 @@ services:
   # ==========================================================================
   # EntDB Server (Go binary)
   #
-  # `--seed-tenant=e2e-test` pre-creates the tenant + alice/bob users +
-  # seed node so RPCs can target it without an out-of-band bootstrap
-  # (matches what the cross-impl contract harness does for the Python
-  # in-process fixture — see tests/python/integration/conftest.py).
+  # `--seed-profile=e2e --seed-tenant=e2e-test` pre-creates the tenant,
+  # the `user:e2e-runner` actor (tenant owner), and the User/Product/
+  # Order schema (typeIDs 8001/8002/8003) the e2e suite expects. This
+  # matches the actor/tenant pair hard-coded in tests/python/e2e/test_e2e.py
+  # (`TENANT="e2e-test"`, `ACTOR="user:e2e-runner"`).
   # ==========================================================================
   server:
     build:
@@ -38,6 +39,7 @@ services:
       - "-addr=:50051"
       - "-data-dir=/var/lib/entdb"
       - "-wal-backend=memory"
+      - "-seed-profile=e2e"
       - "-seed-tenant=e2e-test"
     # No HEALTHCHECK in the distroless image (no shell, no grpc probe
     # binary baked in). The test runner retries its own connect with

--- a/tests/python/integration/conftest.py
+++ b/tests/python/integration/conftest.py
@@ -374,6 +374,8 @@ async def _start_go_server(tmp_path_factory) -> AsyncIterator[int]:
             str(data_dir),
             "--wal-backend",
             "memory",
+            "--seed-profile",
+            "contract",
             "--seed-tenant",
             TENANT,
         ]


### PR DESCRIPTION
## Summary

Wave 6 of EPIC #407 (Python → Go server port).

PR #475 (Wave 5) wired the Go server into the e2e harness but the binary
only knew how to seed the contract-suite schema (User/Task/AssignedTo,
typeIDs 1/2/100) and the contract actors (alice/bob). The e2e suite
(`tests/python/e2e/test_e2e.py`) targets a different shape:

- Schema: `User`/`Product`/`Order` + `Purchased`/`PlacedOrder`/`OrderContains` edges, typeIDs 8001/8002/8003 + 8101/8102/8103 (declared in `tests/python/e2e/e2e_schema.proto`).
- Tenant: `e2e-test`.
- Actor: `user:e2e-runner` — must be an active tenant member.

This PR introduces a named-profile seeding interface so a single Go
binary can serve both harnesses:

- New `--seed-profile {none, contract, e2e}` flag on `entdb-server`.
  Default `none` (no seeding). For backwards compatibility, a bare
  `--seed-tenant <id>` without `--seed-profile` defaults to `contract`
  (matches the Wave-4 contract harness invocation).
- `testseed.RegisterE2ESchema` registers the User/Product/Order
  registry; `testseed.SeedTenantE2E` creates the tenant + `e2e-runner`
  owner. The existing contract seed is renamed `SeedTenantContract`;
  `SeedTenant` is retained as a deprecated alias.
- `tests/python/e2e/docker-compose.e2e.go.yml` passes
  `--seed-profile=e2e --seed-tenant=e2e-test`.
- `tests/python/integration/conftest.py` passes
  `--seed-profile=contract --seed-tenant=acme` (the integration suite).

## Results under `ENTDB_SERVER_TARGET=go`

| Suite | Before this PR | After this PR |
|---|---|---|
| Cross-impl contract (`tests/python/integration/test_grpc_contract.py`) | 70 / 70 | **70 / 70** |
| E2E (`tests/python/e2e/`) | 0 / 12 (PERMISSION_DENIED at handshake) | **8 / 12** |

Python E2E regression check: still **12 / 12** under the default
`ENTDB_SERVER_TARGET=python`.

## Residual Go E2E failures (Wave 7)

The 4 remaining e2e failures are all downstream of a single applier
bug, surfaced by `tests/python/e2e/test_e2e.py::test_create_edges`:

```
entdb-server: applier exited: InvalidArgument: poison event:
  create_edge missing from/to
```

The Go applier rejects `create_edge` ops that carry `$alias` references
(`\"$charlie\"`, `\"$phone\"`) instead of resolved node IDs. The
`create_edges` test's `ExecuteAtomic` call succeeds at the wire (so the
test itself passes), but the applier poison-pills on the way back out
and dies — every subsequent RPC that needs the applier (anything with
`wait_applied=True` or a follow-up read) returns UNAVAILABLE because the
server has shut down.

Affected tests:
- `get_edges_from_node` — uses `\$eve`/`\$book`/`\$gobook` aliases on
  `edge_create`.
- `delete_edge` — uses `\$henry`/`\$mug` aliases.
- `large_payload` — would pass standalone but the server is already dead.
- `concurrent_transactions` — same: server unavailable.

Tracking these as Wave 7: teach the Go applier to resolve `$alias`
references in `create_edge` / `delete_edge` ops the same way Python
does, then re-run e2e to confirm 12 / 12.

## Test plan

- [x] `cd server/go && go vet ./... && go test ./...` — clean.
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed.
- [x] `ENTDB_SERVER_TARGET=go python -m pytest tests/python/integration/test_grpc_contract.py` — 70 / 70.
- [x] `ENTDB_SERVER_TARGET=go bash tests/python/e2e/run-e2e.sh` — 8 / 12 (target was 12 / 12; residuals are Wave-7 applier bug).
- [x] `bash tests/python/e2e/run-e2e.sh` — 12 / 12 (Python target regression check).
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` — clean.

Refs #407