### PR TITLE
docs: rewrite CLAUDE.md for Go-only server (post Phase 4D)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,21 @@
 # EntDB — Agent Instructions
 
+> Server is Go-only as of EPIC #407 Phase 4D; the historical Python server has
+> been deleted. See `docs/decisions/python-server-retired.md` for the
+> retirement evidence ladder (contract parity, e2e parity, perf, release-image
+> swap).
+
 ## Workflow (MUST follow)
 
 ### Always run CI locally before pushing
 Before every `git push`, run the full local CI suite and fix any failures:
 
 ```bash
-python -m pytest tests/python/unit/ tests/python/integration/ -q   # all tests must pass
-uvx ruff@0.15.7 check .                                            # lint must be clean
-uvx ruff@0.15.7 format --check .                                   # format must be clean
-cd sdk/go/entdb && go vet ./... && go test ./...                    # Go SDK (if modified)
+cd server/go && go vet ./... && go test ./...           # Go server (source of truth)
+cd sdk/go/entdb && go vet ./... && go test ./...        # Go SDK
+python -m pytest tests/python/integration/ -q           # SDK contract suite vs Go server
+uvx ruff@0.15.7 check .                                 # lint must be clean
+uvx ruff@0.15.7 format --check .                        # format must be clean
 ```
 
 Do NOT push code that you haven't verified locally. Do NOT rely on GitHub CI to catch failures — fix them before push.
@@ -17,8 +23,8 @@ Do NOT push code that you haven't verified locally. Do NOT rely on GitHub CI to 
 ### Releases
 
 Tagging `vX.Y.Z` on `main` triggers `.github/workflows/release.yml` which:
-1. Builds + pushes Docker images to ghcr.io
-2. Publishes Python SDK to PyPI (`pip install entdb-sdk==X.Y.Z`)
+1. Builds + pushes the Go server Docker image to `ghcr.io/elloloop/tenant-shard-db:vX.Y.Z` (same image name as before; Go binary inside).
+2. Publishes Python SDK to PyPI (`pip install entdb-sdk==X.Y.Z`).
 3. Publishes Go SDK by tagging `sdk/go/entdb/vX.Y.Z` and warming the Go module proxy. Consumers install with `go get github.com/elloloop/tenant-shard-db/sdk/go/entdb@vX.Y.Z`. Docs auto-render at `pkg.go.dev/github.com/elloloop/tenant-shard-db/sdk/go/entdb`.
 
 Go modules don't need a registry — the Go proxy pulls directly from git tags. Sub-module tags MUST be prefixed `sdk/go/entdb/vX.Y.Z` (the release workflow creates them automatically).
@@ -26,68 +32,68 @@ Go modules don't need a registry — the Go proxy pulls directly from git tags. 
 ## Architecture Invariants (MUST NOT violate)
 
 ### 1. All writes go through the WAL
-EntDB is event-sourced. The WAL (Kafka/Kinesis/S3) is the **source of truth**. SQLite is a materialized view rebuilt by replaying the WAL.
+EntDB is event-sourced. The WAL (Kafka/Redpanda, in-memory for tests) is the **source of truth**. SQLite is a materialized view rebuilt by replaying the WAL.
 
-**Every mutation** — including admin ops, GDPR, transfers, revocations — MUST be appended to the WAL via `wal.append()` and applied by the `Applier`. Direct SQLite writes from handlers bypass the event log and will be **silently lost** on rebuild.
+**Every mutation** — including admin ops, GDPR, transfers, revocations — MUST be appended to the WAL via `wal.Append` and applied by the `Applier` in `server/go/internal/apply/`. Direct SQLite writes from handlers bypass the event log and will be **silently lost** on rebuild.
 
 ```
-CORRECT:   handler → wal.append(event) → Applier.apply_event() → SQLite
-WRONG:     handler → global_store.update_something() → SQLite (direct)
+CORRECT:   handler → wal.Append(event) → Applier.Apply() → store (SQLite)
+WRONG:     handler → store.WriteSomething() (direct)
 ```
 
-If you need a new operation type, add it to `TransactionEvent.ops` and handle it in `Applier.apply_event()`.
+If you need a new operation type, add it to the `Event`/`Op` types in `server/go/internal/wal/event.go` and handle it in `server/go/internal/apply/applier.go`.
 
 ### 2. The WAL is the audit log
-S3 Object Lock (COMPLIANCE mode) provides tamper-evident, immutable audit trails. Do NOT build separate audit log tables with hash chains — they're redundant and weaker than S3 Object Lock. Use `export_audit_trail()` from `server/python/entdb_server/audit/compliance.py` for compliance exports.
+S3 Object Lock (COMPLIANCE mode) layered over the Kafka/Redpanda backend in `server/go/internal/wal/kafka.go` provides tamper-evident, immutable audit trails. Do NOT build separate audit log tables with hash chains — they're redundant and weaker than S3 Object Lock.
 
-### 3. Async-only on the gRPC server
-The gRPC server uses `grpc.aio`. All interceptors, handlers, and middleware MUST be async (`grpc.aio.ServerInterceptor`, not `grpc.ServerInterceptor`). Never use `asyncio.run()` or `ThreadPoolExecutor` to bridge sync/async in request handlers — it destroys throughput.
+### 3. Single consumer goroutine for the applier
+The applier runs as a single consumer goroutine per server (Python-parity ordering guarantee). A per-tenant worker pool is deferred — do NOT add ad-hoc per-tenant goroutines that fan out applies, as it breaks per-tenant offset ordering and rebuild determinism. gRPC handlers themselves are goroutine-per-request (Go-native); the invariant is only about the apply path.
 
 ### 4. Per-tenant SQLite isolation
-Each tenant has its own SQLite file. Never read/write across tenant boundaries in a single SQLite transaction. Cross-tenant operations go through `global_store` (which has its own SQLite).
+Each tenant has its own SQLite file (via `modernc.org/sqlite`, managed by `server/go/internal/store/pool.go`). Never read/write across tenant boundaries in a single SQLite transaction. Cross-tenant operations go through `server/go/internal/globalstore/` (which has its own SQLite).
 
 ### 5. Proto is the type system
-Standard `protoc --python_out` generates typed classes. Do NOT build custom codegen that reimplements what protobuf provides (enums, typed fields, message classes). Use `register_proto_schema()` to register proto types with the SDK registry.
+Standard `protoc-gen-go` / `protoc-gen-go-grpc` generates typed stubs into `server/go/internal/pb/`. Do NOT build custom codegen that reimplements what protobuf provides (enums, typed fields, message classes). Use `register_proto_schema()` in the SDK to register proto types with the SDK registry.
 
 ### 6. Field IDs, not field names, on disk
-Payloads are stored keyed by `field_id` (e.g. `{"1": "value"}`), not by name. Translation happens at the gRPC boundary only. This makes field renames free.
+Payloads are stored keyed by `field_id` (e.g. `{"1": "value"}`), not by name. Translation happens at the gRPC boundary only (`server/go/internal/payload/`). This makes field renames free.
 
 ## Project Structure
 
-> Server is Go-only as of EPIC #407 Phase 4D; the historical Python server has been deleted. See `docs/decisions/python-server-retired.md`.
-
-Polyglot monorepo, Python today, Go server reimplementation in flight:
-
 ```
 proto/
-  entdb/v1/entdb.proto        — wire contract (entdb.v1.EntDBService)
+  entdb/v1/entdb.proto        — wire contract (44 RPCs)
   console/v1/console.proto    — browser-facing console RPCs
 
 server/
-  python/entdb_server/        — current Python gRPC server (AGPL-3.0-only)
-    api/grpc_server.py        — gRPC handlers (ingress/egress boundary)
-    apply/applier.py          — WAL consumer, applies events to SQLite
-    apply/canonical_store.py  — per-tenant SQLite operations
-    global_store.py           — cross-tenant state
-    wal/                      — WAL backends (Kafka, Kinesis, SQS, memory)
-    audit/                    — S3-based compliance audit export
-    auth/                     — OAuth, API keys, sessions
-    crypto/                   — encryption at rest, key management
-  python/pyproject.toml       — name = "entdb-server"
-  go/                         — placeholder for Go server reimplementation
+  go/                         — Go gRPC server (AGPL-3.0-only)
+    cmd/entdb-server/         — main package
+    internal/
+      api/                    — gRPC handlers (44 RPCs)
+      apply/                  — WAL consumer (Applier)
+      auth/                   — trusted-actor interceptor
+      globalstore/            — cross-tenant SQLite
+      pb/                     — generated protobuf stubs
+      schema/                 — node/edge type registry
+      store/                  — per-tenant SQLite (canonical store)
+      wal/                    — WAL producer/consumer
+                                (in-memory + Kafka/Redpanda backends)
+      acl/                    — typed-capability ACL
+      payload/                — id-keyed payload translation
+      errs/                   — gRPC status mapping
+      testseed/               — test fixture seeding
+    go.mod                    — module: github.com/elloloop/tenant-shard-db/server/go
 
 sdk/
   python/entdb_sdk/           — Python SDK (MIT, PyPI: entdb-sdk)
-  python/pyproject.toml       — name = "entdb-sdk"
   go/entdb/                   — Go SDK (module: github.com/elloloop/tenant-shard-db/sdk/go/entdb)
 
 tests/
-  python/unit/                — unit tests (fast, no external deps)
-  python/integration/         — integration tests (in-memory WAL + SQLite)
-  python/e2e/                 — end-to-end tests (full stack with Docker)
-  python/benchmarks/          — pytest-benchmark suite
-  go/                         — Go test placeholder
-  contract/                   — cross-implementation contract tests placeholder
+  python/                     — all integration/e2e/benchmarks driven through the SDK against the Go gRPC server
+    integration/              — contract suite (~70 cases), per-RPC behavior
+    e2e/                      — Docker-stack tests (22 cases) including crash recovery
+    benchmarks/               — pytest-benchmark suite
+  go/                         — (currently sparse; Go-side unit tests live in server/go/internal/<pkg>/*_test.go)
 
 pyproject.toml                — workspace root, dev tooling only (no [project])
 ```
@@ -95,17 +101,20 @@ pyproject.toml                — workspace root, dev tooling only (no [project]
 ## Testing
 
 ```bash
-python -m pytest tests/python/unit/ -q          # ~1300 tests, <10s
-python -m pytest tests/python/integration/ -q   # ~700 tests, <6s
-cd sdk/go/entdb && go test ./...                # Go SDK tests
-uvx ruff@0.15.7 check .                         # lint
-uvx ruff@0.15.7 format --check .                # format
+cd server/go && go vet ./... && go test ./...           # Go server unit tests
+cd sdk/go/entdb && go test ./...                        # Go SDK tests
+python -m pytest tests/python/integration/ -q           # SDK contract suite (runs vs Go server via conftest harness)
+bash tests/python/e2e/run-e2e.sh                        # Docker-stack e2e (22 cases)
+uvx ruff@0.15.7 check .                                 # lint
+uvx ruff@0.15.7 format --check .                        # format
 ```
+
+`tests/python/integration/` and `tests/python/e2e/` both target the Go server — the Python conftest harness boots `server/go/cmd/entdb-server` (or a docker-compose stack for e2e) and drives it through the Python SDK over gRPC.
 
 ## Key Patterns
 
-- `canonical_store` methods that write to SQLite are `_sync_*` prefixed, wrapped by async methods via `_run_sync` (thread pool)
-- The `SchemaRegistry` holds `NodeTypeDef`/`EdgeTypeDef` — register via `register_node_type()`
-- GDPR: `user_id` (e.g. "alice") vs `tenant_principal` (e.g. "user:alice") — translate at the boundary
-- ACL grants use `Permission` enum, not raw strings
-- Actors use `Actor.user("bob")` / `Actor.group("admins")`, not `"user:bob"` strings
+- Store methods accept `context.Context` as the first argument; the per-tenant SQLite pool is keyed by `tenant_id` (`server/go/internal/store/pool.go`); writes go through `BatchTxn` (`server/go/internal/store/txn.go`) so the applier can commit a multi-op event atomically.
+- The schema registry (`server/go/internal/schema/`) holds node/edge type definitions — register via the schema RPCs; the SDK mirrors them through `register_proto_schema()`.
+- GDPR: `user_id` (e.g. `"alice"`) vs `tenant_principal` (e.g. `"user:alice"`) — translate at the gRPC boundary, never deeper.
+- ACL grants use the `Permission` enum, not raw strings.
+- Actors use `Actor.user("bob")` / `Actor.group("admins")`, not `"user:bob"` strings.


### PR DESCRIPTION
## Summary
- EPIC #407 Phase 4D (#485) deleted `server/python/`. `CLAUDE.md` still read like a polyglot transition document.
- Rewrite to reflect the current single-server reality: Go-only, with Python SDK + tests running against it via gRPC.
- All six architecture invariants (WAL source-of-truth, audit-log, per-tenant SQLite isolation, proto-as-types, field-IDs on disk) are preserved with updated paths under `server/go/internal/`. The Python-specific "async-only on the gRPC server" invariant is replaced with "Single consumer goroutine for the applier (Python parity, deferred per-tenant pool)".

## Test plan
- [x] `wc -l CLAUDE.md` -> 120 (target ~150, hard cap 200)
- [x] `grep -c 'server/python\|entdb_server' CLAUDE.md` -> 0
- [x] `grep -c 'server/go\|/internal/' CLAUDE.md` -> 13 (> 5)
- [x] `.github/workflows/release.yml` parses as YAML (unchanged, sanity only)
- [x] Docs-only change; no code touched.

Refs #407 (closed)