### PR TITLE
[codex] Add encryption key vault foundation

### DIFF
--- a/server/go/internal/crypto/key_manager.go
+++ b/server/go/internal/crypto/key_manager.go
@@ -1,0 +1,195 @@
+// Package crypto contains the encryption-at-rest key hierarchy used by
+// the Go server port. It deliberately owns only key material and vault
+// persistence; SQLCipher connection wiring lands in the store package.
+package crypto
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+const (
+	KeyLength      = 32
+	hkdfInfoPrefix = "entdb-tenant-key:"
+)
+
+var (
+	ErrInvalidMasterKey = errors.New("crypto: master key must be exactly 32 bytes")
+	ErrTenantShredded   = errors.New("crypto: tenant key has been shredded")
+)
+
+type TenantShreddedError struct {
+	TenantID string
+}
+
+func (e *TenantShreddedError) Error() string {
+	return fmt.Sprintf("crypto: tenant %q key has been shredded", e.TenantID)
+}
+
+func (e *TenantShreddedError) Unwrap() error { return ErrTenantShredded }
+
+type KeyManager struct {
+	masterKey []byte
+	vault     *TenantKeyVault
+
+	mu       sync.Mutex
+	cache    map[string][]byte
+	shredded map[string]struct{}
+}
+
+func NewKeyManager(masterKey []byte, vault *TenantKeyVault) (*KeyManager, error) {
+	if len(masterKey) != KeyLength {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMasterKey, len(masterKey))
+	}
+	return &KeyManager{
+		masterKey: append([]byte(nil), masterKey...),
+		vault:     vault,
+		cache:     map[string][]byte{},
+		shredded:  map[string]struct{}{},
+	}, nil
+}
+
+func ParseMasterKeyHex(s string) ([]byte, error) {
+	key, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: parse master key hex: %w", err)
+	}
+	if len(key) != KeyLength {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMasterKey, len(key))
+	}
+	return key, nil
+}
+
+func (m *KeyManager) TenantKey(ctx context.Context, tenantID string) ([]byte, error) {
+	if tenantID == "" {
+		return nil, errors.New("crypto: tenant_id is required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.shredded[tenantID]; ok {
+		return nil, &TenantShreddedError{TenantID: tenantID}
+	}
+	if key, ok := m.cache[tenantID]; ok {
+		return append([]byte(nil), key...), nil
+	}
+
+	var key []byte
+	var err error
+	if m.vault != nil {
+		key, err = m.fetchOrProvisionVault(ctx, tenantID)
+	} else {
+		key, err = m.deriveTenantKey(tenantID)
+	}
+	if err != nil {
+		if errors.Is(err, ErrTenantShredded) {
+			m.shredded[tenantID] = struct{}{}
+		}
+		return nil, err
+	}
+	m.cache[tenantID] = append([]byte(nil), key...)
+	return append([]byte(nil), key...), nil
+}
+
+func (m *KeyManager) ShredTenant(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return errors.New("crypto: tenant_id is required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.cache, tenantID)
+	if m.vault == nil {
+		m.shredded[tenantID] = struct{}{}
+		return nil
+	}
+	row, err := m.vault.GetRow(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	if row == nil {
+		seed, err := m.deriveTenantKey(tenantID)
+		if err != nil {
+			return err
+		}
+		if err := m.vault.Provision(ctx, tenantID, seed); err != nil && !errors.Is(err, ErrTenantKeyAlreadyProvisioned) {
+			return err
+		}
+	}
+	if err := m.vault.Shred(ctx, tenantID); err != nil {
+		return err
+	}
+	m.shredded[tenantID] = struct{}{}
+	return nil
+}
+
+func (m *KeyManager) IsShredded(ctx context.Context, tenantID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.shredded[tenantID]; ok {
+		return true, nil
+	}
+	if m.vault == nil {
+		return false, nil
+	}
+	shredded, err := m.vault.IsShredded(ctx, tenantID)
+	if err != nil {
+		return false, err
+	}
+	if shredded {
+		m.shredded[tenantID] = struct{}{}
+	}
+	return shredded, nil
+}
+
+func (m *KeyManager) CachedTenantIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.cache))
+	for tenantID := range m.cache {
+		out = append(out, tenantID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (m *KeyManager) fetchOrProvisionVault(ctx context.Context, tenantID string) ([]byte, error) {
+	key, err := m.vault.Get(ctx, tenantID)
+	if err == nil {
+		return key, nil
+	}
+	if errors.Is(err, ErrTenantShredded) {
+		return nil, err
+	}
+	if !errors.Is(err, ErrTenantKeyNotFound) {
+		return nil, err
+	}
+	seed, err := m.deriveTenantKey(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.vault.Provision(ctx, tenantID, seed); err != nil {
+		if errors.Is(err, ErrTenantKeyAlreadyProvisioned) {
+			return m.vault.Get(ctx, tenantID)
+		}
+		return nil, err
+	}
+	return seed, nil
+}
+
+func (m *KeyManager) deriveTenantKey(tenantID string) ([]byte, error) {
+	reader := hkdf.New(sha256.New, m.masterKey, nil, []byte(hkdfInfoPrefix+tenantID))
+	key := make([]byte, KeyLength)
+	if _, err := io.ReadFull(reader, key); err != nil {
+		return nil, fmt.Errorf("crypto: derive tenant key: %w", err)
+	}
+	return key, nil
+}

--- a/server/go/internal/crypto/key_manager_test.go
+++ b/server/go/internal/crypto/key_manager_test.go
@@ -1,0 +1,346 @@
+package crypto
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+)
+
+func TestKeyManagerDerivedKeysAreDeterministicAndCopied(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0x11)
+
+	first, err := NewKeyManager(master, nil)
+	if err != nil {
+		t.Fatalf("NewKeyManager first: %v", err)
+	}
+	second, err := NewKeyManager(master, nil)
+	if err != nil {
+		t.Fatalf("NewKeyManager second: %v", err)
+	}
+
+	acme1, err := first.TenantKey(ctx, "acme")
+	if err != nil {
+		t.Fatalf("TenantKey acme first: %v", err)
+	}
+	acme2, err := second.TenantKey(ctx, "acme")
+	if err != nil {
+		t.Fatalf("TenantKey acme second: %v", err)
+	}
+	if !bytes.Equal(acme1, acme2) {
+		t.Fatalf("same master+tenant produced different keys")
+	}
+
+	globex, err := first.TenantKey(ctx, "globex")
+	if err != nil {
+		t.Fatalf("TenantKey globex: %v", err)
+	}
+	if bytes.Equal(acme1, globex) {
+		t.Fatalf("different tenants produced the same key")
+	}
+
+	acme1[0] ^= 0xff
+	acme3, err := first.TenantKey(ctx, "acme")
+	if err != nil {
+		t.Fatalf("TenantKey acme cached: %v", err)
+	}
+	if bytes.Equal(acme1, acme3) {
+		t.Fatalf("caller mutation leaked into the key cache")
+	}
+	if got := first.CachedTenantIDs(); len(got) != 2 || got[0] != "acme" || got[1] != "globex" {
+		t.Fatalf("CachedTenantIDs = %v, want [acme globex]", got)
+	}
+}
+
+func TestParseMasterKeyHex(t *testing.T) {
+	master := testMaster(0x22)
+	encoded := hex.EncodeToString(master)
+
+	got, err := ParseMasterKeyHex(encoded)
+	if err != nil {
+		t.Fatalf("ParseMasterKeyHex valid: %v", err)
+	}
+	if !bytes.Equal(got, master) {
+		t.Fatalf("ParseMasterKeyHex returned wrong key")
+	}
+
+	if _, err := ParseMasterKeyHex("not-hex"); err == nil {
+		t.Fatalf("ParseMasterKeyHex accepted invalid hex")
+	}
+	short := hex.EncodeToString(master[:KeyLength-1])
+	if _, err := ParseMasterKeyHex(short); !errors.Is(err, ErrInvalidMasterKey) {
+		t.Fatalf("ParseMasterKeyHex short: got %v, want ErrInvalidMasterKey", err)
+	}
+}
+
+func TestKeyManagerVaultSeedsAndPersistsKeysInGlobalDB(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0x33)
+	gs := testGlobalStore(t)
+
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault first: %v", err)
+	}
+	manager, err := NewKeyManager(master, vault)
+	if err != nil {
+		t.Fatalf("NewKeyManager first: %v", err)
+	}
+	seeded, err := manager.TenantKey(ctx, "acme")
+	if err != nil {
+		t.Fatalf("TenantKey seeded: %v", err)
+	}
+
+	vault2, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault second: %v", err)
+	}
+	manager2, err := NewKeyManager(master, vault2)
+	if err != nil {
+		t.Fatalf("NewKeyManager second: %v", err)
+	}
+	reopened, err := manager2.TenantKey(ctx, "acme")
+	if err != nil {
+		t.Fatalf("TenantKey reopened: %v", err)
+	}
+	if !bytes.Equal(seeded, reopened) {
+		t.Fatalf("vault did not persist the tenant key")
+	}
+
+	row, err := vault2.GetRow(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetRow: %v", err)
+	}
+	if row == nil || row.TenantID != "acme" || len(row.WrappedKey) <= nonceLength || row.ShreddedAtMS.Valid {
+		t.Fatalf("unexpected vault row: %+v", row)
+	}
+	if bytes.Contains(row.WrappedKey, seeded) {
+		t.Fatalf("wrapped vault blob contains the plaintext DEK")
+	}
+}
+
+func TestKeyManagerVaultShredIsDurable(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0x44)
+	gs := testGlobalStore(t)
+	now := fixedTime(1710000000000)
+
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{
+		DB:        gs.DB(),
+		MasterKey: master,
+		NowFn:     now,
+	})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault first: %v", err)
+	}
+	manager, err := NewKeyManager(master, vault)
+	if err != nil {
+		t.Fatalf("NewKeyManager first: %v", err)
+	}
+	if _, err := manager.TenantKey(ctx, "acme"); err != nil {
+		t.Fatalf("TenantKey before shred: %v", err)
+	}
+	if err := manager.ShredTenant(ctx, "acme"); err != nil {
+		t.Fatalf("ShredTenant: %v", err)
+	}
+	if _, err := manager.TenantKey(ctx, "acme"); !errors.Is(err, ErrTenantShredded) {
+		t.Fatalf("TenantKey after shred: got %v, want ErrTenantShredded", err)
+	}
+
+	vault2, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault second: %v", err)
+	}
+	manager2, err := NewKeyManager(master, vault2)
+	if err != nil {
+		t.Fatalf("NewKeyManager second: %v", err)
+	}
+	shredded, err := manager2.IsShredded(ctx, "acme")
+	if err != nil {
+		t.Fatalf("IsShredded reopened: %v", err)
+	}
+	if !shredded {
+		t.Fatalf("reopened manager did not see durable shred tombstone")
+	}
+	if _, err := manager2.TenantKey(ctx, "acme"); !errors.Is(err, ErrTenantShredded) {
+		t.Fatalf("TenantKey reopened after shred: got %v, want ErrTenantShredded", err)
+	}
+
+	row, err := vault2.GetRow(ctx, "acme")
+	if err != nil {
+		t.Fatalf("GetRow shredded: %v", err)
+	}
+	if row == nil || row.WrappedKey != nil || !row.ShreddedAtMS.Valid || row.ShreddedAtMS.Int64 != 1710000000000 {
+		t.Fatalf("unexpected shredded row: %+v", row)
+	}
+}
+
+func TestTenantKeyVaultProvisionGetAndRewrap(t *testing.T) {
+	ctx := context.Background()
+	oldMaster := testMaster(0x55)
+	newMaster := testMaster(0x66)
+	dek := testMaster(0x77)
+	gs := testGlobalStore(t)
+
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: oldMaster})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault old: %v", err)
+	}
+	if err := vault.Provision(ctx, "acme", dek); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if err := vault.Provision(ctx, "acme", dek); !errors.Is(err, ErrTenantKeyAlreadyProvisioned) {
+		t.Fatalf("duplicate Provision: got %v, want ErrTenantKeyAlreadyProvisioned", err)
+	}
+	got, err := vault.Get(ctx, "acme")
+	if err != nil {
+		t.Fatalf("Get old: %v", err)
+	}
+	if !bytes.Equal(got, dek) {
+		t.Fatalf("Get old returned wrong DEK")
+	}
+
+	count, err := vault.RewrapWithNewMaster(ctx, newMaster)
+	if err != nil {
+		t.Fatalf("RewrapWithNewMaster: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("RewrapWithNewMaster count = %d, want 1", count)
+	}
+	got, err = vault.Get(ctx, "acme")
+	if err != nil {
+		t.Fatalf("Get after rewrap: %v", err)
+	}
+	if !bytes.Equal(got, dek) {
+		t.Fatalf("Get after rewrap returned wrong DEK")
+	}
+
+	reopenedNew, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: newMaster})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault new: %v", err)
+	}
+	got, err = reopenedNew.Get(ctx, "acme")
+	if err != nil {
+		t.Fatalf("Get reopened new: %v", err)
+	}
+	if !bytes.Equal(got, dek) {
+		t.Fatalf("Get reopened new returned wrong DEK")
+	}
+
+	reopenedOld, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: oldMaster})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault old reopened: %v", err)
+	}
+	if _, err := reopenedOld.Get(ctx, "acme"); !errors.Is(err, ErrVaultAuthentication) {
+		t.Fatalf("Get reopened old: got %v, want ErrVaultAuthentication", err)
+	}
+}
+
+func TestTenantKeyVaultBindsWrappedKeyToTenantID(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0x78)
+	dek := testMaster(0x79)
+	gs := testGlobalStore(t)
+
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault: %v", err)
+	}
+	if err := vault.Provision(ctx, "acme", dek); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if _, err := gs.DB().ExecContext(ctx,
+		`UPDATE tenant_key_vault SET tenant_id = ? WHERE tenant_id = ?`,
+		"globex", "acme",
+	); err != nil {
+		t.Fatalf("rename tenant key row: %v", err)
+	}
+	if _, err := vault.Get(ctx, "globex"); !errors.Is(err, ErrVaultAuthentication) {
+		t.Fatalf("Get renamed row: got %v, want ErrVaultAuthentication", err)
+	}
+}
+
+func TestTenantKeyVaultRejectsShreddedProvision(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0x88)
+	dek := testMaster(0x99)
+	gs := testGlobalStore(t)
+
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault: %v", err)
+	}
+	if err := vault.Provision(ctx, "acme", dek); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if err := vault.Shred(ctx, "acme"); err != nil {
+		t.Fatalf("Shred: %v", err)
+	}
+	if err := vault.Provision(ctx, "acme", dek); !errors.Is(err, ErrTenantShredded) {
+		t.Fatalf("Provision after shred: got %v, want ErrTenantShredded", err)
+	}
+}
+
+func TestTenantKeyVaultRejectsEmptyTenantID(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0xaa)
+	dek := testMaster(0xbb)
+	gs := testGlobalStore(t)
+
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault: %v", err)
+	}
+	for name, call := range map[string]func() error{
+		"Get": func() error {
+			_, err := vault.Get(ctx, "")
+			return err
+		},
+		"GetRow": func() error {
+			_, err := vault.GetRow(ctx, "")
+			return err
+		},
+		"Provision": func() error {
+			return vault.Provision(ctx, "", dek)
+		},
+		"Shred": func() error {
+			return vault.Shred(ctx, "")
+		},
+	} {
+		if err := call(); err == nil {
+			t.Fatalf("%s accepted empty tenant_id", name)
+		}
+	}
+}
+
+func testGlobalStore(t *testing.T) *globalstore.GlobalStore {
+	t.Helper()
+	gs, err := globalstore.New(globalstore.Options{
+		DataDir: t.TempDir(),
+		WALMode: true,
+	})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+	return gs
+}
+
+func testMaster(fill byte) []byte {
+	key := make([]byte, KeyLength)
+	for i := range key {
+		key[i] = fill
+	}
+	return key
+}
+
+func fixedTime(ms int64) func() time.Time {
+	return func() time.Time {
+		return time.UnixMilli(ms)
+	}
+}

--- a/server/go/internal/crypto/tenant_key_vault.go
+++ b/server/go/internal/crypto/tenant_key_vault.go
@@ -1,0 +1,306 @@
+package crypto
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+const (
+	vaultTableDDL = `
+CREATE TABLE IF NOT EXISTS tenant_key_vault (
+    tenant_id       TEXT PRIMARY KEY NOT NULL,
+    wrapped_key     BLOB,
+    created_at_ms   INTEGER NOT NULL,
+    shredded_at_ms  INTEGER,
+    CHECK (
+        (wrapped_key IS NOT NULL AND shredded_at_ms IS NULL) OR
+        (wrapped_key IS NULL AND shredded_at_ms IS NOT NULL)
+    )
+);
+`
+	nonceLength = 12
+)
+
+var (
+	ErrTenantKeyNotFound           = errors.New("crypto: tenant key not found")
+	ErrTenantKeyAlreadyProvisioned = errors.New("crypto: tenant key already provisioned")
+	ErrVaultAuthentication         = errors.New("crypto: tenant key vault authentication failed")
+)
+
+type VaultRow struct {
+	TenantID     string
+	WrappedKey   []byte
+	CreatedAtMS  int64
+	ShreddedAtMS sql.NullInt64
+}
+
+type TenantKeyVault struct {
+	db    *sql.DB
+	aead  cipher.AEAD
+	nowFn func() time.Time
+	mu    sync.Mutex
+}
+
+type TenantKeyVaultOptions struct {
+	DB        *sql.DB
+	MasterKey []byte
+	NowFn     func() time.Time
+}
+
+func NewTenantKeyVault(ctx context.Context, opts TenantKeyVaultOptions) (*TenantKeyVault, error) {
+	if opts.DB == nil {
+		return nil, errors.New("crypto: tenant key vault DB is required")
+	}
+	if len(opts.MasterKey) != KeyLength {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMasterKey, len(opts.MasterKey))
+	}
+	block, err := aes.NewCipher(opts.MasterKey)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: create vault cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: create vault AEAD: %w", err)
+	}
+	nowFn := opts.NowFn
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	v := &TenantKeyVault{
+		db:    opts.DB,
+		aead:  aead,
+		nowFn: nowFn,
+	}
+	if err := v.initSchema(ctx); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (v *TenantKeyVault) initSchema(ctx context.Context) error {
+	if _, err := v.db.ExecContext(ctx, vaultTableDDL); err != nil {
+		return fmt.Errorf("crypto: create tenant key vault schema: %w", err)
+	}
+	return nil
+}
+
+func (v *TenantKeyVault) GetRow(ctx context.Context, tenantID string) (*VaultRow, error) {
+	if tenantID == "" {
+		return nil, errors.New("crypto: tenant_id is required")
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.getRowLocked(ctx, tenantID)
+}
+
+func (v *TenantKeyVault) Get(ctx context.Context, tenantID string) ([]byte, error) {
+	if tenantID == "" {
+		return nil, errors.New("crypto: tenant_id is required")
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	row, err := v.getRowLocked(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, fmt.Errorf("%w: %s", ErrTenantKeyNotFound, tenantID)
+	}
+	if row.ShreddedAtMS.Valid {
+		return nil, &TenantShreddedError{TenantID: tenantID}
+	}
+	if len(row.WrappedKey) == 0 {
+		return nil, fmt.Errorf("crypto: vault row %q has no wrapped key", tenantID)
+	}
+	return v.unwrap(row.WrappedKey, tenantID)
+}
+
+func (v *TenantKeyVault) Provision(ctx context.Context, tenantID string, dek []byte) error {
+	if tenantID == "" {
+		return errors.New("crypto: tenant_id is required")
+	}
+	if len(dek) != KeyLength {
+		return fmt.Errorf("crypto: tenant DEK must be exactly %d bytes, got %d", KeyLength, len(dek))
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	row, err := v.getRowLocked(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	if row != nil {
+		if row.ShreddedAtMS.Valid {
+			return &TenantShreddedError{TenantID: tenantID}
+		}
+		return fmt.Errorf("%w: %s", ErrTenantKeyAlreadyProvisioned, tenantID)
+	}
+	wrapped, err := v.wrap(dek, tenantID)
+	if err != nil {
+		return err
+	}
+	if _, err := v.db.ExecContext(ctx,
+		`INSERT INTO tenant_key_vault (tenant_id, wrapped_key, created_at_ms) VALUES (?, ?, ?)`,
+		tenantID, wrapped, v.nowFn().UnixMilli(),
+	); err != nil {
+		return fmt.Errorf("crypto: provision tenant key %q: %w", tenantID, err)
+	}
+	return nil
+}
+
+func (v *TenantKeyVault) Shred(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return errors.New("crypto: tenant_id is required")
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	row, err := v.getRowLocked(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	if row == nil {
+		return fmt.Errorf("%w: %s", ErrTenantKeyNotFound, tenantID)
+	}
+	if row.ShreddedAtMS.Valid {
+		return nil
+	}
+	if _, err := v.db.ExecContext(ctx,
+		`UPDATE tenant_key_vault SET wrapped_key = NULL, shredded_at_ms = ? WHERE tenant_id = ?`,
+		v.nowFn().UnixMilli(), tenantID,
+	); err != nil {
+		return fmt.Errorf("crypto: shred tenant key %q: %w", tenantID, err)
+	}
+	return nil
+}
+
+func (v *TenantKeyVault) IsShredded(ctx context.Context, tenantID string) (bool, error) {
+	row, err := v.GetRow(ctx, tenantID)
+	if err != nil {
+		return false, err
+	}
+	return row != nil && row.ShreddedAtMS.Valid, nil
+}
+
+func (v *TenantKeyVault) RewrapWithNewMaster(ctx context.Context, newMasterKey []byte) (int, error) {
+	if len(newMasterKey) != KeyLength {
+		return 0, fmt.Errorf("%w: got %d", ErrInvalidMasterKey, len(newMasterKey))
+	}
+	block, err := aes.NewCipher(newMasterKey)
+	if err != nil {
+		return 0, fmt.Errorf("crypto: create new vault cipher: %w", err)
+	}
+	newAEAD, err := cipher.NewGCM(block)
+	if err != nil {
+		return 0, fmt.Errorf("crypto: create new vault AEAD: %w", err)
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	tx, err := v.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("crypto: begin vault rewrap: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `SELECT tenant_id, wrapped_key FROM tenant_key_vault WHERE shredded_at_ms IS NULL`)
+	if err != nil {
+		return 0, fmt.Errorf("crypto: list active tenant keys: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type update struct {
+		tenantID string
+		wrapped  []byte
+	}
+	updates := []update{}
+	for rows.Next() {
+		var tenantID string
+		var wrapped []byte
+		if err := rows.Scan(&tenantID, &wrapped); err != nil {
+			return 0, fmt.Errorf("crypto: scan tenant key for rewrap: %w", err)
+		}
+		dek, err := v.unwrap(wrapped, tenantID)
+		if err != nil {
+			return 0, err
+		}
+		newWrapped, err := wrapWithAEAD(newAEAD, dek, tenantID)
+		if err != nil {
+			return 0, err
+		}
+		updates = append(updates, update{tenantID: tenantID, wrapped: newWrapped})
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("crypto: iterate tenant keys for rewrap: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("crypto: close tenant key cursor for rewrap: %w", err)
+	}
+	for _, upd := range updates {
+		if _, err := tx.ExecContext(ctx, `UPDATE tenant_key_vault SET wrapped_key = ? WHERE tenant_id = ?`, upd.wrapped, upd.tenantID); err != nil {
+			return 0, fmt.Errorf("crypto: update rewrapped tenant key %q: %w", upd.tenantID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("crypto: commit vault rewrap: %w", err)
+	}
+	v.aead = newAEAD
+	return len(updates), nil
+}
+
+func (v *TenantKeyVault) getRowLocked(ctx context.Context, tenantID string) (*VaultRow, error) {
+	row := v.db.QueryRowContext(ctx,
+		`SELECT tenant_id, wrapped_key, created_at_ms, shredded_at_ms FROM tenant_key_vault WHERE tenant_id = ?`,
+		tenantID,
+	)
+	var out VaultRow
+	if err := row.Scan(&out.TenantID, &out.WrappedKey, &out.CreatedAtMS, &out.ShreddedAtMS); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("crypto: read tenant key row %q: %w", tenantID, err)
+	}
+	return &out, nil
+}
+
+func (v *TenantKeyVault) wrap(dek []byte, tenantID string) ([]byte, error) {
+	return wrapWithAEAD(v.aead, dek, tenantID)
+}
+
+func (v *TenantKeyVault) unwrap(blob []byte, tenantID string) ([]byte, error) {
+	if len(blob) <= nonceLength {
+		return nil, fmt.Errorf("crypto: vault row %q is too short", tenantID)
+	}
+	nonce := blob[:nonceLength]
+	ciphertext := blob[nonceLength:]
+	dek, err := v.aead.Open(nil, nonce, ciphertext, []byte(tenantID))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrVaultAuthentication, tenantID)
+	}
+	if len(dek) != KeyLength {
+		return nil, fmt.Errorf("crypto: vault row %q unwrapped to %d bytes, want %d", tenantID, len(dek), KeyLength)
+	}
+	return dek, nil
+}
+
+func wrapWithAEAD(aead cipher.AEAD, dek []byte, tenantID string) ([]byte, error) {
+	nonce := make([]byte, nonceLength)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("crypto: generate vault nonce: %w", err)
+	}
+	ciphertext := aead.Seal(nil, nonce, dek, []byte(tenantID))
+	out := make([]byte, 0, len(nonce)+len(ciphertext))
+	out = append(out, nonce...)
+	out = append(out, ciphertext...)
+	return out, nil
+}


### PR DESCRIPTION
## Summary

- Add `server/go/internal/crypto` with HKDF-SHA256 per-tenant key derivation and copy-safe in-memory key caching.
- Add a `tenant_key_vault` table for `global.db` callers that wraps tenant DEKs under an AES-GCM master key, binds ciphertext to `tenant_id` as associated data, and supports master rewrap.
- Add crypto-shred tombstones by nulling wrapped tenant keys and persisting `shredded_at_ms`, with `ErrTenantShredded` surfaced across reopened vault/manager instances.

## Tests

- `go test ./internal/crypto`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `git diff --cached --check`

Refs #519

Notes: this is the key hierarchy / vault / crypto-shred foundation slice only. It intentionally does not close #519 because SQLCipher driver wiring, KMS provider bootstrap, CLI flags, file encryption integration, and GDPR delete-flow wiring remain in the epic.