### PR TITLE
Fix schema-less entdb-server registry wiring

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -94,25 +95,13 @@ func main() {
 
 	srvOpts := []api.Option{}
 
-	// Schema registry. Populated below when a seed profile selects one
-	// so the cross-impl suites' GetSchema/ExecuteAtomic asserts hold;
-	// left empty for profile=none (production wiring lands in a later
-	// wave once the loader hook is connected to a config source).
-	registry := schema.NewRegistry()
-	switch profile {
-	case "contract":
-		if err := testseed.RegisterContractSchema(registry); err != nil {
-			log.Fatalf("entdb-server: register contract schema: %v", err)
-		}
-	case "e2e":
-		if err := testseed.RegisterE2ESchema(registry); err != nil {
-			log.Fatalf("entdb-server: register e2e schema: %v", err)
-		}
+	registry, err := schemaRegistryForProfile(profile)
+	if err != nil {
+		log.Fatalf("entdb-server: schema registry: %v", err)
 	}
-	if _, err := registry.Freeze(); err != nil {
-		log.Fatalf("entdb-server: freeze registry: %v", err)
+	if registry != nil {
+		srvOpts = append(srvOpts, api.WithSchemaRegistry(registry))
 	}
-	srvOpts = append(srvOpts, api.WithSchemaRegistry(registry))
 
 	canonical, err := store.New(store.Options{RootDir: *dataDir, WALMode: true, Registry: registry})
 	if err != nil {
@@ -280,6 +269,37 @@ func main() {
 			log.Printf("entdb-server: archive sidecar exited: %v", err)
 		}
 	}
+}
+
+// schemaRegistryForProfile returns nil for profile=none because a nil
+// registry is the API server's schema-less mode. An empty frozen
+// registry is materially different: QueryNodes rejects every type_id
+// as unknown.
+func schemaRegistryForProfile(profile string) (*schema.Registry, error) {
+	switch profile {
+	case "none":
+		return nil, nil
+	case "contract", "e2e":
+		// handled below
+	default:
+		return nil, fmt.Errorf("invalid profile %q", profile)
+	}
+
+	registry := schema.NewRegistry()
+	switch profile {
+	case "contract":
+		if err := testseed.RegisterContractSchema(registry); err != nil {
+			return nil, fmt.Errorf("register contract schema: %w", err)
+		}
+	case "e2e":
+		if err := testseed.RegisterE2ESchema(registry); err != nil {
+			return nil, fmt.Errorf("register e2e schema: %w", err)
+		}
+	}
+	if _, err := registry.Freeze(); err != nil {
+		return nil, fmt.Errorf("freeze registry: %w", err)
+	}
+	return registry, nil
 }
 
 // splitBrokers parses a comma-separated broker list and returns

--- a/server/go/cmd/entdb-server/main_test.go
+++ b/server/go/cmd/entdb-server/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/testseed"
+)
+
+func TestSchemaRegistryForProfileNoneIsSchemaless(t *testing.T) {
+	reg, err := schemaRegistryForProfile("none")
+	if err != nil {
+		t.Fatalf("schemaRegistryForProfile(none): %v", err)
+	}
+	if reg != nil {
+		t.Fatalf("profile=none registry = %v, want nil for schema-less mode", reg)
+	}
+}
+
+func TestSchemaRegistryForProfileContract(t *testing.T) {
+	reg, err := schemaRegistryForProfile("contract")
+	if err != nil {
+		t.Fatalf("schemaRegistryForProfile(contract): %v", err)
+	}
+	if reg == nil {
+		t.Fatal("profile=contract registry = nil, want populated registry")
+	}
+	if !reg.Frozen() {
+		t.Fatal("profile=contract registry is not frozen")
+	}
+	if got := reg.NodeTypeByID(testseed.UserTypeID); got == nil || got.Name != "User" {
+		t.Fatalf("contract User type = %#v, want User node type", got)
+	}
+	if got := reg.NodeTypeByID(999999); got != nil {
+		t.Fatalf("unexpected unknown type in contract registry: %#v", got)
+	}
+}
+
+func TestSchemaRegistryForProfileE2E(t *testing.T) {
+	reg, err := schemaRegistryForProfile("e2e")
+	if err != nil {
+		t.Fatalf("schemaRegistryForProfile(e2e): %v", err)
+	}
+	if reg == nil {
+		t.Fatal("profile=e2e registry = nil, want populated registry")
+	}
+	if !reg.Frozen() {
+		t.Fatal("profile=e2e registry is not frozen")
+	}
+	if got := reg.NodeTypeByID(testseed.E2EUserTypeID); got == nil || got.Name != "User" {
+		t.Fatalf("e2e User type = %#v, want User node type", got)
+	}
+}
+
+func TestSchemaRegistryForProfileRejectsInvalidProfile(t *testing.T) {
+	_, err := schemaRegistryForProfile("bogus")
+	if err == nil {
+		t.Fatal("schemaRegistryForProfile(bogus) err = nil, want error")
+	}
+	if !strings.Contains(err.Error(), `invalid profile "bogus"`) {
+		t.Fatalf("schemaRegistryForProfile(bogus) err = %q, want invalid profile error", err)
+	}
+}

--- a/server/go/internal/api/query_nodes_test.go
+++ b/server/go/internal/api/query_nodes_test.go
@@ -507,3 +507,49 @@ func TestQueryNodes_UnknownTypeID(t *testing.T) {
 		t.Fatalf("code: got %v, want InvalidArgument", st.Code())
 	}
 }
+
+// TestQueryNodes_SchemaLessAllowsUnknownTypeID pins the profile=none
+// contract used by entdb-server: with no registry wired, QueryNodes
+// treats type_id as an opaque storage discriminator instead of rejecting
+// it as unknown.
+func TestQueryNodes_SchemaLessAllowsUnknownTypeID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cs := newCanonicalStore(t)
+	gs := newGlobalStore(t)
+
+	const tenantID = "tenant-schemaless"
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if _, err := gs.CreateTenant(ctx, tenantID, "Tenant Schemaless", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:     "node-508",
+		TypeID:     508,
+		OwnerActor: "user:alice",
+		Payload:    map[string]any{"1": "schemaless"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithGlobalStore(gs),
+	)
+	resp, err := srv.QueryNodes(ctx, &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		TypeId:  508,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if got := len(resp.GetNodes()); got != 1 {
+		t.Fatalf("nodes: got %d, want 1", got)
+	}
+	if got := resp.GetNodes()[0].GetNodeId(); got != "node-508" {
+		t.Fatalf("node_id: got %q, want node-508", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Keep `--seed-profile=none` schema-less by returning a nil registry instead of an empty frozen registry.
- Only install `api.WithSchemaRegistry` when a seeded profile actually provides a registry.
- Add command-level and QueryNodes regression coverage for the nil-registry path.

Closes #508

## Validation
- `go test ./cmd/entdb-server ./internal/api`
- `go test ./...`