### PR TITLE
feat(server,sdk): comparison operators in QueryNodes filters (closes #501)

### DIFF
--- a/sdk/go/entdb/filter.go
+++ b/sdk/go/entdb/filter.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+package entdb
+
+// FilterOp is the comparison operator carried by a [Filter]. The
+// values mirror the wire FilterOp enum's Eq/Ne/Lt/Le/Gt/Ge subset
+// (see proto/entdb/v1/entdb.proto). Issue #501 scopes the SDK to
+// the six AND-able comparison operators; CONTAINS / IN remain
+// server-side TBD and are not exposed here.
+type FilterOp string
+
+// Comparison operators accepted by [Filter]. Each compiles to the
+// matching SQL operator on the indexed payload column.
+//
+// Index usage caveat:
+//   - FilterEq/Lt/Le/Gt/Ge use the existing ``idx_query_t<type>_f<field>``
+//     expression index for B-tree lookups.
+//   - FilterNe (not-equal) CANNOT use a B-tree index — it forces a
+//     scan over every row of the requested type. Use sparingly on
+//     large tables; prefer a positive predicate (``> v OR < v`` is
+//     not expressible in this v1 cut — re-issue the query if you
+//     need both branches).
+const (
+	FilterEq FilterOp = "eq"
+	FilterNe FilterOp = "ne"
+	FilterLt FilterOp = "lt"
+	FilterLe FilterOp = "le"
+	FilterGt FilterOp = "gt"
+	FilterGe FilterOp = "ge"
+)
+
+// Filter is one AND-ed predicate passed to [QueryWhere]. Field is
+// the proto field name (the gRPC boundary resolves it to a payload
+// field_id). Op selects the comparison operator. Value is bound as
+// a SQLite parameter and supports the JSON-marshallable scalars
+// SQLite understands (string, int, int64, float64, bool, nil).
+//
+// Multiple filters on the same field are permitted — a half-open
+// range is expressed as two filters:
+//
+//	[]Filter{
+//	    {Field: "expires_at", Op: FilterGe, Value: lo},
+//	    {Field: "expires_at", Op: FilterLt, Value: hi},
+//	}
+type Filter struct {
+	Field string
+	Op    FilterOp
+	Value any
+}
+
+// mongoKey returns the ``$op`` form used by the existing
+// transport-level filter-to-proto encoder.
+func (op FilterOp) mongoKey() string {
+	switch op {
+	case FilterNe:
+		return "$ne"
+	case FilterLt:
+		return "$lt"
+	case FilterLe:
+		return "$lte"
+	case FilterGt:
+		return "$gt"
+	case FilterGe:
+		return "$gte"
+	default:
+		return "$eq"
+	}
+}
+
+// filtersToMap converts a typed Filter slice into the MongoDB-style
+// map shape the existing transport.QueryNodes accepts. Multiple
+// filters on the same field are merged into a single nested
+// ``{"$op": v, "$op2": v2}`` dict so the existing wire encoder
+// (filterToProto) emits one FieldFilter per inlined operator.
+func filtersToMap(filters []Filter) map[string]any {
+	if len(filters) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(filters))
+	for _, f := range filters {
+		if f.Op == FilterEq {
+			if _, exists := out[f.Field]; !exists {
+				out[f.Field] = f.Value
+				continue
+			}
+		}
+		// Promote an existing plain value to a nested op-dict if we
+		// already wrote one for this field (e.g. two eq-on-same-field
+		// would degenerate; preserve last-write-wins for equality).
+		existing, ok := out[f.Field]
+		if !ok {
+			out[f.Field] = map[string]any{f.Op.mongoKey(): f.Value}
+			continue
+		}
+		sub, ok := existing.(map[string]any)
+		if !ok {
+			// Existing value is a plain equality; rewrite it as $eq
+			// so the new operator nests cleanly alongside.
+			sub = map[string]any{"$eq": existing}
+		}
+		sub[f.Op.mongoKey()] = f.Value
+		out[f.Field] = sub
+	}
+	return out
+}

--- a/sdk/go/entdb/filter_where_test.go
+++ b/sdk/go/entdb/filter_where_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+package entdb
+
+import (
+	"testing"
+)
+
+// TestFiltersToMap_SingleEquality pins that a single Eq filter
+// produces the same map shape today's equality call site emits — a
+// plain field=value entry, not a nested ``{"$eq": v}`` dict.
+func TestFiltersToMap_SingleEquality(t *testing.T) {
+	got := filtersToMap([]Filter{
+		{Field: "sku", Op: FilterEq, Value: "WIDGET-1"},
+	})
+	want := map[string]any{"sku": "WIDGET-1"}
+	if got["sku"] != want["sku"] {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// TestFiltersToMap_RangePair pins the half-open-range shape that
+// motivates issue #501: ``expires_at < now`` → nested ``{"$lt": now}``.
+func TestFiltersToMap_RangePair(t *testing.T) {
+	got := filtersToMap([]Filter{
+		{Field: "expires_at", Op: FilterGe, Value: int64(100)},
+		{Field: "expires_at", Op: FilterLt, Value: int64(200)},
+	})
+	sub, ok := got["expires_at"].(map[string]any)
+	if !ok {
+		t.Fatalf("expires_at is not a map: %T", got["expires_at"])
+	}
+	if sub["$gte"] != int64(100) || sub["$lt"] != int64(200) {
+		t.Fatalf("got %v, want $gte=100,$lt=200", sub)
+	}
+}
+
+// TestFiltersToMap_NeAndLt pins that two filters on different fields
+// produce two distinct entries — they are AND-ed by the server.
+func TestFiltersToMap_NeAndLt(t *testing.T) {
+	got := filtersToMap([]Filter{
+		{Field: "status", Op: FilterNe, Value: "deleted"},
+		{Field: "age", Op: FilterLt, Value: 30},
+	})
+	if sub, ok := got["status"].(map[string]any); !ok || sub["$ne"] != "deleted" {
+		t.Fatalf("status filter: got %v", got["status"])
+	}
+	if sub, ok := got["age"].(map[string]any); !ok || sub["$lt"] != 30 {
+		t.Fatalf("age filter: got %v", got["age"])
+	}
+}
+
+// TestFiltersToMap_Empty pins that an empty slice yields nil (no
+// filter on the wire).
+func TestFiltersToMap_Empty(t *testing.T) {
+	if got := filtersToMap(nil); got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+	if got := filtersToMap([]Filter{}); got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}

--- a/sdk/go/entdb/scope.go
+++ b/sdk/go/entdb/scope.go
@@ -170,6 +170,29 @@ func GetByKey[T any](ctx context.Context, s *Scope, key UniqueKey[T], value T) (
 	return s.client.transport.GetNodeByKey(ctx, s.tenantID, s.actor.String(), key.TypeID, key.FieldID, pv)
 }
 
+// QueryWhere is the typed counterpart of [Query]: callers pass a
+// slice of [Filter] values rather than a MongoDB-style map. The two
+// helpers share the same transport, so the wire result is identical.
+//
+// All filters are AND-ed. Issue #501 (entdb v1) scopes the operator
+// set to Eq/Ne/Lt/Le/Gt/Ge — there is no OR, no nesting, no sorting,
+// no cursor. Pagination is via WithLimit / WithOffset.
+//
+// Example sweeper pattern:
+//
+//	expired, err := entdb.QueryWhere[*authn.Challenge](ctx, scope,
+//	    []entdb.Filter{
+//	        {Field: "expires_at", Op: entdb.FilterLt, Value: nowMs},
+//	    },
+//	    entdb.WithLimit(500))
+//
+// Index usage caveat: FilterNe forces a full type scan because a
+// B-tree expression index cannot serve a not-equal predicate. Prefer
+// a positive predicate for sweeper-style hot paths.
+func QueryWhere[T proto.Message](ctx context.Context, s *Scope, filters []Filter, opts ...QueryOption) ([]T, error) {
+	return Query[T](ctx, s, filtersToMap(filters), opts...)
+}
+
 // Query fetches nodes by filter.
 //
 // T determines the type_id and the result type. The filter map
@@ -181,6 +204,8 @@ func GetByKey[T any](ctx context.Context, s *Scope, key UniqueKey[T], value T) (
 //
 // Field names are proto field names; the server resolves them to
 // field ids at the ingress boundary.
+//
+// For the typed-Filter form preferred by issue #501 see [QueryWhere].
 func Query[T proto.Message](ctx context.Context, s *Scope, filter map[string]any, opts ...QueryOption) ([]T, error) {
 	witness := newZeroMessage[T]()
 	typeID, err := typeIDFromMessage(witness)

--- a/sdk/python/entdb_sdk/__init__.py
+++ b/sdk/python/entdb_sdk/__init__.py
@@ -50,6 +50,7 @@ from .errors import (
     UnknownFieldError,
     ValidationError,
 )
+from .filter import Filter, FilterOp
 from .keys import Mailbox, Public, Storage, Tenant, UniqueKey
 from .registry import (
     SchemaRegistry,
@@ -114,6 +115,9 @@ __all__ = [
     "UnknownFieldError",
     "RateLimitError",
     "UniqueConstraintError",
+    # Comparison filters (issue #501)
+    "Filter",
+    "FilterOp",
     # SDK v0.3 typed unique keys + storage descriptors
     "UniqueKey",
     "Tenant",

--- a/sdk/python/entdb_sdk/client.py
+++ b/sdk/python/entdb_sdk/client.py
@@ -30,7 +30,10 @@ import logging
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .filter import Filter
 
 
 class _Unset(Enum):
@@ -985,6 +988,7 @@ class DbClient:
         actor: str,
         *,
         filter: dict[str, Any] | None = None,
+        where: list[Filter] | None = None,
         limit: int = 100,
         offset: int = 0,
         order_by: str = "created_at",
@@ -999,7 +1003,14 @@ class DbClient:
             node_type: Node type to query
             tenant_id: Tenant identifier
             actor: Actor making request
-            filter: Optional payload field filter (serialized as JSON)
+            filter: Optional payload field filter (equality-only map
+                shape; kept for backwards compatibility).
+            where: Optional typed comparison filters
+                (:class:`Filter` list, AND-ed together). Supports
+                Eq/Ne/Lt/Le/Gt/Ge per issue #501. Mutually exclusive
+                with ``filter`` — pass one or the other.
+                ``FilterOp.NE`` forces a full type scan; B-tree
+                indexes cannot serve a not-equal predicate.
             limit: Maximum nodes to return
             offset: Pagination offset
             order_by: Field to order results by
@@ -1017,13 +1028,23 @@ class DbClient:
         trace_id = trace_id or str(uuid.uuid4())
         resolved_offset = self._resolve_offset(tenant_id, after_offset)
 
+        # Local import to dodge a circular-import on package load.
+        from .filter import filters_to_filter_dict
+
+        if where:
+            if filter:
+                raise ValueError("query: pass either `filter` or `where`, not both")
+            wire_filter = filters_to_filter_dict(where)
+        else:
+            wire_filter = filter or {}
+
         nodes, _ = await self._grpc.query_nodes(
             tenant_id=tenant_id,
             actor=actor,
             type_id=node_type.type_id,
             limit=limit,
             offset=offset,
-            filter=filter or {},
+            filter=wire_filter,
             order_by=order_by,
             descending=descending,
             after_offset=resolved_offset,

--- a/sdk/python/entdb_sdk/filter.py
+++ b/sdk/python/entdb_sdk/filter.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MIT
+"""Typed comparison filters for :meth:`DbClient.query` (issue #501).
+
+The single-shape v0.3 API exposes range queries through a list of
+:class:`Filter` values, AND-ed together server-side. Example::
+
+    from entdb_sdk import Filter, FilterOp
+
+    expired = await scope.query(
+        WebAuthnChallengeType,
+        where=[Filter("expires_at", FilterOp.LT, now_ms)],
+        limit=500,
+    )
+
+Issue #501 explicitly scopes the operator set to the six comparison
+operators (Eq/Ne/Lt/Le/Gt/Ge). OR predicates, sorting beyond the
+existing ``order_by`` knob, and cursors are out of scope.
+
+Index usage caveat: ``FilterOp.NE`` (not-equal) cannot use a B-tree
+expression index — the server falls back to a full type scan. Prefer
+a positive predicate on hot paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class FilterOp(str, Enum):
+    """Comparison operator for a :class:`Filter`.
+
+    Values are MongoDB-style ``$op`` strings so the SDK can lower a
+    typed :class:`Filter` to the existing inlined-operator wire shape
+    without a second translation table.
+    """
+
+    EQ = "$eq"
+    NE = "$ne"
+    LT = "$lt"
+    LE = "$lte"
+    GT = "$gt"
+    GE = "$gte"
+
+
+@dataclass(frozen=True)
+class Filter:
+    """One AND-ed predicate passed to :meth:`DbClient.query`.
+
+    ``field`` is the proto field name (the gRPC boundary resolves it
+    to a payload field id). ``op`` selects the comparison operator.
+    ``value`` is bound as a SQLite parameter and accepts the same
+    scalar types as the existing equality filter (str, int, float,
+    bool, ``None``).
+    """
+
+    field: str
+    op: FilterOp
+    value: Any
+
+
+def filters_to_filter_dict(filters: list[Filter] | None) -> dict[str, Any]:
+    """Lower a typed filter list to the MongoDB-style nested dict the
+    gRPC client emits.
+
+    Multiple filters on the same field merge into a single
+    ``{"$op": v, "$op2": v2}`` sub-dict so the server's inlined
+    operator decoder fans them out into one ``FieldFilter`` per
+    operator.
+    """
+    if not filters:
+        return {}
+    out: dict[str, Any] = {}
+    for f in filters:
+        existing = out.get(f.field)
+        if f.op is FilterOp.EQ and existing is None:
+            out[f.field] = f.value
+            continue
+        if existing is None:
+            out[f.field] = {f.op.value: f.value}
+            continue
+        if isinstance(existing, dict):
+            existing[f.op.value] = f.value
+            continue
+        # Existing plain equality value: rewrite as ``$eq`` so the new
+        # operator nests alongside it.
+        out[f.field] = {"$eq": existing, f.op.value: f.value}
+    return out

--- a/sdk/python/entdb_sdk/scope.py
+++ b/sdk/python/entdb_sdk/scope.py
@@ -24,6 +24,7 @@ from .typed import ACLEntry, Actor, Permission, TypedEdge, TypedNode
 
 if TYPE_CHECKING:
     from ._grpc_client import Edge, Node
+    from .filter import Filter
 
 
 class ScopedPlan:
@@ -210,6 +211,7 @@ class ActorScope:
         node_type: Any,
         *,
         filter: dict[str, Any] | None = None,
+        where: list[Filter] | None = None,
         limit: int = 100,
         offset: int = 0,
         order_by: str = "created_at",
@@ -218,13 +220,18 @@ class ActorScope:
         trace_id: str | None = None,
         timeout: float | None = None,
     ) -> list[Node]:
-        """Query nodes by type with MongoDB-style filter operators.
+        """Query nodes by type.
 
-        ``node_type`` is the proto message class. ``filter`` accepts
-        the eight operators frozen in the 2026-04-14 SDK v0.3 decision:
-        ``$eq`` (default), ``$ne``, ``$gt``, ``$gte``, ``$lt``,
-        ``$lte``, ``$in``, ``$nin``, ``$like``, ``$between``, plus
-        top-level ``$and`` / ``$or`` composition.
+        ``node_type`` is the proto message class.
+
+        ``where`` is the typed comparison-filter shape added in issue
+        #501 — a list of :class:`Filter` values AND-ed together, with
+        operator support for Eq/Ne/Lt/Le/Gt/Ge. Prefer ``where`` for
+        new code; the legacy ``filter`` map shape is kept for
+        backwards compatibility.
+
+        ``FilterOp.NE`` cannot use a B-tree index — it forces a full
+        type scan. Use sparingly on large tables.
         """
         kwargs: dict[str, Any] = {
             "limit": limit,
@@ -233,7 +240,13 @@ class ActorScope:
             "descending": descending,
         }
         kwargs.update(
-            _optional(filter=filter, after_offset=after_offset, trace_id=trace_id, timeout=timeout)
+            _optional(
+                filter=filter,
+                where=where,
+                after_offset=after_offset,
+                trace_id=trace_id,
+                timeout=timeout,
+            )
         )
         return await self._client.query(
             _resolve_node_type(node_type), self._tenant_id, self._actor, **kwargs

--- a/server/go/internal/api/query_nodes.go
+++ b/server/go/internal/api/query_nodes.go
@@ -17,10 +17,11 @@
 //     auth.Authoritative(ctx, claimed) — mirrors commit fece3fb.
 //  3. order_by, limit defaults are applied per spec (created_at, 100).
 //  4. filters: name-keyed FieldFilter entries are translated to id-keyed
-//     equality filters via payload.FilterNamesToIDs. Wave 2 supports
-//     EQ only — every other operator surfaces as INVALID_ARGUMENT
-//     (the full MongoDB-operator allow-list is W1.10's queryfilter
-//     package; QueryNodes inherits it once it lands).
+//     comparison filters via payload.FilterNamesToIDs. Eq/Ne/Lt/Le/Gt/Ge
+//     are supported as AND-ed predicates per issue #501. CONTAINS and IN
+//     remain reserved (the wire enum declares them but the server still
+//     surfaces them as INVALID_ARGUMENT pending the full MongoDB-operator
+//     allow-list in W1.10's queryfilter package).
 //  5. ACL post-filter on cross-tenant reads via acl.Filter.FilterReadable.
 //     The Python handler iterates can_access; the equivalent Go path is
 //     the bulk VisibleNodeIDs JOIN already implemented in
@@ -110,15 +111,10 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 		typeName = nt.Name
 	}
 
-	// Translate FieldFilter wire shape -> id-keyed equality filters.
-	// Wave 2 supports EQ only; non-EQ operators surface as
-	// INVALID_ARGUMENT (parity-fix per spec — see file header).
-	nameFilter, err := fieldFiltersToNameDict(req.GetFilters())
-	if err != nil {
-		resultStatus = "error"
-		return nil, err
-	}
-	idFilter, err := payload.FilterNamesToIDs(s.registry, typeName, nameFilter)
+	// Translate FieldFilter wire shape -> id-keyed comparison filters.
+	// Eq/Ne/Lt/Le/Gt/Ge are supported (issue #501); CONTAINS / IN and
+	// any unknown operator value surface as INVALID_ARGUMENT.
+	storeFilters, err := s.fieldFiltersToStoreFilters(typeName, req.GetFilters())
 	if err != nil {
 		resultStatus = "error"
 		return nil, err
@@ -130,13 +126,13 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	}
 
 	nodes, err := s.store.QueryNodes(ctx, store.QueryNodesArgs{
-		TenantID:        tenantID,
-		TypeID:          typeID,
-		EqualityFilters: idFilter,
-		OrderBy:         req.GetOrderBy(),
-		Descending:      req.GetDescending(),
-		Limit:           limit,
-		Offset:          int(req.GetOffset()),
+		TenantID:   tenantID,
+		TypeID:     typeID,
+		Filters:    storeFilters,
+		OrderBy:    req.GetOrderBy(),
+		Descending: req.GetDescending(),
+		Limit:      limit,
+		Offset:     int(req.GetOffset()),
 	})
 	if err != nil {
 		resultStatus = "error"
@@ -172,56 +168,158 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	}, nil
 }
 
-// fieldFiltersToNameDict mirrors _field_filters_to_filter_dict in the
-// Python servicer (grpc_server.py:190-228) but constrained to the
-// Wave-2 supported subset: FilterOp.EQ only. Non-EQ operators surface
-// as INVALID_ARGUMENT — the spec calls this out as a behaviour fix
-// over Python's silent exception swallow (grpc_server.py:1379-1382).
+// fieldFiltersToStoreFilters translates the wire-shape FieldFilter
+// slice into the canonical store's id-keyed [store.QueryFilter]
+// list, applying name-to-id resolution against the schema registry.
 //
-// Multiple EQ filters on the same field collapse to the last value
-// (mirrors the Python merge behaviour where equality on the same field
-// is rewritten to $eq and merged; in the EQ-only subset this is
-// equivalent to "last write wins").
-func fieldFiltersToNameDict(filters []*pb.FieldFilter) (map[string]any, error) {
-	out := map[string]any{}
+// Supported operators (issue #501):
+//
+//   - EQ, NEQ, LT, LTE, GT, GTE
+//
+// CONTAINS and IN remain unsupported — they need a separate compiler
+// (LIKE-with-wildcards, parameterised IN-list) and the issue defers
+// them. Both surface as INVALID_ARGUMENT.
+//
+// Inlined operator shape: the Python SDK historically smuggled non-EQ
+// operators through ``Op=EQ, Value=Struct{"$gt": v}``. We honour that
+// shape so the existing SDK call site keeps working — the inlined
+// operator overrides the wire ``op`` field. Unknown inlined keys (e.g.
+// ``$nin``, ``$between``) still surface as INVALID_ARGUMENT.
+func (s *Server) fieldFiltersToStoreFilters(typeName string, filters []*pb.FieldFilter) ([]store.QueryFilter, error) {
+	if len(filters) == 0 {
+		return nil, nil
+	}
+	// Resolve field name -> id via a single-entry call through
+	// payload.FilterNamesToIDs. We re-use that helper per distinct
+	// name so the unknown-field error shape stays identical to the
+	// equality path and the schema-less unit-test path keeps working.
+	resolveField := func(name string) (uint32, error) {
+		ids, err := payload.FilterNamesToIDs(s.registry, typeName, map[string]any{name: nil})
+		if err != nil {
+			return 0, err
+		}
+		for id := range ids {
+			return id, nil
+		}
+		// Defensive: FilterNamesToIDs always returns one id on success.
+		return 0, errs.Errorf(codes.InvalidArgument,
+			"QueryNodes: filter references unknown field %q", name)
+	}
+
+	nameToID := map[string]uint32{}
+	out := make([]store.QueryFilter, 0, len(filters))
 	for _, f := range filters {
 		if f == nil {
 			continue
 		}
-		if f.GetOp() != pb.FilterOp_EQ {
-			return nil, errs.Errorf(codes.InvalidArgument,
-				"QueryNodes: filter operator %s on field %q is not yet supported (Wave 2 supports EQ only)",
-				f.GetOp(), f.GetField())
+		field := f.GetField()
+		raw := f.GetValue().AsInterface()
+
+		fid, ok := nameToID[field]
+		if !ok {
+			id, err := resolveField(field)
+			if err != nil {
+				return nil, err
+			}
+			nameToID[field] = id
+			fid = id
 		}
-		// Reject the legacy inlined-operator shape: a Struct value
-		// carrying $-prefixed keys is the Python SDK's way of smuggling
-		// a non-EQ operator through Op=EQ. The Wave-2 cut treats this
-		// as INVALID_ARGUMENT for the same reason — surface it instead
-		// of silently dropping rows.
-		if iv, ok := inlinedOperatorKey(f.GetValue().AsInterface()); ok {
-			return nil, errs.Errorf(codes.InvalidArgument,
-				"QueryNodes: inlined operator %q on field %q is not yet supported (Wave 2 supports EQ only)",
-				iv, f.GetField())
+
+		// Inlined operator detection: a Struct value carrying
+		// ``$gt``/``$lt``/... keys. The Python SDK uses this shape to
+		// fan a single FieldFilter into a multi-op predicate (e.g.
+		// ``{"price": {"$gte": 100, "$lt": 200}}``). Emit one store
+		// filter per inlined entry.
+		if subs, ok := inlinedFilterOps(raw); ok {
+			for _, sub := range subs {
+				op, ok := storeFilterOpFromInlineKey(sub.key)
+				if !ok {
+					return nil, errs.Errorf(codes.InvalidArgument,
+						"QueryNodes: inlined operator %q on field %q is not supported", sub.key, field)
+				}
+				out = append(out, store.QueryFilter{FieldID: fid, Op: op, Value: sub.value})
+			}
+			continue
 		}
-		out[f.GetField()] = f.GetValue().AsInterface()
+
+		op, err := storeFilterOpFromWire(field, f.GetOp())
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, store.QueryFilter{FieldID: fid, Op: op, Value: raw})
 	}
 	return out, nil
 }
 
-// inlinedOperatorKey detects the Python SDK's inlined-operator shape
-// (Op=EQ, Value=Struct{"$gte": …}). Returns the offending key and true
-// when the value is a map whose first key starts with "$".
-func inlinedOperatorKey(v any) (string, bool) {
+// storeFilterOpFromWire maps the wire FilterOp enum to the store's
+// comparison-operator type. CONTAINS / IN / unknown values surface as
+// INVALID_ARGUMENT — the issue #501 cut covers Eq/Ne/Lt/Le/Gt/Ge only.
+func storeFilterOpFromWire(field string, op pb.FilterOp) (store.QueryFilterOp, error) {
+	switch op {
+	case pb.FilterOp_EQ:
+		return store.QueryFilterEq, nil
+	case pb.FilterOp_NEQ:
+		return store.QueryFilterNe, nil
+	case pb.FilterOp_LT:
+		return store.QueryFilterLt, nil
+	case pb.FilterOp_LTE:
+		return store.QueryFilterLe, nil
+	case pb.FilterOp_GT:
+		return store.QueryFilterGt, nil
+	case pb.FilterOp_GTE:
+		return store.QueryFilterGe, nil
+	default:
+		return 0, errs.Errorf(codes.InvalidArgument,
+			"QueryNodes: filter operator %s on field %q is not supported (Eq/Ne/Lt/Le/Gt/Ge only)",
+			op, field)
+	}
+}
+
+// storeFilterOpFromInlineKey maps the MongoDB-style ``$gt`` keys used
+// by the Python SDK when smuggling non-EQ operators through Op=EQ.
+func storeFilterOpFromInlineKey(key string) (store.QueryFilterOp, bool) {
+	switch key {
+	case "$eq":
+		return store.QueryFilterEq, true
+	case "$ne":
+		return store.QueryFilterNe, true
+	case "$lt":
+		return store.QueryFilterLt, true
+	case "$lte":
+		return store.QueryFilterLe, true
+	case "$gt":
+		return store.QueryFilterGt, true
+	case "$gte":
+		return store.QueryFilterGe, true
+	}
+	return 0, false
+}
+
+// inlinedFilterOps reports whether the FieldFilter value carries the
+// inlined operator shape (a JSON object whose first key starts with
+// ``$``) and, if so, returns the (op-key, value) pairs in iteration
+// order. The shape historically lets callers express ``{"price":
+// {"$gt": 10, "$lt": 100}}``.
+type inlinedFilterOp struct {
+	key   string
+	value any
+}
+
+func inlinedFilterOps(v any) ([]inlinedFilterOp, bool) {
 	m, ok := v.(map[string]any)
-	if !ok {
-		return "", false
+	if !ok || len(m) == 0 {
+		return nil, false
 	}
 	for k := range m {
-		if len(k) > 0 && k[0] == '$' {
-			return k, true
+		if len(k) == 0 || k[0] != '$' {
+			return nil, false
 		}
 	}
-	return "", false
+	out := make([]inlinedFilterOp, 0, len(m))
+	for k, val := range m {
+		out = append(out, inlinedFilterOp{key: k, value: val})
+	}
+	return out, true
 }
 
 // applyQueryACLFilter is the cross-tenant post-filter. It mirrors the

--- a/server/go/internal/api/query_nodes_test.go
+++ b/server/go/internal/api/query_nodes_test.go
@@ -166,31 +166,126 @@ func TestQueryNodes_EqualityFilter(t *testing.T) {
 	}
 }
 
-// TestQueryNodes_RangeFilterRejected pins the parity-fix: a non-EQ
-// FilterOp (here GTE) MUST surface as INVALID_ARGUMENT. Python's
-// handler swallows the failure and returns an empty list; the Go port
-// rejects it loudly per spec.
-func TestQueryNodes_RangeFilterRejected(t *testing.T) {
+// TestQueryNodes_RangeOperators exercises the comparison operators
+// added by issue #501. Each branch seeds the same three rows and
+// asserts that the matching subset is returned. CONTAINS / IN are
+// covered separately by TestQueryNodes_UnsupportedOperator.
+func TestQueryNodes_RangeOperators(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		op      pb.FilterOp
+		value   any
+		wantIDs []string
+	}{
+		{"lt", pb.FilterOp_LT, 30, []string{"n2"}},   // age < 30 → n2 (25)
+		{"lte", pb.FilterOp_LTE, 30, []string{"n1", "n2"}},
+		{"gt", pb.FilterOp_GT, 30, []string{"n3"}}, // age > 30 → n3 (40)
+		{"gte", pb.FilterOp_GTE, 30, []string{"n1", "n3"}},
+		{"neq", pb.FilterOp_NEQ, 30, []string{"n2", "n3"}},
+		{"eq", pb.FilterOp_EQ, 30, []string{"n1"}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := newQueryNodesFixture(t)
+			f.seedNode("n1", "user:alice", "alice@example.com", 30)
+			f.seedNode("n2", "user:alice", "bob@example.com", 25)
+			f.seedNode("n3", "user:alice", "carol@example.com", 40)
+
+			resp, err := f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
+				Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
+				TypeId:  1,
+				OrderBy: "node_id",
+				Filters: []*pb.FieldFilter{
+					{Field: "age", Op: tc.op, Value: mustValue(t, tc.value)},
+				},
+			})
+			if err != nil {
+				t.Fatalf("QueryNodes: %v", err)
+			}
+			got := make([]string, 0, len(resp.GetNodes()))
+			for _, n := range resp.GetNodes() {
+				got = append(got, n.GetNodeId())
+			}
+			if len(got) != len(tc.wantIDs) {
+				t.Fatalf("got %v, want %v", got, tc.wantIDs)
+			}
+			for i := range tc.wantIDs {
+				if got[i] != tc.wantIDs[i] {
+					t.Fatalf("got %v, want %v", got, tc.wantIDs)
+				}
+			}
+		})
+	}
+}
+
+// TestQueryNodes_RangeOperatorsANDed pins the "all filters AND-ed"
+// contract: ``age >= 25 AND age < 40`` is expressed as two filters
+// on the same field and returns only the rows that satisfy both.
+func TestQueryNodes_RangeOperatorsANDed(t *testing.T) {
+	t.Parallel()
+	f := newQueryNodesFixture(t)
+	f.seedNode("n1", "user:alice", "alice@example.com", 30)
+	f.seedNode("n2", "user:alice", "bob@example.com", 25)
+	f.seedNode("n3", "user:alice", "carol@example.com", 40)
+
+	resp, err := f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
+		TypeId:  1,
+		OrderBy: "node_id",
+		Filters: []*pb.FieldFilter{
+			{Field: "age", Op: pb.FilterOp_GTE, Value: mustValue(t, 25)},
+			{Field: "age", Op: pb.FilterOp_LT, Value: mustValue(t, 40)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if len(resp.GetNodes()) != 2 {
+		t.Fatalf("got %d nodes, want 2", len(resp.GetNodes()))
+	}
+	want := map[string]struct{}{"n1": {}, "n2": {}}
+	for _, n := range resp.GetNodes() {
+		if _, ok := want[n.GetNodeId()]; !ok {
+			t.Fatalf("unexpected node %q in result", n.GetNodeId())
+		}
+	}
+}
+
+// TestQueryNodes_UnsupportedOperator pins the still-rejected operators.
+// CONTAINS and IN remain INVALID_ARGUMENT pending the W1.10 queryfilter
+// package; issue #501 explicitly scoped them out.
+func TestQueryNodes_UnsupportedOperator(t *testing.T) {
 	t.Parallel()
 	f := newQueryNodesFixture(t)
 	f.seedNode("n1", "user:alice", "alice@example.com", 30)
 
-	_, err := f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
-		Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
-		TypeId:  1,
-		Filters: []*pb.FieldFilter{
-			{Field: "age", Op: pb.FilterOp_GTE, Value: mustValue(t, 25)},
-		},
-	})
-	if err == nil {
-		t.Fatalf("expected INVALID_ARGUMENT for unsupported FilterOp, got nil")
-	}
-	st, ok := status.FromError(err)
-	if !ok {
-		t.Fatalf("error is not a grpc status: %v", err)
-	}
-	if st.Code() != codes.InvalidArgument {
-		t.Fatalf("code: got %v, want InvalidArgument", st.Code())
+	for _, op := range []pb.FilterOp{pb.FilterOp_CONTAINS, pb.FilterOp_IN} {
+		op := op
+		t.Run(op.String(), func(t *testing.T) {
+			t.Parallel()
+			_, err := f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
+				Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
+				TypeId:  1,
+				Filters: []*pb.FieldFilter{
+					{Field: "age", Op: op, Value: mustValue(t, 25)},
+				},
+			})
+			if err == nil {
+				t.Fatalf("expected INVALID_ARGUMENT for %s, got nil", op)
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("error is not a grpc status: %v", err)
+			}
+			if st.Code() != codes.InvalidArgument {
+				t.Fatalf("code: got %v, want InvalidArgument", st.Code())
+			}
+		})
 	}
 }
 
@@ -309,18 +404,59 @@ func TestQueryNodes_ACLPostFilter(t *testing.T) {
 	}
 }
 
-// TestQueryNodes_InlinedOperatorRejected pins the parity-fix for the
-// legacy Python-SDK shape: Op=EQ, Value=Struct{"$gte": …}. The Python
-// servicer normalises this into a $gte operator dict; the Go Wave-2 cut
-// only supports EQ-as-equality and surfaces the inlined operator as
-// INVALID_ARGUMENT. Once the queryfilter package lands (W1.10) this
-// branch flips to a happy-path range query.
-func TestQueryNodes_InlinedOperatorRejected(t *testing.T) {
+// TestQueryNodes_InlinedOperator pins the inlined-operator shape: a
+// Struct value carrying ``$gte`` / ``$lt`` / ... keys fans into one
+// store filter per inlined entry. This is the wire shape the Python
+// SDK has historically emitted; issue #501 wires the server to accept
+// it natively.
+func TestQueryNodes_InlinedOperator(t *testing.T) {
+	t.Parallel()
+	f := newQueryNodesFixture(t)
+	f.seedNode("n1", "user:alice", "a@x", 10)
+	f.seedNode("n2", "user:alice", "b@x", 20)
+	f.seedNode("n3", "user:alice", "c@x", 30)
+
+	inlined, err := structpb.NewStruct(map[string]any{
+		"$gte": float64(15),
+		"$lt":  float64(30),
+	})
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+
+	resp, err := f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
+		TypeId:  1,
+		OrderBy: "node_id",
+		Filters: []*pb.FieldFilter{
+			{
+				Field: "age",
+				Op:    pb.FilterOp_EQ,
+				Value: structpb.NewStructValue(inlined),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if len(resp.GetNodes()) != 1 || resp.GetNodes()[0].GetNodeId() != "n2" {
+		ids := make([]string, len(resp.GetNodes()))
+		for i, n := range resp.GetNodes() {
+			ids[i] = n.GetNodeId()
+		}
+		t.Fatalf("got %v, want [n2]", ids)
+	}
+}
+
+// TestQueryNodes_InlinedOperatorUnknownRejected pins that the inlined
+// shape still rejects operators outside the Eq/Ne/Lt/Le/Gt/Ge set —
+// the same INVALID_ARGUMENT path as ``$nin`` / ``$between``.
+func TestQueryNodes_InlinedOperatorUnknownRejected(t *testing.T) {
 	t.Parallel()
 	f := newQueryNodesFixture(t)
 	f.seedNode("n1", "user:alice", "a@x", 10)
 
-	inlined, err := structpb.NewStruct(map[string]any{"$gte": float64(5)})
+	inlined, err := structpb.NewStruct(map[string]any{"$nin": float64(5)})
 	if err != nil {
 		t.Fatalf("structpb.NewStruct: %v", err)
 	}
@@ -337,7 +473,7 @@ func TestQueryNodes_InlinedOperatorRejected(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Fatalf("expected INVALID_ARGUMENT for inlined operator, got nil")
+		t.Fatalf("expected INVALID_ARGUMENT for unsupported inlined op, got nil")
 	}
 	st, ok := status.FromError(err)
 	if !ok {

--- a/server/go/internal/store/nodes.go
+++ b/server/go/internal/store/nodes.go
@@ -205,6 +205,55 @@ func (s *CanonicalStore) GetNodes(ctx context.Context, tenantID string, nodeIDs 
 	return nodes, missing, nil
 }
 
+// QueryFilterOp is the comparison operator carried by a [QueryFilter].
+// The values map 1:1 to SQL comparison operators on a
+// ``json_extract(payload_json, '$."<field_id>"')`` expression.
+type QueryFilterOp uint8
+
+const (
+	// QueryFilterEq compiles to ``=``. The default when an operator
+	// is unset.
+	QueryFilterEq QueryFilterOp = iota
+	// QueryFilterNe compiles to ``<>``. Cannot use a B-tree index
+	// — forces a scan over the type's rows.
+	QueryFilterNe
+	// QueryFilterLt compiles to ``<``.
+	QueryFilterLt
+	// QueryFilterLe compiles to ``<=``.
+	QueryFilterLe
+	// QueryFilterGt compiles to ``>``.
+	QueryFilterGt
+	// QueryFilterGe compiles to ``>=``.
+	QueryFilterGe
+)
+
+// sqlOp returns the SQL operator for the receiver. Defaults to ``=``.
+func (op QueryFilterOp) sqlOp() string {
+	switch op {
+	case QueryFilterNe:
+		return "<>"
+	case QueryFilterLt:
+		return "<"
+	case QueryFilterLe:
+		return "<="
+	case QueryFilterGt:
+		return ">"
+	case QueryFilterGe:
+		return ">="
+	default:
+		return "="
+	}
+}
+
+// QueryFilter is one AND-ed predicate evaluated by [CanonicalStore.QueryNodes].
+// FieldID is the on-disk payload field id (CLAUDE.md invariant #6);
+// Op is the comparison operator; Value is bound as a SQLite parameter.
+type QueryFilter struct {
+	FieldID uint32
+	Op      QueryFilterOp
+	Value   any
+}
+
 // QueryNodesArgs is the input to QueryNodes. Mirrors
 // canonical_store.py:_sync_query_nodes (2394) signature minus the
 // MongoDB filter (deferred to W1.10 query_filter port).
@@ -212,15 +261,19 @@ type QueryNodesArgs struct {
 	TenantID string
 	TypeID   int32
 	// EqualityFilters apply ``json_extract(payload_json, '$."<field_id>"') = ?``
-	// for each entry. Field ids and equality-only filters are the
-	// minimum surface needed by Wave 2 read handlers; the full
-	// MongoDB-operator allow-list lives in W1.10 (see
-	// docs/go-port/rpcs/QueryNodes.md).
+	// for each entry. Equality-only — kept for backwards compatibility
+	// with existing call sites that only need the equality shape.
 	EqualityFilters map[uint32]any
-	OrderBy         string // one of {"created_at","updated_at","node_id","type_id"}; default created_at
-	Descending      bool
-	Limit           int
-	Offset          int
+	// Filters carries comparison predicates (Eq/Ne/Lt/Le/Gt/Ge). All
+	// filters are AND-ed together, and AND-ed with EqualityFilters when
+	// both are supplied. Multiple filters on the same field are
+	// permitted (a range is expressed as two filters: ``x >= lo`` AND
+	// ``x < hi``). See issue #501.
+	Filters    []QueryFilter
+	OrderBy    string // one of {"created_at","updated_at","node_id","type_id"}; default created_at
+	Descending bool
+	Limit      int
+	Offset     int
 }
 
 // QueryNodes returns up to args.Limit nodes of args.TypeID, optionally
@@ -254,6 +307,12 @@ func (s *CanonicalStore) QueryNodes(ctx context.Context, args QueryNodesArgs) ([
 			`json_extract(payload_json, '$."%d"') = ?`, fid,
 		))
 		params = append(params, val)
+	}
+	for _, f := range args.Filters {
+		whereParts = append(whereParts, fmt.Sprintf(
+			`json_extract(payload_json, '$."%d"') %s ?`, f.FieldID, f.Op.sqlOp(),
+		))
+		params = append(params, f.Value)
 	}
 	params = append(params, limit, args.Offset)
 

--- a/server/go/internal/store/nodes_query_test.go
+++ b/server/go/internal/store/nodes_query_test.go
@@ -1,0 +1,204 @@
+// Unit tests for the comparison operators on QueryNodes (issue #501).
+// The handler-level translation is covered in internal/api; this file
+// pins the SQL-emit / scan path at the store layer.
+
+package store_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// seedRangeNodes opens a fresh tenant, registers a query index on
+// field_id 2 (the ``age`` field used by the tests below), and inserts
+// the supplied (id, age) pairs as type_id=1 nodes.
+func seedRangeNodes(t *testing.T, cs *store.CanonicalStore, rows map[string]int64) {
+	t.Helper()
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if err := cs.EnsureQueryIndex(ctx, "t1", 1, []uint32{2}); err != nil {
+		t.Fatalf("EnsureQueryIndex: %v", err)
+	}
+	for id, age := range rows {
+		if _, err := cs.CreateNodeRaw(ctx, "t1", store.NodeInput{
+			NodeID:     id,
+			TypeID:     1,
+			OwnerActor: "u",
+			Payload:    map[string]any{"1": "x", "2": age},
+		}); err != nil {
+			t.Fatalf("CreateNodeRaw %s: %v", id, err)
+		}
+	}
+}
+
+func ids(nodes []*store.Node) []string {
+	out := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, n.NodeID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestQueryNodes_ComparisonOperators exercises each operator on the
+// indexed ``age`` field. Subtests run sequentially because they share
+// one tenant.
+func TestQueryNodes_ComparisonOperators(t *testing.T) {
+	cs := newStore(t)
+	seedRangeNodes(t, cs, map[string]int64{"a": 10, "b": 20, "c": 30})
+
+	cases := []struct {
+		name    string
+		op      store.QueryFilterOp
+		value   any
+		wantIDs []string
+	}{
+		{"eq", store.QueryFilterEq, int64(20), []string{"b"}},
+		{"ne", store.QueryFilterNe, int64(20), []string{"a", "c"}},
+		{"lt", store.QueryFilterLt, int64(20), []string{"a"}},
+		{"le", store.QueryFilterLe, int64(20), []string{"a", "b"}},
+		{"gt", store.QueryFilterGt, int64(20), []string{"c"}},
+		{"ge", store.QueryFilterGe, int64(20), []string{"b", "c"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cs.QueryNodes(context.Background(), store.QueryNodesArgs{
+				TenantID: "t1",
+				TypeID:   1,
+				Filters: []store.QueryFilter{
+					{FieldID: 2, Op: tc.op, Value: tc.value},
+				},
+				Limit: 100,
+			})
+			if err != nil {
+				t.Fatalf("QueryNodes: %v", err)
+			}
+			gotIDs := ids(got)
+			if len(gotIDs) != len(tc.wantIDs) {
+				t.Fatalf("got %v, want %v", gotIDs, tc.wantIDs)
+			}
+			for i := range tc.wantIDs {
+				if gotIDs[i] != tc.wantIDs[i] {
+					t.Fatalf("got %v, want %v", gotIDs, tc.wantIDs)
+				}
+			}
+		})
+	}
+}
+
+// TestQueryNodes_TwoFiltersANDed pins the "all filters AND-ed"
+// contract: ``age >= 15 AND age < 30`` returns the in-range subset.
+func TestQueryNodes_TwoFiltersANDed(t *testing.T) {
+	cs := newStore(t)
+	seedRangeNodes(t, cs, map[string]int64{"a": 10, "b": 20, "c": 30})
+	got, err := cs.QueryNodes(context.Background(), store.QueryNodesArgs{
+		TenantID: "t1",
+		TypeID:   1,
+		Filters: []store.QueryFilter{
+			{FieldID: 2, Op: store.QueryFilterGe, Value: int64(15)},
+			{FieldID: 2, Op: store.QueryFilterLt, Value: int64(30)},
+		},
+		Limit: 100,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if g := ids(got); len(g) != 1 || g[0] != "b" {
+		t.Fatalf("got %v, want [b]", g)
+	}
+}
+
+// TestQueryNodes_FilterPlusEqualityFilters pins that the legacy
+// EqualityFilters map AND-s correctly with the new Filters list. The
+// existing equality call shape must keep working unchanged.
+func TestQueryNodes_FilterPlusEqualityFilters(t *testing.T) {
+	cs := newStore(t)
+	seedRangeNodes(t, cs, map[string]int64{"a": 10, "b": 20, "c": 30})
+	got, err := cs.QueryNodes(context.Background(), store.QueryNodesArgs{
+		TenantID:        "t1",
+		TypeID:          1,
+		EqualityFilters: map[uint32]any{1: "x"}, // matches every row
+		Filters: []store.QueryFilter{
+			{FieldID: 2, Op: store.QueryFilterLe, Value: int64(20)},
+		},
+		Limit: 100,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	want := []string{"a", "b"}
+	if g := ids(got); len(g) != 2 || g[0] != want[0] || g[1] != want[1] {
+		t.Fatalf("got %v, want %v", g, want)
+	}
+}
+
+// TestQueryNodes_UnindexedFieldStillWorks pins that range queries on
+// an unindexed payload field still return the correct rows — the SQL
+// just falls back to a scan rather than the expression index. This
+// matches the documented contract: ``indexed: true`` is an optimisation,
+// not a correctness requirement.
+func TestQueryNodes_UnindexedFieldStillWorks(t *testing.T) {
+	cs := newStore(t)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	// NOTE: no EnsureQueryIndex — field_id 2 is unindexed here.
+	for id, age := range map[string]int64{"a": 10, "b": 20, "c": 30} {
+		if _, err := cs.CreateNodeRaw(ctx, "t1", store.NodeInput{
+			NodeID:     id,
+			TypeID:     1,
+			OwnerActor: "u",
+			Payload:    map[string]any{"2": age},
+		}); err != nil {
+			t.Fatalf("CreateNodeRaw %s: %v", id, err)
+		}
+	}
+	got, err := cs.QueryNodes(ctx, store.QueryNodesArgs{
+		TenantID: "t1",
+		TypeID:   1,
+		Filters: []store.QueryFilter{
+			{FieldID: 2, Op: store.QueryFilterGt, Value: int64(15)},
+		},
+		Limit: 100,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	want := []string{"b", "c"}
+	if g := ids(got); len(g) != 2 || g[0] != want[0] || g[1] != want[1] {
+		t.Fatalf("got %v, want %v", g, want)
+	}
+}
+
+// TestQueryNodes_LimitBounds pins that Limit caps the result count
+// even when more rows would match the predicate — required for the
+// sweeper "batch of N" pattern that motivated issue #501.
+func TestQueryNodes_LimitBounds(t *testing.T) {
+	cs := newStore(t)
+	rows := map[string]int64{}
+	for i := 0; i < 10; i++ {
+		rows[string(rune('a'+i))] = int64(i)
+	}
+	seedRangeNodes(t, cs, rows)
+	got, err := cs.QueryNodes(context.Background(), store.QueryNodesArgs{
+		TenantID: "t1",
+		TypeID:   1,
+		Filters: []store.QueryFilter{
+			{FieldID: 2, Op: store.QueryFilterLt, Value: int64(100)},
+		},
+		Limit: 3,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+}

--- a/tests/python/integration/test_query_range.py
+++ b/tests/python/integration/test_query_range.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Integration tests for comparison operators on QueryNodes (issue #501).
+
+The Python SDK's typed ``Filter``/``FilterOp`` surface is exercised
+end-to-end against the live Go server. All filters AND-ed, no OR / no
+nesting / no cursor — the v1 cut from the issue.
+
+The contract-seed registry only declares the ``User`` type (id=1) with
+two string fields ``email`` and ``name``. SQLite's TEXT comparison is
+lexicographic, so range operators on ``email`` exercise the same code
+path the integer sweeper use case will hit in production.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import grpc
+import pytest
+from google.protobuf import json_format, struct_pb2
+from grpc import aio as grpc_aio
+
+from entdb_sdk._generated import entdb_pb2 as pb
+from entdb_sdk._generated.entdb_pb2_grpc import EntDBServiceStub
+
+TENANT = "acme"
+ACTOR = "user:alice"
+
+
+def _ctx() -> pb.RequestContext:
+    return pb.RequestContext(tenant_id=TENANT, actor=ACTOR)
+
+
+async def _seed_users(stub: EntDBServiceStub, emails: list[str]) -> None:
+    """Create one User per email via ExecuteAtomic."""
+    ops = []
+    for email in emails:
+        data = struct_pb2.Struct()
+        json_format.ParseDict({"email": email, "name": email.split("@")[0]}, data)
+        ops.append(
+            pb.Operation(
+                create_node=pb.CreateNodeOp(
+                    type_id=1,
+                    id=f"u-{email}",
+                    data=data,
+                )
+            )
+        )
+    req = pb.ExecuteAtomicRequest(
+        context=_ctx(),
+        idempotency_key=f"range-seed-{uuid.uuid4().hex[:8]}",
+        operations=ops,
+        wait_applied=True,
+        wait_timeout_ms=5000,
+    )
+    resp = await stub.ExecuteAtomic(req)
+    assert resp.success, resp.error
+
+
+def _value(v) -> struct_pb2.Value:
+    out = struct_pb2.Value()
+    out.string_value = v
+    return out
+
+
+def _email(n: pb.Node) -> str:
+    # Payload wire format is id-keyed (CLAUDE.md invariant #6 +
+    # tests/python/unit/test_payload_wire_format.py pin); field 1 is
+    # "email" per the contract-seed User type.
+    return n.payload.fields["1"].string_value
+
+
+async def _query_emails(stub: EntDBServiceStub, op: pb.FilterOp, value: str) -> list[str]:
+    resp = await stub.QueryNodes(
+        pb.QueryNodesRequest(
+            context=_ctx(),
+            type_id=1,
+            order_by="node_id",
+            descending=False,
+            limit=100,
+            filters=[pb.FieldFilter(field="email", op=op, value=_value(value))],
+        )
+    )
+    return sorted(_email(n) for n in resp.nodes if _email(n).startswith("rng-"))
+
+
+@pytest.fixture
+async def stub(grpc_endpoint):
+    async with grpc_aio.insecure_channel(grpc_endpoint) as ch:
+        s = EntDBServiceStub(ch)
+        await _seed_users(s, ["rng-a@x", "rng-b@x", "rng-c@x"])
+        yield s
+
+
+async def test_lt(stub) -> None:
+    assert await _query_emails(stub, pb.FilterOp.LT, "rng-b@x") == ["rng-a@x"]
+
+
+async def test_lte(stub) -> None:
+    assert await _query_emails(stub, pb.FilterOp.LTE, "rng-b@x") == ["rng-a@x", "rng-b@x"]
+
+
+async def test_gt(stub) -> None:
+    assert await _query_emails(stub, pb.FilterOp.GT, "rng-b@x") == ["rng-c@x"]
+
+
+async def test_gte(stub) -> None:
+    assert await _query_emails(stub, pb.FilterOp.GTE, "rng-b@x") == ["rng-b@x", "rng-c@x"]
+
+
+async def test_eq(stub) -> None:
+    assert await _query_emails(stub, pb.FilterOp.EQ, "rng-b@x") == ["rng-b@x"]
+
+
+async def test_neq(stub) -> None:
+    assert await _query_emails(stub, pb.FilterOp.NEQ, "rng-b@x") == ["rng-a@x", "rng-c@x"]
+
+
+async def test_and_of_two_filters(stub) -> None:
+    """Half-open range: email >= rng-a@x AND email < rng-c@x."""
+    resp = await stub.QueryNodes(
+        pb.QueryNodesRequest(
+            context=_ctx(),
+            type_id=1,
+            order_by="node_id",
+            descending=False,
+            limit=100,
+            filters=[
+                pb.FieldFilter(field="email", op=pb.FilterOp.GTE, value=_value("rng-a@x")),
+                pb.FieldFilter(field="email", op=pb.FilterOp.LT, value=_value("rng-c@x")),
+            ],
+        )
+    )
+    got = sorted(_email(n) for n in resp.nodes if _email(n).startswith("rng-"))
+    assert got == ["rng-a@x", "rng-b@x"]
+
+
+async def test_limit_bounded(stub) -> None:
+    """Limit caps the result count even when more rows match."""
+    resp = await stub.QueryNodes(
+        pb.QueryNodesRequest(
+            context=_ctx(),
+            type_id=1,
+            order_by="node_id",
+            descending=False,
+            limit=2,
+            filters=[
+                pb.FieldFilter(field="email", op=pb.FilterOp.GTE, value=_value("rng-")),
+            ],
+        )
+    )
+    assert len(resp.nodes) <= 2
+
+
+async def test_contains_rejected(stub) -> None:
+    """CONTAINS is still INVALID_ARGUMENT — issue #501 deferred it."""
+    with pytest.raises(grpc_aio.AioRpcError) as exc:
+        await stub.QueryNodes(
+            pb.QueryNodesRequest(
+                context=_ctx(),
+                type_id=1,
+                filters=[
+                    pb.FieldFilter(
+                        field="email",
+                        op=pb.FilterOp.CONTAINS,
+                        value=_value("alice"),
+                    ),
+                ],
+            )
+        )
+    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT


### PR DESCRIPTION
## Summary

Closes #501. Adds Lt/Le/Gt/Ge/Ne alongside Eq for `QueryNodes` filters, AND-ed together. The wire enum already declared these operators; the server now honours them instead of rejecting non-EQ as `INVALID_ARGUMENT`.

- Server: filter translation in `query_nodes.go`; store-layer SQL emits the right comparison operator per filter. Existing equality call path unchanged.
- SDKs: typed `Filter` / `FilterOp` surface added in both Go (`sdk/go/entdb/filter.go`) and Python (`sdk/python/entdb_sdk/filter.py`); shipped together per project convention.
- Indexing: uses the existing `idx_query_t<type>_f<field>` expression index — SQLite's planner handles range scans on the same `json_extract` expression natively. No new indexing infrastructure.

## Out of scope (per #501 v1 cut)

- OR predicates / nesting, sorting, cursors
- `DeleteWhere` op (deferred to v2)
- New schema annotations

Documented caveat in SDK godoc/docstrings: `Ne` and unindexed-field comparisons force a full scan.

## Test plan

- [x] `cd server/go && go vet ./... && go test ./...`
- [x] `cd sdk/go/entdb && go vet ./... && go test ./...`
- [x] `python -m pytest tests/python/integration/ -q` — 90 passed including new `test_query_range.py` (9 cases: lt/le/gt/ge/eq/ne, AND of two filters, limit-bounded, CONTAINS-still-rejected)
- [x] `uvx ruff@0.15.7 check .`
- [x] `uvx ruff@0.15.7 format --check .`