### PR TITLE
Implement encryption at rest and gRPC TLS controls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,8 @@ jobs:
           # server image is the Go reimplementation (Phase 4D of
           # EPIC #407 — Python server retired). Image name is
           # unchanged (ghcr.io/<repo>:vX.Y.Z) so downstream consumers
-          # see a drop-in replacement. CGO is disabled in the Dockerfile
-          # (pure-Go SQLite via modernc.org/sqlite) so both arch legs
-          # build natively without QEMU.
+          # see a drop-in replacement. SQLCipher requires CGO, so each
+          # arch leg builds on a native runner instead of cross-compiling.
           - target: server
             suffix: ""
             dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 # EntDB Server (Go) Dockerfile
 #
 # Multi-stage build that compiles server/go/cmd/entdb-server into a
-# minimal distroless runtime image. Uses modernc.org/sqlite (pure-Go
-# SQLite) so CGO_ENABLED=0 and the binary lands in a "static" distroless
-# base — no glibc, no shell, no package manager.
+# minimal distroless runtime image. The server links SQLCipher via cgo
+# so tenant/global SQLite files can be encrypted at rest.
 #
 # Wave 5 (EPIC #407) ships this image alongside the existing Python
 # server image (see ../Dockerfile) so the E2E suite can target either
@@ -21,7 +20,7 @@
 #   docker run --rm entdb-server-go:test -help
 
 # =============================================================================
-# Builder stage — compile the binary with CGO disabled
+# Builder stage — compile the binary with CGO enabled for SQLCipher
 # =============================================================================
 FROM golang:1.25-bookworm AS builder
 
@@ -35,11 +34,11 @@ RUN cd server/go && go mod download
 # Bring in the rest of the Go server source.
 COPY server/go/ ./server/go/
 
-# CGO disabled so the resulting binary is statically linked and runs on
-# `gcr.io/distroless/static-debian12`. modernc.org/sqlite is pure Go, so
-# this works for the persistence layer too.
+# CGO is required by github.com/mutecomm/go-sqlcipher/v4. Release builds
+# run on native amd64/arm64 runners, so no cross-compiled cgo toolchain
+# is needed here.
 RUN cd server/go && \
-    CGO_ENABLED=0 GOOS=linux go build \
+    CGO_ENABLED=1 GOOS=linux go build \
         -trimpath -ldflags="-s -w" \
         -o /entdb-server \
         ./cmd/entdb-server
@@ -51,9 +50,9 @@ RUN cd server/go && \
 RUN mkdir -p /staging/var/lib/entdb && chown -R 65532:65532 /staging
 
 # =============================================================================
-# Runtime stage — distroless static, just the binary
+# Runtime stage — distroless base with glibc for the cgo-linked binary
 # =============================================================================
-FROM gcr.io/distroless/static-debian12:nonroot AS server
+FROM gcr.io/distroless/base-debian12:nonroot AS server
 
 ARG VERSION=dev
 ARG COMMIT=unknown
@@ -75,7 +74,7 @@ EXPOSE 50051
 
 USER nonroot:nonroot
 
-# distroless/static has no shell, so we must use the exec form. The
+# distroless has no shell, so we must use the exec form. The
 # default flags wire up an in-memory WAL (the only backend the Go server
 # supports today — Kafka/etc land in a later wave) and point the data
 # directory at /var/lib/entdb. Override the full command at `docker run`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -328,6 +328,34 @@ platforms: linux/amd64,linux/arm64
 | `ENTDB_GRPC_PORT` | No | gRPC port (default: 50051) |
 | `ENTDB_HTTP_PORT` | No | HTTP port (default: 8080) |
 
+The Go server is configured with flags rather than environment
+variables. Production launches should include the security flags below:
+
+```bash
+/entdb-server \
+  -addr=:50051 \
+  -data-dir=/var/lib/entdb \
+  -wal-backend=kafka \
+  -wal-brokers="$KAFKA_BROKERS" \
+  -tls-cert=/etc/entdb/tls/server.pem \
+  -tls-key=/etc/entdb/tls/server-key.pem \
+  -tls-ca=/etc/entdb/tls/client-ca.pem \
+  -require-tls=true \
+  -require-client-cert=true \
+  -kms-provider=aws \
+  -kms-key-id="$AWS_KMS_KEY_ID" \
+  -encryption-required=true
+```
+
+`-kms-provider=file` accepts `-kms-key-id=/path/to/master.key` or
+`-kms-key-id=env:ENTDB_MASTER_KEY` for local development. The key
+material must be 32 raw bytes, 64 hex characters, or base64-encoded
+32 bytes. `-kms-provider=aws` uses AWS KMS envelope encryption: the
+server generates one 256-bit data key on first boot, persists only the
+KMS ciphertext blob under `-data-dir`, and decrypts it on later boots.
+`-kms-provider=vault` uses Vault Transit data keys with `VAULT_ADDR`,
+`VAULT_TOKEN`, and optional `VAULT_NAMESPACE`.
+
 ### Secrets
 
 Store sensitive values in AWS Secrets Manager:
@@ -490,6 +518,26 @@ resource "aws_iam_role_policy" "ecs_task" {
 
 ### Encryption
 
+- EntDB SQLite files with SQLCipher (`-encryption-required=true`)
 - S3 buckets with SSE-S3 or SSE-KMS
 - MSK with TLS and encryption at rest
 - Secrets in Secrets Manager
+
+`global.db` and every `tenant_<id>.db` file are opened with SQLCipher
+when a master key is configured. Existing plaintext files are refused
+when encryption is configured, so migrate data before enabling
+`-encryption-required=true` on an existing plaintext deployment.
+
+### gRPC TLS and mTLS
+
+Run plaintext only for local development. In production set
+`-require-tls=true`; set `-require-client-cert=true` when service
+callers authenticate with client certificates. The server verifies
+client certificates against `-tls-ca` and maps the verified URI SAN,
+DNS SAN, email SAN, or CommonName into a trusted `system:<id>` actor
+for request authorization.
+
+Certificates may be issued by ACME, a cloud-managed private CA, or an
+internal CA. Keep the certificate, key, and CA bundle on disk and send
+`SIGHUP` to the process after rotation; new TLS handshakes use the
+reloaded cert/key/CA without restarting the server.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,6 +4,21 @@ Guide for operating EntDB in production.
 
 ## Monitoring
 
+## Production Checklist
+
+- Start `entdb-server` with `-require-tls=true`.
+- Use `-tls-min-version=1.3` unless a documented legacy client still
+  requires `1.2`.
+- Configure `-tls-cert`, `-tls-key`, and `-tls-ca`; use
+  `-require-client-cert=true` for service-to-service mTLS.
+- Rotate cert/key/CA files by replacing them atomically and sending
+  `SIGHUP` to the server process.
+- Start with `-encryption-required=true` plus `-kms-provider` and
+  `-kms-key-id`; verify `global.db` and tenant DB files are SQLCipher
+  files before accepting production traffic.
+- Leave `-gdpr-worker-enabled=true` so due `DeleteUser` jobs complete
+  and personal tenant keys are crypto-shredded after grace expiry.
+
 ### Key Metrics
 
 #### Request Metrics

--- a/sdk/python/entdb_sdk/_grpc_client.py
+++ b/sdk/python/entdb_sdk/_grpc_client.py
@@ -532,7 +532,7 @@ class GrpcClient:
         sub-channels managed by the redirect cache.
         """
         if self._secure:
-            if self._credentials:
+            if self._credentials is not None:
                 return grpc_aio.secure_channel(address, self._credentials)
             return grpc_aio.secure_channel(address, grpc.ssl_channel_credentials())
         return grpc_aio.insecure_channel(

--- a/sdk/python/entdb_sdk/client.py
+++ b/sdk/python/entdb_sdk/client.py
@@ -686,6 +686,7 @@ class DbClient:
         *,
         secure: bool = False,
         api_key: str | None = None,
+        credentials: Any | None = None,
         max_retries: int = 3,
         registry: SchemaRegistry | None = None,
         schema_module: Any | None = None,
@@ -699,6 +700,8 @@ class DbClient:
             address: Server address (host:port or just host)
             secure: Whether to use TLS
             api_key: Optional API key for authentication
+            credentials: Optional gRPC channel credentials. When set,
+                `secure` should also be true.
             max_retries: Maximum number of retries for transient gRPC failures
             registry: Optional schema registry
             schema_module: Optional generated schema module (e.g. the module
@@ -737,6 +740,7 @@ class DbClient:
             host=host,
             port=port,
             secure=secure,
+            credentials=credentials,
             api_key=api_key,
             max_retries=max_retries,
             registry=self.registry,

--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -24,6 +24,9 @@ import (
 	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/audit"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/gdpr"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
@@ -41,6 +44,12 @@ func main() {
 	tlsMinVersion := flag.String("tls-min-version", "1.3", "minimum TLS version: 1.3 | 1.2")
 	requireTLS := flag.Bool("require-tls", false, "refuse to start unless TLS is configured")
 	requireClientCert := flag.Bool("require-client-cert", false, "require and verify client certificates (mTLS; requires --tls-ca)")
+	kmsProvider := flag.String("kms-provider", "", "encryption master-key provider: file | aws | gcp | azure | vault")
+	kmsKeyID := flag.String("kms-key-id", "", "master-key provider identifier; file provider accepts path or env:NAME")
+	encryptionRequired := flag.Bool("encryption-required", false, "require encrypted global.db and tenant SQLite files")
+	gdprWorkerEnabled := flag.Bool("gdpr-worker-enabled", true, "run GDPR deletion_queue worker that performs due deletes and crypto-shred")
+	gdprWorkerInterval := flag.Duration("gdpr-worker-interval", time.Minute, "how often the GDPR worker scans for due deletions")
+	cryptoShredDeleteFiles := flag.Bool("crypto-shred-delete-files", false, "delete tenant .db/-wal/-shm files after key shred")
 	walBackend := flag.String("wal-backend", "memory", "WAL backend: memory | kafka")
 	walTopic := flag.String("wal-topic", "entdb-wal", "WAL topic name")
 	walGroup := flag.String("wal-group", "entdb-applier", "WAL consumer group id")
@@ -109,19 +118,66 @@ func main() {
 		srvOpts = append(srvOpts, api.WithSchemaRegistry(registry))
 	}
 
-	canonical, err := store.New(store.Options{RootDir: *dataDir, WALMode: true, Registry: registry})
-	if err != nil {
-		log.Fatalf("entdb-server: open canonical store: %v", err)
-	}
-	defer func() { _ = canonical.Close() }()
-	srvOpts = append(srvOpts, api.WithStore(canonical))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	global, err := globalstore.New(globalstore.Options{DataDir: *dataDir, WALMode: true})
+	var masterKey []byte
+	encryptionConfigured := *encryptionRequired ||
+		strings.TrimSpace(*kmsProvider) != "" ||
+		strings.TrimSpace(*kmsKeyID) != ""
+	if encryptionConfigured {
+		masterKey, err = entcrypto.LoadMasterKey(ctx, entcrypto.MasterKeyConfig{
+			Provider: *kmsProvider,
+			KeyID:    *kmsKeyID,
+			DataDir:  *dataDir,
+		})
+		if err != nil {
+			log.Fatalf("entdb-server: encryption master key: %v", err)
+		}
+	}
+
+	global, err := globalstore.New(globalstore.Options{
+		DataDir:            *dataDir,
+		WALMode:            true,
+		EncryptionKey:      masterKey,
+		EncryptionRequired: *encryptionRequired,
+	})
 	if err != nil {
 		log.Fatalf("entdb-server: open global store: %v", err)
 	}
 	defer func() { _ = global.Close() }()
 	srvOpts = append(srvOpts, api.WithGlobalStore(global))
+
+	var keyManager *entcrypto.KeyManager
+	if len(masterKey) > 0 {
+		vault, err := entcrypto.NewTenantKeyVault(ctx, entcrypto.TenantKeyVaultOptions{
+			DB:        global.DB(),
+			MasterKey: masterKey,
+		})
+		if err != nil {
+			log.Fatalf("entdb-server: tenant key vault: %v", err)
+		}
+		keyManager, err = entcrypto.NewKeyManager(masterKey, vault)
+		if err != nil {
+			log.Fatalf("entdb-server: key manager: %v", err)
+		}
+		log.Printf("entdb-server: encryption-at-rest enabled (kms-provider=%s encryption-required=%v)", effectiveKMSProvider(*kmsProvider), *encryptionRequired)
+	} else {
+		log.Printf("entdb-server: WARNING: encryption-at-rest disabled; plaintext SQLite files are for local/dev use only")
+	}
+
+	canonical, err := store.New(store.Options{
+		RootDir:            *dataDir,
+		WALMode:            true,
+		Registry:           registry,
+		KeyManager:         keyManager,
+		EncryptionRequired: *encryptionRequired,
+	})
+	if err != nil {
+		log.Fatalf("entdb-server: open canonical store: %v", err)
+	}
+	defer func() { _ = canonical.Close() }()
+	srvOpts = append(srvOpts, api.WithStore(canonical))
 
 	// WAL backend wiring. memory: in-process, lost on restart (dev /
 	// short-running tests). kafka: Kafka/Redpanda; production-grade,
@@ -143,13 +199,10 @@ func main() {
 	default:
 		log.Fatalf("entdb-server: unsupported wal backend %q (want memory|kafka)", *walBackend)
 	}
-	if err := walImpl.Connect(context.Background()); err != nil {
+	if err := walImpl.Connect(ctx); err != nil {
 		log.Fatalf("entdb-server: wal connect: %v", err)
 	}
 	srvOpts = append(srvOpts, api.WithWALProducer(walImpl), api.WithWALTopic(*walTopic))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	var archiver *audit.Archiver
 	if *archiveEnabled {
@@ -217,6 +270,22 @@ func main() {
 			archiveErr <- archiver.Run(ctx)
 		}()
 	}
+	gdprErr := make(chan error, 1)
+	if *gdprWorkerEnabled {
+		gdprProcessor, err := gdpr.New(gdpr.Options{
+			Global:                global,
+			Store:                 canonical,
+			Keys:                  keyManager,
+			RemoveCiphertextFiles: *cryptoShredDeleteFiles,
+		})
+		if err != nil {
+			log.Fatalf("entdb-server: gdpr worker: %v", err)
+		}
+		go func() {
+			gdprErr <- gdprProcessor.Run(ctx, *gdprWorkerInterval)
+		}()
+		log.Printf("entdb-server: GDPR deletion worker enabled (interval=%s crypto-shred-delete-files=%v)", *gdprWorkerInterval, *cryptoShredDeleteFiles)
+	}
 
 	// Test-only seed: the cross-impl harnesses boot the binary with
 	// --seed-tenant <id> --seed-profile <name> and expect the tenant +
@@ -240,7 +309,7 @@ func main() {
 		}
 	}
 
-	grpcServerOpts, tlsEnabled, err := grpcServerTLSOptions(serverTLSConfig{
+	grpcServerOpts, tlsEnabled, tlsReloader, err := grpcServerTLSOptions(serverTLSConfig{
 		certFile:          *tlsCert,
 		keyFile:           *tlsKey,
 		caFile:            *tlsCA,
@@ -252,6 +321,10 @@ func main() {
 		log.Fatalf("entdb-server: TLS config: %v", err)
 	}
 	if tlsEnabled {
+		grpcServerOpts = append(grpcServerOpts,
+			grpc.ChainUnaryInterceptor(auth.MTLSPeerIdentityUnaryInterceptor()),
+			grpc.ChainStreamInterceptor(auth.MTLSPeerIdentityStreamInterceptor()),
+		)
 		log.Printf("entdb-server: TLS enabled (min-version=%s client-auth=%s)", *tlsMinVersion, clientAuthMode(*tlsCA, *requireClientCert))
 	} else {
 		log.Printf("entdb-server: WARNING: TLS disabled; plaintext gRPC listener is for local/dev use only")
@@ -267,6 +340,25 @@ func main() {
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+	if tlsReloader != nil {
+		reload := make(chan os.Signal, 1)
+		signal.Notify(reload, syscall.SIGHUP)
+		go func() {
+			defer signal.Stop(reload)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-reload:
+					if err := tlsReloader.Reload(); err != nil {
+						log.Printf("entdb-server: TLS reload failed: %v", err)
+					} else {
+						log.Printf("entdb-server: TLS cert/key/CA reloaded after SIGHUP")
+					}
+				}
+			}
+		}()
+	}
 	go func() {
 		<-stop
 		log.Printf("entdb-server: shutting down")
@@ -290,6 +382,10 @@ func main() {
 	case err := <-archiveErr:
 		if err != nil && err != context.Canceled {
 			log.Printf("entdb-server: archive sidecar exited: %v", err)
+		}
+	case err := <-gdprErr:
+		if err != nil && err != context.Canceled {
+			log.Printf("entdb-server: gdpr worker exited: %v", err)
 		}
 	}
 }
@@ -337,4 +433,11 @@ func splitBrokers(s string) []string {
 		}
 	}
 	return out
+}
+
+func effectiveKMSProvider(provider string) string {
+	if strings.TrimSpace(provider) == "" {
+		return "file"
+	}
+	return strings.TrimSpace(provider)
 }

--- a/server/go/cmd/entdb-server/tls.go
+++ b/server/go/cmd/entdb-server/tls.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -20,18 +21,18 @@ type serverTLSConfig struct {
 	requireClientCert bool
 }
 
-func grpcServerTLSOptions(cfg serverTLSConfig) ([]grpc.ServerOption, bool, error) {
-	tlsCfg, enabled, err := buildServerTLSConfig(cfg)
+func grpcServerTLSOptions(cfg serverTLSConfig) ([]grpc.ServerOption, bool, *tlsReloader, error) {
+	tlsCfg, enabled, reloader, err := buildServerTLSConfig(cfg)
 	if err != nil {
-		return nil, false, err
+		return nil, false, nil, err
 	}
 	if !enabled {
-		return nil, false, nil
+		return nil, false, nil, nil
 	}
-	return []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}, true, nil
+	return []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}, true, reloader, nil
 }
 
-func buildServerTLSConfig(cfg serverTLSConfig) (*tls.Config, bool, error) {
+func buildServerTLSConfig(cfg serverTLSConfig) (*tls.Config, bool, *tlsReloader, error) {
 	certFile := strings.TrimSpace(cfg.certFile)
 	keyFile := strings.TrimSpace(cfg.keyFile)
 	caFile := strings.TrimSpace(cfg.caFile)
@@ -39,55 +40,114 @@ func buildServerTLSConfig(cfg serverTLSConfig) (*tls.Config, bool, error) {
 	tlsRequested := certFile != "" || keyFile != "" || caFile != ""
 	if !tlsRequested {
 		if cfg.requireTLS {
-			return nil, false, fmt.Errorf("--require-tls requires --tls-cert and --tls-key")
+			return nil, false, nil, fmt.Errorf("--require-tls requires --tls-cert and --tls-key")
 		}
 		if cfg.requireClientCert {
-			return nil, false, fmt.Errorf("--require-client-cert requires TLS and --tls-ca")
+			return nil, false, nil, fmt.Errorf("--require-client-cert requires TLS and --tls-ca")
 		}
-		return nil, false, nil
+		return nil, false, nil, nil
 	}
 	if certFile == "" || keyFile == "" {
-		return nil, false, fmt.Errorf("TLS requires both --tls-cert and --tls-key")
+		return nil, false, nil, fmt.Errorf("TLS requires both --tls-cert and --tls-key")
 	}
 
 	minVersion, err := parseTLSMinVersion(cfg.minVersion)
 	if err != nil {
-		return nil, false, err
+		return nil, false, nil, err
 	}
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, false, fmt.Errorf("load server certificate/key: %w", err)
-	}
-
-	tlsCfg := &tls.Config{
-		MinVersion:   minVersion,
-		Certificates: []tls.Certificate{cert},
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-		},
-	}
-
+	clientAuth := tls.NoClientCert
 	if caFile != "" {
-		pool, err := loadCertPool(caFile)
-		if err != nil {
-			return nil, false, err
-		}
-		tlsCfg.ClientCAs = pool
-		tlsCfg.ClientAuth = tls.VerifyClientCertIfGiven
+		clientAuth = tls.VerifyClientCertIfGiven
 	}
 	if cfg.requireClientCert {
 		if caFile == "" {
-			return nil, false, fmt.Errorf("--require-client-cert requires --tls-ca")
+			return nil, false, nil, fmt.Errorf("--require-client-cert requires --tls-ca")
 		}
-		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+		clientAuth = tls.RequireAndVerifyClientCert
 	}
 
-	return tlsCfg, true, nil
+	reloader, err := newTLSReloader(serverTLSConfig{
+		certFile:          certFile,
+		keyFile:           keyFile,
+		caFile:            caFile,
+		minVersion:        cfg.minVersion,
+		requireTLS:        cfg.requireTLS,
+		requireClientCert: cfg.requireClientCert,
+	}, minVersion, clientAuth)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	tlsCfg := reloader.currentConfig()
+	tlsCfg.GetConfigForClient = reloader.GetConfigForClient
+	return tlsCfg, true, reloader, nil
+}
+
+type tlsReloader struct {
+	cfg        serverTLSConfig
+	minVersion uint16
+	clientAuth tls.ClientAuthType
+
+	mu        sync.RWMutex
+	cert      tls.Certificate
+	clientCAs *x509.CertPool
+}
+
+func newTLSReloader(cfg serverTLSConfig, minVersion uint16, clientAuth tls.ClientAuthType) (*tlsReloader, error) {
+	r := &tlsReloader{
+		cfg:        cfg,
+		minVersion: minVersion,
+		clientAuth: clientAuth,
+	}
+	if err := r.Reload(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *tlsReloader) Reload() error {
+	cert, err := tls.LoadX509KeyPair(r.cfg.certFile, r.cfg.keyFile)
+	if err != nil {
+		return fmt.Errorf("load server certificate/key: %w", err)
+	}
+	var pool *x509.CertPool
+	if strings.TrimSpace(r.cfg.caFile) != "" {
+		pool, err = loadCertPool(r.cfg.caFile)
+		if err != nil {
+			return err
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cert = cert
+	r.clientCAs = pool
+	return nil
+}
+
+func (r *tlsReloader) GetConfigForClient(*tls.ClientHelloInfo) (*tls.Config, error) {
+	return r.currentConfig(), nil
+}
+
+func (r *tlsReloader) currentConfig() *tls.Config {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return &tls.Config{
+		MinVersion:   r.minVersion,
+		Certificates: []tls.Certificate{r.cert},
+		ClientCAs:    r.clientCAs,
+		ClientAuth:   r.clientAuth,
+		CipherSuites: modernCipherSuites(),
+	}
+}
+
+func modernCipherSuites() []uint16 {
+	return []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	}
 }
 
 func parseTLSMinVersion(version string) (uint16, error) {

--- a/server/go/cmd/entdb-server/tls_test.go
+++ b/server/go/cmd/entdb-server/tls_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -9,15 +10,22 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func TestBuildServerTLSConfigPlaintextAllowed(t *testing.T) {
-	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{})
+	tlsCfg, enabled, reloader, err := buildServerTLSConfig(serverTLSConfig{})
 	if err != nil {
 		t.Fatalf("buildServerTLSConfig: %v", err)
 	}
@@ -27,10 +35,13 @@ func TestBuildServerTLSConfigPlaintextAllowed(t *testing.T) {
 	if tlsCfg != nil {
 		t.Fatalf("tlsCfg = %#v, want nil", tlsCfg)
 	}
+	if reloader != nil {
+		t.Fatalf("reloader = %#v, want nil", reloader)
+	}
 }
 
 func TestBuildServerTLSConfigRequireTLSRejectsPlaintext(t *testing.T) {
-	_, _, err := buildServerTLSConfig(serverTLSConfig{requireTLS: true})
+	_, _, _, err := buildServerTLSConfig(serverTLSConfig{requireTLS: true})
 	if err == nil {
 		t.Fatal("buildServerTLSConfig err = nil, want require TLS error")
 	}
@@ -42,7 +53,7 @@ func TestBuildServerTLSConfigRequireTLSRejectsPlaintext(t *testing.T) {
 func TestBuildServerTLSConfigServerTLS(t *testing.T) {
 	certFile, keyFile, _ := writeTLSFixture(t)
 
-	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{
+	tlsCfg, enabled, reloader, err := buildServerTLSConfig(serverTLSConfig{
 		certFile: certFile,
 		keyFile:  keyFile,
 	})
@@ -51,6 +62,9 @@ func TestBuildServerTLSConfigServerTLS(t *testing.T) {
 	}
 	if !enabled {
 		t.Fatal("enabled = false, want true")
+	}
+	if reloader == nil {
+		t.Fatal("reloader = nil, want non-nil")
 	}
 	if tlsCfg.MinVersion != tls.VersionTLS13 {
 		t.Fatalf("MinVersion = %x, want TLS 1.3", tlsCfg.MinVersion)
@@ -66,7 +80,7 @@ func TestBuildServerTLSConfigServerTLS(t *testing.T) {
 func TestBuildServerTLSConfigOptionalClientCertVerification(t *testing.T) {
 	certFile, keyFile, caFile := writeTLSFixture(t)
 
-	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{
+	tlsCfg, enabled, _, err := buildServerTLSConfig(serverTLSConfig{
 		certFile: certFile,
 		keyFile:  keyFile,
 		caFile:   caFile,
@@ -88,7 +102,7 @@ func TestBuildServerTLSConfigOptionalClientCertVerification(t *testing.T) {
 func TestBuildServerTLSConfigRequiresClientCert(t *testing.T) {
 	certFile, keyFile, caFile := writeTLSFixture(t)
 
-	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{
+	tlsCfg, enabled, _, err := buildServerTLSConfig(serverTLSConfig{
 		certFile:          certFile,
 		keyFile:           keyFile,
 		caFile:            caFile,
@@ -108,7 +122,7 @@ func TestBuildServerTLSConfigRequiresClientCert(t *testing.T) {
 func TestBuildServerTLSConfigRequireClientCertNeedsCA(t *testing.T) {
 	certFile, keyFile, _ := writeTLSFixture(t)
 
-	_, _, err := buildServerTLSConfig(serverTLSConfig{
+	_, _, _, err := buildServerTLSConfig(serverTLSConfig{
 		certFile:          certFile,
 		keyFile:           keyFile,
 		requireClientCert: true,
@@ -124,7 +138,7 @@ func TestBuildServerTLSConfigRequireClientCertNeedsCA(t *testing.T) {
 func TestBuildServerTLSConfigTLS12Compat(t *testing.T) {
 	certFile, keyFile, _ := writeTLSFixture(t)
 
-	tlsCfg, enabled, err := buildServerTLSConfig(serverTLSConfig{
+	tlsCfg, enabled, _, err := buildServerTLSConfig(serverTLSConfig{
 		certFile:   certFile,
 		keyFile:    keyFile,
 		minVersion: "1.2",
@@ -146,7 +160,7 @@ func TestBuildServerTLSConfigTLS12Compat(t *testing.T) {
 func TestBuildServerTLSConfigRejectsInvalidMinVersion(t *testing.T) {
 	certFile, keyFile, _ := writeTLSFixture(t)
 
-	_, _, err := buildServerTLSConfig(serverTLSConfig{
+	_, _, _, err := buildServerTLSConfig(serverTLSConfig{
 		certFile:   certFile,
 		keyFile:    keyFile,
 		minVersion: "1.1",
@@ -159,10 +173,109 @@ func TestBuildServerTLSConfigRejectsInvalidMinVersion(t *testing.T) {
 	}
 }
 
+func TestBuildServerTLSConfigReloadsCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile, _ := writeTLSFixtureInDir(t, dir, 2)
+	tlsCfg, enabled, reloader, err := buildServerTLSConfig(serverTLSConfig{
+		certFile: certFile,
+		keyFile:  keyFile,
+	})
+	if err != nil {
+		t.Fatalf("buildServerTLSConfig: %v", err)
+	}
+	if !enabled || reloader == nil {
+		t.Fatalf("enabled=%v reloader=%v, want TLS reloader", enabled, reloader)
+	}
+	if got := leafSerial(t, tlsCfg); got != 2 {
+		t.Fatalf("initial cert serial = %d, want 2", got)
+	}
+
+	writeTLSFixtureInDir(t, dir, 99)
+	if err := reloader.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if got := leafSerial(t, tlsCfg); got != 99 {
+		t.Fatalf("reloaded cert serial = %d, want 99", got)
+	}
+}
+
+func TestMTLSHandshakeRequiresClientCertificate(t *testing.T) {
+	certFile, keyFile, caFile, clientCertFile, clientKeyFile := writeMTLSFixture(t)
+	tlsCfg, enabled, _, err := buildServerTLSConfig(serverTLSConfig{
+		certFile:          certFile,
+		keyFile:           keyFile,
+		caFile:            caFile,
+		requireClientCert: true,
+	})
+	if err != nil {
+		t.Fatalf("buildServerTLSConfig: %v", err)
+	}
+	if !enabled {
+		t.Fatal("TLS disabled, want enabled")
+	}
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	srv := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsCfg)))
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	defer srv.Stop()
+
+	if err := callHealth(t, lis.Addr().String(), insecure.NewCredentials()); err == nil {
+		t.Fatal("plaintext health call succeeded, want TLS handshake failure")
+	}
+
+	rootPool, err := loadCertPool(caFile)
+	if err != nil {
+		t.Fatalf("loadCertPool: %v", err)
+	}
+	noClientCert := credentials.NewTLS(&tls.Config{
+		RootCAs:    rootPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS13,
+	})
+	if err := callHealth(t, lis.Addr().String(), noClientCert); err == nil {
+		t.Fatal("TLS health call without client cert succeeded, want mTLS failure")
+	}
+
+	clientCert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair client: %v", err)
+	}
+	withClientCert := credentials.NewTLS(&tls.Config{
+		RootCAs:      rootPool,
+		ServerName:   "localhost",
+		Certificates: []tls.Certificate{clientCert},
+		MinVersion:   tls.VersionTLS13,
+	})
+	if err := callHealth(t, lis.Addr().String(), withClientCert); err != nil {
+		t.Fatalf("mTLS health call with client cert failed: %v", err)
+	}
+}
+
+func callHealth(t *testing.T, addr string, creds credentials.TransportCredentials) error {
+	t.Helper()
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err = healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{})
+	return err
+}
+
 func writeTLSFixture(t *testing.T) (certFile, keyFile, caFile string) {
 	t.Helper()
-	dir := t.TempDir()
+	return writeTLSFixtureInDir(t, t.TempDir(), 2)
+}
 
+func writeTLSFixtureInDir(t *testing.T, dir string, serverSerial int64) (certFile, keyFile, caFile string) {
+	t.Helper()
 	caKey := newECDSAKey(t)
 	caTemplate := &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
@@ -180,7 +293,7 @@ func writeTLSFixture(t *testing.T) (certFile, keyFile, caFile string) {
 
 	serverKey := newECDSAKey(t)
 	serverTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
+		SerialNumber: big.NewInt(serverSerial),
 		Subject:      pkix.Name{CommonName: "localhost"},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
@@ -200,6 +313,77 @@ func writeTLSFixture(t *testing.T) (certFile, keyFile, caFile string) {
 	writePEM(t, certFile, "CERTIFICATE", serverDER)
 	writeECPrivateKey(t, keyFile, serverKey)
 	return certFile, keyFile, caFile
+}
+
+func writeMTLSFixture(t *testing.T) (serverCertFile, serverKeyFile, caFile, clientCertFile, clientKeyFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	caKey := newECDSAKey(t)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "entdb-mtls-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(ca): %v", err)
+	}
+	serverKey := newECDSAKey(t)
+	serverDER, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(server): %v", err)
+	}
+	clientKey := newECDSAKey(t)
+	clientDER, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(client): %v", err)
+	}
+	caFile = filepath.Join(dir, "ca.pem")
+	serverCertFile = filepath.Join(dir, "server.pem")
+	serverKeyFile = filepath.Join(dir, "server-key.pem")
+	clientCertFile = filepath.Join(dir, "client.pem")
+	clientKeyFile = filepath.Join(dir, "client-key.pem")
+	writePEM(t, caFile, "CERTIFICATE", caDER)
+	writePEM(t, serverCertFile, "CERTIFICATE", serverDER)
+	writeECPrivateKey(t, serverKeyFile, serverKey)
+	writePEM(t, clientCertFile, "CERTIFICATE", clientDER)
+	writeECPrivateKey(t, clientKeyFile, clientKey)
+	return serverCertFile, serverKeyFile, caFile, clientCertFile, clientKeyFile
+}
+
+func leafSerial(t *testing.T, tlsCfg *tls.Config) int64 {
+	t.Helper()
+	cfg, err := tlsCfg.GetConfigForClient(&tls.ClientHelloInfo{})
+	if err != nil {
+		t.Fatalf("GetConfigForClient: %v", err)
+	}
+	if len(cfg.Certificates) != 1 || len(cfg.Certificates[0].Certificate) == 0 {
+		t.Fatalf("GetConfigForClient certificates = %#v, want one leaf", cfg.Certificates)
+	}
+	leaf, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	return leaf.SerialNumber.Int64()
 }
 
 func newECDSAKey(t *testing.T) *ecdsa.PrivateKey {

--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -6,10 +6,14 @@ require (
 	github.com/IBM/sarama v1.48.1
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
+	github.com/aws/aws-sdk-go-v2/service/kms v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
+	github.com/aws/smithy-go v1.25.1
 	github.com/google/uuid v1.6.0
+	github.com/mutecomm/go-sqlcipher/v4 v4.4.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	golang.org/x/crypto v0.51.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.50.0
@@ -30,7 +34,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
-	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -55,7 +58,6 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/server/go/go.sum
+++ b/server/go/go.sum
@@ -24,6 +24,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 h1:pbrxO/ku
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23/go.mod h1:/CMNUqoj46HpS3MNRDEDIwcgEnrtZlKRaHNaHxIFpNA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 h1:03xatSQO4+AM1lTAbnRg5OK528EUg744nW7F73U8DKw=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23/go.mod h1:M8l3mwgx5ToK7wot2sBBce/ojzgnPzZXUV445gTSyE8=
+github.com/aws/aws-sdk-go-v2/service/kms v1.51.1 h1:zuSf4olLKZW8cF/W9Y5wvGT+/0raY/3kVp49KsGs0QY=
+github.com/aws/aws-sdk-go-v2/service/kms v1.51.1/go.mod h1:Y0+uxvxz6ib4KktRdK0V4X45Vcs/JyYoz8H71pO8xeI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lAsTJFeXWFDsDcWOU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
@@ -93,6 +95,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mutecomm/go-sqlcipher/v4 v4.4.2 h1:eM10bFtI4UvibIsKr10/QT7Yfz+NADfjZYh0GKrXUNc=
+github.com/mutecomm/go-sqlcipher/v4 v4.4.2/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
@@ -116,6 +120,7 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/server/go/internal/auth/identity.go
+++ b/server/go/internal/auth/identity.go
@@ -20,7 +20,7 @@ import "context"
 // methods. It is a generic map so handlers don't take a hard dependency on
 // any particular JWT library.
 type Identity struct {
-	// Method is "oauth" | "api_key" | "session". Constants below match
+	// Method is "oauth" | "api_key" | "session" | "mtls". Constants below match
 	// the Python AuthContext.method values verbatim.
 	Method   string
 	Subject  string
@@ -36,6 +36,7 @@ const (
 	MethodOAuth   = "oauth"
 	MethodAPIKey  = "api_key"
 	MethodSession = "session"
+	MethodMTLS    = "mtls"
 )
 
 // IsZero reports whether the Identity carries no method and no subject.

--- a/server/go/internal/auth/mtls.go
+++ b/server/go/internal/auth/mtls.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"context"
+	"crypto/x509"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+// IdentityFromPeerCertificate extracts the verified mTLS client
+// certificate identity from ctx, when the gRPC transport has one.
+func IdentityFromPeerCertificate(ctx context.Context) (Identity, bool) {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.AuthInfo == nil {
+		return Identity{}, false
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok || len(tlsInfo.State.PeerCertificates) == 0 {
+		return Identity{}, false
+	}
+	return IdentityFromCertificate(tlsInfo.State.PeerCertificates[0])
+}
+
+// IdentityFromCertificate maps a verified client certificate to an EntDB
+// trusted Identity. URI SANs are preferred, then DNS SANs, email SANs,
+// CommonName, and finally the full subject DN.
+func IdentityFromCertificate(cert *x509.Certificate) (Identity, bool) {
+	if cert == nil {
+		return Identity{}, false
+	}
+	subject := ""
+	switch {
+	case len(cert.URIs) > 0:
+		subject = cert.URIs[0].String()
+	case len(cert.DNSNames) > 0:
+		subject = cert.DNSNames[0]
+	case len(cert.EmailAddresses) > 0:
+		subject = cert.EmailAddresses[0]
+	case cert.Subject.CommonName != "":
+		subject = cert.Subject.CommonName
+	default:
+		subject = cert.Subject.String()
+	}
+	if subject == "" {
+		return Identity{}, false
+	}
+	return Identity{
+		Method:  MethodMTLS,
+		Subject: "system:" + subject,
+		Metadata: map[string]any{
+			"subject_dn":    cert.Subject.String(),
+			"serial_number": cert.SerialNumber.String(),
+			"dns_sans":      append([]string(nil), cert.DNSNames...),
+			"email_sans":    append([]string(nil), cert.EmailAddresses...),
+			"uri_sans":      certificateURIs(cert),
+		},
+	}, true
+}
+
+// MTLSPeerIdentityUnaryInterceptor installs an mTLS Identity on the
+// request context when the transport presented a verified client cert.
+func MTLSPeerIdentityUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if id, ok := IdentityFromPeerCertificate(ctx); ok {
+			ctx = WithIdentity(ctx, id)
+		}
+		return handler(ctx, req)
+	}
+}
+
+// MTLSPeerIdentityStreamInterceptor is the stream equivalent of
+// MTLSPeerIdentityUnaryInterceptor.
+func MTLSPeerIdentityStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := ss.Context()
+		if id, ok := IdentityFromPeerCertificate(ctx); ok {
+			ctx = WithIdentity(ctx, id)
+			ss = &serverStreamWithContext{ServerStream: ss, ctx: ctx}
+		}
+		return handler(srv, ss)
+	}
+}
+
+func certificateURIs(cert *x509.Certificate) []string {
+	out := make([]string, 0, len(cert.URIs))
+	for _, uri := range cert.URIs {
+		out = append(out, uri.String())
+	}
+	return out
+}

--- a/server/go/internal/auth/mtls_test.go
+++ b/server/go/internal/auth/mtls_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+func TestIdentityFromCertificatePrefersURISAN(t *testing.T) {
+	uri, err := url.Parse("spiffe://entdb/ns/prod/sa/ingestor")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	id, ok := IdentityFromCertificate(&x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: "ignored-cn"},
+		DNSNames:     []string{"ignored.example.com"},
+		URIs:         []*url.URL{uri},
+	})
+	if !ok {
+		t.Fatal("IdentityFromCertificate ok=false, want true")
+	}
+	if id.Method != MethodMTLS || id.Subject != "system:spiffe://entdb/ns/prod/sa/ingestor" {
+		t.Fatalf("identity = %+v, want mTLS spiffe system subject", id)
+	}
+	if got := Authoritative(WithIdentity(context.Background(), id), User("alice")); got != System("spiffe://entdb/ns/prod/sa/ingestor") {
+		t.Fatalf("Authoritative = %v, want SPIFFE system actor", got)
+	}
+}
+
+func TestMTLSUnaryInterceptorInstallsPeerIdentity(t *testing.T) {
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(7),
+		Subject:      pkix.Name{CommonName: "billing-worker"},
+	}
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{cert},
+		}},
+	})
+	var captured context.Context
+	handler := func(ctx context.Context, req any) (any, error) {
+		captured = ctx
+		return nil, nil
+	}
+	if _, err := MTLSPeerIdentityUnaryInterceptor()(ctx, struct{}{}, &grpc.UnaryServerInfo{FullMethod: "/entdb.v1.EntDBService/GetNode"}, handler); err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	id, ok := IdentityFromContext(captured)
+	if !ok {
+		t.Fatal("IdentityFromContext ok=false, want true")
+	}
+	if id.Method != MethodMTLS || id.Subject != "system:billing-worker" {
+		t.Fatalf("identity = %+v, want billing-worker mTLS identity", id)
+	}
+}
+
+func TestMTLSUnaryInterceptorLeavesContextWithoutClientCert(t *testing.T) {
+	var captured context.Context
+	handler := func(ctx context.Context, req any) (any, error) {
+		captured = ctx
+		return nil, nil
+	}
+	if _, err := MTLSPeerIdentityUnaryInterceptor()(context.Background(), struct{}{}, &grpc.UnaryServerInfo{FullMethod: "/entdb.v1.EntDBService/GetNode"}, handler); err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	if _, ok := IdentityFromContext(captured); ok {
+		t.Fatal("IdentityFromContext ok=true, want no identity without peer cert")
+	}
+}

--- a/server/go/internal/crypto/key_manager.go
+++ b/server/go/internal/crypto/key_manager.go
@@ -1,6 +1,7 @@
 // Package crypto contains the encryption-at-rest key hierarchy used by
-// the Go server port. It deliberately owns only key material and vault
-// persistence; SQLCipher connection wiring lands in the store package.
+// the Go server port. It owns key material, KMS bootstrap, SQLCipher
+// DSN helpers, and vault persistence; tenant connection pooling lives
+// in the store package.
 package crypto
 
 import (

--- a/server/go/internal/crypto/key_manager_test.go
+++ b/server/go/internal/crypto/key_manager_test.go
@@ -3,12 +3,19 @@ package crypto
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	_ "modernc.org/sqlite"
 )
 
 func TestKeyManagerDerivedKeysAreDeterministicAndCopied(t *testing.T) {
@@ -78,12 +85,110 @@ func TestParseMasterKeyHex(t *testing.T) {
 	}
 }
 
+func TestLoadMasterKeyFileProvider(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0x2a)
+	dir := t.TempDir()
+
+	hexPath := filepath.Join(dir, "master.hex")
+	if err := os.WriteFile(hexPath, []byte(hex.EncodeToString(master)+"\n"), 0o600); err != nil {
+		t.Fatalf("write hex key: %v", err)
+	}
+	got, err := LoadMasterKey(ctx, MasterKeyConfig{Provider: "file", KeyID: hexPath})
+	if err != nil {
+		t.Fatalf("LoadMasterKey hex file: %v", err)
+	}
+	if !bytes.Equal(got, master) {
+		t.Fatalf("hex file key mismatch")
+	}
+
+	b64Path := filepath.Join(dir, "master.b64")
+	if err := os.WriteFile(b64Path, []byte(base64.StdEncoding.EncodeToString(master)), 0o600); err != nil {
+		t.Fatalf("write base64 key: %v", err)
+	}
+	got, err = LoadMasterKey(ctx, MasterKeyConfig{Provider: "file", KeyID: b64Path})
+	if err != nil {
+		t.Fatalf("LoadMasterKey base64 file: %v", err)
+	}
+	if !bytes.Equal(got, master) {
+		t.Fatalf("base64 file key mismatch")
+	}
+
+	t.Setenv("ENTDB_TEST_MASTER_KEY", hex.EncodeToString(master))
+	got, err = LoadMasterKey(ctx, MasterKeyConfig{Provider: "file", KeyID: "env:ENTDB_TEST_MASTER_KEY"})
+	if err != nil {
+		t.Fatalf("LoadMasterKey env: %v", err)
+	}
+	if !bytes.Equal(got, master) {
+		t.Fatalf("env key mismatch")
+	}
+}
+
+func TestLoadMasterKeyVaultProviderPersistsEnvelope(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0x2b)
+	ciphertext := "vault:v1:test-ciphertext"
+	calls := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.URL.Path)
+		if got := r.Header.Get("X-Vault-Token"); got != "test-token" {
+			t.Fatalf("X-Vault-Token = %q, want test-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/transit/datakey/plaintext/entdb":
+			_, _ = fmt.Fprintf(w, `{"data":{"plaintext":%q,"ciphertext":%q}}`,
+				base64.StdEncoding.EncodeToString(master), ciphertext)
+		case "/v1/transit/decrypt/entdb":
+			_, _ = fmt.Fprintf(w, `{"data":{"plaintext":%q}}`,
+				base64.StdEncoding.EncodeToString(master))
+		default:
+			t.Fatalf("unexpected Vault path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("VAULT_ADDR", server.URL)
+	t.Setenv("VAULT_TOKEN", "test-token")
+	dir := filepath.Join(t.TempDir(), "first-boot", "data")
+
+	got, err := LoadMasterKey(ctx, MasterKeyConfig{
+		Provider:   "vault",
+		KeyID:      "entdb",
+		DataDir:    dir,
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("LoadMasterKey vault first: %v", err)
+	}
+	if !bytes.Equal(got, master) {
+		t.Fatalf("vault first key mismatch")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("vault provider did not create data dir: %v", err)
+	}
+	got, err = LoadMasterKey(ctx, MasterKeyConfig{
+		Provider:   "vault",
+		KeyID:      "entdb",
+		DataDir:    dir,
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("LoadMasterKey vault second: %v", err)
+	}
+	if !bytes.Equal(got, master) {
+		t.Fatalf("vault second key mismatch")
+	}
+	if len(calls) != 2 || calls[0] != "/v1/transit/datakey/plaintext/entdb" || calls[1] != "/v1/transit/decrypt/entdb" {
+		t.Fatalf("Vault calls = %v, want datakey then decrypt", calls)
+	}
+}
+
 func TestKeyManagerVaultSeedsAndPersistsKeysInGlobalDB(t *testing.T) {
 	ctx := context.Background()
 	master := testMaster(0x33)
-	gs := testGlobalStore(t)
+	db := testVaultDB(t)
 
-	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault first: %v", err)
 	}
@@ -96,7 +201,7 @@ func TestKeyManagerVaultSeedsAndPersistsKeysInGlobalDB(t *testing.T) {
 		t.Fatalf("TenantKey seeded: %v", err)
 	}
 
-	vault2, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	vault2, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault second: %v", err)
 	}
@@ -127,11 +232,11 @@ func TestKeyManagerVaultSeedsAndPersistsKeysInGlobalDB(t *testing.T) {
 func TestKeyManagerVaultShredIsDurable(t *testing.T) {
 	ctx := context.Background()
 	master := testMaster(0x44)
-	gs := testGlobalStore(t)
+	db := testVaultDB(t)
 	now := fixedTime(1710000000000)
 
 	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{
-		DB:        gs.DB(),
+		DB:        db,
 		MasterKey: master,
 		NowFn:     now,
 	})
@@ -152,7 +257,7 @@ func TestKeyManagerVaultShredIsDurable(t *testing.T) {
 		t.Fatalf("TenantKey after shred: got %v, want ErrTenantShredded", err)
 	}
 
-	vault2, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	vault2, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault second: %v", err)
 	}
@@ -185,9 +290,9 @@ func TestTenantKeyVaultProvisionGetAndRewrap(t *testing.T) {
 	oldMaster := testMaster(0x55)
 	newMaster := testMaster(0x66)
 	dek := testMaster(0x77)
-	gs := testGlobalStore(t)
+	db := testVaultDB(t)
 
-	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: oldMaster})
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: oldMaster})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault old: %v", err)
 	}
@@ -220,7 +325,7 @@ func TestTenantKeyVaultProvisionGetAndRewrap(t *testing.T) {
 		t.Fatalf("Get after rewrap returned wrong DEK")
 	}
 
-	reopenedNew, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: newMaster})
+	reopenedNew, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: newMaster})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault new: %v", err)
 	}
@@ -232,7 +337,7 @@ func TestTenantKeyVaultProvisionGetAndRewrap(t *testing.T) {
 		t.Fatalf("Get reopened new returned wrong DEK")
 	}
 
-	reopenedOld, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: oldMaster})
+	reopenedOld, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: oldMaster})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault old reopened: %v", err)
 	}
@@ -245,16 +350,16 @@ func TestTenantKeyVaultBindsWrappedKeyToTenantID(t *testing.T) {
 	ctx := context.Background()
 	master := testMaster(0x78)
 	dek := testMaster(0x79)
-	gs := testGlobalStore(t)
+	db := testVaultDB(t)
 
-	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault: %v", err)
 	}
 	if err := vault.Provision(ctx, "acme", dek); err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
-	if _, err := gs.DB().ExecContext(ctx,
+	if _, err := db.ExecContext(ctx,
 		`UPDATE tenant_key_vault SET tenant_id = ? WHERE tenant_id = ?`,
 		"globex", "acme",
 	); err != nil {
@@ -269,9 +374,9 @@ func TestTenantKeyVaultRejectsShreddedProvision(t *testing.T) {
 	ctx := context.Background()
 	master := testMaster(0x88)
 	dek := testMaster(0x99)
-	gs := testGlobalStore(t)
+	db := testVaultDB(t)
 
-	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault: %v", err)
 	}
@@ -290,9 +395,9 @@ func TestTenantKeyVaultRejectsEmptyTenantID(t *testing.T) {
 	ctx := context.Background()
 	master := testMaster(0xaa)
 	dek := testMaster(0xbb)
-	gs := testGlobalStore(t)
+	db := testVaultDB(t)
 
-	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
 	if err != nil {
 		t.Fatalf("NewTenantKeyVault: %v", err)
 	}
@@ -318,17 +423,14 @@ func TestTenantKeyVaultRejectsEmptyTenantID(t *testing.T) {
 	}
 }
 
-func testGlobalStore(t *testing.T) *globalstore.GlobalStore {
+func testVaultDB(t *testing.T) *sql.DB {
 	t.Helper()
-	gs, err := globalstore.New(globalstore.Options{
-		DataDir: t.TempDir(),
-		WALMode: true,
-	})
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "vault.db"))
 	if err != nil {
-		t.Fatalf("globalstore.New: %v", err)
+		t.Fatalf("sql.Open vault db: %v", err)
 	}
-	t.Cleanup(func() { _ = gs.Close() })
-	return gs
+	t.Cleanup(func() { _ = db.Close() })
+	return db
 }
 
 func testMaster(fill byte) []byte {

--- a/server/go/internal/crypto/master_key.go
+++ b/server/go/internal/crypto/master_key.go
@@ -1,0 +1,285 @@
+package crypto
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	awskmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+// MasterKeyConfig configures server bootstrap of the 32-byte EntDB
+// encryption master key.
+type MasterKeyConfig struct {
+	Provider string
+	KeyID    string
+	DataDir  string
+
+	HTTPClient *http.Client
+}
+
+// LoadMasterKey resolves a 32-byte master key from the configured
+// provider. Envelope providers persist only ciphertext blobs in DataDir;
+// they call the backing KMS on boot to decrypt the plaintext key.
+func LoadMasterKey(ctx context.Context, cfg MasterKeyConfig) ([]byte, error) {
+	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
+	keyID := strings.TrimSpace(cfg.KeyID)
+	if provider == "" {
+		provider = "file"
+	}
+	switch provider {
+	case "file":
+		return loadFileMasterKey(keyID)
+	case "aws":
+		return loadAWSMasterKey(ctx, cfg)
+	case "vault":
+		return loadVaultMasterKey(ctx, cfg)
+	case "gcp", "azure":
+		return nil, fmt.Errorf("crypto: kms provider %q is not implemented in this binary; use file, aws, or vault", provider)
+	default:
+		return nil, fmt.Errorf("crypto: unsupported kms provider %q (want file|aws|gcp|azure|vault)", cfg.Provider)
+	}
+}
+
+func loadFileMasterKey(keyID string) ([]byte, error) {
+	if keyID == "" {
+		return nil, errors.New("crypto: file master key provider requires --kms-key-id path or env:NAME")
+	}
+	if name, ok := strings.CutPrefix(keyID, "env:"); ok {
+		value := os.Getenv(name)
+		if value == "" {
+			return nil, fmt.Errorf("crypto: master key env var %s is empty or unset", name)
+		}
+		return parseMasterKeyMaterial([]byte(value))
+	}
+	data, err := os.ReadFile(keyID)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: read master key file %q: %w", keyID, err)
+	}
+	return parseMasterKeyMaterial(data)
+}
+
+func parseMasterKeyMaterial(data []byte) ([]byte, error) {
+	if len(data) == KeyLength {
+		return append([]byte(nil), data...), nil
+	}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == KeyLength {
+		return append([]byte(nil), trimmed...), nil
+	}
+	if key, err := hex.DecodeString(string(trimmed)); err == nil {
+		if len(key) != KeyLength {
+			return nil, fmt.Errorf("%w: got %d", ErrInvalidMasterKey, len(key))
+		}
+		return key, nil
+	}
+	if key, err := base64.StdEncoding.DecodeString(string(trimmed)); err == nil {
+		if len(key) != KeyLength {
+			return nil, fmt.Errorf("%w: got %d", ErrInvalidMasterKey, len(key))
+		}
+		return key, nil
+	}
+	return nil, fmt.Errorf("%w: expected 32 raw bytes, 64 hex chars, or base64", ErrInvalidMasterKey)
+}
+
+func envelopePath(dataDir, provider, keyID string) (string, error) {
+	if strings.TrimSpace(dataDir) == "" {
+		return "", errors.New("crypto: KMS envelope providers require --data-dir")
+	}
+	sum := sha256.Sum256([]byte(provider + "\x00" + keyID))
+	name := fmt.Sprintf(".entdb-master-key.%s.%s.blob", provider, hex.EncodeToString(sum[:8]))
+	return filepath.Join(dataDir, name), nil
+}
+
+func writeMasterKeyEnvelope(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create envelope dir %q: %w", dir, err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func loadAWSMasterKey(ctx context.Context, cfg MasterKeyConfig) ([]byte, error) {
+	keyID := strings.TrimSpace(cfg.KeyID)
+	if keyID == "" {
+		return nil, errors.New("crypto: aws kms provider requires --kms-key-id")
+	}
+	path, err := envelopePath(cfg.DataDir, "aws", keyID)
+	if err != nil {
+		return nil, err
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: load AWS config for KMS: %w", err)
+	}
+	client := awskms.NewFromConfig(awsCfg)
+	if ciphertext, err := os.ReadFile(path); err == nil {
+		out, err := client.Decrypt(ctx, &awskms.DecryptInput{CiphertextBlob: ciphertext})
+		if err != nil {
+			return nil, fmt.Errorf("crypto: AWS KMS decrypt master key envelope: %w", err)
+		}
+		return validatePlaintextMasterKey(out.Plaintext)
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("crypto: read AWS master key envelope %q: %w", path, err)
+	}
+	out, err := client.GenerateDataKey(ctx, &awskms.GenerateDataKeyInput{
+		KeyId:   aws.String(keyID),
+		KeySpec: awskmstypes.DataKeySpecAes256,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("crypto: AWS KMS generate data key: %w", err)
+	}
+	key, err := validatePlaintextMasterKey(out.Plaintext)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeMasterKeyEnvelope(path, out.CiphertextBlob); err != nil {
+		return nil, fmt.Errorf("crypto: write AWS master key envelope %q: %w", path, err)
+	}
+	return key, nil
+}
+
+func validatePlaintextMasterKey(key []byte) ([]byte, error) {
+	if len(key) != KeyLength {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMasterKey, len(key))
+	}
+	return append([]byte(nil), key...), nil
+}
+
+type vaultDataKeyResponse struct {
+	Data struct {
+		Plaintext  string `json:"plaintext"`
+		Ciphertext string `json:"ciphertext"`
+	} `json:"data"`
+	Errors []string `json:"errors"`
+}
+
+type vaultDecryptResponse struct {
+	Data struct {
+		Plaintext string `json:"plaintext"`
+	} `json:"data"`
+	Errors []string `json:"errors"`
+}
+
+func loadVaultMasterKey(ctx context.Context, cfg MasterKeyConfig) ([]byte, error) {
+	keyID := strings.Trim(strings.TrimSpace(cfg.KeyID), "/")
+	if keyID == "" {
+		return nil, errors.New("crypto: vault kms provider requires --kms-key-id transit key name")
+	}
+	path, err := envelopePath(cfg.DataDir, "vault", keyID)
+	if err != nil {
+		return nil, err
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	if ciphertext, err := os.ReadFile(path); err == nil {
+		return vaultDecrypt(ctx, client, keyID, strings.TrimSpace(string(ciphertext)))
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("crypto: read Vault master key envelope %q: %w", path, err)
+	}
+	key, ciphertext, err := vaultGenerateDataKey(ctx, client, keyID)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeMasterKeyEnvelope(path, []byte(ciphertext)); err != nil {
+		return nil, fmt.Errorf("crypto: write Vault master key envelope %q: %w", path, err)
+	}
+	return key, nil
+}
+
+func vaultGenerateDataKey(ctx context.Context, client *http.Client, keyID string) ([]byte, string, error) {
+	var out vaultDataKeyResponse
+	if err := vaultDo(ctx, client, "transit/datakey/plaintext/"+url.PathEscape(keyID), map[string]any{"bits": 256}, &out); err != nil {
+		return nil, "", err
+	}
+	if len(out.Errors) > 0 {
+		return nil, "", fmt.Errorf("crypto: Vault datakey error: %s", strings.Join(out.Errors, "; "))
+	}
+	raw, err := base64.StdEncoding.DecodeString(out.Data.Plaintext)
+	if err != nil {
+		return nil, "", fmt.Errorf("crypto: decode Vault plaintext data key: %w", err)
+	}
+	key, err := validatePlaintextMasterKey(raw)
+	if err != nil {
+		return nil, "", err
+	}
+	if out.Data.Ciphertext == "" {
+		return nil, "", errors.New("crypto: Vault datakey response omitted ciphertext")
+	}
+	return key, out.Data.Ciphertext, nil
+}
+
+func vaultDecrypt(ctx context.Context, client *http.Client, keyID, ciphertext string) ([]byte, error) {
+	var out vaultDecryptResponse
+	if err := vaultDo(ctx, client, "transit/decrypt/"+url.PathEscape(keyID), map[string]any{"ciphertext": ciphertext}, &out); err != nil {
+		return nil, err
+	}
+	if len(out.Errors) > 0 {
+		return nil, fmt.Errorf("crypto: Vault decrypt error: %s", strings.Join(out.Errors, "; "))
+	}
+	raw, err := base64.StdEncoding.DecodeString(out.Data.Plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: decode Vault plaintext master key: %w", err)
+	}
+	return validatePlaintextMasterKey(raw)
+}
+
+func vaultDo(ctx context.Context, client *http.Client, path string, payload map[string]any, out any) error {
+	addr := strings.TrimRight(strings.TrimSpace(os.Getenv("VAULT_ADDR")), "/")
+	if addr == "" {
+		return errors.New("crypto: VAULT_ADDR is required for vault kms provider")
+	}
+	token := strings.TrimSpace(os.Getenv("VAULT_TOKEN"))
+	if token == "" {
+		return errors.New("crypto: VAULT_TOKEN is required for vault kms provider")
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, addr+"/v1/"+path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("crypto: build Vault request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Vault-Token", token)
+	if ns := strings.TrimSpace(os.Getenv("VAULT_NAMESPACE")); ns != "" {
+		req.Header.Set("X-Vault-Namespace", ns)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("crypto: Vault request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("crypto: read Vault response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("crypto: Vault request returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("crypto: parse Vault response: %w", err)
+	}
+	return nil
+}

--- a/server/go/internal/crypto/sqlcipher.go
+++ b/server/go/internal/crypto/sqlcipher.go
@@ -1,0 +1,56 @@
+package crypto
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"time"
+
+	sqlcipher "github.com/mutecomm/go-sqlcipher/v4"
+)
+
+const (
+	// SQLCipherDriverName is the database/sql driver registered by
+	// github.com/mutecomm/go-sqlcipher/v4.
+	SQLCipherDriverName = "sqlite3"
+
+	sqlcipherPageSize = 4096
+)
+
+// SQLCipherDSN returns a database/sql DSN that opens path with key as a
+// raw 256-bit SQLCipher key.
+func SQLCipherDSN(path string, key []byte, busyTimeout time.Duration) (string, error) {
+	if len(key) != KeyLength {
+		return "", fmt.Errorf("%w: got %d", ErrInvalidMasterKey, len(key))
+	}
+	if busyTimeout <= 0 {
+		busyTimeout = 5 * time.Second
+	}
+	return fmt.Sprintf(
+		"file:%s?_pragma_key=x'%s'&_pragma_cipher_page_size=%d&_busy_timeout=%d",
+		path,
+		hex.EncodeToString(key),
+		sqlcipherPageSize,
+		busyTimeout.Milliseconds(),
+	), nil
+}
+
+// SQLiteFileEncryptionStatus reports whether path exists and, when it
+// already holds a complete SQLite header, whether SQLCipher encrypted it.
+func SQLiteFileEncryptionStatus(path string) (encrypted bool, hasDatabase bool, err error) {
+	st, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, false, nil
+		}
+		return false, false, fmt.Errorf("crypto: stat sqlite file %q: %w", path, err)
+	}
+	if st.Size() == 0 {
+		return false, false, nil
+	}
+	encrypted, err = sqlcipher.IsEncrypted(path)
+	if err != nil {
+		return false, true, fmt.Errorf("crypto: inspect sqlite encryption %q: %w", path, err)
+	}
+	return encrypted, true, nil
+}

--- a/server/go/internal/gdpr/processor.go
+++ b/server/go/internal/gdpr/processor.go
@@ -1,0 +1,188 @@
+// Package gdpr executes due account-deletion jobs and performs durable
+// crypto-shred for personal tenants.
+package gdpr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// Options configures a deletion processor.
+type Options struct {
+	Global                *globalstore.GlobalStore
+	Store                 *store.CanonicalStore
+	Keys                  *entcrypto.KeyManager
+	NowFn                 func() int64
+	RemoveCiphertextFiles bool
+}
+
+// Processor runs executable GDPR deletion_queue entries.
+type Processor struct {
+	global                *globalstore.GlobalStore
+	store                 *store.CanonicalStore
+	keys                  *entcrypto.KeyManager
+	nowFn                 func() int64
+	removeCiphertextFiles bool
+}
+
+// Summary reports one RunOnce pass.
+type Summary struct {
+	EntriesCompleted   int
+	PersonalTenants    int
+	TenantKeysShredded int
+	TenantFilesDeleted int
+}
+
+// New constructs a Processor.
+func New(opts Options) (*Processor, error) {
+	if opts.Global == nil {
+		return nil, errors.New("gdpr: global store is required")
+	}
+	nowFn := opts.NowFn
+	if nowFn == nil {
+		nowFn = func() int64 { return time.Now().Unix() }
+	}
+	return &Processor{
+		global:                opts.Global,
+		store:                 opts.Store,
+		keys:                  opts.Keys,
+		nowFn:                 nowFn,
+		removeCiphertextFiles: opts.RemoveCiphertextFiles,
+	}, nil
+}
+
+// Run executes due deletions immediately and then at interval until ctx
+// is cancelled.
+func (p *Processor) Run(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		return errors.New("gdpr: interval must be positive")
+	}
+	for {
+		if _, err := p.RunOnce(ctx); err != nil {
+			return err
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// RunOnce processes every due pending deletion.
+func (p *Processor) RunOnce(ctx context.Context) (*Summary, error) {
+	entries, err := p.global.GetExecutableDeletions(ctx, p.nowFn())
+	if err != nil {
+		return nil, err
+	}
+	summary := &Summary{}
+	for _, entry := range entries {
+		if err := p.processEntry(ctx, entry, summary); err != nil {
+			return summary, err
+		}
+	}
+	return summary, nil
+}
+
+func (p *Processor) processEntry(ctx context.Context, entry *globalstore.DeletionEntry, summary *Summary) error {
+	memberships, err := p.global.GetUserTenants(ctx, entry.UserID)
+	if err != nil {
+		return fmt.Errorf("gdpr: list user tenants %q: %w", entry.UserID, err)
+	}
+	for _, membership := range memberships {
+		personal, err := p.isPersonalTenant(ctx, entry.UserID, membership.TenantID)
+		if err != nil {
+			return err
+		}
+		if !personal {
+			continue
+		}
+		summary.PersonalTenants++
+		if err := p.cryptoShredTenant(ctx, membership.TenantID, summary); err != nil {
+			return err
+		}
+		if ok, err := p.global.SetTenantStatus(ctx, membership.TenantID, "deleted"); err != nil {
+			return fmt.Errorf("gdpr: mark tenant %q deleted: %w", membership.TenantID, err)
+		} else if !ok {
+			return fmt.Errorf("gdpr: tenant %q disappeared during deletion", membership.TenantID)
+		}
+	}
+	if _, err := p.global.RemoveAllSharedForUser(ctx, entry.UserID); err != nil {
+		return err
+	}
+	if _, err := p.global.RemoveAllMembershipsForUser(ctx, entry.UserID); err != nil {
+		return err
+	}
+	if ok, err := p.global.DeleteUser(ctx, entry.UserID); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("gdpr: user %q disappeared during deletion", entry.UserID)
+	}
+	if ok, err := p.global.MarkDeletionCompleted(ctx, entry.UserID); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("gdpr: deletion row for %q disappeared during deletion", entry.UserID)
+	}
+	summary.EntriesCompleted++
+	return nil
+}
+
+func (p *Processor) isPersonalTenant(ctx context.Context, userID, tenantID string) (bool, error) {
+	members, err := p.global.GetTenantMembers(ctx, tenantID)
+	if err != nil {
+		return false, fmt.Errorf("gdpr: list tenant members %q: %w", tenantID, err)
+	}
+	if len(members) != 1 {
+		return false, nil
+	}
+	return members[0].UserID == userID && members[0].Role == "owner", nil
+}
+
+func (p *Processor) cryptoShredTenant(ctx context.Context, tenantID string, summary *Summary) error {
+	if p.store != nil {
+		if err := p.store.CloseTenant(tenantID); err != nil {
+			return fmt.Errorf("gdpr: close tenant %q before shred: %w", tenantID, err)
+		}
+	}
+	if p.keys != nil {
+		if err := p.keys.ShredTenant(ctx, tenantID); err != nil && !errors.Is(err, entcrypto.ErrTenantShredded) {
+			return fmt.Errorf("gdpr: shred tenant key %q: %w", tenantID, err)
+		}
+		summary.TenantKeysShredded++
+	}
+	if p.removeCiphertextFiles && p.store != nil {
+		deleted, err := p.deleteTenantFiles(tenantID)
+		if err != nil {
+			return err
+		}
+		summary.TenantFilesDeleted += deleted
+	}
+	return nil
+}
+
+func (p *Processor) deleteTenantFiles(tenantID string) (int, error) {
+	path, err := p.store.TenantDBPath(tenantID)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	for _, candidate := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Remove(candidate); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return deleted, fmt.Errorf("gdpr: delete tenant file %q: %w", candidate, err)
+		}
+		deleted++
+	}
+	return deleted, nil
+}

--- a/server/go/internal/gdpr/processor_test.go
+++ b/server/go/internal/gdpr/processor_test.go
@@ -1,0 +1,118 @@
+package gdpr_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/gdpr"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+func TestProcessorCryptoShredsPersonalTenantAfterGraceExpiry(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	master := gdprTestMaster(0x51)
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true, NowFn: func() int64 { return 1000 }})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+	vault, err := entcrypto.NewTenantKeyVault(ctx, entcrypto.TenantKeyVaultOptions{DB: gs.DB(), MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault: %v", err)
+	}
+	keys, err := entcrypto.NewKeyManager(master, vault)
+	if err != nil {
+		t.Fatalf("NewKeyManager: %v", err)
+	}
+	cs, err := store.New(store.Options{
+		RootDir:            dir,
+		WALMode:            true,
+		KeyManager:         keys,
+		EncryptionRequired: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := gs.CreateTenantWithOwner(ctx, "personal", "Alice Personal", "", "alice"); err != nil {
+		t.Fatalf("CreateTenantWithOwner: %v", err)
+	}
+	if _, err := cs.CreateNodeRaw(ctx, "personal", store.NodeInput{
+		NodeID:     "secret-node",
+		TypeID:     7,
+		OwnerActor: "user:alice",
+		Payload:    map[string]any{"1": "private"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+	if _, err := gs.QueueDeletion(ctx, "alice", 0); err != nil {
+		t.Fatalf("QueueDeletion: %v", err)
+	}
+
+	processor, err := gdpr.New(gdpr.Options{
+		Global: gs,
+		Store:  cs,
+		Keys:   keys,
+		NowFn:  func() int64 { return 1000 },
+	})
+	if err != nil {
+		t.Fatalf("gdpr.New: %v", err)
+	}
+	summary, err := processor.RunOnce(ctx)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if summary.EntriesCompleted != 1 || summary.PersonalTenants != 1 || summary.TenantKeysShredded != 1 {
+		t.Fatalf("summary = %+v, want one completed personal shred", summary)
+	}
+	if _, err := keys.TenantKey(ctx, "personal"); !errors.Is(err, entcrypto.ErrTenantShredded) {
+		t.Fatalf("TenantKey after deletion = %v, want ErrTenantShredded", err)
+	}
+	if err := cs.OpenTenant(ctx, "personal"); !errors.Is(err, entcrypto.ErrTenantShredded) {
+		t.Fatalf("OpenTenant after deletion = %v, want ErrTenantShredded", err)
+	}
+	entry, err := gs.GetDeletionEntry(ctx, "alice")
+	if err != nil {
+		t.Fatalf("GetDeletionEntry: %v", err)
+	}
+	if entry == nil || entry.Status != "completed" {
+		t.Fatalf("deletion entry = %+v, want completed", entry)
+	}
+	user, err := gs.GetUser(ctx, "alice")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if user == nil || user.Status != "deleted" {
+		t.Fatalf("user = %+v, want deleted", user)
+	}
+	tenant, err := gs.GetTenant(ctx, "personal")
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
+	}
+	if tenant == nil || tenant.Status != "deleted" {
+		t.Fatalf("tenant = %+v, want deleted", tenant)
+	}
+	members, err := gs.GetUserTenants(ctx, "alice")
+	if err != nil {
+		t.Fatalf("GetUserTenants: %v", err)
+	}
+	if len(members) != 0 {
+		t.Fatalf("memberships after deletion = %+v, want none", members)
+	}
+}
+
+func gdprTestMaster(fill byte) []byte {
+	key := make([]byte, entcrypto.KeyLength)
+	for i := range key {
+		key[i] = fill
+	}
+	return key
+}

--- a/server/go/internal/globalstore/globalstore.go
+++ b/server/go/internal/globalstore/globalstore.go
@@ -23,8 +23,8 @@
 //
 // # Driver
 //
-// modernc.org/sqlite (pure Go, no cgo). Same driver the per-tenant
-// `store` package will use in W1.8.
+// The default driver is modernc.org/sqlite. When Options.EncryptionKey
+// is configured, global.db is opened through SQLCipher instead.
 
 package globalstore
 
@@ -36,6 +36,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
 
 	// modernc.org/sqlite registers the "sqlite" driver with database/sql
 	// in its init(); a side-effect import is the canonical way to use it.
@@ -62,6 +64,14 @@ type Options struct {
 	// can drive calendar-month rollover deterministically. nil ->
 	// time.Now().Unix().
 	NowFn func() int64
+
+	// EncryptionKey enables SQLCipher encryption for global.db. It must
+	// be exactly 32 bytes when present.
+	EncryptionKey []byte
+
+	// EncryptionRequired refuses to open global.db without EncryptionKey
+	// and rejects pre-existing plaintext global.db files.
+	EncryptionRequired bool
 }
 
 // GlobalStore is the cross-tenant SQLite handle.
@@ -83,6 +93,9 @@ func New(opts Options) (*GlobalStore, error) {
 	if opts.DataDir == "" {
 		return nil, errors.New("globalstore: Options.DataDir is required")
 	}
+	if opts.EncryptionRequired && len(opts.EncryptionKey) == 0 {
+		return nil, errors.New("globalstore: encryption required but no encryption key configured")
+	}
 	if err := os.MkdirAll(opts.DataDir, 0o755); err != nil {
 		return nil, fmt.Errorf("globalstore: create data dir %q: %w", opts.DataDir, err)
 	}
@@ -96,11 +109,11 @@ func New(opts Options) (*GlobalStore, error) {
 	}
 	path := filepath.Join(opts.DataDir, "global.db")
 
-	// modernc.org/sqlite accepts a query-string DSN for PRAGMAs. We
-	// set busy_timeout via DSN so even the schema-init query honours
-	// it; the rest of the PRAGMAs are issued imperatively below.
-	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)", path, busy.Milliseconds())
-	db, err := sql.Open("sqlite", dsn)
+	driver, dsn, err := globalOpenParams(path, busy, opts.EncryptionKey)
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open(driver, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("globalstore: open %q: %w", path, err)
 	}
@@ -140,6 +153,24 @@ func New(opts Options) (*GlobalStore, error) {
 		path:  path,
 		nowFn: nowFn,
 	}, nil
+}
+
+func globalOpenParams(path string, busy time.Duration, encryptionKey []byte) (driver, dsn string, err error) {
+	if len(encryptionKey) == 0 {
+		return "sqlite", fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)", path, busy.Milliseconds()), nil
+	}
+	encrypted, hasDatabase, err := entcrypto.SQLiteFileEncryptionStatus(path)
+	if err != nil {
+		return "", "", err
+	}
+	if hasDatabase && !encrypted {
+		return "", "", fmt.Errorf("globalstore: refusing to open unencrypted global.db %q with encryption configured", path)
+	}
+	dsn, err = entcrypto.SQLCipherDSN(path, encryptionKey, busy)
+	if err != nil {
+		return "", "", err
+	}
+	return entcrypto.SQLCipherDriverName, dsn, nil
 }
 
 // Close releases the SQLite connection. Idempotent.

--- a/server/go/internal/globalstore/globalstore_test.go
+++ b/server/go/internal/globalstore/globalstore_test.go
@@ -10,10 +10,13 @@ package globalstore_test
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	"google.golang.org/grpc/codes"
@@ -47,6 +50,101 @@ func TestMaxOpenConns(t *testing.T) {
 	stats := gs.DB().Stats()
 	if stats.MaxOpenConnections != 1 {
 		t.Fatalf("MaxOpenConnections: got %d, want 1", stats.MaxOpenConnections)
+	}
+}
+
+func TestEncryptedGlobalStoreUnreadableWithoutKey(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	key := globalTestMaster(0x41)
+	gs, err := globalstore.New(globalstore.Options{
+		DataDir:            dir,
+		WALMode:            true,
+		EncryptionKey:      key,
+		EncryptionRequired: true,
+	})
+	if err != nil {
+		t.Fatalf("New encrypted: %v", err)
+	}
+	if _, err := gs.CreateUser(ctx, "alice", "alice@example.com", "Alice"); err != nil {
+		t.Fatalf("CreateUser encrypted: %v", err)
+	}
+	path := gs.Path()
+	if err := gs.Close(); err != nil {
+		t.Fatalf("Close encrypted: %v", err)
+	}
+
+	encrypted, hasDB, err := entcrypto.SQLiteFileEncryptionStatus(path)
+	if err != nil {
+		t.Fatalf("SQLiteFileEncryptionStatus: %v", err)
+	}
+	if !hasDB || !encrypted {
+		t.Fatalf("global db encryption status encrypted=%v hasDB=%v, want encrypted database", encrypted, hasDB)
+	}
+
+	raw, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("open raw sqlite: %v", err)
+	}
+	defer raw.Close()
+	var n int
+	if err := raw.QueryRowContext(ctx, `SELECT count(*) FROM user_registry`).Scan(&n); err == nil {
+		t.Fatalf("raw sqlite read succeeded with count=%d; want encrypted global db to be unreadable", n)
+	}
+
+	reopened, err := globalstore.New(globalstore.Options{
+		DataDir:            dir,
+		WALMode:            true,
+		EncryptionKey:      key,
+		EncryptionRequired: true,
+	})
+	if err != nil {
+		t.Fatalf("New encrypted reopen: %v", err)
+	}
+	defer reopened.Close()
+	got, err := reopened.GetUser(ctx, "alice")
+	if err != nil {
+		t.Fatalf("GetUser encrypted reopen: %v", err)
+	}
+	if got == nil || got.UserID != "alice" {
+		t.Fatalf("GetUser encrypted reopen = %+v, want alice", got)
+	}
+}
+
+func TestEncryptedGlobalStoreRequiresKey(t *testing.T) {
+	_, err := globalstore.New(globalstore.Options{
+		DataDir:            t.TempDir(),
+		WALMode:            true,
+		EncryptionRequired: true,
+	})
+	if err == nil {
+		t.Fatal("New encryption required without key err = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "encryption required") {
+		t.Fatalf("New error = %q, want encryption required", err)
+	}
+}
+
+func TestEncryptedGlobalStoreRefusesPlaintextFile(t *testing.T) {
+	dir := t.TempDir()
+	plain, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("New plaintext: %v", err)
+	}
+	if err := plain.Close(); err != nil {
+		t.Fatalf("Close plaintext: %v", err)
+	}
+	_, err = globalstore.New(globalstore.Options{
+		DataDir:            dir,
+		WALMode:            true,
+		EncryptionKey:      globalTestMaster(0x42),
+		EncryptionRequired: true,
+	})
+	if err == nil {
+		t.Fatal("New encrypted over plaintext err = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "refusing to open unencrypted global.db") {
+		t.Fatalf("New error = %q, want unencrypted refusal", err)
 	}
 }
 
@@ -111,6 +209,14 @@ func TestUserCRUD(t *testing.T) {
 	if err != nil || got != nil {
 		t.Fatalf("GetUser ghost: got (%v, %v)", got, err)
 	}
+}
+
+func globalTestMaster(fill byte) []byte {
+	key := make([]byte, entcrypto.KeyLength)
+	for i := range key {
+		key[i] = fill
+	}
+	return key
 }
 
 // TestUserUniqueEmail asserts that a duplicate user_id or email raises

--- a/server/go/internal/store/canonical.go
+++ b/server/go/internal/store/canonical.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
 )
 
@@ -31,6 +32,15 @@ type Options struct {
 	// May be nil; methods that need it will skip index creation when
 	// nil, which is what tests want when they exercise raw CRUD paths.
 	Registry *schema.Registry
+
+	// KeyManager enables SQLCipher encryption for tenant database files.
+	// When set, OpenTenant derives/unwraps the per-tenant DEK and opens
+	// tenant_<id>.db through SQLCipher.
+	KeyManager *entcrypto.KeyManager
+
+	// EncryptionRequired refuses to construct a store unless KeyManager
+	// is configured. It also rejects pre-existing plaintext tenant files.
+	EncryptionRequired bool
 }
 
 // CanonicalStore is the per-tenant SQLite materialized view of the WAL.
@@ -59,7 +69,13 @@ type CanonicalStore struct {
 // New constructs a CanonicalStore. Caller must Close. RootDir is created
 // (recursively) if it does not exist.
 func New(opts Options) (*CanonicalStore, error) {
-	p, err := newPool(opts.RootDir, opts.BusyTimeout, opts.WALMode)
+	p, err := newPool(poolOptions{
+		rootDir:            opts.RootDir,
+		busyTimeout:        opts.BusyTimeout,
+		walMode:            opts.WALMode,
+		keyManager:         opts.KeyManager,
+		encryptionRequired: opts.EncryptionRequired,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -146,4 +162,13 @@ func (s *CanonicalStore) Registry() *schema.Registry { return s.registry }
 // a code smell.
 func (s *CanonicalStore) AdminDB(tenantID string) (*sql.DB, error) {
 	return s.db(tenantID)
+}
+
+// TenantDBPath returns the absolute tenant SQLite file path. It is used
+// by compliance workers and tests that need to inspect on-disk state.
+func (s *CanonicalStore) TenantDBPath(tenantID string) (string, error) {
+	if err := validateTenantID(tenantID); err != nil {
+		return "", err
+	}
+	return s.pool.dbPath(tenantID), nil
 }

--- a/server/go/internal/store/pool.go
+++ b/server/go/internal/store/pool.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
+
 	// modernc.org/sqlite registers the "sqlite" driver via init().
 	_ "modernc.org/sqlite"
 )
@@ -65,25 +67,44 @@ type pool struct {
 
 	// walMode toggles PRAGMA journal_mode=WAL. true in production.
 	walMode bool
+
+	// keyManager switches tenant DB opens to SQLCipher.
+	keyManager *entcrypto.KeyManager
+
+	// encryptionRequired rejects plaintext files and missing key config.
+	encryptionRequired bool
+}
+
+type poolOptions struct {
+	rootDir            string
+	busyTimeout        time.Duration
+	walMode            bool
+	keyManager         *entcrypto.KeyManager
+	encryptionRequired bool
 }
 
 // newPool returns a pool ready to lazy-open tenant DBs. The rootDir is
 // created with 0o755 if it does not already exist.
-func newPool(rootDir string, busyTimeout time.Duration, walMode bool) (*pool, error) {
-	if rootDir == "" {
+func newPool(opts poolOptions) (*pool, error) {
+	if opts.rootDir == "" {
 		return nil, fmt.Errorf("store: rootDir is required")
 	}
-	if err := os.MkdirAll(rootDir, 0o755); err != nil {
-		return nil, fmt.Errorf("store: mkdir %q: %w", rootDir, err)
+	if opts.encryptionRequired && opts.keyManager == nil {
+		return nil, fmt.Errorf("store: encryption required but no key manager configured")
 	}
-	if busyTimeout <= 0 {
-		busyTimeout = 5 * time.Second
+	if err := os.MkdirAll(opts.rootDir, 0o755); err != nil {
+		return nil, fmt.Errorf("store: mkdir %q: %w", opts.rootDir, err)
+	}
+	if opts.busyTimeout <= 0 {
+		opts.busyTimeout = 5 * time.Second
 	}
 	return &pool{
-		entries:     map[string]*poolEntry{},
-		rootDir:     rootDir,
-		busyTimeout: busyTimeout,
-		walMode:     walMode,
+		entries:            map[string]*poolEntry{},
+		rootDir:            opts.rootDir,
+		busyTimeout:        opts.busyTimeout,
+		walMode:            opts.walMode,
+		keyManager:         opts.keyManager,
+		encryptionRequired: opts.encryptionRequired,
 	}, nil
 }
 
@@ -123,8 +144,11 @@ func (p *pool) open(ctx context.Context, tenantID string) (*poolEntry, error) {
 	}
 
 	path := p.dbPath(tenantID)
-	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)", path, p.busyTimeout.Milliseconds())
-	db, err := sql.Open("sqlite", dsn)
+	driver, dsn, err := p.openParams(ctx, tenantID, path)
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open(driver, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("store: open %q: %w", path, err)
 	}
@@ -155,6 +179,28 @@ func (p *pool) open(ctx context.Context, tenantID string) (*poolEntry, error) {
 	e := &poolEntry{db: db}
 	p.entries[tenantID] = e
 	return e, nil
+}
+
+func (p *pool) openParams(ctx context.Context, tenantID, path string) (driver, dsn string, err error) {
+	if p.keyManager == nil {
+		return "sqlite", fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)", path, p.busyTimeout.Milliseconds()), nil
+	}
+	encrypted, hasDatabase, err := entcrypto.SQLiteFileEncryptionStatus(path)
+	if err != nil {
+		return "", "", err
+	}
+	if hasDatabase && !encrypted {
+		return "", "", fmt.Errorf("store: refusing to open unencrypted tenant DB %q with encryption configured", path)
+	}
+	key, err := p.keyManager.TenantKey(ctx, tenantID)
+	if err != nil {
+		return "", "", fmt.Errorf("store: tenant key %q: %w", tenantID, err)
+	}
+	dsn, err = entcrypto.SQLCipherDSN(path, key, p.busyTimeout)
+	if err != nil {
+		return "", "", err
+	}
+	return entcrypto.SQLCipherDriverName, dsn, nil
 }
 
 // get returns an opened entry for tenantID without creating it. Returns

--- a/server/go/internal/store/store_test.go
+++ b/server/go/internal/store/store_test.go
@@ -6,12 +6,15 @@ package store_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 )
@@ -64,6 +67,128 @@ func TestSchemaInitIdempotent(t *testing.T) {
 	}
 }
 
+func TestEncryptedTenantDatabaseUnreadableWithoutKey(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	manager, err := entcrypto.NewKeyManager(testMaster(0x31), nil)
+	if err != nil {
+		t.Fatalf("NewKeyManager: %v", err)
+	}
+	cs, err := store.New(store.Options{
+		RootDir:            dir,
+		WALMode:            true,
+		KeyManager:         manager,
+		EncryptionRequired: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New encrypted: %v", err)
+	}
+	if err := cs.OpenTenant(ctx, "tenant1"); err != nil {
+		t.Fatalf("OpenTenant encrypted: %v", err)
+	}
+	if _, err := cs.CreateNodeRaw(ctx, "tenant1", store.NodeInput{
+		NodeID:     "encrypted-node",
+		TypeID:     7,
+		OwnerActor: "user:alice",
+		Payload:    map[string]any{"1": "secret"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw encrypted: %v", err)
+	}
+	path, err := cs.TenantDBPath("tenant1")
+	if err != nil {
+		t.Fatalf("TenantDBPath: %v", err)
+	}
+	if err := cs.Close(); err != nil {
+		t.Fatalf("Close encrypted store: %v", err)
+	}
+
+	encrypted, hasDB, err := entcrypto.SQLiteFileEncryptionStatus(path)
+	if err != nil {
+		t.Fatalf("SQLiteFileEncryptionStatus: %v", err)
+	}
+	if !hasDB || !encrypted {
+		t.Fatalf("tenant db encryption status encrypted=%v hasDB=%v, want encrypted database", encrypted, hasDB)
+	}
+
+	raw, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("open raw sqlite: %v", err)
+	}
+	defer raw.Close()
+	var n int
+	if err := raw.QueryRowContext(ctx, `SELECT count(*) FROM nodes`).Scan(&n); err == nil {
+		t.Fatalf("raw sqlite read succeeded with count=%d; want encrypted file to be unreadable", n)
+	}
+
+	reopened, err := store.New(store.Options{
+		RootDir:            dir,
+		WALMode:            true,
+		KeyManager:         manager,
+		EncryptionRequired: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New encrypted reopen: %v", err)
+	}
+	defer reopened.Close()
+	if err := reopened.OpenTenant(ctx, "tenant1"); err != nil {
+		t.Fatalf("OpenTenant encrypted reopen: %v", err)
+	}
+	if _, err := reopened.GetNode(ctx, "tenant1", "encrypted-node"); err != nil {
+		t.Fatalf("GetNode encrypted reopen: %v", err)
+	}
+}
+
+func TestEncryptionRequiredNeedsKeyManager(t *testing.T) {
+	_, err := store.New(store.Options{
+		RootDir:            t.TempDir(),
+		WALMode:            true,
+		EncryptionRequired: true,
+	})
+	if err == nil {
+		t.Fatal("store.New encryption required without key manager err = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "encryption required") {
+		t.Fatalf("store.New error = %q, want encryption required", err)
+	}
+}
+
+func TestEncryptedStoreRefusesPlaintextTenantFile(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	plain, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New plaintext: %v", err)
+	}
+	if err := plain.OpenTenant(ctx, "tenant1"); err != nil {
+		t.Fatalf("OpenTenant plaintext: %v", err)
+	}
+	if err := plain.Close(); err != nil {
+		t.Fatalf("Close plaintext: %v", err)
+	}
+
+	manager, err := entcrypto.NewKeyManager(testMaster(0x32), nil)
+	if err != nil {
+		t.Fatalf("NewKeyManager: %v", err)
+	}
+	encrypted, err := store.New(store.Options{
+		RootDir:            dir,
+		WALMode:            true,
+		KeyManager:         manager,
+		EncryptionRequired: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New encrypted: %v", err)
+	}
+	defer encrypted.Close()
+	err = encrypted.OpenTenant(ctx, "tenant1")
+	if err == nil {
+		t.Fatal("OpenTenant encrypted over plaintext err = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "refusing to open unencrypted tenant DB") {
+		t.Fatalf("OpenTenant error = %q, want unencrypted refusal", err)
+	}
+}
+
 func TestInvalidTenantID(t *testing.T) {
 	cs := newStore(t)
 	ctx := context.Background()
@@ -76,6 +201,14 @@ func TestInvalidTenantID(t *testing.T) {
 			t.Fatalf("OpenTenant(%q): got %v, want errs.ErrInvalidArgument", bad, err)
 		}
 	}
+}
+
+func testMaster(fill byte) []byte {
+	key := make([]byte, entcrypto.KeyLength)
+	for i := range key {
+		key[i] = fill
+	}
+	return key
 }
 
 func TestNodeRoundTrip(t *testing.T) {

--- a/tests/python/e2e/conftest.py
+++ b/tests/python/e2e/conftest.py
@@ -79,6 +79,7 @@ from entdb_sdk import DbClient, register_proto_schema  # noqa: E402
 HOST = os.environ.get("ENTDB_HOST", "server")
 PORT = int(os.environ.get("ENTDB_PORT", "50051"))
 TENANT = os.environ.get("ENTDB_TENANT", "e2e-test")
+TLS_CA = os.environ.get("ENTDB_TLS_CA", "")
 ACTOR = "user:e2e-runner"
 ADMIN_ACTOR = "system:e2e-admin"
 
@@ -166,7 +167,17 @@ async def db_client(grpc_target: str) -> AsyncGenerator[DbClient, None]:
         _wait_for_grpc(HOST, PORT, timeout=60)
         _BOOT_WAITED = True
 
-    client = DbClient(grpc_target)
+    client_kwargs = {}
+    if TLS_CA:
+        import grpc
+
+        with open(TLS_CA, "rb") as f:
+            client_kwargs = {
+                "secure": True,
+                "credentials": grpc.ssl_channel_credentials(root_certificates=f.read()),
+            }
+
+    client = DbClient(grpc_target, **client_kwargs)
     last_exc: Exception | None = None
     for _ in range(30):
         try:
@@ -300,7 +311,14 @@ def grpc_channel(grpc_target: str) -> Generator[object, None, None]:
     except ImportError:
         pytest.skip("grpcio not installed")
 
-    channel = grpc.insecure_channel(grpc_target)
+    if TLS_CA:
+        with open(TLS_CA, "rb") as f:
+            channel = grpc.secure_channel(
+                grpc_target,
+                grpc.ssl_channel_credentials(root_certificates=f.read()),
+            )
+    else:
+        channel = grpc.insecure_channel(grpc_target)
     try:
         yield channel
     finally:

--- a/tests/python/e2e/docker-compose.e2e.yml
+++ b/tests/python/e2e/docker-compose.e2e.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # =============================================================================
 # EntDB E2E Test Environment — Go server target
 # =============================================================================
@@ -18,6 +16,35 @@ version: "3.8"
 # =============================================================================
 
 services:
+  tls-certs:
+    image: alpine:3.20
+    command:
+      - sh
+      - -c
+      - |
+        set -euo pipefail
+        apk add --no-cache openssl
+        mkdir -p /tls
+        if [ ! -s /tls/ca.pem ] || [ ! -s /tls/server.pem ] || [ ! -s /tls/server-key.pem ]; then
+          openssl ecparam -genkey -name prime256v1 -noout -out /tls/ca-key.pem
+          openssl req -x509 -new -nodes -key /tls/ca-key.pem -sha256 -days 2 \
+            -subj "/CN=entdb-e2e-ca" \
+            -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" \
+            -out /tls/ca.pem
+          openssl ecparam -genkey -name prime256v1 -noout -out /tls/server-key.pem
+          openssl req -new -key /tls/server-key.pem \
+            -subj "/CN=server" \
+            -out /tls/server.csr
+          printf "subjectAltName=DNS:server,DNS:localhost,IP:127.0.0.1\nextendedKeyUsage=serverAuth\nkeyUsage=digitalSignature\n" > /tls/server.ext
+          openssl x509 -req -in /tls/server.csr -CA /tls/ca.pem -CAkey /tls/ca-key.pem -CAcreateserial \
+            -out /tls/server.pem -days 2 -sha256 -extfile /tls/server.ext
+        fi
+        chown -R 65532:65532 /tls
+        chmod 0444 /tls/*.pem
+    volumes:
+      - tls-certs:/tls
+
   # ==========================================================================
   # Redpanda (Kafka-compatible WAL backend)
   #
@@ -78,11 +105,18 @@ services:
       - "-wal-group=entdb-applier-e2e"
       - "-seed-profile=e2e"
       - "-seed-tenant=e2e-test"
+      - "-tls-cert=/etc/entdb/tls/server.pem"
+      - "-tls-key=/etc/entdb/tls/server-key.pem"
+      - "-tls-ca=/etc/entdb/tls/ca.pem"
+      - "-require-tls=true"
     depends_on:
+      tls-certs:
+        condition: service_completed_successfully
       redpanda:
         condition: service_healthy
     volumes:
       - go-server-data:/var/lib/entdb
+      - tls-certs:/etc/entdb/tls:ro
     # No HEALTHCHECK in the distroless image (no shell, no grpc probe
     # binary baked in). The test runner retries its own connect with
     # MAX_RETRIES so a TCP-ready server is sufficient.
@@ -102,15 +136,18 @@ services:
       - ENTDB_PORT=50051
       - ENTDB_TENANT=e2e-test
       - ENTDB_SERVER_TARGET=go
+      - ENTDB_TLS_CA=/etc/entdb/tls/ca.pem
       - COMPOSE_PROJECT_NAME=e2e-go
     depends_on:
       - server
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker-compose.e2e.yml:/compose/docker-compose.yml:ro
+      - tls-certs:/etc/entdb/tls:ro
 
 volumes:
   go-server-data:
+  tls-certs:
 
 networks:
   default:

--- a/tests/python/e2e/run-e2e.sh
+++ b/tests/python/e2e/run-e2e.sh
@@ -58,11 +58,15 @@ echo ""
 cd "$PROJECT_ROOT"
 
 # Build and run tests
-echo "[1/3] Building containers..."
+echo "[1/4] Resetting existing e2e containers..."
+docker compose -f "$COMPOSE_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
+
+echo ""
+echo "[2/4] Building containers..."
 docker compose -f "$COMPOSE_FILE" build $NO_CACHE
 
 echo ""
-echo "[2/3] Starting infrastructure..."
+echo "[3/4] Starting infrastructure..."
 
 # Go server uses Kafka/Redpanda as its WAL. The distroless image carries
 # no healthcheck binary; the test runner retries its own connect, so plain
@@ -73,7 +77,7 @@ echo "Waiting briefly for Go server to bind its listener..."
 sleep 3
 
 echo ""
-echo "[3/4] Running e2e tests..."
+echo "[4/4] Running e2e tests..."
 set +e  # Don't exit on error, we want to capture the exit code
 
 docker compose -f "$COMPOSE_FILE" up --exit-code-from e2e-tests e2e-tests
@@ -91,11 +95,11 @@ fi
 # Cleanup
 if [ "$KEEP_RUNNING" = false ]; then
     echo ""
-    echo "[4/4] Cleaning up..."
+    echo "[cleanup] Cleaning up..."
     docker compose -f "$COMPOSE_FILE" down -v
 else
     echo ""
-    echo "[4/4] Keeping containers running (use 'docker compose -f $COMPOSE_FILE down -v' to clean up)"
+    echo "[cleanup] Keeping containers running (use 'docker compose -f $COMPOSE_FILE down -v' to clean up)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Implements the remaining production security controls from #519 and #520:

- wires SQLCipher for `global.db` and tenant SQLite files, with plaintext refusal when encryption is configured or required
- adds master-key bootstrap for file, AWS KMS envelope encryption, and Vault Transit envelope encryption, plus tenant key vault integration
- adds GDPR deletion worker crypto-shred flow for personal tenants and regression tests proving shredded tenants cannot reopen
- adds gRPC TLS/mTLS flags, TLS 1.3 default, optional TLS 1.2 compatibility, client-cert identity mapping, and SIGHUP cert/key/CA reload
- updates the Python e2e harness to exercise TLS with a generated CA and to avoid stale cert volumes between runs
- switches the server image/release notes to CGO-enabled SQLCipher builds and documents production deployment flags

The Go port currently has no active `public.db` or per-user mailbox SQLite files; those paths remain deferred/deprecated stubs in the repo docs, so this PR encrypts the physical files that exist today: `global.db` and `tenant_<id>.db`.

Closes #519.
Closes #520.

## Validation

- `go test ./...` in `server/go`
- `go vet ./...` in `server/go`
- `python -m compileall -q sdk/python/entdb_sdk tests/python/e2e`
- `uvx ruff@0.15.7 check sdk/python/entdb_sdk/_grpc_client.py sdk/python/entdb_sdk/client.py tests/python/e2e/conftest.py`
- `COMPOSE_PROJECT_NAME=e2e-go docker compose -f tests/python/e2e/docker-compose.e2e.yml config`
- `git diff --check`
- `tests/python/e2e/run-e2e.sh --logs` (22 passed)