### PR TITLE
[codex] Add server TLS configuration flags

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -35,6 +35,12 @@ import (
 func main() {
 	addr := flag.String("addr", ":50051", "gRPC bind address (host:port)")
 	dataDir := flag.String("data-dir", "", "directory for per-tenant SQLite + global.db")
+	tlsCert := flag.String("tls-cert", "", "server TLS certificate PEM file")
+	tlsKey := flag.String("tls-key", "", "server TLS private key PEM file")
+	tlsCA := flag.String("tls-ca", "", "client CA PEM file for mTLS verification")
+	tlsMinVersion := flag.String("tls-min-version", "1.3", "minimum TLS version: 1.3 | 1.2")
+	requireTLS := flag.Bool("require-tls", false, "refuse to start unless TLS is configured")
+	requireClientCert := flag.Bool("require-client-cert", false, "require and verify client certificates (mTLS; requires --tls-ca)")
 	walBackend := flag.String("wal-backend", "memory", "WAL backend: memory | kafka")
 	walTopic := flag.String("wal-topic", "entdb-wal", "WAL topic name")
 	walGroup := flag.String("wal-group", "entdb-applier", "WAL consumer group id")
@@ -234,7 +240,24 @@ func main() {
 		}
 	}
 
-	srv := grpc.NewServer()
+	grpcServerOpts, tlsEnabled, err := grpcServerTLSOptions(serverTLSConfig{
+		certFile:          *tlsCert,
+		keyFile:           *tlsKey,
+		caFile:            *tlsCA,
+		minVersion:        *tlsMinVersion,
+		requireTLS:        *requireTLS,
+		requireClientCert: *requireClientCert,
+	})
+	if err != nil {
+		log.Fatalf("entdb-server: TLS config: %v", err)
+	}
+	if tlsEnabled {
+		log.Printf("entdb-server: TLS enabled (min-version=%s client-auth=%s)", *tlsMinVersion, clientAuthMode(*tlsCA, *requireClientCert))
+	} else {
+		log.Printf("entdb-server: WARNING: TLS disabled; plaintext gRPC listener is for local/dev use only")
+	}
+
+	srv := grpc.NewServer(grpcServerOpts...)
 	pb.RegisterEntDBServiceServer(srv, api.New(srvOpts...))
 
 	lis, err := net.Listen("tcp", *addr)

--- a/server/go/cmd/entdb-server/tls.go
+++ b/server/go/cmd/entdb-server/tls.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+type serverTLSConfig struct {
+	certFile          string
+	keyFile           string
+	caFile            string
+	minVersion        string
+	requireTLS        bool
+	requireClientCert bool
+}
+
+func grpcServerTLSOptions(cfg serverTLSConfig) ([]grpc.ServerOption, bool, error) {
+	tlsCfg, enabled, err := buildServerTLSConfig(cfg)
+	if err != nil {
+		return nil, false, err
+	}
+	if !enabled {
+		return nil, false, nil
+	}
+	return []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}, true, nil
+}
+
+func buildServerTLSConfig(cfg serverTLSConfig) (*tls.Config, bool, error) {
+	certFile := strings.TrimSpace(cfg.certFile)
+	keyFile := strings.TrimSpace(cfg.keyFile)
+	caFile := strings.TrimSpace(cfg.caFile)
+
+	tlsRequested := certFile != "" || keyFile != "" || caFile != ""
+	if !tlsRequested {
+		if cfg.requireTLS {
+			return nil, false, fmt.Errorf("--require-tls requires --tls-cert and --tls-key")
+		}
+		if cfg.requireClientCert {
+			return nil, false, fmt.Errorf("--require-client-cert requires TLS and --tls-ca")
+		}
+		return nil, false, nil
+	}
+	if certFile == "" || keyFile == "" {
+		return nil, false, fmt.Errorf("TLS requires both --tls-cert and --tls-key")
+	}
+
+	minVersion, err := parseTLSMinVersion(cfg.minVersion)
+	if err != nil {
+		return nil, false, err
+	}
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, false, fmt.Errorf("load server certificate/key: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion:   minVersion,
+		Certificates: []tls.Certificate{cert},
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		},
+	}
+
+	if caFile != "" {
+		pool, err := loadCertPool(caFile)
+		if err != nil {
+			return nil, false, err
+		}
+		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = tls.VerifyClientCertIfGiven
+	}
+	if cfg.requireClientCert {
+		if caFile == "" {
+			return nil, false, fmt.Errorf("--require-client-cert requires --tls-ca")
+		}
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return tlsCfg, true, nil
+}
+
+func parseTLSMinVersion(version string) (uint16, error) {
+	switch strings.ToLower(strings.TrimSpace(version)) {
+	case "", "1.3", "tls1.3", "tls13":
+		return tls.VersionTLS13, nil
+	case "1.2", "tls1.2", "tls12":
+		return tls.VersionTLS12, nil
+	default:
+		return 0, fmt.Errorf("unsupported --tls-min-version %q (want 1.3 or 1.2)", version)
+	}
+}
+
+func loadCertPool(path string) (*x509.CertPool, error) {
+	pemBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --tls-ca: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, fmt.Errorf("parse --tls-ca: no certificates found")
+	}
+	return pool, nil
+}
+
+func clientAuthMode(caFile string, requireClientCert bool) string {
+	switch {
+	case requireClientCert:
+		return "require-and-verify"
+	case strings.TrimSpace(caFile) != "":
+		return "verify-if-present"
+	default:
+		return "none"
+	}
+}

--- a/server/go/cmd/entdb-server/tls_test.go
+++ b/server/go/cmd/entdb-server/tls_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildServerTLSConfigPlaintextAllowed(t *testing.T) {
+	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{})
+	if err != nil {
+		t.Fatalf("buildServerTLSConfig: %v", err)
+	}
+	if enabled {
+		t.Fatal("enabled = true, want false")
+	}
+	if tlsCfg != nil {
+		t.Fatalf("tlsCfg = %#v, want nil", tlsCfg)
+	}
+}
+
+func TestBuildServerTLSConfigRequireTLSRejectsPlaintext(t *testing.T) {
+	_, _, err := buildServerTLSConfig(serverTLSConfig{requireTLS: true})
+	if err == nil {
+		t.Fatal("buildServerTLSConfig err = nil, want require TLS error")
+	}
+	if !strings.Contains(err.Error(), "--require-tls") {
+		t.Fatalf("err = %q, want --require-tls", err)
+	}
+}
+
+func TestBuildServerTLSConfigServerTLS(t *testing.T) {
+	certFile, keyFile, _ := writeTLSFixture(t)
+
+	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{
+		certFile: certFile,
+		keyFile:  keyFile,
+	})
+	if err != nil {
+		t.Fatalf("buildServerTLSConfig: %v", err)
+	}
+	if !enabled {
+		t.Fatal("enabled = false, want true")
+	}
+	if tlsCfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("MinVersion = %x, want TLS 1.3", tlsCfg.MinVersion)
+	}
+	if got := len(tlsCfg.Certificates); got != 1 {
+		t.Fatalf("certificates len = %d, want 1", got)
+	}
+	if tlsCfg.ClientAuth != tls.NoClientCert {
+		t.Fatalf("ClientAuth = %v, want NoClientCert", tlsCfg.ClientAuth)
+	}
+}
+
+func TestBuildServerTLSConfigOptionalClientCertVerification(t *testing.T) {
+	certFile, keyFile, caFile := writeTLSFixture(t)
+
+	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{
+		certFile: certFile,
+		keyFile:  keyFile,
+		caFile:   caFile,
+	})
+	if err != nil {
+		t.Fatalf("buildServerTLSConfig: %v", err)
+	}
+	if !enabled {
+		t.Fatal("enabled = false, want true")
+	}
+	if tlsCfg.ClientCAs == nil {
+		t.Fatal("ClientCAs = nil, want CA pool")
+	}
+	if tlsCfg.ClientAuth != tls.VerifyClientCertIfGiven {
+		t.Fatalf("ClientAuth = %v, want VerifyClientCertIfGiven", tlsCfg.ClientAuth)
+	}
+}
+
+func TestBuildServerTLSConfigRequiresClientCert(t *testing.T) {
+	certFile, keyFile, caFile := writeTLSFixture(t)
+
+	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{
+		certFile:          certFile,
+		keyFile:           keyFile,
+		caFile:            caFile,
+		requireClientCert: true,
+	})
+	if err != nil {
+		t.Fatalf("buildServerTLSConfig: %v", err)
+	}
+	if !enabled {
+		t.Fatal("enabled = false, want true")
+	}
+	if tlsCfg.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("ClientAuth = %v, want RequireAndVerifyClientCert", tlsCfg.ClientAuth)
+	}
+}
+
+func TestBuildServerTLSConfigRequireClientCertNeedsCA(t *testing.T) {
+	certFile, keyFile, _ := writeTLSFixture(t)
+
+	_, _, err := buildServerTLSConfig(serverTLSConfig{
+		certFile:          certFile,
+		keyFile:           keyFile,
+		requireClientCert: true,
+	})
+	if err == nil {
+		t.Fatal("buildServerTLSConfig err = nil, want --tls-ca error")
+	}
+	if !strings.Contains(err.Error(), "--tls-ca") {
+		t.Fatalf("err = %q, want --tls-ca", err)
+	}
+}
+
+func TestBuildServerTLSConfigTLS12Compat(t *testing.T) {
+	certFile, keyFile, _ := writeTLSFixture(t)
+
+	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{
+		certFile:   certFile,
+		keyFile:    keyFile,
+		minVersion: "1.2",
+	})
+	if err != nil {
+		t.Fatalf("buildServerTLSConfig: %v", err)
+	}
+	if !enabled {
+		t.Fatal("enabled = false, want true")
+	}
+	if tlsCfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %x, want TLS 1.2", tlsCfg.MinVersion)
+	}
+	if len(tlsCfg.CipherSuites) == 0 {
+		t.Fatal("CipherSuites empty, want pinned modern TLS 1.2 suites")
+	}
+}
+
+func TestBuildServerTLSConfigRejectsInvalidMinVersion(t *testing.T) {
+	certFile, keyFile, _ := writeTLSFixture(t)
+
+	_, _, err := buildServerTLSConfig(serverTLSConfig{
+		certFile:   certFile,
+		keyFile:    keyFile,
+		minVersion: "1.1",
+	})
+	if err == nil {
+		t.Fatal("buildServerTLSConfig err = nil, want invalid version error")
+	}
+	if !strings.Contains(err.Error(), "--tls-min-version") {
+		t.Fatalf("err = %q, want --tls-min-version", err)
+	}
+}
+
+func writeTLSFixture(t *testing.T) (certFile, keyFile, caFile string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey := newECDSAKey(t)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "entdb-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(ca): %v", err)
+	}
+
+	serverKey := newECDSAKey(t)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(server): %v", err)
+	}
+
+	caFile = filepath.Join(dir, "ca.pem")
+	certFile = filepath.Join(dir, "server.pem")
+	keyFile = filepath.Join(dir, "server-key.pem")
+	writePEM(t, caFile, "CERTIFICATE", caDER)
+	writePEM(t, certFile, "CERTIFICATE", serverDER)
+	writeECPrivateKey(t, keyFile, serverKey)
+	return certFile, keyFile, caFile
+}
+
+func newECDSAKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return key
+}
+
+func writePEM(t *testing.T, path, typ string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Create(%s): %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := pem.Encode(f, &pem.Block{Type: typ, Bytes: der}); err != nil {
+		t.Fatalf("pem.Encode(%s): %v", path, err)
+	}
+}
+
+func writeECPrivateKey(t *testing.T, path string, key *ecdsa.PrivateKey) {
+	t.Helper()
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey: %v", err)
+	}
+	writePEM(t, path, "EC PRIVATE KEY", der)
+}


### PR DESCRIPTION
## Summary
- Add entdb-server TLS flags for server cert/key, client CA, min TLS version, `--require-tls`, and `--require-client-cert`.
- Construct `grpc.NewServer` with `credentials.NewTLS` when TLS is configured, while keeping plaintext dev mode with a startup warning.
- Add mTLS modes: verify client certs when `--tls-ca` is supplied, and require client certs when `--require-client-cert=true`.
- Cover plaintext, require-TLS rejection, server TLS, optional client cert verification, required mTLS, TLS 1.2 compatibility, and invalid version handling.

Refs #520

## Validation
- `go test ./cmd/entdb-server`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Still out of scope for #520
- Certificate reload / rotation without restart.
- Client certificate subject/SAN extraction into trusted actor identity.
- Docker-compose TLS E2E and deployment/operations docs.