### PR TITLE
ci(release): drop stale write to server/python/_version.py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,6 @@ jobs:
           VER="${GITHUB_REF_NAME#v}"
           echo "$VER" > VERSION
           echo "__version__ = \"$VER\"" > sdk/python/entdb_sdk/_version.py
-          echo "__version__ = \"$VER\"" > server/python/entdb_server/_version.py
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

- Phase 4D (#485) deleted `server/python/` but `.github/workflows/release.yml:90` still wrote `__version__` there. The next tag-driven release would fail with "No such file or directory" at the inject-version step.
- One-line deletion. The Python SDK version write (line 89) is unaffected.
- Surfaced as a follow-up during the PR #490 principal-engineer review.

## Test plan

- [x] Reviewed both release.yml inject-version steps — the second (SDK-only) was already correct; only the first was stale.
- [ ] Will be exercised end-to-end by the upcoming v1.11.0 tag.