### PR TITLE
fix(sdk,server): pin id-keyed wire payloads end-to-end (CLAUDE.md invariant #6)

### DIFF
--- a/docs/go-port/shared/payload-translation.md
+++ b/docs/go-port/shared/payload-translation.md
@@ -104,9 +104,16 @@ against any handler that silently depends on Go map iteration order or
   `schema/types.py:427`.
 - Lookup table built per call: `name → field_id` from `node_type.fields`
   (`field_id_translation.py:107`).
-- **Schema-less mode**: when the registry has no entry for `type_id`, the
-  payload passes through unchanged (`field_id_translation.py:101`). This
-  keeps tests and legacy schema-less tenants working.
+- **Schema-less mode** (Go server, post v1.12.2): when the registry has
+  no entry for `type_id`, only **id-keyed** payloads are accepted. A
+  payload with any name-keyed entry is rejected with
+  `INVALID_ARGUMENT`, since without a schema the server has no
+  name→id mapping. This is the post-fix tightening of the Python-era
+  silent-passthrough — silently dropping or persisting name-keyed
+  fields on a schemaless type violated invariant #6. The SDKs do the
+  name→id translation client-side from the proto descriptor (where
+  `fd.Number()` IS the `field_id` by ADR-006), so the wire is
+  always id-keyed regardless of whether the server has the schema.
 - **Pre-translated keys**: a digit-only string that matches a known
   `field_id` is left alone, allowing typed clients (Go SDK) to send
   pre-translated payloads (`field_id_translation.py:114`).
@@ -217,12 +224,15 @@ Notes:
    2^53. Document the cutoff; reject values outside it on ingress.
 5. **Missing schema (chicken-and-egg on first write).** A tenant's first
    `RegisterSchema` op itself carries no payload, but subsequent ops
-   before the schema is durably applied will hit `get_node_type → nil`
-   and pass through as schema-less. Risk: a row written in this window is
-   stored name-keyed and later re-read against a now-present schema gets
-   the legacy fallback path (`field_id_translation.py:166`). Mitigation:
-   the existing `migrate_payloads_to_field_ids` helper. Go port must
-   provide an equivalent and run it on tenant init.
+   before the schema is durably applied will hit
+   `get_node_type → nil`. Since v1.12.2 the schema-less ingress
+   accepts **only id-keyed payloads** (and rejects any name-keyed
+   entry with `INVALID_ARGUMENT`); the SDK does the name→id
+   translation client-side from the proto descriptor, so the wire
+   is id-keyed regardless of the server's schema state. No
+   migration helper is needed: rows stored during the
+   schema-not-yet-applied window are already id-keyed and remain
+   correct once the schema lands.
 6. **Pre-translated digit keys colliding with names.** If a future schema
    names a field literally `"1"`, the digit-key passthrough heuristic
    (`field_id_translation.py:114`) becomes ambiguous. Document and

--- a/sdk/python/entdb_sdk/_grpc_client.py
+++ b/sdk/python/entdb_sdk/_grpc_client.py
@@ -393,14 +393,61 @@ def _node_from_proto(n: Any, registry: Any = None) -> Node:
     )
 
 
-def _edge_from_proto(e: Any) -> Edge:
-    """Build a user-facing Edge directly from a proto Edge message."""
+def _edge_props_id_to_name(
+    props: dict[str, Any], edge_type_id: int, registry: Any
+) -> dict[str, Any]:
+    """Translate an id-keyed edge props dict to a name-keyed dict.
+
+    Mirrors ``_payload_id_to_name`` for node payloads. Edge props
+    on the wire are id-keyed per CLAUDE.md invariant #6; the SDK
+    re-keys to names using the local registry's
+    :class:`EdgeTypeDef.props` for ergonomic user code.
+
+    Falls back to the raw dict when the registry doesn't know the
+    edge type (schemaless / forward-compat).
+    """
+    if not props:
+        return {}
+    if registry is None or not hasattr(registry, "get_edge_type"):
+        return dict(props)
+    edge_type = registry.get_edge_type(edge_type_id)
+    if edge_type is None:
+        return dict(props)
+    id_to_name: dict[int, str] = {}
+    for p in getattr(edge_type, "props", ()) or ():
+        fid = getattr(p, "field_id", None)
+        fname = getattr(p, "name", None)
+        if fid is not None and fname is not None:
+            id_to_name[int(fid)] = fname
+    out: dict[str, Any] = {}
+    for key, value in props.items():
+        if isinstance(key, str) and key.isdigit():
+            name = id_to_name.get(int(key))
+            out[name if name is not None else key] = value
+        else:
+            out[key] = value
+    return out
+
+
+def _edge_from_proto(e: Any, registry: Any = None) -> Edge:
+    """Build a user-facing Edge directly from a proto Edge message.
+
+    The wire props are id-keyed; the SDK re-keys to names via the
+    supplied registry. When no registry is supplied (or the edge type
+    is not registered) the props pass through unchanged.
+    """
+    raw_props = _struct_to_dict(e.props)
+    props = (
+        _edge_props_id_to_name(raw_props, e.edge_type_id, registry)
+        if registry is not None
+        else raw_props
+    )
     return Edge(
         tenant_id=e.tenant_id,
         edge_type_id=e.edge_type_id,
         from_node_id=e.from_node_id,
         to_node_id=e.to_node_id,
-        props=_struct_to_dict(e.props),
+        props=props,
         created_at=e.created_at,
     )
 
@@ -1278,7 +1325,7 @@ class GrpcClient:
             tenant_id=tenant_id,
         )
 
-        edges = [_edge_from_proto(e) for e in response.edges]
+        edges = [_edge_from_proto(e, self._registry) for e in response.edges]
 
         return edges, response.has_more
 
@@ -1325,7 +1372,7 @@ class GrpcClient:
             tenant_id=tenant_id,
         )
 
-        edges = [_edge_from_proto(e) for e in response.edges]
+        edges = [_edge_from_proto(e, self._registry) for e in response.edges]
 
         return edges, response.has_more
 

--- a/sdk/python/entdb_sdk/client.py
+++ b/sdk/python/entdb_sdk/client.py
@@ -106,12 +106,10 @@ def _proto_payload_from_set_fields(msg: Any) -> dict[str, Any]:
     Uses ``ListFields()`` (which only yields explicitly-set fields)
     so that ``Product(price_cents=1499)`` produces ``{"price_cents":
     1499}`` and not the full set of scalar defaults. This is the
-    exact semantics we want for both create (only the fields the
-    caller intends to set are sent) and update (the patch is exactly
-    the set of fields present on the message). The wire-level
-    translation from field name to field id happens server-side via
-    the schema registry — see CLAUDE.md "Field IDs, not field names,
-    on disk".
+    name-keyed form consumed by the SDK-local ``validate_payload``
+    check; callers re-key to ``field_id``-keyed via ``_names_to_ids``
+    before the payload leaves the SDK boundary, since the wire
+    format is id-keyed per CLAUDE.md invariant #6.
 
     We read scalars directly off the proto message rather than going
     through ``MessageToDict`` so that 64-bit integers stay as Python
@@ -149,6 +147,41 @@ def _proto_payload_from_set_fields(msg: Any) -> dict[str, Any]:
         else:
             out[fd.name] = value
     return out
+
+
+def _names_to_ids(name_to_id: dict[str, int], payload: dict[str, Any]) -> dict[str, Any]:
+    """Re-key a name-keyed payload to id-keyed for the wire.
+
+    Per CLAUDE.md invariant #6 the wire and on-disk storage are keyed
+    by stable numeric ``field_id``. The mapping comes from the proto
+    descriptor (``fd.number`` IS the ``field_id`` by ADR-006) or from
+    the SDK-local ``NodeTypeDef.fields``. Digit-only keys are passed
+    through — they're already id-keyed (e.g. bulk import via
+    ``dynamicpb``).
+
+    Unknown names are dropped silently. In normal flow ``validate_payload``
+    rejects them before this runs, so reaching here with an unknown
+    name means a typed caller bypassed validation deliberately.
+    """
+    out: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(key, str) and key.isdigit():
+            out[key] = value
+            continue
+        fid = name_to_id.get(key)
+        if fid is not None:
+            out[str(fid)] = value
+    return out
+
+
+def _name_to_id_from_proto(descriptor: Any) -> dict[str, int]:
+    """Build ``{field_name: field_number}`` from a proto descriptor."""
+    return {fd.name: fd.number for fd in descriptor.fields}
+
+
+def _name_to_id_from_node_type(node_type: Any) -> dict[str, int]:
+    """Build ``{field_name: field_id}`` from an SDK-local NodeTypeDef."""
+    return {f.name: f.field_id for f in node_type.fields}
 
 
 def _resolve_create_input(
@@ -357,6 +390,12 @@ class Plan:
                 raise UnknownFieldError(field_name, node_type.name, suggestions)
             raise ValidationError("; ".join(errors), errors=errors)
 
+        if _is_proto_message(msg):
+            name_to_id = _name_to_id_from_proto(msg.DESCRIPTOR)
+        else:
+            name_to_id = _name_to_id_from_node_type(node_type)
+        payload = _names_to_ids(name_to_id, payload)
+
         acl_dicts = _acl_entries_to_dicts(acl) if acl else None
 
         op: dict[str, Any] = {
@@ -442,6 +481,7 @@ class Plan:
 
         type_id = _node_type_id_from_descriptor(msg.DESCRIPTOR)
         patch = _proto_payload_from_set_fields(msg)
+        patch = _names_to_ids(_name_to_id_from_proto(msg.DESCRIPTOR), patch)
 
         update_op: dict[str, Any] = {
             "type_id": type_id,
@@ -539,7 +579,9 @@ class Plan:
         }
 
         if props:
-            op["create_edge"]["props"] = props
+            op["create_edge"]["props"] = _names_to_ids(
+                _name_to_id_from_proto(edge_type.DESCRIPTOR), props
+            )
 
         self._operations.append(op)
         return self

--- a/server/go/internal/payload/translate.go
+++ b/server/go/internal/payload/translate.go
@@ -31,20 +31,31 @@ import (
 // id-keyed internal payload representation map[uint32]any. Used on the
 // ingress side of CreateNode / UpdateNode.
 //
-// Behavior (mirrors name_to_id_keys in the Python port):
+// Wire shape (per CLAUDE.md invariant #6):
+// The wire payload is keyed by stringified field_ids ("1", "2", ...).
+// The SDKs do the name→id translation client-side from the proto
+// descriptor (where fd.Number() IS the field_id per ADR-006). Storage
+// and WAL events deal exclusively with id-keyed maps; renames are
+// metadata-only, so storage cannot key on names.
+//
+// Behavior:
 //
 //   - nil / empty s -> empty map (never nil) so downstream JSON
 //     marshalling stays deterministic.
 //   - reg == nil OR nodeTypeName == "" OR registry has no entry for
-//     nodeTypeName -> schema-less passthrough: keys are interpreted
-//     verbatim. Digit-only keys parse to uint32 ids; non-digit keys
-//     are dropped (silently) since the internal map is uint32-keyed.
+//     nodeTypeName -> schema-less ingress: only digit-string keys are
+//     accepted. Name-keyed payloads on an unregistered type are
+//     rejected with INVALID_ARGUMENT (rather than silently dropped)
+//     so the client learns immediately that its SDK is misconfigured
+//     or out of date.
 //   - Schema-aware path:
 //       - Digit-only key matching a known field_id is kept as-is.
-//       - String key matching a field name is translated to its id.
-//       - Unknown name keys are dropped silently (matches Python
-//         contract: ingress is permissive so legacy clients sending
-//         deprecated fields don't break writes).
+//       - String key matching a field name is translated to its id
+//         (back-compat for pre-fix SDKs; new SDKs send id-keyed and
+//         skip this path).
+//       - Unknown name keys are dropped silently (Python parity:
+//         ingress is permissive so legacy clients sending deprecated
+//         fields don't break writes).
 //   - Field-kind coercion (only when schema is known):
 //       - BYTES: structpb has no bytes type; the wire carries base64
 //         strings. Decode to []byte for storage.
@@ -61,15 +72,32 @@ func StructToPayload(reg *schema.Registry, nodeTypeName string, s *structpb.Stru
 		return map[uint32]any{}, nil
 	}
 
-	// Schema-less passthrough: the wire is treated as already id-keyed.
-	// Digit-only keys map to uint32; everything else is dropped.
+	// Schema-less ingress: the wire is required to be id-keyed because
+	// without a registered schema the server has no name→id mapping.
+	// Silently dropping name keys (the prior behavior) caused silent
+	// data loss for SDKs that emitted name-keyed payloads.
 	nt := lookupNodeType(reg, nodeTypeName)
 	if nt == nil {
 		out := make(map[uint32]any, len(s.GetFields()))
+		var firstName string
 		for k, v := range s.GetFields() {
 			if id, ok := parseFieldID(k); ok {
 				out[id] = v.AsInterface()
+				continue
 			}
+			if firstName == "" {
+				firstName = k
+			}
+		}
+		if firstName != "" {
+			return nil, errs.Errorf(codes.InvalidArgument,
+				"payload for type_id with name %q (not in schema registry) "+
+					"contains name-keyed field %q; wire payload must be "+
+					"id-keyed (e.g. {\"1\": value}). Either register the "+
+					"schema for this type or upgrade the SDK to one that "+
+					"pre-translates names to field_ids client-side "+
+					"(CLAUDE.md invariant #6).",
+				nodeTypeName, firstName)
 		}
 		return out, nil
 	}

--- a/server/go/internal/payload/translate_test.go
+++ b/server/go/internal/payload/translate_test.go
@@ -294,6 +294,60 @@ func TestPayloadToStruct_BytesEncodedAsBase64(t *testing.T) {
 	}
 }
 
+// TestStructToPayload_SchemalessIdKeyedAccepted: name-keyed ingress is
+// rejected on an unregistered type, but id-keyed ingress is accepted
+// and preserved verbatim. This is the schemaless contract: the SDK
+// pre-translates names to field_ids client-side, so the wire is
+// always id-keyed even when the server has no schema for the type.
+func TestStructToPayload_SchemalessIdKeyedAccepted(t *testing.T) {
+	// Empty (but frozen) registry — no types registered.
+	reg := schema.NewRegistry()
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("freeze: %v", err)
+	}
+	s := mustStruct(t, map[string]any{
+		"1": "alice@example.com",
+		"2": "Alice",
+	})
+	got, err := StructToPayload(reg, "Unknown", s)
+	if err != nil {
+		t.Fatalf("StructToPayload(schemaless, id-keyed): %v", err)
+	}
+	if got[1] != "alice@example.com" || got[2] != "Alice" {
+		t.Fatalf("expected id-keyed passthrough, got %v", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(got), got)
+	}
+}
+
+// TestStructToPayload_SchemalessNameKeyedRejected: name-keyed ingress
+// on an unregistered type returns INVALID_ARGUMENT. Without a schema
+// the server has no name→id mapping; silently dropping the keys
+// (the prior behavior) caused silent data loss.
+func TestStructToPayload_SchemalessNameKeyedRejected(t *testing.T) {
+	reg := schema.NewRegistry()
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("freeze: %v", err)
+	}
+	s := mustStruct(t, map[string]any{
+		"email": "alice@example.com",
+		"name":  "Alice",
+	})
+	_, err := StructToPayload(reg, "Unknown", s)
+	if err == nil {
+		t.Fatal("expected INVALID_ARGUMENT, got nil")
+	}
+	if !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("expected InvalidArgument, got %v", err)
+	}
+	// The error message should name the offending field so the SDK author
+	// can locate the bug.
+	if !strings.Contains(err.Error(), "email") && !strings.Contains(err.Error(), "name") {
+		t.Fatalf("error should mention offending field, got: %v", err)
+	}
+}
+
 func TestPayloadToStruct_TimestampInt64IsNumberValue(t *testing.T) {
 	reg := fixtureRegistry(t)
 	got, err := PayloadToStruct(reg, "User", map[uint32]any{6: int64(1715000000000)})
@@ -561,22 +615,34 @@ func TestPayloadJSONToNames_InverseOfStructToPayload(t *testing.T) {
 
 // --- Schema-less ingress -------------------------------------------------
 
+// Schema-less ingress accepts id-keyed payloads (CLAUDE.md invariant #6:
+// the SDKs pre-translate names client-side from the proto descriptor,
+// so the wire is always id-keyed). A mixed payload with even one
+// name key is rejected — that signals a misconfigured or out-of-date
+// SDK and the prior silent-drop behavior caused silent data loss.
 func TestStructToPayload_SchemaLessDigitKeyPassthrough(t *testing.T) {
+	// Pure id-keyed: accepted, passed through verbatim.
 	got, err := StructToPayload(nil, "", mustStruct(t, map[string]any{
+		"1": "id-keyed",
+		"2": "also-id-keyed",
+	}))
+	if err != nil {
+		t.Fatalf("StructToPayload(schema-less, id-keyed): %v", err)
+	}
+	if got[1] != "id-keyed" || got[2] != "also-id-keyed" {
+		t.Fatalf("expected id-keyed passthrough, got %v", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d (%v)", len(got), got)
+	}
+
+	// Mixed payload with a name key: rejected.
+	_, err = StructToPayload(nil, "", mustStruct(t, map[string]any{
 		"1":    "id-keyed",
 		"name": "name-keyed-but-no-schema",
 	}))
-	if err != nil {
-		t.Fatalf("StructToPayload(schema-less): %v", err)
-	}
-	if got[1] != "id-keyed" {
-		t.Fatalf("expected digit passthrough, got %v", got)
-	}
-	if _, ok := got[0]; ok {
-		t.Fatalf("schema-less: name keys should be dropped (no resolver), got %v", got)
-	}
-	if len(got) != 1 {
-		t.Fatalf("expected 1 entry, got %d (%v)", len(got), got)
+	if err == nil || !errors.Is(err, errs.ErrInvalidArgument) {
+		t.Fatalf("expected InvalidArgument for mixed payload, got %v", err)
 	}
 }
 

--- a/tests/python/integration/test_sdk_client.py
+++ b/tests/python/integration/test_sdk_client.py
@@ -95,7 +95,9 @@ class TestPlanBuilder:
         assert "update_node" in op
         assert op["update_node"]["type_id"] == 9001
         assert op["update_node"]["id"] == "node_123"
-        assert op["update_node"]["patch"] == {"name": "Updated Name"}
+        # Patch is id-keyed on the wire per CLAUDE.md invariant #6.
+        # Product.name is field_id 2.
+        assert op["update_node"]["patch"] == {"2": "Updated Name"}
 
     def test_plan_delete_node(self):
         """Plan can delete nodes — type witness is the proto class."""

--- a/tests/python/unit/test_sdk_hierarchical.py
+++ b/tests/python/unit/test_sdk_hierarchical.py
@@ -306,8 +306,9 @@ class TestScopedPlan:
         assert "update_node" in op
         assert op["update_node"]["id"] == "n1"
         # Patch contains only the explicitly-set field — that's the
-        # SDK v0.3 partial-update semantics.
-        assert op["update_node"]["patch"] == {"name": "Updated"}
+        # SDK v0.3 partial-update semantics. Keyed by field_id on the
+        # wire per CLAUDE.md invariant #6; Product.name is field 2.
+        assert op["update_node"]["patch"] == {"2": "Updated"}
 
     def test_scoped_plan_delete(self, proto_client):
         scope = proto_client.tenant("t1").actor("user:bob")

--- a/tests/python/unit/test_sdk_v3_shape.py
+++ b/tests/python/unit/test_sdk_v3_shape.py
@@ -148,7 +148,9 @@ class TestCanonicalFlow:
         await plan2.commit(wait_applied=True)
         last_call = db._grpc.execute_atomic.call_args
         ops = last_call.kwargs["operations"]
-        assert ops[0]["update_node"]["patch"] == {"price_cents": 1499}
+        # Wire patch is id-keyed per CLAUDE.md invariant #6.
+        # Product.price_cents is field_id 3.
+        assert ops[0]["update_node"]["patch"] == {"3": 1499}
         assert ops[0]["update_node"]["type_id"] == 9001
         assert ops[0]["update_node"]["id"] == node_id
 


### PR DESCRIPTION
## Summary

Closes a silent-data-loss regression where the Python SDK emitted
name-keyed payloads on the wire and the Go server's schema-less
ingress silently dropped them on unregistered types. After this PR
both ends are consistent with CLAUDE.md invariant #6: the wire and
on-disk storage are keyed by stable numeric `field_id`, and SDKs do
the name→id translation client-side from the proto descriptor.

### Python SDK
- New `_names_to_ids` helper uses `fd.number` from the proto
  descriptor (which IS the EntDB `field_id` per ADR-006).
- `Plan.create`, `Plan.update`, `Plan.edge_create` now emit id-keyed
  payloads / patches / props on the wire.
- Local validation runs against the name-keyed dict (human-readable
  errors); re-key happens after.

### Go server
- Schema-less ingress (no registry / unregistered type_name) returns
  `INVALID_ARGUMENT` on any name-keyed field instead of silently
  dropping it. The id-keyed path is unchanged.
- Schema-aware ingress is unchanged (back-compat for pre-fix SDKs).

### Why this matters
A real-world Python SDK call against a schema-less tenant on the Go
server would write a node with `payload = {}` — every field silently
gone. The Python 1.10.2 server stored it (violating invariant #6);
the Go 1.12.0/1 server dropped it (invariant-preserving but silent).
This PR fixes both: SDK pre-translates, server rejects unambiguous
name-keyed payloads loudly.

## Test plan
- [x] `go vet ./... && go test ./...` (server + SDK) green
- [x] `python -m pytest tests/python/integration/ tests/python/unit/ -q` — 464 passed
- [x] `uvx ruff@0.15.7 check . && uvx ruff@0.15.7 format --check .` clean
- [x] Two new payload tests pin the schemaless contract
- [ ] CI green on the PR

After merge: tag `v1.12.2` and release.yml publishes the Docker
image, Python SDK, and Go SDK.