### PR TITLE
test(go-rewrite): dual-stack parity check — Phase 4A

### DIFF
--- a/tests/python/parity/Dockerfile.parity
+++ b/tests/python/parity/Dockerfile.parity
@@ -1,0 +1,57 @@
+# EntDB Parity Test Runner — Phase 4A (EPIC #407)
+#
+# Container that drives the Python and Go gRPC servers in parallel
+# via the Python SDK and asserts state equivalence. Mirrors the e2e
+# Dockerfile but copies the parity test dir instead.
+#
+# Transitional: deletes alongside server/python/ in Phase 4D.
+
+FROM python:3.11-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# docker-ce-cli + docker-compose-plugin let the restart-parity scenario
+# issue `docker compose restart` against the bind-mounted compose file
+# at /compose/docker-compose.yml.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+       | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+        "grpcio>=1.60.0" \
+        "grpcio-tools>=1.60.0" \
+        "protobuf>=6.31.0" \
+        "pytest>=7.4,<9" \
+        "pytest-asyncio>=0.23,<0.25" \
+        "pytest-timeout>=2.1"
+
+# Copy SDK (self-contained — bundles _generated/entdb_pb2.py).
+COPY sdk/python/entdb_sdk/ /app/entdb_sdk/
+
+# Copy the e2e schema (reused for parity to avoid schema-divergence
+# bugs masquerading as parity divergences) and the parity test dir.
+COPY tests/python/e2e/e2e_schema_pb2.py /app/tests/python/parity/e2e_schema_pb2.py
+COPY tests/python/parity/ /app/tests/python/parity/
+
+ENV PYTHONPATH="/app:/app/tests/python/parity"
+
+# pytest entry — rootdir is the parity dir so the repo-root
+# pyproject.toml isn't picked up. `-p no:cacheprovider` avoids a
+# stale .pytest_cache from a previous run.
+CMD ["pytest", \
+     "-v", \
+     "--tb=short", \
+     "-p", "no:cacheprovider", \
+     "-o", "asyncio_mode=auto", \
+     "/app/tests/python/parity"]

--- a/tests/python/parity/README.md
+++ b/tests/python/parity/README.md
@@ -1,0 +1,100 @@
+# EntDB Dual-Stack Parity Suite — Phase 4A (EPIC #407)
+
+Pre-deletion sanity check for the Python -> Go server port. Boots the
+Python and Go gRPC servers side-by-side on independent Kafka clusters,
+replays the same multi-RPC sequences against each, and asserts the
+resulting SQLite + ACL state is semantically equivalent.
+
+## What it covers
+
+The cross-impl contract harness (#428) and e2e suites (#478, #479)
+already give us per-RPC parity (70/70 contract + 22/22 e2e under both
+targets). This suite fills the remaining gap:
+
+* **Stateful sequence parity** — multi-RPC traffic patterns (CRUD,
+  edges, share/revoke, idempotent retry, concurrent writers, restart)
+  produce equivalent end-state on both servers.
+* **WAL replay parity** — write -> `docker compose restart` -> read.
+  Both servers must rebuild the same SQLite view from the WAL.
+
+## When to run it
+
+This suite is **transitional**. Run it locally before any release that
+touches the Go server, and especially before Phase 4D when
+`server/python/` is deleted. It does **not** have a CI job — adding
+one would impose ~5 minutes of CI runtime for parity assertions that
+are already covered by contract + e2e at the RPC level.
+
+After Phase 4D deletes `server/python/`, the Python server image
+build will fail and this suite becomes unrunnable. **Delete
+`tests/python/parity/` in the same commit** — track it in the Phase
+4D cleanup checklist.
+
+## Running locally
+
+```bash
+bash tests/python/parity/run-parity.sh
+# Useful flags:
+#   --no-cache   force a clean container build
+#   --logs       dump server logs on failure
+#   --keep       keep containers up after the run (for debug)
+```
+
+The script spins up Redpanda x2, MinIO, both server containers, and
+the `parity-tests` runner. Total runtime on a warm cache is ~3-5
+minutes; first run incurs ~5-8 minutes of image build.
+
+## Architecture
+
+```
+parity-tests ──┬── server-python:50051  ── redpanda-py
+               └── server-go:50051      ── redpanda-go
+```
+
+Both servers use the same e2e schema (`User`/`Product`/`Order` +
+`Purchased`/`PlacedOrder`/`OrderContains` edges, type IDs 8001-8003,
+edge IDs 8101-8103). Each test allocates a private tenant via
+`CreateTenant` on the Go server (which has its global store enabled);
+the Python server auto-creates tenants on first write (its global
+store is disabled in dev mode).
+
+Each server reads its own dedicated Redpanda cluster. **This matters**:
+if both servers consumed from the same Kafka topic, the harness would
+be testing replay-determinism (replaying the same WAL twice into two
+appliers) rather than parity (two servers, two independent WALs,
+identical responses). Independent clusters force each server to
+generate its own WAL entries from its own ingress path, which is what
+parity actually means.
+
+## Divergence policy
+
+The normalisation helpers in `conftest.py` strip values that
+legitimately differ between independent servers:
+
+* `node_id`, `id` (receipt ID), generated UUIDs — replaced with
+  `<UUID>` placeholders.
+* `created_at`, `updated_at`, `applied_at`, `ts_ms` — wall-clock
+  timestamps, stripped.
+* `stream_position`, `offset` — independent WALs => independent
+  offsets, stripped.
+* `tenant_id` — per-test random tenant ids, stripped.
+
+**Everything else must match exactly** after normalisation. If a
+parity scenario fails it indicates a real semantic divergence between
+the Python and Go implementations and is a **Phase 4 blocker** —
+either fix the Go server before deleting the Python one or document
+the divergence as an intentional behaviour change.
+
+## Files
+
+* `docker-compose.parity.yml` — two-stack topology with independent
+  Kafka clusters.
+* `Dockerfile.parity` — parity-tests runner image; mirrors the e2e
+  runner but pinned at the parity test directory.
+* `conftest.py` — `python_client` / `go_client` fixtures, per-test
+  `parity_tenant`, normalisation + snapshot helpers, `restart_servers`.
+* `test_parity_scenarios.py` — six parity scenarios.
+* `run-parity.sh` — one-shot driver.
+* `e2e_schema_pb2.py` — generated proto module, copied from
+  `tests/python/e2e/` at container-build time (kept in lock-step via
+  the Dockerfile, not duplicated in version control).

--- a/tests/python/parity/__init__.py
+++ b/tests/python/parity/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Dual-stack parity test suite — Phase 4A of EPIC #407.
+
+Transitional. Deletes alongside server/python/ in Phase 4D.
+"""

--- a/tests/python/parity/conftest.py
+++ b/tests/python/parity/conftest.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Dual-stack parity fixtures — Phase 4A (EPIC #407).
+
+The parity suite boots the Python and Go gRPC servers side-by-side
+(see ``docker-compose.parity.yml``) and drives the same RPC sequences
+against each via two separate SDK clients. These fixtures handle:
+
+* connecting both clients (with retry-on-boot mirroring the e2e
+  conftest)
+* a private, freshly-allocated tenant per test (so test-order
+  independence holds and there's no cross-contamination from one
+  scenario's writes into another's read-back)
+* normalisation of nodes / receipts (UUIDs, timestamps, WAL offsets,
+  list-order non-determinism) so the parity assertion focuses on
+  semantic equivalence
+* state-snapshot + deep-equality helpers
+* a ``restart_servers`` callable for the WAL-replay parity test
+
+This module is intentionally **not** a permanent CI fixture. Once
+Phase 4D deletes ``server/python/`` the file becomes dead — track it
+in the cleanup task for that phase.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import subprocess
+import sys
+import time
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+# Make ``import e2e_schema_pb2`` resolve regardless of CWD.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import e2e_schema_pb2 as pb  # noqa: E402
+
+from entdb_sdk import DbClient, register_proto_schema  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+PYTHON_HOST = os.environ.get("ENTDB_PYTHON_HOST", "server-python")
+PYTHON_PORT = int(os.environ.get("ENTDB_PYTHON_PORT", "50051"))
+GO_HOST = os.environ.get("ENTDB_GO_HOST", "server-go")
+GO_PORT = int(os.environ.get("ENTDB_GO_PORT", "50051"))
+
+# The seed tenant is created on the Go server via --seed-profile=e2e;
+# the Python server lacks an analogous flag (its global_store is
+# disabled in dev-mode), so the first write to a tenant id creates
+# it. Each test allocates its own private tenant so cross-test state
+# never leaks into the parity comparison.
+DEFAULT_TENANT = os.environ.get("ENTDB_TENANT", "e2e-test")
+ACTOR = "user:e2e-runner"
+
+COMPOSE_FILE_IN_CONTAINER = "/compose/docker-compose.yml"
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_tcp(host: str, port: int, timeout: int = 90) -> None:
+    """Block until ``host:port`` accepts a TCP connection.
+
+    The Go server starts almost immediately; the Python server can
+    take ~30s in a cold-build container. 90s is a generous
+    upper-bound that still fails fast when the container is missing.
+    """
+    import socket
+
+    deadline = time.time() + timeout
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=2):
+                return
+        except (TimeoutError, OSError) as exc:
+            last_err = exc
+            time.sleep(1)
+    raise RuntimeError(
+        f"gRPC server at {host}:{port} not reachable after {timeout}s (last error: {last_err!r})"
+    )
+
+
+_SCHEMA_REGISTERED = False
+
+
+async def _connect(target: str) -> DbClient:
+    """Build a connected DbClient with the e2e schema registered."""
+    global _SCHEMA_REGISTERED
+    if not _SCHEMA_REGISTERED:
+        register_proto_schema(pb)
+        _SCHEMA_REGISTERED = True
+
+    client = DbClient(target)
+    last_exc: Exception | None = None
+    for _ in range(30):
+        try:
+            await client.connect()
+            return client
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            await asyncio.sleep(2)
+    raise RuntimeError(f"could not connect to {target}: {last_exc!r}")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def python_target() -> str:
+    return f"{PYTHON_HOST}:{PYTHON_PORT}"
+
+
+@pytest.fixture(scope="session")
+def go_target() -> str:
+    return f"{GO_HOST}:{GO_PORT}"
+
+
+@pytest.fixture(scope="session")
+def actor() -> str:
+    return ACTOR
+
+
+_BOOT_WAITED = False
+
+
+@pytest_asyncio.fixture
+async def python_client(python_target: str) -> AsyncGenerator[DbClient, None]:
+    """Connected SDK client for the Python server.
+
+    Function-scoped (mirrors e2e conftest): pytest-asyncio's default
+    event loop is per-function and ``grpc.aio`` channels are bound to
+    the loop they're built on, so reusing one across tests yields the
+    well-known "attached to a different loop" error.
+    """
+    global _BOOT_WAITED
+    if not _BOOT_WAITED:
+        _wait_for_tcp(PYTHON_HOST, PYTHON_PORT)
+        _wait_for_tcp(GO_HOST, GO_PORT)
+        _BOOT_WAITED = True
+
+    client = await _connect(python_target)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest_asyncio.fixture
+async def go_client(go_target: str) -> AsyncGenerator[DbClient, None]:
+    """Connected SDK client for the Go server."""
+    global _BOOT_WAITED
+    if not _BOOT_WAITED:
+        _wait_for_tcp(PYTHON_HOST, PYTHON_PORT)
+        _wait_for_tcp(GO_HOST, GO_PORT)
+        _BOOT_WAITED = True
+
+    client = await _connect(go_target)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest_asyncio.fixture
+async def parity_tenant(python_client: DbClient, go_client: DbClient) -> str:
+    """Allocate the same private tenant id on BOTH servers.
+
+    Per-test tenant isolation is what lets us write `final state must
+    be identical` (rather than `final state must be a superset of the
+    pre-test state`). Side-by-side scenarios pollute each other's
+    universal-tenant state otherwise.
+
+    The Go server boots with its global_store enabled, so we must
+    CreateTenant + AddTenantMember explicitly. The Python server runs
+    with global_store disabled (dev mode) so any tenant id is auto-
+    created on first write — simply minting the id is sufficient.
+    """
+    import uuid
+
+    tid = f"parity-{uuid.uuid4().hex[:10]}"
+
+    # Go server requires an explicit tenant.
+    create = await go_client.create_tenant(
+        tenant_id=tid,
+        name=f"parity {tid}",
+        actor="system:parity-admin",
+    )
+    if not create.get("success"):
+        raise RuntimeError(f"go CreateTenant({tid}) failed: {create.get('error')}")
+    await go_client.add_tenant_member(
+        tenant_id=tid,
+        user_id="e2e-runner",
+        role="owner",
+        actor="system:parity-admin",
+    )
+
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# Restart helper (used by the WAL-replay parity scenario)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def restart_servers() -> Callable[[], Awaitable[None]]:
+    """Return an async callable that restarts BOTH servers via the
+    bind-mounted compose file. Skips when the docker socket or
+    compose file aren't available (e.g. ad-hoc host-side runs).
+    """
+
+    async def _restart() -> None:
+        if not os.path.exists("/var/run/docker.sock"):
+            pytest.skip("restart_servers requires /var/run/docker.sock")
+        if not os.path.exists(COMPOSE_FILE_IN_CONTAINER):
+            pytest.skip(f"restart_servers requires {COMPOSE_FILE_IN_CONTAINER}")
+
+        def _cmd() -> None:
+            subprocess.run(
+                [
+                    "docker",
+                    "compose",
+                    "-f",
+                    COMPOSE_FILE_IN_CONTAINER,
+                    "restart",
+                    "server-python",
+                    "server-go",
+                ],
+                check=True,
+                capture_output=True,
+            )
+
+        await asyncio.to_thread(_cmd)
+
+        # Wait for both listeners to come back. Python's Kafka
+        # consumer has to rejoin its group + replay; the Go server
+        # restarts in <1s. The applier-replay settle wait is the same
+        # 5s the e2e conftest uses for the Python target.
+        await asyncio.to_thread(_wait_for_tcp, PYTHON_HOST, PYTHON_PORT, 90)
+        await asyncio.to_thread(_wait_for_tcp, GO_HOST, GO_PORT, 90)
+        await asyncio.sleep(5)
+
+    return _restart
+
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+# UUIDs (canonical 8-4-4-4-12 hex form, both lowercase and uppercase).
+_UUID_RE = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+
+# RFC3339-ish timestamps.
+_TS_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b")
+
+
+def _replace_uuids(s: str) -> str:
+    return _UUID_RE.sub("<UUID>", s)
+
+
+def _replace_ts(s: str) -> str:
+    return _TS_RE.sub("<TS>", s)
+
+
+def _normalise_value(v: Any) -> Any:
+    """Recursively normalise a value: replace UUIDs / timestamps in
+    strings, swallow timestamp-shaped ints, and pass dict/list through
+    field-by-field. ``created_at`` / ``updated_at`` / ``applied_at`` /
+    ``ts_ms`` / ``stream_position`` are emptied because their values
+    legitimately differ between independent servers running on
+    independent WALs."""
+    if isinstance(v, str):
+        return _replace_ts(_replace_uuids(v))
+    if isinstance(v, (int, float, bool)) or v is None:
+        return v
+    if isinstance(v, dict):
+        return {k: _normalise_value(val) for k, val in v.items()}
+    if isinstance(v, list):
+        return [_normalise_value(x) for x in v]
+    if is_dataclass(v):
+        return _normalise_value(asdict(v))
+    # Fall through: unknown object — stringify and normalise.
+    return _replace_ts(_replace_uuids(str(v)))
+
+
+# Fields whose values legitimately differ between servers and MUST be
+# stripped before comparison. These are wall-clock or WAL-position
+# artefacts, not semantic state.
+_STRIPPED_KEYS = frozenset(
+    {
+        "node_id",
+        "id",  # receipt.id
+        "created_at",
+        "updated_at",
+        "applied_at",
+        "ts_ms",
+        "stream_position",
+        "offset",
+        "wal_offset",
+        "receipt_id",
+        "idempotency_key_uuid",  # parity tests use deterministic
+        # idempotency_key values for the
+        # idempotent scenario; if a future
+        # field added a per-call uuid it
+        # would be elided here.
+        "trace_id",
+        "tenant_id",  # private per-test tenant ids differ by run.
+    }
+)
+
+
+def _strip_volatile(d: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in d.items():
+        if k in _STRIPPED_KEYS:
+            continue
+        if isinstance(v, dict):
+            out[k] = _strip_volatile(v)
+        elif isinstance(v, list):
+            out[k] = [_strip_volatile(x) if isinstance(x, dict) else _normalise_value(x) for x in v]
+        else:
+            out[k] = _normalise_value(v)
+    return out
+
+
+def normalise_node(node: Any) -> dict[str, Any]:
+    """Reduce a Node to its parity-comparable form: type_id + payload
+    + owner_actor + sorted-acl. Everything else (id, timestamps,
+    tenant_id) is volatile or per-server.
+    """
+    d = asdict(node) if is_dataclass(node) else dict(node)
+    return _strip_volatile(d)
+
+
+def normalise_edge(edge: Any) -> dict[str, Any]:
+    d = asdict(edge) if is_dataclass(edge) else dict(edge)
+    return _strip_volatile(d)
+
+
+def _sort_key(d: dict[str, Any]) -> str:
+    """Stable sort key for normalised nodes/edges. We sort by the
+    canonical payload because node_id is stripped and payloads carry
+    the semantic identity (email / sku / order_number)."""
+    import json
+
+    return json.dumps(d, sort_keys=True, default=str)
+
+
+def normalise_node_list(nodes: list[Any]) -> list[dict[str, Any]]:
+    return sorted((normalise_node(n) for n in nodes), key=_sort_key)
+
+
+def normalise_edge_list(edges: list[Any]) -> list[dict[str, Any]]:
+    return sorted((normalise_edge(e) for e in edges), key=_sort_key)
+
+
+# ---------------------------------------------------------------------------
+# State snapshot + equivalence assertion
+# ---------------------------------------------------------------------------
+
+
+async def _snapshot(client: DbClient, tenant_id: str) -> dict[str, Any]:
+    """Snapshot the parity-relevant slice of a server's state for one
+    tenant: every User / Product / Order node + every outgoing edge
+    from every node. Returns a normalised, sort-stable structure.
+    """
+    scope = client.tenant(tenant_id).actor(ACTOR)
+
+    users = await scope.query(pb.User, limit=500, order_by="created_at", descending=False)
+    products = await scope.query(pb.Product, limit=500, order_by="created_at", descending=False)
+    orders = await scope.query(pb.Order, limit=500, order_by="created_at", descending=False)
+
+    # Edges: walk every source node and collect outgoing.
+    edges: list[Any] = []
+    for src in [*users, *products, *orders]:
+        for edge_type in (pb.Purchased, pb.PlacedOrder, pb.OrderContains):
+            try:
+                edges.extend(await scope.edges_out(src.node_id, edge_type=edge_type))
+            except Exception:
+                # An edge type may legitimately not exist for a given
+                # source type — skip rather than fail the parity
+                # comparison, both servers should respond identically
+                # (either succeed-empty or 404).
+                pass
+
+    return {
+        "users": normalise_node_list(users),
+        "products": normalise_node_list(products),
+        "orders": normalise_node_list(orders),
+        "edges": normalise_edge_list(edges),
+    }
+
+
+async def assert_state_equivalent(
+    python_client: DbClient,
+    go_client: DbClient,
+    tenant_id: str,
+) -> None:
+    """Snapshot both servers and diff their normalised state.
+
+    Raises ``AssertionError`` with a human-readable diff on mismatch.
+    """
+    py_state = await _snapshot(python_client, tenant_id)
+    go_state = await _snapshot(go_client, tenant_id)
+
+    if py_state == go_state:
+        return
+
+    import json
+
+    py_dump = json.dumps(py_state, indent=2, sort_keys=True, default=str)
+    go_dump = json.dumps(go_state, indent=2, sort_keys=True, default=str)
+    diff_lines: list[str] = []
+    for key in sorted(set(py_state.keys()) | set(go_state.keys())):
+        if py_state.get(key) != go_state.get(key):
+            diff_lines.append(f"  - section {key!r} differs:")
+            diff_lines.append(f"    python: {py_state.get(key)!r}")
+            diff_lines.append(f"    go:     {go_state.get(key)!r}")
+    diff = "\n".join(diff_lines)
+    raise AssertionError(
+        "Python and Go servers disagree on tenant state:\n"
+        + diff
+        + "\n\n--- python full state ---\n"
+        + py_dump
+        + "\n--- go full state ---\n"
+        + go_dump
+    )
+
+
+def normalise_commit_result(result: Any) -> dict[str, Any]:
+    """Reduce a CommitResult to its parity-comparable form."""
+    d = asdict(result) if is_dataclass(result) else dict(result)
+    # `created_node_ids` is a list of generated UUIDs — collapse to
+    # `["<UUID>"] * n` so the cardinality is preserved but the
+    # specific ids (which legitimately differ) don't break parity.
+    created = d.get("created_node_ids") or []
+    d["created_node_ids"] = ["<UUID>"] * len(created)
+    return _strip_volatile(d)
+
+
+def assert_receipts_equivalent(
+    python_results: list[Any],
+    go_results: list[Any],
+) -> None:
+    """Diff a list of commit results from each server. Position-
+    sensitive: we compare result[i] against result[i] because the
+    parity scenarios fire the same ordered sequence at each server.
+    """
+    assert len(python_results) == len(go_results), (
+        f"receipt count mismatch: python={len(python_results)} go={len(go_results)}"
+    )
+    for i, (py, go) in enumerate(zip(python_results, go_results, strict=True)):
+        py_n = normalise_commit_result(py)
+        go_n = normalise_commit_result(go)
+        assert py_n == go_n, f"receipt {i} differs:\n  python={py_n!r}\n  go={go_n!r}"
+
+
+# ---------------------------------------------------------------------------
+# Replay helper
+# ---------------------------------------------------------------------------
+
+
+async def replay_against_both(
+    python_client: DbClient,
+    go_client: DbClient,
+    tenant_id: str,
+    sequence: Callable[[DbClient, str], Awaitable[list[Any]]],
+) -> tuple[list[Any], list[Any]]:
+    """Run the same async-callable sequence against each server and
+    return ``(python_results, go_results)``.
+
+    The sequence is invoked with ``(client, tenant_id)`` so it can use
+    any combination of plan-commit, share/revoke, query, etc. The
+    parity test asserts on the returned results + on
+    ``assert_state_equivalent``.
+    """
+    py = await sequence(python_client, tenant_id)
+    go = await sequence(go_client, tenant_id)
+    return py, go

--- a/tests/python/parity/docker-compose.parity.yml
+++ b/tests/python/parity/docker-compose.parity.yml
@@ -1,0 +1,201 @@
+version: "3.8"
+
+# =============================================================================
+# EntDB Dual-Stack Parity Test Environment — Phase 4A (EPIC #407)
+# =============================================================================
+#
+# Boots the Python and Go gRPC servers side-by-side, each backed by its
+# own dedicated Redpanda cluster (separate broker => separate WAL =>
+# we exercise parity rather than replay-determinism on a shared log).
+#
+# Topology:
+#
+#     parity-tests ──┬── server-python:50051  ── redpanda-py:9092
+#                    └── server-go:50051      ── redpanda-go:9092
+#
+# Both servers boot with the same e2e schema (User/Product/Order +
+# Purchased/PlacedOrder/OrderContains edges) so the SDK can drive
+# identical proto traffic against each. Tenant `e2e-test` is pre-seeded
+# on the Go target via --seed-profile=e2e; the Python target auto-
+# creates tenants on first write (global_store disabled in dev mode).
+#
+# This suite is transitional. After Phase 4D deletes server/python/ this
+# compose file becomes unrunnable and should be removed alongside the
+# rest of tests/python/parity/. See README.md.
+#
+# Usage:
+#   bash tests/python/parity/run-parity.sh
+# =============================================================================
+
+services:
+  # ==========================================================================
+  # Redpanda (Python target WAL)
+  # ==========================================================================
+  redpanda-py:
+    image: docker.redpanda.com/redpandadata/redpanda:v23.3.5
+    command:
+      - redpanda
+      - start
+      - --smp=1
+      - --memory=256M
+      - --reserve-memory=0M
+      - --overprovisioned
+      - --node-id=0
+      - --kafka-addr=PLAINTEXT://0.0.0.0:9092
+      - --advertise-kafka-addr=PLAINTEXT://redpanda-py:9092
+    healthcheck:
+      test: ["CMD", "rpk", "cluster", "health"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
+
+  # ==========================================================================
+  # Redpanda (Go target WAL) — separate cluster so the two servers
+  # genuinely consume independent logs.
+  # ==========================================================================
+  redpanda-go:
+    image: docker.redpanda.com/redpandadata/redpanda:v23.3.5
+    command:
+      - redpanda
+      - start
+      - --smp=1
+      - --memory=256M
+      - --reserve-memory=0M
+      - --overprovisioned
+      - --node-id=0
+      - --kafka-addr=PLAINTEXT://0.0.0.0:9092
+      - --advertise-kafka-addr=PLAINTEXT://redpanda-go:9092
+    healthcheck:
+      test: ["CMD", "rpk", "cluster", "health"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
+
+  # ==========================================================================
+  # MinIO (S3-compatible storage — required by the Python server image)
+  # ==========================================================================
+  minio:
+    image: minio/minio:RELEASE.2024-01-18T22-51-28Z
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  minio-init:
+    image: minio/mc:RELEASE.2024-01-18T07-03-39Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set myminio http://minio:9000 minioadmin minioadmin;
+      mc mb --ignore-existing myminio/entdb-storage;
+      echo 'Bucket created';
+      exit 0;
+      "
+
+  # ==========================================================================
+  # Python EntDB Server
+  # ==========================================================================
+  server-python:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+      target: server
+    environment:
+      - GRPC_BIND=0.0.0.0:50051
+      - WAL_BACKEND=kafka
+      - KAFKA_BROKERS=redpanda-py:9092
+      - KAFKA_TOPIC=entdb-wal-parity
+      - KAFKA_CONSUMER_GROUP=entdb-applier-parity-py
+      - S3_BUCKET=entdb-storage
+      - S3_ENDPOINT=http://minio:9000
+      - S3_REGION=us-east-1
+      - AWS_ACCESS_KEY_ID=minioadmin
+      - AWS_SECRET_ACCESS_KEY=minioadmin
+      - DATA_DIR=/var/lib/entdb
+      - LOG_LEVEL=INFO
+      - LOG_FORMAT=text
+    depends_on:
+      redpanda-py:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    volumes:
+      - py-server-data:/var/lib/entdb
+    healthcheck:
+      test: ["CMD", "python", "-c", "import grpc; ch = grpc.insecure_channel('localhost:50051'); grpc.channel_ready_future(ch).result(timeout=5)"]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+      start_period: 10s
+
+  # ==========================================================================
+  # Go EntDB Server
+  # ==========================================================================
+  server-go:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile.go
+      target: server
+    image: entdb-server-go:parity
+    command:
+      - "-addr=:50051"
+      - "-data-dir=/var/lib/entdb"
+      - "-wal-backend=kafka"
+      - "-wal-brokers=redpanda-go:9092"
+      - "-wal-topic=entdb-wal-parity"
+      - "-wal-group=entdb-applier-parity-go"
+      - "-seed-profile=e2e"
+      - "-seed-tenant=e2e-test"
+    depends_on:
+      redpanda-go:
+        condition: service_healthy
+    volumes:
+      - go-server-data:/var/lib/entdb
+    # Distroless image: no shell-based healthcheck; the parity-tests
+    # container retries the TCP connect itself.
+
+  # ==========================================================================
+  # Parity Test Runner — drives BOTH servers in parallel via the SDK.
+  # ==========================================================================
+  parity-tests:
+    build:
+      context: ../../..
+      dockerfile: tests/python/parity/Dockerfile.parity
+    environment:
+      - ENTDB_PYTHON_HOST=server-python
+      - ENTDB_PYTHON_PORT=50051
+      - ENTDB_GO_HOST=server-go
+      - ENTDB_GO_PORT=50051
+      - ENTDB_TENANT=e2e-test
+    depends_on:
+      server-python:
+        condition: service_healthy
+      server-go:
+        condition: service_started
+      redpanda-py:
+        condition: service_healthy
+      redpanda-go:
+        condition: service_healthy
+    # Mount the docker socket + compose file so the restart-parity
+    # scenario can `docker compose restart` both servers.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./docker-compose.parity.yml:/compose/docker-compose.yml:ro
+
+volumes:
+  py-server-data:
+  go-server-data:
+
+networks:
+  default:
+    name: entdb-parity-network

--- a/tests/python/parity/run-parity.sh
+++ b/tests/python/parity/run-parity.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# =============================================================================
+# EntDB Dual-Stack Parity Test Runner — Phase 4A (EPIC #407)
+# =============================================================================
+#
+# Boots the Python and Go gRPC servers side-by-side on independent
+# Kafka clusters, runs the parity suite (tests/python/parity/), and
+# tears the stack down.
+#
+# Transitional: this script + ../parity/ delete together with
+# server/python/ in Phase 4D. There is intentionally no CI job
+# pointing at it (one-off pre-deletion sanity, not a recurring gate).
+#
+# Options:
+#   --no-cache   Rebuild containers without cache.
+#   --keep       Don't tear the stack down at exit (debug).
+#   --logs       Show server logs on test failure.
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.parity.yml"
+export COMPOSE_PROJECT_NAME="entdb-parity"
+
+NO_CACHE=""
+KEEP_RUNNING=false
+SHOW_LOGS=false
+
+for arg in "$@"; do
+    case $arg in
+        --no-cache) NO_CACHE="--no-cache" ;;
+        --keep) KEEP_RUNNING=true ;;
+        --logs) SHOW_LOGS=true ;;
+    esac
+done
+
+echo "=============================================="
+echo "EntDB Dual-Stack Parity Suite (Phase 4A)"
+echo "=============================================="
+echo ""
+
+cd "$PROJECT_ROOT"
+
+echo "[1/4] Building containers..."
+docker compose -f "$COMPOSE_FILE" build $NO_CACHE
+
+echo ""
+echo "[2/4] Starting infrastructure (Redpanda x2, MinIO)..."
+docker compose -f "$COMPOSE_FILE" up -d --wait redpanda-py redpanda-go minio
+docker compose -f "$COMPOSE_FILE" up -d minio-init
+
+echo ""
+echo "[3/4] Starting both EntDB servers..."
+docker compose -f "$COMPOSE_FILE" up -d server-python server-go
+echo "Waiting for Python server healthcheck..."
+docker compose -f "$COMPOSE_FILE" up -d --wait server-python
+echo "Giving the Go server a beat to bind its listener..."
+sleep 3
+
+echo ""
+echo "[4/4] Running parity scenarios..."
+set +e
+docker compose -f "$COMPOSE_FILE" up --exit-code-from parity-tests parity-tests
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -ne 0 ] && [ "$SHOW_LOGS" = true ]; then
+    echo ""
+    echo "[!] Parity tests failed. Showing server logs..."
+    echo "--- python server ---"
+    docker compose -f "$COMPOSE_FILE" logs server-python
+    echo "--- go server ---"
+    docker compose -f "$COMPOSE_FILE" logs server-go
+fi
+
+if [ "$KEEP_RUNNING" = false ]; then
+    echo ""
+    echo "Cleaning up..."
+    docker compose -f "$COMPOSE_FILE" down -v
+else
+    echo ""
+    echo "Containers left running (use 'docker compose -f $COMPOSE_FILE down -v' to clean up)"
+fi
+
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "=============================================="
+    echo "Parity Suite PASSED"
+    echo "=============================================="
+else
+    echo "=============================================="
+    echo "Parity Suite FAILED (exit code: $EXIT_CODE)"
+    echo "=============================================="
+fi
+
+exit $EXIT_CODE

--- a/tests/python/parity/test_parity_scenarios.py
+++ b/tests/python/parity/test_parity_scenarios.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Dual-stack parity scenarios — Phase 4A (EPIC #407).
+
+Each test runs the same RPC sequence against the Python and Go
+servers (independent Kafka instances + private per-test tenant) and
+asserts that:
+
+  1. the per-call commit receipts are semantically equivalent
+     (modulo UUIDs/timestamps/offsets — see ``conftest.normalise_*``),
+  2. the post-replay SQLite state on each server is byte-identical
+     after normalisation.
+
+If either assertion fails the test reports a real divergence; the
+parity suite is a transitional gate, so divergences are blockers for
+Phase 4D's ``server/python/`` deletion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import e2e_schema_pb2 as pb
+from conftest import (
+    assert_receipts_equivalent,
+    assert_state_equivalent,
+    replay_against_both,
+)
+
+# =============================================================================
+# 1. Basic CRUD parity
+# =============================================================================
+
+
+async def test_basic_crud_parity(python_client, go_client, parity_tenant) -> None:
+    """Create -> Get -> Update -> Delete a single node. After deletion
+    both servers must report an empty User set for this tenant."""
+
+    async def _seq(client, tenant_id):
+        results: list = []
+        scope = client.tenant(tenant_id).actor("user:e2e-runner")
+        idem_create = f"crud-create-{tenant_id}"
+        idem_update = f"crud-update-{tenant_id}"
+        idem_delete = f"crud-delete-{tenant_id}"
+
+        # 1. Create
+        plan = scope.plan(idempotency_key=idem_create)
+        plan.create(
+            pb.User(email="crud@example.com", name="CRUD User", age=30),
+            as_="u",
+        )
+        results.append(await plan.commit(wait_applied=True))
+        node_id = results[-1].created_node_ids[0]
+
+        # 2. Get (round-trip check inside the sequence)
+        await scope.get(pb.User, node_id)
+
+        # 3. Update
+        plan2 = scope.plan(idempotency_key=idem_update)
+        plan2.update(node_id, pb.User(age=31, active=True))
+        results.append(await plan2.commit(wait_applied=True))
+
+        # 4. Delete
+        plan3 = scope.plan(idempotency_key=idem_delete)
+        plan3.delete(pb.User, node_id)
+        results.append(await plan3.commit(wait_applied=True))
+        return results
+
+    py_results, go_results = await replay_against_both(
+        python_client, go_client, parity_tenant, _seq
+    )
+    assert_receipts_equivalent(py_results, go_results)
+    await assert_state_equivalent(python_client, go_client, parity_tenant)
+
+
+# =============================================================================
+# 2. Edge creation parity
+# =============================================================================
+
+
+async def test_edge_creation_parity(python_client, go_client, parity_tenant) -> None:
+    """Create 3 nodes (1 user, 2 products) and 2 edges between them.
+    Both servers must report the same edge set."""
+
+    sku1 = f"PARITY-A-{uuid.uuid4().hex[:6]}"
+    sku2 = f"PARITY-B-{uuid.uuid4().hex[:6]}"
+
+    async def _seq(client, tenant_id):
+        scope = client.tenant(tenant_id).actor("user:e2e-runner")
+        plan = scope.plan(idempotency_key=f"edges-{tenant_id}")
+        plan.create(pb.User(email="edges@example.com", name="Edge User"), as_="u")
+        plan.create(
+            pb.Product(sku=sku1, name="Prod A", price=10.0, category="electronics"),
+            as_="p1",
+        )
+        plan.create(
+            pb.Product(sku=sku2, name="Prod B", price=20.0, category="electronics"),
+            as_="p2",
+        )
+        plan.edge_create(pb.Purchased, "$u", "$p1", props={"quantity": 1, "price_paid": 10.0})
+        plan.edge_create(pb.Purchased, "$u", "$p2", props={"quantity": 2, "price_paid": 40.0})
+        return [await plan.commit(wait_applied=True)]
+
+    py_results, go_results = await replay_against_both(
+        python_client, go_client, parity_tenant, _seq
+    )
+    assert_receipts_equivalent(py_results, go_results)
+    await assert_state_equivalent(python_client, go_client, parity_tenant)
+
+
+# =============================================================================
+# 3. Share / Revoke parity
+# =============================================================================
+
+
+async def test_share_revoke_parity(python_client, go_client, parity_tenant) -> None:
+    """Create a node, share it with `user:bob`, then revoke. After
+    revocation both servers' ACL state must match (which, since
+    revoke removes the grant, means: identical normalised node ACL)."""
+
+    async def _seq(client, tenant_id):
+        results: list = []
+        scope = client.tenant(tenant_id).actor("user:e2e-runner")
+
+        # Create the target node.
+        plan = scope.plan(idempotency_key=f"share-create-{tenant_id}")
+        plan.create(pb.User(email="share@example.com", name="Share Target"), as_="u")
+        cr = await plan.commit(wait_applied=True)
+        results.append(cr)
+        node_id = cr.created_node_ids[0]
+
+        # Share it with bob (read permission).
+        ok = await scope.share(node_id, "user:bob")
+        results.append({"share_ok": bool(ok)})
+
+        # Revoke.
+        ok2 = await scope.revoke(node_id, "user:bob")
+        results.append({"revoke_ok": bool(ok2)})
+
+        return results
+
+    py_results, go_results = await replay_against_both(
+        python_client, go_client, parity_tenant, _seq
+    )
+    assert_receipts_equivalent(py_results, go_results)
+    await assert_state_equivalent(python_client, go_client, parity_tenant)
+
+
+# =============================================================================
+# 4. Idempotent retry parity
+# =============================================================================
+
+
+async def test_idempotent_retry_parity(python_client, go_client, parity_tenant) -> None:
+    """The same idempotency_key sent N times must produce exactly one
+    write on each server. Both servers must agree on:
+      * N receipts returned (success on each call),
+      * exactly one node in the post-replay state."""
+
+    key = f"idem-{uuid.uuid4().hex}"
+    email = f"idem-{uuid.uuid4().hex[:8]}@example.com"
+
+    async def _seq(client, tenant_id):
+        scope = client.tenant(tenant_id).actor("user:e2e-runner")
+        results: list = []
+        for i in range(4):
+            plan = scope.plan(idempotency_key=key)
+            plan.create(pb.User(email=email, name="Idem User"), as_="u")
+            # First call waits-applied; later ones don't (per the
+            # e2e test_idempotent_create note — the server short-
+            # circuits via the cached receipt and the offset never
+            # advances on the applier, so wait would block forever).
+            results.append(await plan.commit(wait_applied=(i == 0)))
+        # Drop SDK offset tracking so the parity state-snapshot doesn't
+        # block waiting for an offset the applier never advanced past.
+        scope._client.clear_offsets()
+        return results
+
+    py_results, go_results = await replay_against_both(
+        python_client, go_client, parity_tenant, _seq
+    )
+    # Every result.success must be True on both sides.
+    assert all(r.success for r in py_results), "python: idempotent retry failed"
+    assert all(r.success for r in go_results), "go: idempotent retry failed"
+    assert_receipts_equivalent(py_results, go_results)
+    await assert_state_equivalent(python_client, go_client, parity_tenant)
+
+
+# =============================================================================
+# 5. Concurrent writers parity
+# =============================================================================
+
+
+async def test_concurrent_writers_parity(python_client, go_client, parity_tenant) -> None:
+    """N concurrent writers fire distinct creates; after settle both
+    servers' User sets must be byte-identical (modulo normalisation
+    order, which the sort-stable snapshot handles)."""
+
+    N = 10
+    # Stable email tags so the post-replay state is deterministic
+    # across both servers — generating uuid4 per-loop would give us
+    # different sets on each server.
+    emails = [f"conc-{i:02d}-{uuid.uuid4().hex[:6]}@example.com" for i in range(N)]
+
+    async def _seq(client, tenant_id):
+        scope = client.tenant(tenant_id).actor("user:e2e-runner")
+
+        async def _create(i: int):
+            plan = scope.plan(idempotency_key=f"conc-{tenant_id}-{i}")
+            plan.create(pb.User(email=emails[i], name=f"Conc {i}"), as_="u")
+            return await plan.commit(wait_applied=True)
+
+        results = await asyncio.gather(*[_create(i) for i in range(N)])
+        return list(results)
+
+    py_results, go_results = await replay_against_both(
+        python_client, go_client, parity_tenant, _seq
+    )
+    # Concurrent ordering means receipt-list order is non-
+    # deterministic per-server, so we don't position-compare; just
+    # require both sides to be all-success and the same length.
+    assert all(r.success for r in py_results), "python: a concurrent write failed"
+    assert all(r.success for r in go_results), "go: a concurrent write failed"
+    assert len(py_results) == len(go_results) == N
+    # And the durable end-state on both servers must match.
+    await assert_state_equivalent(python_client, go_client, parity_tenant)
+
+
+# =============================================================================
+# 6. WAL replay after restart parity
+# =============================================================================
+
+
+async def test_replay_after_restart_parity(
+    python_client,
+    go_client,
+    parity_tenant,
+    restart_servers,
+) -> None:
+    """Write data, restart BOTH servers, then assert both servers
+    rebuild semantically-identical SQLite state from their WALs."""
+
+    # IMPORTANT: precompute the sku OUTSIDE the closure. _seq runs twice
+    # (once per server) and a uuid generated inside would yield different
+    # sku values on each side, breaking the state-equivalence assertion.
+    replay_sku = f"REPLAY-{uuid.uuid4().hex[:8]}"
+
+    async def _seq(client, tenant_id):
+        scope = client.tenant(tenant_id).actor("user:e2e-runner")
+        plan = scope.plan(idempotency_key=f"replay-{tenant_id}")
+        plan.create(
+            pb.User(email="replay@example.com", name="Replay User", age=42),
+            as_="u",
+        )
+        plan.create(
+            pb.Product(
+                sku=replay_sku,
+                name="Replay Product",
+                price=99.99,
+                category="other",
+            ),
+            as_="p",
+        )
+        plan.edge_create(pb.Purchased, "$u", "$p", props={"quantity": 1, "price_paid": 99.99})
+        return [await plan.commit(wait_applied=True)]
+
+    py_results, go_results = await replay_against_both(
+        python_client, go_client, parity_tenant, _seq
+    )
+    assert_receipts_equivalent(py_results, go_results)
+    # Sanity: pre-restart state must already match.
+    await assert_state_equivalent(python_client, go_client, parity_tenant)
+
+    # Drop the offset cursors — after a restart the WAL position the
+    # SDK remembers may no longer match the applier's cursor.
+    python_client.clear_offsets()
+    go_client.clear_offsets()
+
+    await restart_servers()
+
+    # The fixture-scoped channels were bound to a pre-restart server
+    # process. Re-connect via a fresh channel; the SDK auto-reconnects
+    # on next use, but an explicit connect-loop avoids transient
+    # "channel closed" flakes on the first post-restart RPC.
+    last_err: Exception | None = None
+    for _ in range(30):
+        try:
+            await assert_state_equivalent(python_client, go_client, parity_tenant)
+            return
+        except Exception as exc:  # noqa: BLE001
+            last_err = exc
+            await asyncio.sleep(2)
+    raise AssertionError(f"post-restart parity assertion never settled (last error: {last_err!r})")


### PR DESCRIPTION
## Summary

Phase 4A pre-deletion sanity check for the Python -> Go server port. Boots
the Python and Go servers in parallel (independent Redpanda clusters,
shared MinIO) and replays multi-RPC sequences against each to assert the
final SQLite + ACL state is semantically equivalent.

- Adds `tests/python/parity/` with a six-scenario suite (basic CRUD,
  edge creation, share/revoke, idempotent retry, concurrent writers,
  WAL replay after restart).
- Normalises generated UUIDs, timestamps, and WAL offsets so the
  divergence policy is `everything else must match exactly`.
- Transitional only: this suite is unrunnable after Phase 4D deletes
  `server/python/` and is documented for deletion at that point.
- No CI workflow added (intentional — pre-deletion gate only).

Refs #407.

## Parity results (local run)

`bash tests/python/parity/run-parity.sh`

| Scenario | Result |
| --- | --- |
| test_basic_crud_parity | PASS |
| test_edge_creation_parity | PASS |
| test_share_revoke_parity | **FAIL — real divergence (see below)** |
| test_idempotent_retry_parity | PASS |
| test_concurrent_writers_parity | PASS |
| test_replay_after_restart_parity | PASS |

**5 / 6 scenarios pass.**

## Divergences found (Phase-4 blockers)

### 1. `ShareNode`: owner cannot self-share on Python; can on Go

- **Go** (e2e seed profile): `ShareNode` succeeds when invoked by the
  node owner (`TestShareNode_OwnerHappyPath` in
  `server/go/internal/api/share_node_test.go`).
- **Python**: `_check_capability` requires an explicit ADMIN
  capability grant to `ShareNode` regardless of ownership. The
  `_is_admin_or_system` short-circuit only matches `system:*` actors,
  not the node's owner. With no grants present on a freshly-created
  node, `share()` returns `success=False` with
  `Actor user:e2e-runner lacks capability ... on node <id>`.

This is a real semantic divergence and a Phase-4 blocker for deleting
`server/python/`. The owner-can-self-share behaviour is the more
intuitive one and matches the Go contract test; the fix is on the
Python side (extend the `_is_admin_or_system` short-circuit to
include the node owner, or wire an implicit owner-ADMIN grant during
node creation). Resolution will be tracked as a follow-up before
Phase 4D.

## Test plan

- [x] `bash tests/python/parity/run-parity.sh` — 5/6 passing (above).
- [x] `python -m pytest tests/python/unit/ tests/python/integration/ -q` — 2529 passed (no regressions; parity dir not collected because it requires the bundled `e2e_schema_pb2.py` only present in the docker image).
- [x] `uvx ruff@0.15.7 check .` — clean.
- [x] `uvx ruff@0.15.7 format --check .` — clean.
- [x] `cd server/go && go vet ./...` — clean.
- [x] No CI workflow added (intentional, per Phase-4A scope).
- [x] No edits to Go or Python server source.