### PR TITLE
feat(go-rewrite): atomic CreateTenant + tenant onboarding deploy story

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,13 +5,14 @@ EntDB is a production-grade Database-as-a-Service (DBaaS) system designed for mu
 ## Table of Contents
 
 1. [Getting Started](getting-started.md)
-2. [Architecture Overview](architecture.md)
-3. [Schema Evolution](schema-evolution.md)
-4. [Durability Guarantees](durability.md)
-5. [Deployment Guide](deployment.md)
-6. [SDK Reference](sdk-reference.md)
-7. [API Reference](api-reference.md)
-8. [Operations Guide](operations.md)
+2. [Onboarding](onboarding.md)
+3. [Architecture Overview](architecture.md)
+4. [Schema Evolution](schema-evolution.md)
+5. [Durability Guarantees](durability.md)
+6. [Deployment Guide](deployment.md)
+7. [SDK Reference](sdk-reference.md)
+8. [API Reference](api-reference.md)
+9. [Operations Guide](operations.md)
 
 ## Quick Start
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -277,6 +277,18 @@ terraform plan -var="environment=production" -var="image_tag=v1.0.0"
 terraform apply -var="environment=production" -var="image_tag=v1.0.0"
 ```
 
+## Tenant Onboarding
+
+The Go server does not auto-create tenants, users, or memberships —
+every tenant and every actor that performs writes must be onboarded
+explicitly through `Admin.CreateUser` → `Admin.CreateTenant` →
+`Admin.AddTenantMember` from an admin/system caller. Wire your identity
+service to call these RPCs whenever a new customer or principal needs
+to be provisioned.
+
+See [Onboarding](onboarding.md) for the worked example, the admin-actor
+production wiring (OAuth/API-key/session), and the idempotency contract.
+
 ## Container Image
 
 ### Build and Push

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,7 +93,42 @@ MemberOf = EdgeTypeDef(
 )
 ```
 
-### 4. Connect and Create Data
+### 4. Onboard the Tenant and User
+
+EntDB does not auto-create tenants or users — every tenant and every
+actor must be registered through admin RPCs before data-plane calls
+will succeed. See [Onboarding](onboarding.md) for the full contract.
+The minimum bring-up is three calls:
+
+```python
+import asyncio
+from entdb_sdk import DbClient
+
+async def onboard():
+    admin = DbClient(
+        endpoint="localhost:50051",
+        tenant_id="_admin",
+        actor="system:admin",
+    )
+    await admin.connect()
+
+    await admin.create_user(
+        user_id="admin", email="admin@example.com", name="Admin",
+        actor="system:admin",
+    )
+    await admin.create_tenant(
+        tenant_id="my_company", name="My Company", actor="system:admin",
+    )
+    await admin.add_tenant_member(
+        tenant_id="my_company", user_id="admin", role="member",
+        actor="system:admin",
+    )
+    await admin.close()
+
+asyncio.run(onboard())
+```
+
+### 5. Connect and Create Data
 
 ```python
 import asyncio
@@ -137,7 +172,7 @@ async def main():
 asyncio.run(main())
 ```
 
-### 5. Verify in Redpanda Console
+### 6. Verify in Redpanda Console
 
 Open http://localhost:8081 to see events in the WAL stream.
 
@@ -167,6 +202,7 @@ my-app/
 
 ## Next Steps
 
+- [Onboarding](onboarding.md) - Tenant, user, and membership setup
 - [Schema Evolution](schema-evolution.md) - Learn about safe schema changes
 - [Durability Guarantees](durability.md) - Understand the durability model
 - [SDK Reference](sdk-reference.md) - Complete SDK documentation

--- a/docs/go-port/rpcs/CreateTenant.md
+++ b/docs/go-port/rpcs/CreateTenant.md
@@ -222,12 +222,17 @@ each individual step is independently idempotent.
   (b) Document `global_store.db` as a non-WAL control-plane and rely on
       filesystem snapshots for DR. Risk: divergence between control-plane
       DBs across regions.
-- **Non-atomic three-step write.** Crash between `create_tenant`,
-  `initialize_tenant`, and `add_member` leaves an orphan registry row, an
-  orphan SQLite file, or a tenant with no owner. Filesystem ops are
-  particularly risky: an SQLite file half-created is invalid. Mitigation:
-  WAL-driven applier with idempotent steps; or a startup self-heal pass
-  that completes interrupted creations.
+- **Non-atomic three-step write.** *Closed in the Go port (post Phase
+  4D).* The registry row and the owner-membership row are now written
+  in a single SQLite transaction via
+  `globalstore.CreateTenantWithOwner` (see
+  `server/go/internal/globalstore/tenants.go`), so a crash between
+  those two steps cannot leave an orphan tenant. The per-tenant SQLite
+  file is still created lazily on first data-plane use and is
+  independently idempotent (open-or-create), so no `initialize_tenant`
+  step exists at create time. The Python-parity carve-out comment in
+  `server/go/internal/api/create_tenant.go` was removed alongside this
+  change.
 - **Replay determinism for filesystem init.** If `initialize_tenant` is
   driven by the `Applier` on WAL replay across a fresh disk, the SQLite
   file MUST end up at the same path with the same schema version. Risk:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,227 @@
+# Tenant & User Onboarding
+
+EntDB does **not** auto-create tenants, users, or memberships on first
+use. Every tenant and every actor that performs writes must be onboarded
+explicitly via three admin RPCs before any data-plane RPC will succeed.
+
+This is a deliberate change from pre-v1.12 behavior — the old Python
+server implicitly registered tenants on first write, which was a
+multi-tenant abuse vector and made auditability impossible. The Go
+server (v1.12+, see [`docs/decisions/python-server-retired.md`][retired])
+requires explicit onboarding.
+
+[retired]: decisions/python-server-retired.md
+
+## The three admin RPCs
+
+A new actor on a new tenant takes three calls, in this order, from an
+admin/system caller:
+
+| # | RPC | What it creates | Idempotent? |
+|---|-----|-----------------|-------------|
+| 1 | `Admin.CreateUser` | Global `users` row keyed by `user_id` (also unique by email) | Returns `ALREADY_EXISTS` |
+| 2 | `Admin.CreateTenant` | `tenant_registry` row + caller as `owner` in `tenant_members`, atomic | Returns `ALREADY_EXISTS` |
+| 3 | `Admin.AddTenantMember` | `tenant_members` row binding the user to the tenant with a role | Returns `ALREADY_EXISTS` |
+
+After all three land, the user (as `user:<user_id>`) can perform any
+data-plane RPC on that tenant subject to ACL grants. Skip any one of
+them and the data-plane returns `PERMISSION_DENIED` or `NOT_FOUND`.
+
+### Why three, not one
+
+The triple is intentional: a user can belong to multiple tenants, a
+tenant can have multiple users, and the global `users` row is the place
+email-uniqueness is enforced. Step 2 atomically attaches the **creator**
+as the first owner (you cannot bootstrap a tenant without an owner — the
+membership row is required for any subsequent admin operation on that
+tenant); step 3 is for every additional user.
+
+## Worked examples
+
+### Python SDK
+
+```python
+import asyncio
+from entdb_sdk import DbClient
+
+async def onboard():
+    # Connect as a control-plane caller. The `actor` here is the
+    # default for subsequent data-plane calls; admin RPCs take their
+    # own `actor=` kwarg.
+    admin_client = DbClient(
+        endpoint="entdb.internal:50051",
+        tenant_id="_admin",          # placeholder; admin RPCs ignore it
+        actor="system:admin",
+    )
+    await admin_client.connect()
+
+    # 1. Register the user globally.
+    await admin_client.create_user(
+        user_id="alice",
+        email="alice@acme.test",
+        name="Alice",
+        actor="system:admin",
+    )
+
+    # 2. Create the tenant. The caller (system:admin) becomes the
+    #    first owner atomically — the registry row and the owner
+    #    membership row land in a single transaction, so a crashed
+    #    create cannot leave an orphan tenant.
+    await admin_client.create_tenant(
+        tenant_id="acme",
+        name="Acme Corp",
+        region="us-east-1",
+        actor="system:admin",
+    )
+
+    # 3. Bind the user to the tenant as a member.
+    await admin_client.add_tenant_member(
+        tenant_id="acme",
+        user_id="alice",
+        role="member",          # or "admin" / "viewer"
+        actor="system:admin",
+    )
+
+    await admin_client.close()
+
+asyncio.run(onboard())
+```
+
+### Go SDK
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/elloloop/tenant-shard-db/sdk/go/entdb"
+)
+
+func main() {
+    ctx := context.Background()
+    client, err := entdb.NewClient("entdb.internal:50051")
+    if err != nil {
+        log.Fatal(err)
+    }
+    if err := client.Connect(ctx); err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close()
+
+    admin := client.Admin()
+
+    // 1. Register the user globally.
+    if _, err := admin.CreateUser(ctx,
+        "system:admin", "alice", "alice@acme.test", "Alice",
+    ); err != nil {
+        log.Fatal(err)
+    }
+
+    // 2. Create the tenant (caller becomes owner atomically).
+    if _, err := admin.CreateTenant(ctx,
+        "system:admin", "acme", "Acme Corp",
+        entdb.WithRegion("us-east-1"),
+    ); err != nil {
+        log.Fatal(err)
+    }
+
+    // 3. Add the user as a member of the tenant.
+    if err := admin.AddTenantMember(ctx,
+        "system:admin", "acme", "alice", "member",
+    ); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+## Admin/system actors in production
+
+The trusted-actor interceptor (`server/go/internal/auth/`) recognises
+three privileged actor prefixes that bypass the per-tenant membership
+check:
+
+- `admin:<id>` — operator/admin identity
+- `system:<service>` — internal service identity (e.g. `system:provisioner`)
+- `__system__` — bootstrap/replay actor (never legitimate on the wire)
+
+Onboarding RPCs require one of these. How a caller *obtains* such an
+identity in production depends on the credential carrier configured on
+the interceptor (in priority order):
+
+1. **OAuth/OIDC bearer token** — `authorization: Bearer <jwt>`. The
+   `sub` claim becomes the verified actor. To grant admin, mint a token
+   with `sub: "system:provisioner"` (or `admin:root`). Any prefix the
+   verifier accepts is honored verbatim — namespace your IdP-issued
+   admin tokens so they cannot collide with regular user `sub`s.
+2. **API key** — `x-api-key: <secret>`. The key's `name` becomes the
+   verified actor. Provision API keys named `system:provisioner` or
+   `admin:onboarder` and treat them as control-plane credentials.
+3. **Session token** — `x-session-token: <token>`. The session's
+   `user_id` becomes the verified actor. Operator consoles typically
+   use this path; mint admin sessions only from a hardened admin UI.
+
+The wire-level `actor` field in every RPC request is **untrusted**: the
+trusted-actor interceptor's verified identity always wins. A user
+authenticated as `user:alice` who sets `actor: "system:admin"` in the
+request body is rejected with `PERMISSION_DENIED`. See
+[`docs/go-port/shared/auth-interceptor.md`][auth] for the full contract.
+
+[auth]: go-port/shared/auth-interceptor.md
+
+### Recommended production wiring
+
+For a control-plane integration (identity service onboarding new
+customers):
+
+- Provision an API key named `system:provisioner` and store it in your
+  secrets manager.
+- Have the identity service inject `x-api-key: <secret>` on every
+  EntDB admin call.
+- Bind EntDB to a private subnet so the admin RPCs are not reachable
+  from public networks; if they must be exposed, gate them behind a
+  separate listener with stricter network policy.
+
+For local development, the no-auth fallback applies: if no interceptor
+is configured (or no credentials are sent), the server trusts the wire
+`actor` field. **Production servers MUST run the auth interceptor** —
+without it, every caller can claim `system:admin`.
+
+## Idempotency & retry
+
+All three onboarding RPCs are safe to retry:
+
+- **`CreateUser`** — duplicate `user_id` (or duplicate `email`) returns
+  `ALREADY_EXISTS`. Callers can treat this as success.
+- **`CreateTenant`** — duplicate `tenant_id` returns `ALREADY_EXISTS`.
+  The registry row and owner membership are inserted in a single SQLite
+  transaction (`globalstore.CreateTenantWithOwner`), so a crashed call
+  cannot leave an orphan tenant; either both land or neither does.
+- **`AddTenantMember`** — duplicate `(tenant_id, user_id)` returns
+  `ALREADY_EXISTS`. Role changes go through `Admin.ChangeMemberRole`,
+  not a re-add.
+
+A typical onboarding driver wraps each call with "succeed-or-already-
+exists" handling and proceeds to the next step on either outcome.
+
+## Where things live
+
+- Admin RPC handlers: `server/go/internal/api/create_user.go`,
+  `create_tenant.go`, `add_tenant_member.go`.
+- Atomic registry+owner write:
+  `server/go/internal/globalstore/tenants.go` (`CreateTenantWithOwner`).
+- Tenant gate (rejects RPCs on unknown tenants):
+  `server/go/internal/tenant/check.go`, wired via
+  `Server.checkTenant` in `server/go/internal/api/server.go`.
+- Trusted-actor resolution: `server/go/internal/auth/authoritative.go`.
+
+## Common errors
+
+| You see | Likely cause |
+|---|---|
+| `NOT_FOUND: tenant "acme" not found` on a data-plane RPC | Step 2 (`CreateTenant`) was never run for this tenant |
+| `PERMISSION_DENIED: ... is not a member of "acme"` | Step 3 (`AddTenantMember`) was never run for this user/tenant |
+| `PERMISSION_DENIED: CreateTenant requires admin or system actor` | Verified actor on the request is `user:<...>`, not `admin:` / `system:` — check your auth interceptor |
+| `ALREADY_EXISTS: tenant "acme" already exists` | Idempotent retry of step 2; safe to swallow and proceed |
+| `ALREADY_EXISTS: user "alice@acme.test" already exists` | Idempotent retry of step 1; safe to swallow and proceed |

--- a/server/go/internal/api/create_tenant.go
+++ b/server/go/internal/api/create_tenant.go
@@ -22,22 +22,17 @@ import (
 // tenant-registry control plane): the write goes directly into the
 // globalstore SQLite without a WAL append. tenant_registry is a
 // non-WAL-backed control plane in this port; the per-tenant SQLite file
-// is created lazily on first data-plane use, NOT here. Wave 2 deliberately
-// keeps this carve-out so the bring-up path doesn't depend on the WAL
-// applier landing first; a follow-up may either (a) introduce a
-// TenantCreated WAL op or (b) document the control plane formally.
+// is created lazily on first data-plane use, NOT here.
 //
-// Three-step shape (non-atomic, mirrors Python):
+// Two-step shape:
 //
 //  1. validate (admin gate, non-empty fields)
-//  2. globalstore.CreateTenant (registry row + region pin column)
-//  3. globalstore.AddTenantMember (creator → "owner")
+//  2. globalstore.CreateTenantWithOwner (registry row + owner member,
+//     atomic in a single SQLite transaction)
 //
-// A crash between steps 2 and 3 leaves an orphan tenant with no owner.
-// This is the Python parity hazard flagged in the spec under "Open
-// questions / risks: Non-atomic three-step write" — preserved here on
-// purpose so the contract matches; do NOT wrap these in a single SQLite
-// transaction without updating the spec and Python source together.
+// The registry + member writes are now atomic — the Python-parity orphan-
+// tenant hazard (crash between the registry INSERT and the membership
+// INSERT) was closed when the Python source was retired in Phase 4D.
 //
 // Auth contract:
 //   - Wire actor (req.Actor) is UNTRUSTED. The trusted principal is
@@ -100,11 +95,11 @@ func (s *Server) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) 
 		region = s.region
 	}
 
-	// Step 2: globalstore write. UNIQUE on tenant_registry.tenant_id
-	// surfaces as ALREADY_EXISTS; the handler maps that to a typed gRPC
-	// error (NOT the Python success=false channel — Wave-2 decision per
-	// task spec, gives SDKs a real status code to dispatch on).
-	tenant, err := s.global.CreateTenant(ctx, req.GetTenantId(), req.GetName(), region)
+	// Step 2: atomic globalstore write. The registry row and the owner
+	// membership row land (or don't) in a single SQLite transaction.
+	// UNIQUE on tenant_registry.tenant_id surfaces as ALREADY_EXISTS;
+	// the handler maps that to a typed gRPC error.
+	tenant, err := s.global.CreateTenantWithOwner(ctx, req.GetTenantId(), req.GetName(), region, principal.ID())
 	if err != nil {
 		resultStatus = "error"
 		if errors.Is(err, errs.ErrAlreadyExists) {
@@ -112,18 +107,6 @@ func (s *Server) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) 
 		}
 		return nil, errs.Errorf(codes.Internal,
 			"create_tenant: %v", err)
-	}
-
-	// Step 3: record the creator as owner. Idempotent on retry — an
-	// already-existing membership is swallowed so a crash-then-retry
-	// after step 2 succeeds without surfacing a spurious error. The
-	// step is non-atomic with step 2 by design (see top-of-file note).
-	if err := s.global.AddTenantMember(ctx, tenant.TenantID, principal.ID(), "owner"); err != nil {
-		if !errors.Is(err, errs.ErrAlreadyExists) {
-			resultStatus = "error"
-			return nil, errs.Errorf(codes.Internal,
-				"add_tenant_member: %v", err)
-		}
 	}
 
 	return &pb.CreateTenantResponse{

--- a/server/go/internal/globalstore/globalstore_test.go
+++ b/server/go/internal/globalstore/globalstore_test.go
@@ -196,6 +196,41 @@ func TestTenantIdempotentCreate(t *testing.T) {
 	}
 }
 
+// TestCreateTenantWithOwner_Atomic verifies the registry row + owner
+// membership row land in a single transaction: success leaves both, and
+// a duplicate tenant_id leaves the prior owner intact without mutating
+// state. Closes the Python-parity orphan-tenant hazard.
+func TestCreateTenantWithOwner_Atomic(t *testing.T) {
+	gs := newStore(t, nil)
+	ctx := context.Background()
+
+	tn, err := gs.CreateTenantWithOwner(ctx, "acme", "Acme", "", "root")
+	if err != nil {
+		t.Fatalf("CreateTenantWithOwner: %v", err)
+	}
+	if tn.Region != globalstore.DefaultRegion {
+		t.Fatalf("region: got %q, want %q", tn.Region, globalstore.DefaultRegion)
+	}
+	members, err := gs.GetTenantMembers(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetTenantMembers: %v", err)
+	}
+	if len(members) != 1 || members[0].UserID != "root" || members[0].Role != "owner" {
+		t.Fatalf("members: got %+v, want [{root owner}]", members)
+	}
+
+	// Duplicate tenant_id → ALREADY_EXISTS, and the prior owner row is
+	// unchanged (no second membership row appended).
+	_, err = gs.CreateTenantWithOwner(ctx, "acme", "Acme2", "", "intruder")
+	if errs.Code(err) != codes.AlreadyExists {
+		t.Fatalf("dup: code=%v err=%v", errs.Code(err), err)
+	}
+	members, _ = gs.GetTenantMembers(ctx, "acme")
+	if len(members) != 1 || members[0].UserID != "root" {
+		t.Fatalf("members after dup: got %+v, want unchanged [{root owner}]", members)
+	}
+}
+
 // TestLegalHoldStatus toggles tenant_registry.status between active and
 // legal_hold.
 func TestLegalHoldStatus(t *testing.T) {

--- a/server/go/internal/globalstore/tenants.go
+++ b/server/go/internal/globalstore/tenants.go
@@ -51,6 +51,56 @@ func (g *GlobalStore) CreateTenant(ctx context.Context, tenantID, name, region s
 	}, nil
 }
 
+// CreateTenantWithOwner atomically inserts the tenant_registry row and
+// the creator's tenant_members owner row in a single SQLite transaction.
+// Either both land or neither does — the orphan-tenant hazard that the
+// Python parity port carried (registry row written without an owner if
+// the process crashed between the two INSERTs) is closed here.
+//
+// Returns ErrAlreadyExists on duplicate tenant_id; the membership insert
+// is not attempted in that case. Empty `region` is filled with
+// DefaultRegion.
+func (g *GlobalStore) CreateTenantWithOwner(ctx context.Context, tenantID, name, region, ownerUserID string) (*Tenant, error) {
+	if region == "" {
+		region = DefaultRegion
+	}
+	tx, err := g.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("globalstore: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := g.now()
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO tenant_registry (tenant_id, name, status, created_at, region)
+		 VALUES (?, ?, 'active', ?, ?)`,
+		tenantID, name, now, region,
+	); err != nil {
+		if isUniqueViolation(err) {
+			return nil, errs.Errorf(codes.AlreadyExists,
+				"globalstore: tenant %q already exists", tenantID)
+		}
+		return nil, fmt.Errorf("globalstore: create tenant %q: %w", tenantID, err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO tenant_members (tenant_id, user_id, role, joined_at)
+		 VALUES (?, ?, 'owner', ?)`,
+		tenantID, ownerUserID, now,
+	); err != nil {
+		return nil, fmt.Errorf("globalstore: add owner member (%q,%q): %w", tenantID, ownerUserID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("globalstore: commit create tenant %q: %w", tenantID, err)
+	}
+	return &Tenant{
+		TenantID:  tenantID,
+		Name:      name,
+		Status:    "active",
+		CreatedAt: now,
+		Region:    region,
+	}, nil
+}
+
 // GetTenant returns the row, or (nil, nil) if not present.
 func (g *GlobalStore) GetTenant(ctx context.Context, tenantID string) (*Tenant, error) {
 	row := g.db.QueryRowContext(ctx,


### PR DESCRIPTION
## Summary

Closes the Python-parity orphan-tenant hazard and documents the
production onboarding contract that the v1.12 / Phase 4D server now
requires.

- `globalstore.CreateTenantWithOwner`: registry row + owner-membership
  row land in a single SQLite transaction. The two-step shape that
  could orphan a tenant on crash is gone.
- `api.CreateTenant` uses the atomic helper; the dead step-3
  `AddTenantMember` call and the "non-atomic by design" carve-out are
  removed.
- New `docs/onboarding.md` covering the three-RPC flow
  (`Admin.CreateUser` → `Admin.CreateTenant` → `Admin.AddTenantMember`)
  with Python + Go SDK worked examples, admin-actor production wiring
  (OAuth bearer / API key / session-token paths), idempotency
  contract, and a common-errors table.
- `docs/getting-started.md`, `docs/deployment.md`, `docs/README.md`:
  cross-link onboarding.
- `docs/go-port/rpcs/CreateTenant.md`: mark the non-atomic-write open
  question as closed.

## Test plan

- [x] `go vet ./... && go test ./...` (server + Go SDK) green
- [x] `python -m pytest tests/python/integration/ -q` — 79/79
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` clean
- [x] New `TestCreateTenantWithOwner_Atomic` in
      `internal/globalstore/globalstore_test.go` covers the duplicate
      case (no membership mutation on `ALREADY_EXISTS`)
- [ ] CI green on the PR