### PR TITLE
feat(sdk): expose WithID / id_ on Plan.Create (closes #498)

### DIFF
--- a/sdk/go/entdb/options.go
+++ b/sdk/go/entdb/options.go
@@ -104,6 +104,7 @@ type createConfig struct {
 	storage      StorageMode
 	targetUserID string
 	alias        string
+	id           string
 }
 
 // CreateOption configures a single Plan.Create call.
@@ -152,6 +153,20 @@ func InPublic() CreateOption {
 // unique alias automatically.
 func As(alias string) CreateOption {
 	return func(c *createConfig) { c.alias = alias }
+}
+
+// WithID requests the server use the supplied id when creating the
+// node, rather than generating a fresh UUID. Useful for idempotent
+// upserts where the caller derives the id from external content
+// (e.g. ``uuid.NewSHA1(ns, []byte(slug))``).
+//
+// The id must be a valid UUID string; validation happens server-side
+// — malformed ids surface as INVALID_ARGUMENT and duplicate ids in
+// the same tenant + type scope surface as ALREADY_EXISTS, which the
+// SDK reports as [*UniqueConstraintError]. Clients building
+// idempotent flows should treat ALREADY_EXISTS as "use Get instead".
+func WithID(id string) CreateOption {
+	return func(c *createConfig) { c.id = id }
 }
 
 // ── Scope.Query options ─────────────────────────────────────────────

--- a/sdk/go/entdb/plan.go
+++ b/sdk/go/entdb/plan.go
@@ -93,6 +93,7 @@ func (p *Plan) Create(msg proto.Message, opts ...CreateOption) string {
 	p.operations = append(p.operations, Operation{
 		Type:         OpCreateNode,
 		TypeID:       int(typeID),
+		NodeID:       cfg.id,
 		Alias:        cfg.alias,
 		Data:         payload,
 		ACL:          cfg.acl,

--- a/sdk/go/entdb/plan_test.go
+++ b/sdk/go/entdb/plan_test.go
@@ -109,6 +109,30 @@ func TestPlan_Create_InPublic(t *testing.T) {
 	}
 }
 
+func TestPlan_Create_WithID(t *testing.T) {
+	mock := &mockTransport{}
+	plan := newPlan(mock, "t1", "user:alice", "key-1")
+
+	const id = "11111111-2222-3333-4444-555555555555"
+	plan.Create(newProduct("D1", "Deterministic", 1), WithID(id))
+
+	ops := plan.Operations()
+	if ops[0].NodeID != id {
+		t.Errorf("NodeID = %q, want %q", ops[0].NodeID, id)
+	}
+}
+
+func TestPlan_Create_NoID_LeavesNodeIDEmpty(t *testing.T) {
+	mock := &mockTransport{}
+	plan := newPlan(mock, "t1", "user:alice", "key-1")
+
+	plan.Create(newProduct("R1", "Random", 1))
+
+	if got := plan.Operations()[0].NodeID; got != "" {
+		t.Errorf("NodeID = %q, want empty (server-generated)", got)
+	}
+}
+
 func TestPlan_Create_As_ExplicitAlias(t *testing.T) {
 	mock := &mockTransport{}
 	plan := newPlan(mock, "t1", "user:alice", "key-1")

--- a/sdk/python/entdb_sdk/client.py
+++ b/sdk/python/entdb_sdk/client.py
@@ -301,6 +301,7 @@ class Plan:
         storage: Storage | None = None,
         as_: str | None = None,
         fanout_to: list[str] | None = None,
+        id_: str | None = None,
     ) -> Plan:
         """Create a node from a proto message.
 
@@ -322,6 +323,12 @@ class Plan:
                 endpoint).
             fanout_to: Optional list of mailbox user ids to fan this
                 node out to.
+            id_: Optional deterministic node id. When omitted, the
+                server generates a fresh UUID. When supplied, the
+                server uses the given id; duplicates in the same
+                tenant + type scope surface as
+                :class:`UniqueConstraintError`. Useful for idempotent
+                upserts where the id is derived from external content.
 
         Returns:
             Self for chaining.
@@ -356,6 +363,8 @@ class Plan:
             }
         }
 
+        if id_:
+            op["create_node"]["id"] = id_
         if acl_dicts:
             op["create_node"]["acl"] = acl_dicts
         if as_:

--- a/tests/python/integration/test_sdk_client.py
+++ b/tests/python/integration/test_sdk_client.py
@@ -50,6 +50,29 @@ class TestPlanBuilder:
         assert plan._operations[0]["create_node"]["type_id"] == 9001
         assert plan._operations[0]["create_node"]["as"] == "product1"
 
+    def test_plan_create_node_with_id(self):
+        """Plan.create accepts a deterministic id via id_."""
+        client = _mock_client()
+        plan = Plan(client, tenant_id="t1", actor="user:alice")
+
+        plan.create(
+            ts.Product(sku="DET-1", name="Deterministic", price_cents=10),
+            id_="11111111-2222-3333-4444-555555555555",
+        )
+
+        op = plan._operations[0]["create_node"]
+        assert op["id"] == "11111111-2222-3333-4444-555555555555"
+
+    def test_plan_create_node_without_id_omits_field(self):
+        """Plan.create without id_ leaves the id field out (server generates)."""
+        client = _mock_client()
+        plan = Plan(client, tenant_id="t1", actor="user:alice")
+
+        plan.create(ts.Product(sku="RND-1", name="Random", price_cents=1))
+
+        op = plan._operations[0]["create_node"]
+        assert "id" not in op
+
     def test_plan_multiple_operations(self):
         """Plan can hold multiple operations."""
         client = _mock_client()


### PR DESCRIPTION
## Summary

Both the Go and Python SDKs were missing a way to supply a deterministic node id on `Plan.Create`, even though the wire protocol (`CreateNodeOp.id`) has always supported it. This blocked idempotent-upsert flows where the caller derives the id from external content (e.g. a content-sync CI run keyed by slug).

Per the "both SDKs ship in one PR" rule, both sides land together.

```go
// Go
plan.Create(msg, entdb.WithID(uuid.NewSHA1(ns, []byte(slug)).String()))
```

```python
# Python
plan.create(msg, id_=str(uuid.uuid5(ns, slug)))
```

## Wiring

- Go: `WithID(id string) CreateOption` mirrors `WithACL` / `As`. The wire path (`sdk/go/entdb/wire.go:156`) already maps `Operation.NodeID` → `pb.CreateNodeOp.Id`; the only missing piece was carrying the option through to `Operation.NodeID` in `Plan.Create`.
- Python: `id_` kwarg mirrors `as_` (avoiding the Python builtin clash, matching how the file already handles `as`). The dict-to-proto converter (`sdk/python/entdb_sdk/_grpc_client.py:740`) already maps `create["id"]` → `CreateNodeOp.id`; the only missing piece was adding `"id"` to the dict from the kwarg.

## Validation

Pass-through. Malformed ids surface as `INVALID_ARGUMENT`; duplicate ids in the same tenant + type scope surface as `ALREADY_EXISTS` (`UniqueConstraintError` in Python). Documented in both SDKs' docstrings so callers can build idempotent flows around the duplicate case.

## Test plan

- [x] Go: `TestPlan_Create_WithID` — assert `Operation.NodeID` carries the supplied id
- [x] Go: `TestPlan_Create_NoID_LeavesNodeIDEmpty` — assert no id leaves the field empty (server generates)
- [x] Python: `test_plan_create_node_with_id` — assert `op["create_node"]["id"]` carries the supplied id
- [x] Python: `test_plan_create_node_without_id_omits_field` — assert no `id_` omits the dict key
- [x] `go vet ./... && go test ./...` (server + SDK) — all green
- [x] `pytest tests/python/integration/ -q` — 81 passed (was 79, +2 new)
- [x] `ruff check . && ruff format --check .` — clean

## Notes

- `Plan.Update` / `Plan.Delete` already accept node ids (they have to — they target existing nodes). This PR only extends `Plan.Create`.
- The consumer in [elloloop/learning-monorepo#348](https://github.com/elloloop/learning-monorepo/pull/348) can bump from SDK v1.10.2 → v1.11.1 after this merges + a tag is cut.

Closes #498