### PR TITLE
[codex] Expose SDK client interceptor hooks

### DIFF
--- a/docs/generated/sdk-go.md
+++ b/docs/generated/sdk-go.md
@@ -320,7 +320,7 @@ func (a *Admin) CreateTenant(ctx context.Context, actor, tenantID, name string, 
     Pass WithRegion to pin the tenant to a specific geographic region (e.g.
     “WithRegion("eu-west-1")“); when omitted the server defaults the
     tenant to its own served region. The pinned region is reflected on
-    TenantDetail.Region.
+    [TenantDetail.Region].
 
 func (a *Admin) CreateUser(ctx context.Context, actor, userID, email, name string) (*UserInfo, error)
     CreateUser registers a new user in the global registry. “email“ is unique
@@ -434,8 +434,25 @@ func WithRetryBudget(d time.Duration) ClientOption
 func WithSecure() ClientOption
     WithSecure enables TLS for the gRPC connection.
 
+func WithStreamClientInterceptors(interceptors ...grpc.StreamClientInterceptor) ClientOption
+    WithStreamClientInterceptors prepends caller-supplied stream gRPC client
+    interceptors to the SDK's internal interceptor chain.
+
+    The current EntDB wire API is unary-only, but exposing the stream hook keeps
+    the SDK option surface aligned with grpc-go and future-proofs streaming RPC
+    additions.
+
 func WithTimeout(d time.Duration) ClientOption
     WithTimeout sets the default timeout for RPCs.
+
+func WithUnaryClientInterceptors(interceptors ...grpc.UnaryClientInterceptor) ClientOption
+    WithUnaryClientInterceptors prepends caller-supplied unary gRPC client
+    interceptors to the SDK's internal interceptor chain.
+
+    This is intended for cross-cutting concerns such as OpenTelemetry tracing,
+    metrics, request correlation, or custom propagation. When SDK-owned
+    interceptors are also installed, for example node redirect handling,
+    these interceptors run first and wrap the full outbound RPC.
 
 type CommitResult struct {
 	Success        bool     `json:"success"`

--- a/sdk/go/entdb/README.md
+++ b/sdk/go/entdb/README.md
@@ -183,6 +183,27 @@ captures tenant + actor once so you never repeat them on every call.
 Actors are strongly typed — use `UserActor`, `GroupActor`, or
 `ServiceActor` rather than raw `"user:alice"` strings.
 
+## Observability hooks
+
+Install gRPC client interceptors when your service needs outbound
+tracing, metrics, or request-correlation propagation around SDK calls:
+
+```go
+import (
+    "github.com/elloloop/tenant-shard-db/sdk/go/entdb"
+    "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+)
+
+client, err := entdb.NewClient("api.example.com:443",
+    entdb.WithSecure(),
+    entdb.WithUnaryClientInterceptors(otelgrpc.UnaryClientInterceptor()),
+)
+```
+
+Caller-supplied interceptors wrap the SDK's own redirect handling, so
+spans and propagation cover typed calls, admin calls, and raw transport
+RPCs reached through the client.
+
 ## Creating nodes
 
 `Plan.Create(msg, opts...)` is the only way to create a node:

--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -5,8 +5,6 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -264,22 +262,14 @@ func (t *grpcTransport) Connect(_ context.Context) error {
 		t.redirectCache = newTenantEndpointCache(dialerFromConfig(t.config))
 	}
 
-	opts := append([]grpc.DialOption(nil), t.config.dialOptions...)
-	if !hasTransportCreds(opts) {
-		var creds credentials.TransportCredentials
-		if t.config.secure {
-			creds = credentials.NewTLS(nil)
-		} else {
-			creds = insecure.NewCredentials()
-		}
-		opts = append(opts, grpc.WithTransportCredentials(creds))
-	}
+	opts := dialOptionsFromConfig(t.config)
 	// Interceptor chain, outermost first. The retry interceptor
-	// wraps the redirect interceptor so every retry attempt still
-	// follows tenant redirects (and a redirect-follow that fails
-	// transiently is itself retried). grpc.WithChainUnaryInterceptor
-	// invokes interceptors in slice order — index 0 is outermost.
-	var chain []grpc.UnaryClientInterceptor
+	// wraps the redirect interceptor so every retry attempt still follows
+	// tenant redirects. Caller interceptors run before SDK-owned
+	// interceptors so tracing/propagation wraps the full logical SDK call.
+	// grpc.WithChainUnaryInterceptor invokes interceptors in slice order:
+	// index 0 is outermost.
+	chain := append([]grpc.UnaryClientInterceptor(nil), t.config.unaryClientInterceptors...)
 	if t.config.maxRetries > 0 {
 		chain = append(chain, retryInterceptor(t.config.maxRetries, t.config.retryBudget, t.config.retryJitter))
 	}
@@ -288,6 +278,9 @@ func (t *grpcTransport) Connect(_ context.Context) error {
 	}
 	if len(chain) > 0 {
 		opts = append(opts, grpc.WithChainUnaryInterceptor(chain...))
+	}
+	if len(t.config.streamClientInterceptors) > 0 {
+		opts = append(opts, grpc.WithChainStreamInterceptor(t.config.streamClientInterceptors...))
 	}
 
 	conn, err := grpc.NewClient(t.address, opts...)
@@ -1253,12 +1246,12 @@ func (t *grpcTransport) clearOffsets() { t.offsets.clear() }
 
 // ClearOffsets drops every tracked per-tenant write offset, so the
 // next read no longer pins to a past write. Mirrors the Python SDK's
-// ``DbClient.clear_offsets()`` — useful in tests and when a caller
+// “DbClient.clear_offsets()“ — useful in tests and when a caller
 // deliberately wants to stop enforcing read-after-write.
 //
 // Automatic offset tracking otherwise needs zero application code:
-// every Commit records ``receipt.stream_position`` for its tenant
-// and every subsequent read auto-attaches it as ``after_offset``.
+// every Commit records “receipt.stream_position“ for its tenant
+// and every subsequent read auto-attaches it as “after_offset“.
 func (c *DbClient) ClearOffsets() {
 	if oc, ok := c.transport.(offsetClearer); ok {
 		oc.clearOffsets()

--- a/sdk/go/entdb/client_test.go
+++ b/sdk/go/entdb/client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -332,6 +333,46 @@ func TestWithTimeout(t *testing.T) {
 	cfg := client.Config()
 	if cfg.timeout != 5*time.Second {
 		t.Errorf("timeout = %v, want %v", cfg.timeout, 5*time.Second)
+	}
+}
+
+func TestClientInterceptorOptions(t *testing.T) {
+	unary := func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+	stream := func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+
+	client, err := NewClient(
+		"localhost:50051",
+		WithUnaryClientInterceptors(nil, unary, unary),
+		WithStreamClientInterceptors(nil, stream),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg := client.Config()
+	if got := len(cfg.unaryClientInterceptors); got != 2 {
+		t.Fatalf("unaryClientInterceptors len = %d, want 2", got)
+	}
+	if got := len(cfg.streamClientInterceptors); got != 1 {
+		t.Fatalf("streamClientInterceptors len = %d, want 1", got)
 	}
 }
 

--- a/sdk/go/entdb/options.go
+++ b/sdk/go/entdb/options.go
@@ -28,6 +28,11 @@ type clientConfig struct {
 	// sub-channels. Tests use it to install a contextDialer for
 	// bufconn-backed in-process servers.
 	dialOptions []grpc.DialOption
+	// unaryClientInterceptors are caller-supplied interceptors that
+	// run before SDK-owned interceptors such as redirect handling.
+	unaryClientInterceptors []grpc.UnaryClientInterceptor
+	// streamClientInterceptors are caller-supplied stream interceptors.
+	streamClientInterceptors []grpc.StreamClientInterceptor
 }
 
 // defaultConfig returns a clientConfig with sensible defaults.
@@ -117,6 +122,39 @@ func WithNodeResolver(r NodeResolver) ClientOption {
 func WithBaseDomain(baseDomain string) ClientOption {
 	return func(c *clientConfig) {
 		c.nodeResolver = &DNSTemplateResolver{BaseDomain: baseDomain}
+	}
+}
+
+// WithUnaryClientInterceptors prepends caller-supplied unary gRPC
+// client interceptors to the SDK's internal interceptor chain.
+//
+// This is intended for cross-cutting concerns such as OpenTelemetry
+// tracing, metrics, request correlation, or custom propagation. When
+// SDK-owned interceptors are also installed, for example node redirect
+// handling, these interceptors run first and wrap the full outbound RPC.
+func WithUnaryClientInterceptors(interceptors ...grpc.UnaryClientInterceptor) ClientOption {
+	return func(c *clientConfig) {
+		for _, interceptor := range interceptors {
+			if interceptor != nil {
+				c.unaryClientInterceptors = append(c.unaryClientInterceptors, interceptor)
+			}
+		}
+	}
+}
+
+// WithStreamClientInterceptors prepends caller-supplied stream gRPC
+// client interceptors to the SDK's internal interceptor chain.
+//
+// The current EntDB wire API is unary-only, but exposing the stream hook
+// keeps the SDK option surface aligned with grpc-go and future-proofs
+// streaming RPC additions.
+func WithStreamClientInterceptors(interceptors ...grpc.StreamClientInterceptor) ClientOption {
+	return func(c *clientConfig) {
+		for _, interceptor := range interceptors {
+			if interceptor != nil {
+				c.streamClientInterceptors = append(c.streamClientInterceptors, interceptor)
+			}
+		}
 	}
 }
 

--- a/sdk/go/entdb/redirect_cache.go
+++ b/sdk/go/entdb/redirect_cache.go
@@ -227,20 +227,24 @@ func redirectInterceptor(resolver NodeResolver, cache *tenantEndpointCache) grpc
 // connection (TLS / insecure, plus any explicit dial options).
 func dialerFromConfig(cfg clientConfig) func(string) (*grpc.ClientConn, error) {
 	return func(endpoint string) (*grpc.ClientConn, error) {
-		opts := append([]grpc.DialOption(nil), cfg.dialOptions...)
-		// Caller-supplied dial options win — only apply our
-		// transport-credentials default when they did not.
-		if !hasTransportCreds(opts) {
-			var creds credentials.TransportCredentials
-			if cfg.secure {
-				creds = credentials.NewTLS(nil)
-			} else {
-				creds = insecure.NewCredentials()
-			}
-			opts = append(opts, grpc.WithTransportCredentials(creds))
-		}
-		return grpc.NewClient(endpoint, opts...)
+		return grpc.NewClient(endpoint, dialOptionsFromConfig(cfg)...)
 	}
+}
+
+func dialOptionsFromConfig(cfg clientConfig) []grpc.DialOption {
+	opts := append([]grpc.DialOption(nil), cfg.dialOptions...)
+	// Caller-supplied dial options win — only apply our
+	// transport-credentials default when they did not.
+	if !hasTransportCreds(opts) {
+		var creds credentials.TransportCredentials
+		if cfg.secure {
+			creds = credentials.NewTLS(nil)
+		} else {
+			creds = insecure.NewCredentials()
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	}
+	return opts
 }
 
 // hasTransportCreds reports whether “opts“ already carries a

--- a/sdk/go/entdb/redirect_cache_test.go
+++ b/sdk/go/entdb/redirect_cache_test.go
@@ -28,13 +28,28 @@ type redirectFakeServer struct {
 
 	nodeID       string // "node-a" / "node-b" — used in redirect trailer
 	redirectTo   string // empty = serve normally
+	failCode     codes.Code
+	failN        int32
 	hits         atomic.Int32
 	lastTenantID atomic.Value // string — tenant on the last received call
+	lastUserHook atomic.Value // string — marker from caller-supplied interceptor
 }
 
 func (s *redirectFakeServer) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNodeResponse, error) {
-	s.hits.Add(1)
+	n := s.hits.Add(1)
 	s.lastTenantID.Store(req.GetContext().GetTenantId())
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if vals := md.Get("x-user-interceptor"); len(vals) > 0 {
+			s.lastUserHook.Store(vals[0])
+		}
+	}
+	if n <= s.failN {
+		code := s.failCode
+		if code == codes.OK {
+			code = codes.Unavailable
+		}
+		return nil, status.Errorf(code, "transient %d", n)
+	}
 	if s.redirectTo != "" {
 		_ = grpc.SetTrailer(ctx, metadata.Pairs("entdb-redirect-node", s.redirectTo))
 		return nil, status.Errorf(
@@ -85,7 +100,7 @@ func (r *bufconnResolver) Resolve(nodeID string) (string, error) {
 	return "passthrough:///" + nodeID + ".bufnet", nil
 }
 
-func newRedirectTransport(t *testing.T, primaryNode string, lis map[string]*bufconn.Listener) *grpcTransport {
+func newRedirectTransport(t *testing.T, primaryNode string, lis map[string]*bufconn.Listener, opts ...ClientOption) *grpcTransport {
 	t.Helper()
 	resolver := &bufconnResolver{listeners: lis}
 
@@ -102,6 +117,10 @@ func newRedirectTransport(t *testing.T, primaryNode string, lis map[string]*bufc
 	}
 
 	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	cfg.retryJitter = fixedJitter{0.0}
 	cfg.nodeResolver = resolver
 	cfg.dialOptions = []grpc.DialOption{
 		grpc.WithContextDialer(dialer),
@@ -117,6 +136,90 @@ func newRedirectTransport(t *testing.T, primaryNode string, lis map[string]*bufc
 	}
 	t.Cleanup(func() { _ = tr.Close() })
 	return tr
+}
+
+func TestUnaryClientInterceptorsWrapRedirectInterceptor(t *testing.T) {
+	srvA := &redirectFakeServer{nodeID: "node-a", redirectTo: "node-b"}
+	srvB := &redirectFakeServer{nodeID: "node-b"}
+	listeners := map[string]*bufconn.Listener{
+		"node-a": startRedirectServer(t, srvA),
+		"node-b": startRedirectServer(t, srvB),
+	}
+
+	var userInterceptorCalls atomic.Int32
+	userInterceptor := func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		userInterceptorCalls.Add(1)
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-user-interceptor", "outer")
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+
+	tr := newRedirectTransport(t, "node-a", listeners, WithUnaryClientInterceptors(userInterceptor))
+
+	got, err := tr.GetNode(context.Background(), "tenant-b", "user:alice", 1, "n1")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got == nil || got.NodeID != "n1" {
+		t.Fatalf("expected node n1, got %+v", got)
+	}
+	if calls := userInterceptorCalls.Load(); calls != 1 {
+		t.Fatalf("user interceptor calls = %d, want 1", calls)
+	}
+	if hook, _ := srvB.lastUserHook.Load().(string); hook != "outer" {
+		t.Fatalf("redirect target saw user hook %q, want outer", hook)
+	}
+}
+
+func TestRetryInterceptorWrapsRedirectInterceptor(t *testing.T) {
+	srvA := &redirectFakeServer{nodeID: "node-a", redirectTo: "node-b"}
+	srvB := &redirectFakeServer{nodeID: "node-b", failCode: codes.Unavailable, failN: 1}
+	listeners := map[string]*bufconn.Listener{
+		"node-a": startRedirectServer(t, srvA),
+		"node-b": startRedirectServer(t, srvB),
+	}
+
+	var userInterceptorCalls atomic.Int32
+	userInterceptor := func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		userInterceptorCalls.Add(1)
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-user-interceptor", "outer")
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+
+	tr := newRedirectTransport(t, "node-a", listeners, WithUnaryClientInterceptors(userInterceptor))
+
+	got, err := tr.GetNode(context.Background(), "tenant-b", "user:alice", 1, "n1")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got == nil || got.NodeID != "n1" {
+		t.Fatalf("expected node n1, got %+v", got)
+	}
+	if hits := srvA.hits.Load(); hits != 1 {
+		t.Fatalf("primary hits = %d, want 1", hits)
+	}
+	if hits := srvB.hits.Load(); hits != 2 {
+		t.Fatalf("redirect target hits = %d, want 2", hits)
+	}
+	if calls := userInterceptorCalls.Load(); calls != 1 {
+		t.Fatalf("user interceptor calls = %d, want 1", calls)
+	}
+	if hook, _ := srvB.lastUserHook.Load().(string); hook != "outer" {
+		t.Fatalf("redirect target saw user hook %q, want outer", hook)
+	}
 }
 
 func TestRedirect_FollowsHintAndCaches(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add public `WithUnaryClientInterceptors` and `WithStreamClientInterceptors` SDK client options.
- Chain caller unary interceptors before SDK-owned redirect handling so tracing/propagation wraps redirected RPCs as one outbound SDK call.
- Add regression coverage for option storage, nil filtering, and redirect-path interceptor ordering.
- Document the OpenTelemetry-style usage in the Go SDK README.

Closes #517

## Validation
- `go test ./...`
- `go vet ./...`
- `git diff --check`