### PR TITLE
fix(go-rewrite): $alias resolution in ExecuteAtomic — Wave 7

### DIFF
--- a/server/go/internal/api/execute_atomic.go
+++ b/server/go/internal/api/execute_atomic.go
@@ -41,6 +41,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -159,20 +160,56 @@ func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest
 		return nil, err
 	}
 
-	// Server-fill empty create_node IDs and collect created_node_ids in
-	// op order. Generated BEFORE WAL append so replays read the same
-	// IDs off the log (determinism).
+	// Server-fill empty create_node IDs, collect created_node_ids in
+	// op order, and resolve in-transaction "$alias" references on edge
+	// from/to so the WAL event only ever carries concrete node ids.
+	//
+	// Why resolve at ingress (deviation from Python, which resolves at
+	// apply time): the WAL is the audit-of-record; a bare UUID is a
+	// stable, unambiguous identity, whereas "$alias" is meaningful only
+	// in the context of one in-flight transaction. Resolving here keeps
+	// the applier dispatch table free of map-shape branching for the
+	// alias_ref payload and prevents alias bugs from poisoning the
+	// consumer loop (the original symptom: "poison event: create_edge
+	// missing from/to" halted the applier for every subsequent RPC).
+	//
+	// Ordering: we walk ops in declared order. Each create_node with an
+	// "as" field publishes its (server-filled) id into the alias map;
+	// subsequent edge ops referencing that alias resolve against the
+	// map. A reference to an alias that has not been previously defined
+	// in the SAME transaction is an INVALID_ARGUMENT — matches the
+	// Python applier's lookup miss (which would surface as a poison
+	// event today). Aliases never span transactions.
 	createdNodeIDs := make([]string, 0)
+	aliasMap := make(map[string]string)
 	for _, op := range ops {
-		if op["op"] != opCreateNode {
-			continue
+		switch op["op"].(string) {
+		case opCreateNode:
+			id, _ := op["id"].(string)
+			if id == "" {
+				id = uuid.NewString()
+				op["id"] = id
+			}
+			createdNodeIDs = append(createdNodeIDs, id)
+			if alias, _ := op["as"].(string); alias != "" {
+				aliasMap[alias] = id
+			}
+		case opCreateEdge, opDeleteEdge:
+			resolved, err := resolveEdgeRef(op["from"], aliasMap)
+			if err != nil {
+				outcome = "error"
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"%s: from: %v", op["op"], err)
+			}
+			op["from"] = resolved
+			resolved, err = resolveEdgeRef(op["to"], aliasMap)
+			if err != nil {
+				outcome = "error"
+				return nil, errs.Errorf(codes.InvalidArgument,
+					"%s: to: %v", op["op"], err)
+			}
+			op["to"] = resolved
 		}
-		id, _ := op["id"].(string)
-		if id == "" {
-			id = uuid.NewString()
-			op["id"] = id
-		}
-		createdNodeIDs = append(createdNodeIDs, id)
 	}
 
 	// Build the WAL event. The persisted actor is the trusted identity,
@@ -409,6 +446,81 @@ func convertACL(in []*pb.AclEntry) []any {
 		out = append(out, entry)
 	}
 	return out
+}
+
+// resolveEdgeRef collapses the three on-wire ref shapes — bare id
+// string, {"ref": "$alias"}, and {"type_id":N, "id":"X"} — down to a
+// single bare-string node id, using the per-transaction alias map.
+//
+// Shape contract (must match convertNodeRef output):
+//
+//   - string ""          → missing ref; surfaced as INVALID_ARGUMENT.
+//   - string "id"        → returned as-is (bare-id; no $-prefix).
+//   - {"ref":"$a"}       → resolved against aliasMap; unresolved → error.
+//                          Supports "$a" and "$a.id" (Python parity, see
+//                          applier.py:_resolve_ref); only the dotted
+//                          prefix before the first "." is the alias name.
+//   - {"type_id":N,"id"} → returned as the id string (typed lookup is a
+//                          read-time concern, not a write-time one).
+//
+// Any other shape is treated as a missing ref. The caller wraps the
+// returned error in an InvalidArgument so the gRPC client sees a
+// stable status code instead of a poisoned applier loop.
+func resolveEdgeRef(raw any, aliasMap map[string]string) (string, error) {
+	switch v := raw.(type) {
+	case nil:
+		return "", fmt.Errorf("missing node reference")
+	case string:
+		if v == "" {
+			return "", fmt.Errorf("missing node reference")
+		}
+		if strings.HasPrefix(v, "$") {
+			// Bare "$alias" string is the Python on-the-wire
+			// short-form some SDKs emit when bypassing NodeRef.
+			// Treat it identically to {"ref":"$alias"}.
+			return resolveAlias(v, aliasMap)
+		}
+		return v, nil
+	case map[string]any:
+		if refStr, ok := v["ref"].(string); ok && refStr != "" {
+			return resolveAlias(refStr, aliasMap)
+		}
+		if idStr, ok := v["id"].(string); ok && idStr != "" {
+			// Typed-ref carries an explicit id; the applier will
+			// look it up by (type_id, id). We forward only the id
+			// string downstream because the legacy edge op shape
+			// expects a bare string. (Typed-ref+missing-id is a
+			// separate validation in the applier.)
+			return idStr, nil
+		}
+		return "", fmt.Errorf("malformed node reference")
+	default:
+		return "", fmt.Errorf("malformed node reference (type %T)", raw)
+	}
+}
+
+// resolveAlias looks up "$alias" or "$alias.id" against the per-
+// transaction alias map. Returns INVALID_ARGUMENT-shaped error when
+// the alias was never published by an earlier create_node in this
+// transaction. Mirrors applier.py:_resolve_ref's "." split.
+func resolveAlias(ref string, aliasMap map[string]string) (string, error) {
+	if !strings.HasPrefix(ref, "$") {
+		// Defensive: caller already type-switched, but if we ever
+		// reach here with a bare id, pass it through.
+		return ref, nil
+	}
+	name := ref[1:]
+	if i := strings.IndexByte(name, '.'); i >= 0 {
+		name = name[:i]
+	}
+	if name == "" {
+		return "", fmt.Errorf("alias reference %q has empty name", ref)
+	}
+	id, ok := aliasMap[name]
+	if !ok {
+		return "", fmt.Errorf("unresolved alias %q (no create_node with as=%q earlier in this transaction)", ref, name)
+	}
+	return id, nil
 }
 
 // convertNodeRef mirrors grpc_server.py:_convert_node_ref. The

--- a/server/go/internal/api/execute_atomic_test.go
+++ b/server/go/internal/api/execute_atomic_test.go
@@ -614,3 +614,421 @@ func tenantShardingDeny() *tenant.Sharding {
 		Owner:  func(string) string { return "owner-node" },
 	}
 }
+
+// =============================================================================
+// W7 — $alias resolution at gRPC ingress.
+//
+// The Python SDK emits {"alias_ref": "$charlie"} for edge endpoints
+// declared with as_="charlie" on a sibling create_node. Before the W7
+// fix the Go server forwarded that ref untouched to the WAL, the
+// applier read op["from"] as an empty string (it's a map, not a
+// string), and halted with "poison event: create_edge missing from/to"
+// — which then took every subsequent RPC down with UNAVAILABLE because
+// the applier's consumer loop was dead.
+//
+// These tests pin the new behavior: aliases are resolved against a
+// per-transaction map at the handler, the WAL only ever sees bare
+// node ids, and unresolved aliases fail in-band with
+// INVALID_ARGUMENT instead of poisoning the applier.
+// =============================================================================
+
+// aliasRefEdge is the shape grpc_server.py:_convert_node_ref produces
+// for an alias_ref-typed NodeRef. We hand-roll the op so tests don't
+// need a registered edge type in the schema.
+func aliasRefEdge(edgeID int32, fromAlias, toAlias string) *pb.Operation {
+	return &pb.Operation{Op: &pb.Operation_CreateEdge{
+		CreateEdge: &pb.CreateEdgeOp{
+			EdgeId: edgeID,
+			From:   &pb.NodeRef{Ref: &pb.NodeRef_AliasRef{AliasRef: fromAlias}},
+			To:     &pb.NodeRef{Ref: &pb.NodeRef_AliasRef{AliasRef: toAlias}},
+		},
+	}}
+}
+
+// TestExecuteAtomic_AliasResolution_SingleCreateNodeAlias pins that a
+// solo create_node with an "as" alias survives ingress untouched and
+// the alias never leaks into the WAL payload (it is recorded only in
+// the handler's per-transaction map).
+func TestExecuteAtomic_AliasResolution_SingleCreateNodeAlias(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "alias-solo-1",
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "charlie",
+				Data: newStruct(t, map[string]any{"email": "c@x"}),
+			}},
+		}},
+	})
+	if err != nil || !resp.GetSuccess() {
+		t.Fatalf("ExecuteAtomic: err=%v resp=%+v", err, resp)
+	}
+	if len(resp.GetCreatedNodeIds()) != 1 {
+		t.Fatalf("CreatedNodeIds: got %v want 1", resp.GetCreatedNodeIds())
+	}
+	uuidNodeID := resp.GetCreatedNodeIds()[0]
+	if uuidNodeID == "" || strings.HasPrefix(uuidNodeID, "$") {
+		t.Fatalf("CreatedNodeIds[0]: got %q want non-empty UUID", uuidNodeID)
+	}
+
+	recs := f.wal.GetAllRecords(xaTopic)
+	if len(recs) != 1 {
+		t.Fatalf("WAL records: got %d want 1", len(recs))
+	}
+	var ev wal.Event
+	if err := json.Unmarshal(recs[0].Value, &ev); err != nil {
+		t.Fatalf("decode WAL event: %v", err)
+	}
+	// The "as" tag is still on the create_node op — that is the
+	// public alias contract for downstream readers — but the node
+	// "id" itself MUST be the server-filled UUID, never "$charlie".
+	if got, _ := ev.Ops[0]["id"].(string); got != uuidNodeID {
+		t.Fatalf("WAL op id: got %q want %q", got, uuidNodeID)
+	}
+	if got, _ := ev.Ops[0]["as"].(string); got != "charlie" {
+		t.Fatalf("WAL op as: got %q want %q", got, "charlie")
+	}
+}
+
+// TestExecuteAtomic_AliasResolution_EdgeReferencesAlias pins the
+// happy path that prompted this fix: create_node($alice) + create_edge
+// referencing $alice. The WAL must carry the server-filled UUID on
+// the edge's from/to as a bare string, NOT a {"ref":"$alice"} map.
+func TestExecuteAtomic_AliasResolution_EdgeReferencesAlias(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "alias-edge-1",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "alice",
+				Data: newStruct(t, map[string]any{"email": "a@x"}),
+			}}},
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "phone",
+				Data: newStruct(t, map[string]any{"email": "p@x"}),
+			}}},
+			aliasRefEdge(99, "$alice", "$phone"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success=false (error=%q code=%q)", resp.GetError(), resp.GetErrorCode())
+	}
+	if len(resp.GetCreatedNodeIds()) != 2 {
+		t.Fatalf("CreatedNodeIds: got %v want 2", resp.GetCreatedNodeIds())
+	}
+	aliceUUID := resp.GetCreatedNodeIds()[0]
+	phoneUUID := resp.GetCreatedNodeIds()[1]
+
+	recs := f.wal.GetAllRecords(xaTopic)
+	if len(recs) != 1 {
+		t.Fatalf("WAL records: got %d want 1", len(recs))
+	}
+	var ev wal.Event
+	if err := json.Unmarshal(recs[0].Value, &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(ev.Ops) != 3 {
+		t.Fatalf("ev.Ops: got %d want 3", len(ev.Ops))
+	}
+	edgeOp := ev.Ops[2]
+	if got, _ := edgeOp["op"].(string); got != "create_edge" {
+		t.Fatalf("op[2] kind: got %q want create_edge", got)
+	}
+	// The contract: from/to are bare strings, not maps. If we ever
+	// regress and let {"ref":"$alice"} slip through, the applier's
+	// stringField will return "" and halt the consumer.
+	from, ok := edgeOp["from"].(string)
+	if !ok {
+		t.Fatalf("from: got %T want string (alias must be resolved at ingress)", edgeOp["from"])
+	}
+	if from != aliceUUID {
+		t.Fatalf("from: got %q want %q (server-filled UUID for $alice)", from, aliceUUID)
+	}
+	to, ok := edgeOp["to"].(string)
+	if !ok {
+		t.Fatalf("to: got %T want string", edgeOp["to"])
+	}
+	if to != phoneUUID {
+		t.Fatalf("to: got %q want %q (server-filled UUID for $phone)", to, phoneUUID)
+	}
+}
+
+// TestExecuteAtomic_AliasResolution_MixedRefShapes pins that bare-id
+// and alias_ref refs can be combined in the same transaction. The
+// bare-id endpoint passes through unchanged, the $alias endpoint
+// resolves against the in-flight alias map.
+func TestExecuteAtomic_AliasResolution_MixedRefShapes(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "alias-mix-1",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "alice", Id: "alice-fixed",
+				Data: newStruct(t, map[string]any{"email": "a@x"}),
+			}}},
+			{Op: &pb.Operation_CreateEdge{CreateEdge: &pb.CreateEdgeOp{
+				EdgeId: 99,
+				From:   &pb.NodeRef{Ref: &pb.NodeRef_AliasRef{AliasRef: "$alice"}},
+				To:     &pb.NodeRef{Ref: &pb.NodeRef_Id{Id: "real-bob"}},
+			}}},
+		},
+	})
+	if err != nil || !resp.GetSuccess() {
+		t.Fatalf("ExecuteAtomic: err=%v resp=%+v", err, resp)
+	}
+	var ev wal.Event
+	if err := json.Unmarshal(f.wal.GetAllRecords(xaTopic)[0].Value, &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	from, _ := ev.Ops[1]["from"].(string)
+	to, _ := ev.Ops[1]["to"].(string)
+	if from != "alice-fixed" {
+		t.Fatalf("from: got %q want %q", from, "alice-fixed")
+	}
+	if to != "real-bob" {
+		t.Fatalf("to: got %q want %q", to, "real-bob")
+	}
+}
+
+// TestExecuteAtomic_AliasResolution_UnresolvedAliasRejected pins the
+// failure mode: a create_edge that references "$ghost" with no prior
+// create_node defining "ghost" gets INVALID_ARGUMENT, NOT a poisoned
+// applier. The fix's reason for being.
+func TestExecuteAtomic_AliasResolution_UnresolvedAliasRejected(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	_, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context: &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "alice-fixed",
+				Data: newStruct(t, map[string]any{"email": "a@x"}),
+			}}},
+			aliasRefEdge(99, "alice-fixed", "$ghost"),
+		},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteAtomic: expected InvalidArgument, got nil")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("code: got %v want InvalidArgument (msg=%v)", got, err)
+	}
+	if n := f.wal.GetRecordCount(xaTopic); n != 0 {
+		t.Fatalf("WAL records: got %d want 0 (handler aborted before append)", n)
+	}
+}
+
+// TestExecuteAtomic_AliasResolution_ForwardReferenceRejected pins that
+// aliases are resolved in op order: an edge that references an alias
+// defined LATER in the same transaction must fail, not silently
+// half-work. (Python parity: the applier's alias map is populated
+// linearly too.)
+func TestExecuteAtomic_AliasResolution_ForwardReferenceRejected(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	_, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context: &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		Operations: []*pb.Operation{
+			// edge first — references an alias that doesn't exist yet.
+			aliasRefEdge(99, "$alice", "$bob"),
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "alice",
+				Data: newStruct(t, map[string]any{"email": "a@x"}),
+			}}},
+		},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteAtomic: expected InvalidArgument, got nil")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("code: got %v want InvalidArgument (msg=%v)", got, err)
+	}
+}
+
+// TestExecuteAtomic_AliasResolution_TransactionIsolation pins that
+// aliases never span transactions: an alias defined in transaction A
+// is NOT visible to transaction B, even on the same handler.
+func TestExecuteAtomic_AliasResolution_TransactionIsolation(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	// txn A defines $alice.
+	_, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "iso-A",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "alice",
+				Data: newStruct(t, map[string]any{"email": "a@x"}),
+			}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic A: %v", err)
+	}
+
+	// txn B tries to reference $alice with no local create_node.
+	_, err = f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "iso-B",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "bob-fixed",
+				Data: newStruct(t, map[string]any{"email": "b@x"}),
+			}}},
+			aliasRefEdge(99, "bob-fixed", "$alice"),
+		},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteAtomic B: expected InvalidArgument (alias must not leak across txns), got nil")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("code: got %v want InvalidArgument", got)
+	}
+}
+
+// TestExecuteAtomic_AliasResolution_MultipleAliasesInOneTxn covers
+// the original e2e failure shape: three aliased creates feeding three
+// edges. Every edge endpoint resolves to a distinct server-filled
+// UUID, all on the same WAL record.
+func TestExecuteAtomic_AliasResolution_MultipleAliasesInOneTxn(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "alias-multi-1",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "charlie",
+				Data: newStruct(t, map[string]any{"email": "c@x"}),
+			}}},
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "phone",
+				Data: newStruct(t, map[string]any{"email": "p@x"}),
+			}}},
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "order1",
+				Data: newStruct(t, map[string]any{"email": "o@x"}),
+			}}},
+			aliasRefEdge(101, "$charlie", "$phone"),
+			aliasRefEdge(102, "$charlie", "$order1"),
+			aliasRefEdge(103, "$order1", "$phone"),
+		},
+	})
+	if err != nil || !resp.GetSuccess() {
+		t.Fatalf("ExecuteAtomic: err=%v resp=%+v", err, resp)
+	}
+	ids := resp.GetCreatedNodeIds()
+	if len(ids) != 3 {
+		t.Fatalf("CreatedNodeIds: got %v want 3", ids)
+	}
+	charlie, phone, order1 := ids[0], ids[1], ids[2]
+
+	var ev wal.Event
+	if err := json.Unmarshal(f.wal.GetAllRecords(xaTopic)[0].Value, &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for i, want := range []struct{ from, to string }{
+		{charlie, phone},
+		{charlie, order1},
+		{order1, phone},
+	} {
+		got := ev.Ops[3+i]
+		if f, _ := got["from"].(string); f != want.from {
+			t.Errorf("op[%d].from: got %q want %q", 3+i, f, want.from)
+		}
+		if to, _ := got["to"].(string); to != want.to {
+			t.Errorf("op[%d].to: got %q want %q", 3+i, to, want.to)
+		}
+	}
+}
+
+// TestExecuteAtomic_AliasResolution_DeleteEdgeAlias pins the symmetric
+// case on the destructive side: delete_edge with $alias refs resolves
+// the same way create_edge does.
+func TestExecuteAtomic_AliasResolution_DeleteEdgeAlias(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "alias-del-1",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "u",
+				Data: newStruct(t, map[string]any{"email": "u@x"}),
+			}}},
+			{Op: &pb.Operation_DeleteEdge{DeleteEdge: &pb.DeleteEdgeOp{
+				EdgeId: 99,
+				From:   &pb.NodeRef{Ref: &pb.NodeRef_AliasRef{AliasRef: "$u"}},
+				To:     &pb.NodeRef{Ref: &pb.NodeRef_Id{Id: "real-target"}},
+			}}},
+		},
+	})
+	if err != nil || !resp.GetSuccess() {
+		t.Fatalf("ExecuteAtomic: err=%v resp=%+v", err, resp)
+	}
+	uUUID := resp.GetCreatedNodeIds()[0]
+
+	var ev wal.Event
+	if err := json.Unmarshal(f.wal.GetAllRecords(xaTopic)[0].Value, &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	from, _ := ev.Ops[1]["from"].(string)
+	to, _ := ev.Ops[1]["to"].(string)
+	if from != uUUID {
+		t.Fatalf("delete_edge.from: got %q want %q", from, uUUID)
+	}
+	if to != "real-target" {
+		t.Fatalf("delete_edge.to: got %q want %q", to, "real-target")
+	}
+}
+
+// TestExecuteAtomic_AliasResolution_DottedFormSupported pins the
+// Python-parity dotted-alias form: "$alice.id" resolves the same as
+// "$alice". applier.py:_resolve_ref splits on "." for legacy reasons.
+func TestExecuteAtomic_AliasResolution_DottedFormSupported(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t)
+
+	resp, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "alias-dot-1",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, As: "alice",
+				Data: newStruct(t, map[string]any{"email": "a@x"}),
+			}}},
+			aliasRefEdge(99, "$alice.id", "$alice.id"),
+		},
+	})
+	if err != nil || !resp.GetSuccess() {
+		t.Fatalf("ExecuteAtomic: err=%v resp=%+v", err, resp)
+	}
+	aliceUUID := resp.GetCreatedNodeIds()[0]
+	var ev wal.Event
+	if err := json.Unmarshal(f.wal.GetAllRecords(xaTopic)[0].Value, &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if from, _ := ev.Ops[1]["from"].(string); from != aliceUUID {
+		t.Fatalf("from: got %q want %q", from, aliceUUID)
+	}
+	if to, _ := ev.Ops[1]["to"].(string); to != aliceUUID {
+		t.Fatalf("to: got %q want %q", to, aliceUUID)
+	}
+}

--- a/server/go/internal/store/offset.go
+++ b/server/go/internal/store/offset.go
@@ -34,10 +34,15 @@ func (s *CanonicalStore) UpdateAppliedOffset(ctx context.Context, tenantID, topi
 	}); err != nil {
 		return err
 	}
-	// Notify any WaitForOffset waiters.
+	// Notify any WaitForOffset waiters. We MUST set the entry even
+	// when offset == 0 (the very first record on an in-memory WAL
+	// starts at offset 0) so that WaitForOffset's "ok && cur >=
+	// target" predicate becomes true. Bumping only when offset > cur
+	// leaves the map unset on first apply and any wait_applied=true
+	// call for the first event hangs until timeout. Pinned by the
+	// Go E2E create_single_node test.
 	s.offsetMu.Lock()
-	cur := s.appliedOffsets[tenantID]
-	if offset > cur {
+	if cur, ok := s.appliedOffsets[tenantID]; !ok || offset > cur {
 		s.appliedOffsets[tenantID] = offset
 	}
 	s.offsetCond.Broadcast()
@@ -67,9 +72,12 @@ func (s *CanonicalStore) UpdateAppliedOffsetTx(ctx context.Context, b *BatchTxn,
 	// state will catch up at the next applied write. Strictly correct
 	// implementations would defer this to BatchTxn.Commit() — kept
 	// simple here, refine in W1.10 if a parity test demands it.
+	//
+	// MUST publish offset 0 on first apply too (see
+	// UpdateAppliedOffset above): otherwise wait_applied=true on the
+	// very first record hangs until timeout.
 	s.offsetMu.Lock()
-	cur := s.appliedOffsets[b.tenantID]
-	if offset > cur {
+	if cur, ok := s.appliedOffsets[b.tenantID]; !ok || offset > cur {
 		s.appliedOffsets[b.tenantID] = offset
 	}
 	s.offsetCond.Broadcast()


### PR DESCRIPTION
## Summary

- Resolve `$alias` node references in `ExecuteAtomic` at the gRPC ingress (Go server). The Python SDK emits `{"alias_ref": "$alias"}` on edge endpoints when a sibling `create_node` was declared with `as_="alias"`; the Go server was forwarding that map straight to the WAL, where the applier read `op["from"]` as an empty string (it's a map, not a string) and halted the consumer loop with `poison event: create_edge missing from/to`. Once down, every subsequent RPC surfaced as `UNAVAILABLE`.
- Walk the ops in declared order, server-fill empty `create_node` ids with UUIDs, publish each `as` value into a per-transaction alias map, and substitute aliased edge endpoints with the resolved id. The WAL only ever carries concrete bare-id strings; the applier dispatch is unchanged. Forward references and aliases from sibling transactions surface as `INVALID_ARGUMENT` instead of poisoning the consumer.
- Fix a latent `WaitForOffset` bug uncovered by the same E2E suite: the in-memory applied-offset map was bumped only when `offset > cur`, leaving the entry unset on first apply (offset 0 > 0 is false) and hanging every `wait_applied=true` call for the very first record until timeout. Set the entry unconditionally on first apply so the `ok && cur >= target` predicate is true at offset 0.

Refs #407.

## Pass counts

- Cross-impl contract suite (`ENTDB_SERVER_TARGET=go pytest tests/python/integration/test_grpc_contract.py`): **70/70** (1 Python-only test skipped).
- Go E2E (`ENTDB_SERVER_TARGET=go bash tests/python/e2e/run-e2e.sh`): **12/12** (was 7/12 on `main`).
- Python E2E (`bash tests/python/e2e/run-e2e.sh`): **12/12** (regression check, no change).
- Python unit + integration: **2529/2529**.
- `go vet ./... && go test ./...` (server/go): clean.
- `ruff check` + `ruff format --check`: clean.

## Test plan

- [x] Cross-impl contract suite passes against the Go server (70/70).
- [x] Go E2E passes (12/12); previously 5 failed including all alias-using tests (`create_edges`, `get_edges_from_node`, `delete_edge`, `large_payload`, `concurrent_transactions`) plus the `wait_applied=true`-on-first-event hang (`create_single_node`).
- [x] Python E2E still passes (12/12).
- [x] Nine new Go unit tests pin the new ingress behavior: single-alias create_node, edge resolution, mixed bare/alias refs, unresolved-alias rejection, forward-reference rejection, transaction isolation, multi-alias one-transaction (mirrors the original e2e failure), delete_edge alias, dotted `$alias.id` form (Python parity).
- [x] All Python unit + integration tests pass (2529/2529).