### PR TITLE
Clamp paginated reads to a max page size (SEC-4 #135)

### DIFF
--- a/server/go/internal/api/get_edges_from.go
+++ b/server/go/internal/api/get_edges_from.go
@@ -105,6 +105,9 @@ func (s *Server) GetEdgesFrom(ctx context.Context, req *pb.GetEdgesRequest) (*pb
 	if limit <= 0 {
 		limit = defaultEdgesLimit
 	}
+	// SEC-4 (#135): cap oversized page requests so the response slice
+	// can't be inflated past MaxPageSize protos.
+	limit = clampPageSize(limit)
 	hasMore := len(edges) > limit
 	if hasMore {
 		edges = edges[:limit]

--- a/server/go/internal/api/get_edges_to.go
+++ b/server/go/internal/api/get_edges_to.go
@@ -90,6 +90,9 @@ func (s *Server) GetEdgesTo(
 	if limit <= 0 {
 		limit = 100
 	}
+	// SEC-4 (#135): cap oversized page requests before the store
+	// fetches limit+1 rows.
+	limit = clampPageSize(limit)
 
 	var edgeType *int32
 	if t := req.GetEdgeTypeId(); t != 0 {

--- a/server/go/internal/api/list_users.go
+++ b/server/go/internal/api/list_users.go
@@ -13,8 +13,11 @@
 //   - Silent error swallow: an internal globalstore error returns
 //     codes.OK with users=[]. Mirrors grpc_server.py:2262-2265 so
 //     contract tests pass.
-//   - No upper cap on limit; negative limit flows through as "unlimited"
-//     (SQLite treats LIMIT -1 as no limit). Mirrors grpc_server.py:2249.
+//   - SEC-4 (#135): the historic "No upper cap on limit; negative limit
+//     flows through as unlimited (SQLite LIMIT -1)" wart is closed. Any
+//     non-positive limit now coerces to the 100 default (was: only ==0),
+//     and a positive limit above MaxPageSize is clamped to MaxPageSize
+//     before it reaches globalstore. The unbounded-scan path is gone.
 //
 // Trusted-actor invariant (CLAUDE.md, commit fece3fb): we still bind the
 // authoritative actor from ctx via auth.Authoritative even though no
@@ -75,9 +78,14 @@ func (s *Server) ListUsers(
 		statusFilter = "active"
 	}
 	limit := int(req.GetLimit())
-	if limit == 0 {
+	if limit <= 0 {
+		// SEC-4 (#135): widened from ==0 to <=0 so a negative limit
+		// (SQLite treats LIMIT -1 as unbounded) can no longer trigger
+		// a full-table scan of the user registry.
 		limit = 100
 	}
+	// SEC-4 (#135): cap oversized page requests before building protos.
+	limit = clampPageSize(limit)
 	offset := int(req.GetOffset())
 
 	rows, err := s.global.ListUsers(ctx, statusFilter, limit, offset)

--- a/server/go/internal/api/pagination.go
+++ b/server/go/internal/api/pagination.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Pagination guardrails (issue #135, SEC-4).
+//
+// Several read RPCs historically applied only a default-when-zero limit
+// with NO upper ceiling. A hostile or buggy client passing
+// limit=10_000_000 would make the server materialise that many protos
+// in memory — an unauthenticated-amplification DoS.
+//
+// MaxPageSize is the single server-wide ceiling for a paged read. It
+// matches the value GetConnectedNodes (MaxConnectedResultLimit) and
+// ListSharedWithMe (listSharedWithMeMaxLimit) already enforce, so the
+// whole read surface now shares one cap.
+//
+// The clamp is applied at handler entry for every uncapped read RPC
+// (QueryNodes, SearchNodes, ListUsers, GetEdgesFrom, GetEdgesTo) AFTER
+// the existing "<=0 => default" coercion, so small/default page sizes
+// are unaffected and only oversized requests are trimmed. The store
+// layer (store.QueryNodes) re-applies the same ceiling as
+// defence-in-depth for any future caller that bypasses the handler.
+
+package api
+
+// MaxPageSize is the maximum number of rows any single paged read RPC
+// will return. Requests asking for more are silently clamped to this
+// value (no error — pagination clients keep working, they just page
+// more). 1000 matches MaxConnectedResultLimit and
+// listSharedWithMeMaxLimit so the read surface is uniform.
+const MaxPageSize = 1000
+
+// clampPageSize applies the MaxPageSize ceiling. It does NOT touch the
+// "<=0 => default" behaviour: callers must coerce the default first,
+// then pass the already-defaulted positive limit through here. A
+// non-positive input is returned unchanged so an accidental call order
+// can't turn "use default" into "return 1000".
+func clampPageSize(limit int) int {
+	if limit > MaxPageSize {
+		return MaxPageSize
+	}
+	return limit
+}

--- a/server/go/internal/api/pagination_clamp_test.go
+++ b/server/go/internal/api/pagination_clamp_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Handler-level tests for the SEC-4 (#135) pagination clamp.
+//
+// These exercise the real gRPC handlers end-to-end (store + registry
+// wired) and assert that an absurd limit (10_000_000) comes back capped
+// at api.MaxPageSize while leaving the existing "<=0 => default"
+// behaviour untouched. The clamp helper itself is unit-tested in
+// pagination_test.go; the store-layer defence-in-depth clamp is pinned
+// in internal/store/nodes_query_test.go.
+
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestQueryNodes_OversizedLimitClampedToMax pins the handler clamp:
+// 1001 nodes seeded, a 10M limit must return exactly MaxPageSize rows.
+func TestQueryNodes_OversizedLimitClampedToMax(t *testing.T) {
+	t.Parallel()
+	f := newQueryNodesFixture(t)
+
+	const seeded = api.MaxPageSize + 1
+	for i := 0; i < seeded; i++ {
+		f.seedNode(fmt.Sprintf("n%04d", i), "user:alice", "alice@example.com", int64(i))
+	}
+
+	resp, err := f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
+		TypeId:  1,
+		Limit:   10_000_000,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if got := len(resp.GetNodes()); got != api.MaxPageSize {
+		t.Fatalf("oversized limit not clamped: got %d nodes, want %d (%d seeded)",
+			got, api.MaxPageSize, seeded)
+	}
+}
+
+// TestQueryNodes_SmallLimitUnaffected pins that the clamp does NOT
+// touch a normal request: a limit well under the ceiling is honoured
+// verbatim, and an unset limit still falls back to the default.
+func TestQueryNodes_SmallLimitUnaffected(t *testing.T) {
+	t.Parallel()
+	f := newQueryNodesFixture(t)
+
+	for i := 0; i < 10; i++ {
+		f.seedNode(fmt.Sprintf("n%02d", i), "user:alice", "alice@example.com", int64(i))
+	}
+
+	// Explicit small limit honoured exactly.
+	resp, err := f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
+		TypeId:  1,
+		Limit:   3,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes(limit=3): %v", err)
+	}
+	if got := len(resp.GetNodes()); got != 3 {
+		t.Fatalf("small limit not honoured: got %d nodes, want 3", got)
+	}
+
+	// Unset limit -> default (100) still applies; 10 seeded rows all
+	// come back (proves the clamp didn't hijack the default path).
+	resp, err = f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
+		TypeId:  1,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes(limit unset): %v", err)
+	}
+	if got := len(resp.GetNodes()); got != 10 {
+		t.Fatalf("default-limit path changed: got %d nodes, want 10", got)
+	}
+}
+
+// TestListUsers_OversizedLimitClampedToMax pins the global-plane clamp:
+// MaxPageSize+1 active users seeded, a 10M limit must cap at
+// MaxPageSize. This closes the documented "No upper cap on limit"
+// parity wart that motivated SEC-4.
+func TestListUsers_OversizedLimitClampedToMax(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	const seeded = api.MaxPageSize + 1
+	for i := 0; i < seeded; i++ {
+		id := fmt.Sprintf("u%05d", i)
+		if _, err := gs.CreateUser(ctx, id, id+"@example.com", id); err != nil {
+			t.Fatalf("CreateUser(%q): %v", id, err)
+		}
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{
+		Actor: "user:admin",
+		Limit: 10_000_000,
+	})
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if got := len(resp.GetUsers()); got != api.MaxPageSize {
+		t.Fatalf("oversized limit not clamped: got %d users, want %d (%d seeded)",
+			got, api.MaxPageSize, seeded)
+	}
+}
+
+// TestListUsers_NegativeLimitCoercedToDefault pins the SEC-4 widening
+// of the zero-coercion to <=0: a negative limit (SQLite LIMIT -1 ==
+// unbounded) must NOT trigger a full-registry scan. With seeded > 100
+// the response must cap at the 100 default, not return everything.
+func TestListUsers_NegativeLimitCoercedToDefault(t *testing.T) {
+	t.Parallel()
+
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	const seeded = 150
+	for i := 0; i < seeded; i++ {
+		id := fmt.Sprintf("u%05d", i)
+		if _, err := gs.CreateUser(ctx, id, id+"@example.com", id); err != nil {
+			t.Fatalf("CreateUser(%q): %v", id, err)
+		}
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{
+		Actor: "user:admin",
+		Limit: -1, // pre-fix: flowed through as SQLite "unlimited"
+	})
+	if err != nil {
+		t.Fatalf("ListUsers(limit=-1): %v", err)
+	}
+	if got := len(resp.GetUsers()); got != 100 {
+		t.Fatalf("negative limit not coerced to default: got %d users, want 100", got)
+	}
+}

--- a/server/go/internal/api/pagination_test.go
+++ b/server/go/internal/api/pagination_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Unit tests for the SEC-4 (#135) pagination clamp helper. Lives in
+// `package api` (not api_test) so it can exercise the unexported
+// clampPageSize directly. Handler-level behaviour (the clamp actually
+// being applied per RPC) is pinned in pagination_clamp_test.go.
+
+package api
+
+import "testing"
+
+func TestMaxPageSize_MatchesSharedCeiling(t *testing.T) {
+	t.Parallel()
+	// MaxPageSize must stay equal to the value GetConnectedNodes and
+	// ListSharedWithMe already enforce, so the whole read surface caps
+	// at one number. If any of these constants is retuned, retune all
+	// of them together (and storeMaxQueryLimit in the store package).
+	if MaxPageSize != 1000 {
+		t.Fatalf("MaxPageSize = %d, want 1000", MaxPageSize)
+	}
+	if MaxConnectedResultLimit != MaxPageSize {
+		t.Fatalf("MaxConnectedResultLimit (%d) != MaxPageSize (%d)",
+			MaxConnectedResultLimit, MaxPageSize)
+	}
+	if listSharedWithMeMaxLimit != MaxPageSize {
+		t.Fatalf("listSharedWithMeMaxLimit (%d) != MaxPageSize (%d)",
+			listSharedWithMeMaxLimit, MaxPageSize)
+	}
+}
+
+func TestClampPageSize(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"under cap is unchanged", 50, 50},
+		{"exactly at cap is unchanged", MaxPageSize, MaxPageSize},
+		{"one over cap is clamped", MaxPageSize + 1, MaxPageSize},
+		{"absurd DoS limit is clamped", 10_000_000, MaxPageSize},
+		{"max int is clamped", int(^uint(0) >> 1), MaxPageSize},
+		// Non-positive inputs are passed through untouched: callers
+		// coerce the "<=0 => default" case BEFORE calling this, so the
+		// helper must not turn a sentinel into 1000.
+		{"zero passes through", 0, 0},
+		{"negative passes through", -1, -1},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := clampPageSize(tc.in); got != tc.want {
+				t.Fatalf("clampPageSize(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/go/internal/api/query_nodes.go
+++ b/server/go/internal/api/query_nodes.go
@@ -124,6 +124,8 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	if limit <= 0 {
 		limit = defaultQueryLimit
 	}
+	// SEC-4 (#135): cap oversized page requests before building protos.
+	limit = clampPageSize(limit)
 
 	nodes, err := s.store.QueryNodes(ctx, store.QueryNodesArgs{
 		TenantID:   tenantID,

--- a/server/go/internal/api/search_nodes.go
+++ b/server/go/internal/api/search_nodes.go
@@ -122,6 +122,9 @@ func (s *Server) SearchNodes(
 	if limit == 0 {
 		limit = 50
 	}
+	// SEC-4 (#135): cap oversized page requests before the FTS JOIN
+	// materialises rows.
+	limit = clampPageSize(limit)
 	offset := int(req.GetOffset())
 
 	rows, ferr := s.store.SearchNodes(ctx, tenantID, typeID, q, searchableFIDs, limit, offset)

--- a/server/go/internal/store/nodes.go
+++ b/server/go/internal/store/nodes.go
@@ -254,6 +254,13 @@ type QueryFilter struct {
 	Value   any
 }
 
+// storeMaxQueryLimit is the defence-in-depth ceiling QueryNodes applies
+// to args.Limit (SEC-4, issue #135). It mirrors api.MaxPageSize (1000)
+// but is duplicated here on purpose: the store package must not import
+// the api package (that would invert the dependency direction). The two
+// values are kept in lock-step by the store-layer clamp test.
+const storeMaxQueryLimit = 1000
+
 // QueryNodesArgs is the input to QueryNodes. Mirrors
 // canonical_store.py:_sync_query_nodes (2394) signature minus the
 // MongoDB filter (deferred to W1.10 query_filter port).
@@ -298,6 +305,14 @@ func (s *CanonicalStore) QueryNodes(ctx context.Context, args QueryNodesArgs) ([
 	limit := args.Limit
 	if limit <= 0 {
 		limit = 100
+	}
+	// SEC-4 (#135) defence-in-depth: the gRPC handlers already clamp to
+	// api.MaxPageSize, but re-apply the same ceiling here so any future
+	// in-process caller that bypasses the handler still cannot ask the
+	// SQLite layer to materialise an unbounded result set. Kept as a
+	// package-local literal (the store package must not import api).
+	if limit > storeMaxQueryLimit {
+		limit = storeMaxQueryLimit
 	}
 
 	whereParts := []string{"tenant_id = ?", "type_id = ?"}

--- a/server/go/internal/store/nodes_query_test.go
+++ b/server/go/internal/store/nodes_query_test.go
@@ -6,6 +6,7 @@ package store_test
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -174,6 +175,47 @@ func TestQueryNodes_UnindexedFieldStillWorks(t *testing.T) {
 	want := []string{"b", "c"}
 	if g := ids(got); len(g) != 2 || g[0] != want[0] || g[1] != want[1] {
 		t.Fatalf("got %v, want %v", g, want)
+	}
+}
+
+// TestQueryNodes_OversizedLimitClampedToMax pins the SEC-4 (#135)
+// defence-in-depth clamp at the store layer: an in-process caller that
+// bypasses the gRPC handlers and passes an absurd Limit still cannot
+// make the SQLite layer materialise an unbounded result set. Seed
+// 1001 rows so the 1000 ceiling is observable (1001 would come back if
+// the clamp regressed; 1000 is the cap).
+func TestQueryNodes_OversizedLimitClampedToMax(t *testing.T) {
+	cs := newStore(t)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	const seeded = 1001
+	for i := 0; i < seeded; i++ {
+		if _, err := cs.CreateNodeRaw(ctx, "t1", store.NodeInput{
+			NodeID:     fmt.Sprintf("n%04d", i),
+			TypeID:     1,
+			OwnerActor: "u",
+			Payload:    map[string]any{"1": "x"},
+		}); err != nil {
+			t.Fatalf("CreateNodeRaw n%04d: %v", i, err)
+		}
+	}
+
+	got, err := cs.QueryNodes(ctx, store.QueryNodesArgs{
+		TenantID: "t1",
+		TypeID:   1,
+		Limit:    10_000_000, // absurd request — must be clamped
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	// Mirrors api.MaxPageSize (1000). The store keeps its own literal
+	// because the store package must not import api.
+	const wantMax = 1000
+	if len(got) != wantMax {
+		t.Fatalf("oversized Limit not clamped: got %d rows, want %d (%d seeded)",
+			len(got), wantMax, seeded)
 	}
 }
 


### PR DESCRIPTION
## Problem

Several read RPCs applied only a default-when-zero limit with **no upper ceiling**. A client passing `limit=10_000_000` to `QueryNodes`, `SearchNodes`, `ListUsers`, `GetEdgesFrom` or `GetEdgesTo` makes the server materialise that many protos in memory — an unauthenticated amplification DoS (issue #135, SEC-4).

`ListUsers` was the worst case: its file header documented *"No upper cap on limit"* and a **negative** limit fell straight through to SQLite as `LIMIT -1` (= unbounded full-table scan of the user registry), because the coercion only handled `== 0`.

`GetConnectedNodes` and `ListSharedWithMe` already clamped at 1000; the rest of the read surface did not.

## Fix

- New `api.MaxPageSize = 1000` constant + `clampPageSize` helper (`server/go/internal/api/pagination.go`). 1000 matches the value `GetConnectedNodes` (`MaxConnectedResultLimit`) and `ListSharedWithMe` (`listSharedWithMeMaxLimit`) already enforce, so the whole read surface now shares one ceiling.
- Clamp applied at handler entry for `QueryNodes`, `SearchNodes`, `ListUsers`, `GetEdgesFrom`, `GetEdgesTo` — **after** the existing `<=0 => default` coercion, so small/default page sizes are unaffected and only oversized requests are trimmed (no error; pagination clients keep working).
- `ListUsers` zero-coercion widened from `== 0` to `<= 0` so a negative limit can no longer trigger an unbounded SQLite scan. File-header parity note updated to record the intentional SEC-4 deviation.
- Defence-in-depth clamp added at the store layer (`store.QueryNodes` in `server/go/internal/store/nodes.go`) via a package-local `storeMaxQueryLimit = 1000`, so a future in-process caller that bypasses the gRPC handler still can't ask SQLite for an unbounded result set. The store package deliberately does not import `api` (would invert the dependency direction); the two literals are kept in lock-step by tests.

Audit notes: `GetNodes` has no `limit` field — it is batch-capped via the existing `maxBatchNodeIDs = 1000`. `ListTenants` has no pagination params. No other read RPC with a `limit` field was left uncapped.

## Testing

Local CI (full suite per CLAUDE.md) all green:

- `cd server/go && go vet ./... && go test ./...` — all packages OK
- `cd sdk/go/entdb && go vet ./... && go test ./...` — all OK
- `python -m pytest tests/python/integration/ -q` — **95 passed**
- `uvx ruff@0.15.7 check .` — All checks passed
- `uvx ruff@0.15.7 format --check .` — 55 files already formatted

New tests:
- `pagination_test.go` (unit): `clampPageSize` table (under/at/over cap, 10M, max-int, zero/negative pass-through) + shared-ceiling invariant (`MaxPageSize == MaxConnectedResultLimit == listSharedWithMeMaxLimit`).
- `pagination_clamp_test.go` (handler): 10M limit returns exactly `MaxPageSize` for `QueryNodes` and `ListUsers`; small/unset limits untouched; negative `ListUsers` limit coerces to the 100 default.
- `internal/store/nodes_query_test.go`: store-layer defence-in-depth clamp pinned (1001 rows seeded, 10M limit returns 1000).

Closes #135