### PR TITLE
feat(sdk/go): add read-only DbClient.Transport accessor

### DIFF
--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -1154,6 +1154,15 @@ func (c *DbClient) Address() string { return c.address }
 // Config returns a copy of the client configuration (for inspection/testing).
 func (c *DbClient) Config() clientConfig { return c.config }
 
+// Transport returns the underlying [Transport] this client uses.
+//
+// It is a read-only accessor intended for advanced consumers (e.g.
+// custom tooling or tests) that need to reach the transport without
+// resorting to reflection and unsafe. The returned value must be
+// treated as read-only; mutating transport state out from under the
+// client is unsupported.
+func (c *DbClient) Transport() Transport { return c.transport }
+
 // Tenant returns a TenantScope for the given tenant.
 //
 //	scope := client.Tenant("acme").Actor(entdb.UserActor("bob"))

--- a/sdk/go/entdb/client_test.go
+++ b/sdk/go/entdb/client_test.go
@@ -222,6 +222,29 @@ func TestNewClient_ValidAddress(t *testing.T) {
 	}
 }
 
+func TestClient_Transport_ReturnsUnderlyingTransport(t *testing.T) {
+	mt := &mockTransport{}
+	client := newTestClient(t, mt)
+
+	got := client.Transport()
+	if got == nil {
+		t.Fatal("expected non-nil Transport, got nil")
+	}
+	if got != Transport(mt) {
+		t.Errorf("expected Transport to return the injected transport %p, got %p", mt, got)
+	}
+}
+
+func TestClient_Transport_RealClient(t *testing.T) {
+	client, err := NewClient("localhost:50051")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.Transport() == nil {
+		t.Fatal("expected non-nil Transport for a real client, got nil")
+	}
+}
+
 func TestNewClient_EmptyAddress(t *testing.T) {
 	_, err := NewClient("")
 	if err == nil {


### PR DESCRIPTION
## Problem

The `Transport` interface is exported from the Go SDK (`sdk/go/entdb/client.go:24`), but the `DbClient.transport` field is private with no accessor. External consumers (custom tooling, advanced tests) that need the underlying transport are forced to reach it via reflection + `unsafe`. See #509.

## Fix

Add a one-line read-only accessor on `DbClient`:

```go
func (c *DbClient) Transport() Transport { return c.transport }
```

Placed alongside the existing `Address()` / `Config()` read-only accessors. Purely additive and non-breaking — no existing signatures change.

## Testing

- `TestClient_Transport_ReturnsUnderlyingTransport` — asserts the accessor returns the exact injected transport (via `newClientWithTransport` / `mockTransport`).
- `TestClient_Transport_RealClient` — asserts a real `NewClient` returns a non-nil transport.

Local CI (Go SDK):

```
cd sdk/go/entdb && go vet ./... && go test ./...
ok  github.com/elloloop/tenant-shard-db/sdk/go/entdb              0.855s
ok  github.com/elloloop/tenant-shard-db/sdk/go/entdb/cmd/entdb    1.406s
ok  github.com/elloloop/tenant-shard-db/sdk/go/entdb/cmd/entdb-console  0.553s
ok  github.com/elloloop/tenant-shard-db/sdk/go/entdb/cmd/entdbctl 1.429s
```

`go vet` clean; full Go SDK test suite green.

Closes #509