### PR TITLE
Go SDK: automatic per-tenant offset tracking (read-after-write)

### DIFF
--- a/sdk/go/entdb/README.md
+++ b/sdk/go/entdb/README.md
@@ -436,6 +436,35 @@ If the same `order-12345` key is replayed by a client after a network
 partition, the server short-circuits the second attempt and hands back
 the same `CreatedNodeIDs` as the first.
 
+## Read-after-write consistency
+
+Reads are automatically consistent with your own writes — zero
+application code. Every `Commit` records the receipt's WAL stream
+position per tenant, and the next `Get` / `GetByKey` / `Query` /
+`GetMany` against that tenant transparently attaches it as the
+`after_offset` so the read observes the just-written data:
+
+```go
+result, _ := plan.Commit(ctx)            // records the offset
+p, _ := entdb.Get[*shop.Product](ctx, scope, result.CreatedNodeIDs[0])
+// p reflects the commit even if the applier is momentarily behind
+```
+
+Per-tenant: a write to tenant `acme` never pins reads of another
+tenant. Override per call when you need to:
+
+```go
+// Force a specific offset (e.g. one shared across processes):
+entdb.Get[*shop.Product](entdb.WithAfterOffset(ctx, "42"), scope, id)
+
+// Opt out — read whatever the replica currently has, no wait:
+entdb.Query[*shop.Product](entdb.WithoutOffsetTracking(ctx), scope, nil)
+```
+
+`client.ClearOffsets()` drops all tracked positions (useful in tests
+or to stop enforcing read-after-write). This mirrors the Python SDK's
+automatic offset tracking exactly.
+
 ## Error handling
 
 All SDK errors implement the `error` interface; use `errors.As` to
@@ -560,6 +589,10 @@ team that uses both can copy the shape of a call between languages:
 | Share | `await scope.share("node-42", Actor.user("bob"), Permission.READ)` | `scope.Share(ctx, "node-42", entdb.UserActor("bob"), entdb.PermissionRead)` |
 | Commit | `await plan.commit()` | `plan.Commit(ctx)` |
 | Idempotent plan | `plan = scope.plan(idempotency_key="order-12345")` | `plan := scope.PlanWithKey("order-12345")` |
+| Read-after-write | automatic (per-tenant offset tracking) | automatic (per-tenant offset tracking) |
+| Override offset | `await scope.get(T, id, after_offset="42")` | `entdb.Get[T](entdb.WithAfterOffset(ctx, "42"), scope, id)` |
+| Opt out of tracking | `await scope.get(T, id, after_offset=None)` | `entdb.Get[T](entdb.WithoutOffsetTracking(ctx), scope, id)` |
+| Clear offsets | `db.clear_offsets()` | `client.ClearOffsets()` |
 
 ## Full example
 

--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -218,12 +218,19 @@ type grpcTransport struct {
 	// [WithBaseDomain]). It caches per-tenant sub-channels for
 	// nodes the SDK has been redirected to.
 	redirectCache *tenantEndpointCache
+	// offsets records the last WAL stream position written per
+	// tenant so reads auto-attach it as ``after_offset`` for
+	// read-after-write consistency (mirrors the Python SDK's
+	// ``DbClient._last_offsets``). Lives on the transport — the
+	// single boundary both Plan commits and Scope reads cross.
+	offsets *offsetTracker
 }
 
 func newGRPCTransport(address string, cfg clientConfig) *grpcTransport {
 	return &grpcTransport{
 		address: address,
 		config:  cfg,
+		offsets: newOffsetTracker(),
 	}
 }
 
@@ -310,11 +317,14 @@ func (t *grpcTransport) GetNode(ctx context.Context, tenantID, actor string, typ
 	if err != nil {
 		return nil, err
 	}
+	offset := t.offsets.resolve(ctx, tenantID)
 	var trailer metadata.MD
 	resp, err := client.GetNode(t.callContext(ctx, tenantID), &pb.GetNodeRequest{
-		Context: &pb.RequestContext{TenantId: tenantID, Actor: actor},
-		TypeId:  int32(typeID),
-		NodeId:  nodeID,
+		Context:       &pb.RequestContext{TenantId: tenantID, Actor: actor},
+		TypeId:        int32(typeID),
+		NodeId:        nodeID,
+		AfterOffset:   offset,
+		WaitTimeoutMs: waitTimeoutForOffset(offset),
 	}, grpc.Trailer(&trailer))
 	if err != nil {
 		return nil, translateGRPCStatusWithTrailer(err, trailer, tenantID, t.address)
@@ -330,13 +340,15 @@ func (t *grpcTransport) GetNodeByKey(ctx context.Context, tenantID, actor string
 	if err != nil {
 		return nil, err
 	}
+	offset := t.offsets.resolve(ctx, tenantID)
 	var trailer metadata.MD
 	resp, err := client.GetNodeByKey(t.callContext(ctx, tenantID), &pb.GetNodeByKeyRequest{
-		TenantId: tenantID,
-		Actor:    actor,
-		TypeId:   typeID,
-		FieldId:  fieldID,
-		Value:    value,
+		TenantId:    tenantID,
+		Actor:       actor,
+		TypeId:      typeID,
+		FieldId:     fieldID,
+		Value:       value,
+		AfterOffset: offsetAsInt64(offset),
 	}, grpc.Trailer(&trailer))
 	if err != nil {
 		return nil, translateGRPCStatusWithTrailer(err, trailer, tenantID, t.address)
@@ -356,11 +368,14 @@ func (t *grpcTransport) QueryNodes(ctx context.Context, tenantID, actor string, 
 	if err != nil {
 		return nil, err
 	}
+	offset := t.offsets.resolve(ctx, tenantID)
 	var trailer metadata.MD
 	resp, err := client.QueryNodes(t.callContext(ctx, tenantID), &pb.QueryNodesRequest{
-		Context: &pb.RequestContext{TenantId: tenantID, Actor: actor},
-		TypeId:  int32(typeID),
-		Filters: filters,
+		Context:       &pb.RequestContext{TenantId: tenantID, Actor: actor},
+		TypeId:        int32(typeID),
+		Filters:       filters,
+		AfterOffset:   offset,
+		WaitTimeoutMs: waitTimeoutForOffset(offset),
 	}, grpc.Trailer(&trailer))
 	if err != nil {
 		return nil, translateGRPCStatusWithTrailer(err, trailer, tenantID, t.address)
@@ -423,6 +438,10 @@ func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idem
 			IdempotencyKey: r.GetIdempotencyKey(),
 			StreamPosition: r.GetStreamPosition(),
 		}
+		// Track last write offset per tenant for read-after-write
+		// consistency — subsequent reads auto-attach it as
+		// after_offset (mirrors the Python SDK).
+		t.offsets.record(tenantID, r.GetStreamPosition())
 	}
 	return &CommitResult{
 		Success:        resp.GetSuccess(),
@@ -570,11 +589,14 @@ func (t *grpcTransport) GetNodes(ctx context.Context, tenantID, actor string, ty
 	if err != nil {
 		return nil, nil, err
 	}
+	offset := t.offsets.resolve(ctx, tenantID)
 	var trailer metadata.MD
 	resp, err := client.GetNodes(t.callContext(ctx, tenantID), &pb.GetNodesRequest{
-		Context: &pb.RequestContext{TenantId: tenantID, Actor: actor},
-		TypeId:  int32(typeID),
-		NodeIds: nodeIDs,
+		Context:       &pb.RequestContext{TenantId: tenantID, Actor: actor},
+		TypeId:        int32(typeID),
+		NodeIds:       nodeIDs,
+		AfterOffset:   offset,
+		WaitTimeoutMs: waitTimeoutForOffset(offset),
 	}, grpc.Trailer(&trailer))
 	if err != nil {
 		return nil, nil, translateGRPCStatusWithTrailer(err, trailer, tenantID, t.address)
@@ -1195,6 +1217,31 @@ func (c *DbClient) GetTenantQuota(ctx context.Context, actor, tenantID string) (
 // commit chain.
 func (c *DbClient) WaitForOffset(ctx context.Context, tenantID, actor, streamPosition string, timeoutMs int32) (bool, string, error) {
 	return c.transport.WaitForOffset(ctx, tenantID, actor, streamPosition, timeoutMs)
+}
+
+// offsetClearer is the optional capability a Transport exposes when
+// it tracks per-tenant write offsets for read-after-write
+// consistency. The production grpcTransport implements it; bare test
+// doubles may not, in which case ClearOffsets is a safe no-op.
+type offsetClearer interface {
+	clearOffsets()
+}
+
+// clearOffsets satisfies offsetClearer on the production transport.
+func (t *grpcTransport) clearOffsets() { t.offsets.clear() }
+
+// ClearOffsets drops every tracked per-tenant write offset, so the
+// next read no longer pins to a past write. Mirrors the Python SDK's
+// ``DbClient.clear_offsets()`` — useful in tests and when a caller
+// deliberately wants to stop enforcing read-after-write.
+//
+// Automatic offset tracking otherwise needs zero application code:
+// every Commit records ``receipt.stream_position`` for its tenant
+// and every subsequent read auto-attaches it as ``after_offset``.
+func (c *DbClient) ClearOffsets() {
+	if oc, ok := c.transport.(offsetClearer); ok {
+		oc.clearOffsets()
+	}
 }
 
 // Health returns a snapshot of server health for liveness /

--- a/sdk/go/entdb/offsets.go
+++ b/sdk/go/entdb/offsets.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+package entdb
+
+import (
+	"context"
+	"strconv"
+	"sync"
+)
+
+// offsetTracker records the last WAL stream position the client has
+// written, keyed by tenant id. It is the Go analogue of the Python
+// SDK's ``DbClient._last_offsets`` map (see
+// ``sdk/python/entdb_sdk/client.py``): every successful Commit /
+// ExecuteAtomic stores ``receipt.stream_position`` for the tenant,
+// and every subsequent read auto-attaches it as the proto
+// ``after_offset`` so the read observes the just-written data
+// (read-after-write consistency) with zero application code.
+//
+// The map is guarded by an RWMutex because a single DbClient is
+// safe for concurrent use across goroutines (commits and reads can
+// race), unlike the Python SDK whose asyncio client is
+// single-threaded.
+type offsetTracker struct {
+	mu      sync.RWMutex
+	offsets map[string]string // tenant_id -> stream_position
+}
+
+func newOffsetTracker() *offsetTracker {
+	return &offsetTracker{offsets: make(map[string]string)}
+}
+
+// record stores the stream position written for a tenant. An empty
+// position is ignored — mirrors the Python guard
+// ``if result.receipt.stream_position:``. A nil tracker is a no-op
+// so transports built without newGRPCTransport (bare struct literals
+// in tests) degrade gracefully instead of panicking.
+func (o *offsetTracker) record(tenantID, streamPosition string) {
+	if o == nil || streamPosition == "" {
+		return
+	}
+	o.mu.Lock()
+	if o.offsets == nil {
+		o.offsets = make(map[string]string)
+	}
+	o.offsets[tenantID] = streamPosition
+	o.mu.Unlock()
+}
+
+// get returns the tracked stream position for a tenant, or ""
+// when nothing has been written for it yet. Nil-safe.
+func (o *offsetTracker) get(tenantID string) string {
+	if o == nil {
+		return ""
+	}
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.offsets[tenantID]
+}
+
+// clear drops every tracked offset. Mirrors the Python
+// ``DbClient.clear_offsets()`` — handy in tests and when a caller
+// deliberately wants to stop pinning reads to past writes. Nil-safe.
+func (o *offsetTracker) clear() {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	o.offsets = make(map[string]string)
+	o.mu.Unlock()
+}
+
+// resolve computes the after_offset to send for a read against
+// ``tenantID``. It mirrors the Python ``_resolve_offset`` three-way
+// semantics, expressed through the request context because Go has
+// no keyword-argument sentinel like Python's ``_UNSET``:
+//
+//   - no offset directive on the context (the common case): use the
+//     tracked offset for the tenant (or "" if none) — automatic
+//     read-after-write.
+//   - WithoutOffsetTracking(ctx): opt out entirely; return "" (the
+//     Python ``after_offset=None`` path).
+//   - WithAfterOffset(ctx, pos): caller-supplied explicit pin;
+//     return ``pos`` verbatim (the Python explicit-string path).
+func (o *offsetTracker) resolve(ctx context.Context, tenantID string) string {
+	switch d := offsetDirectiveFromContext(ctx); d.kind {
+	case offsetOptOut:
+		return ""
+	case offsetExplicit:
+		return d.value
+	default: // offsetAuto
+		return o.get(tenantID)
+	}
+}
+
+// ── Per-request override via context ────────────────────────────────
+//
+// The single-shape Go read surface ([Get] / [GetByKey] / [Query] /
+// [GetMany]) takes no optional offset argument, so a caller that
+// needs to override automatic tracking for one call threads the
+// directive through the request context. This keeps the typed API
+// unchanged while still exposing the Python SDK's three behaviours.
+
+type offsetDirectiveKind int
+
+const (
+	offsetAuto offsetDirectiveKind = iota // use the tracked offset
+	offsetOptOut                          // do not send any after_offset
+	offsetExplicit                        // send an exact after_offset
+)
+
+type offsetDirective struct {
+	kind  offsetDirectiveKind
+	value string
+}
+
+type offsetDirectiveKeyType struct{}
+
+var offsetDirectiveKey offsetDirectiveKeyType
+
+// WithAfterOffset returns a context that pins the next read to the
+// given WAL stream position, overriding automatic offset tracking
+// for that call. Equivalent to passing an explicit ``after_offset``
+// string in the Python SDK.
+//
+//	ctx = entdb.WithAfterOffset(ctx, receipt.StreamPosition)
+//	p, err := entdb.Get[*shop.Product](ctx, scope, "node-42")
+func WithAfterOffset(ctx context.Context, streamPosition string) context.Context {
+	return context.WithValue(ctx, offsetDirectiveKey,
+		offsetDirective{kind: offsetExplicit, value: streamPosition})
+}
+
+// WithoutOffsetTracking returns a context that opts the next read
+// out of automatic offset tracking — no ``after_offset`` is sent
+// even if the client has written for this tenant. Equivalent to
+// passing ``after_offset=None`` in the Python SDK.
+func WithoutOffsetTracking(ctx context.Context) context.Context {
+	return context.WithValue(ctx, offsetDirectiveKey,
+		offsetDirective{kind: offsetOptOut})
+}
+
+func offsetDirectiveFromContext(ctx context.Context) offsetDirective {
+	if ctx == nil {
+		return offsetDirective{kind: offsetAuto}
+	}
+	if d, ok := ctx.Value(offsetDirectiveKey).(offsetDirective); ok {
+		return d
+	}
+	return offsetDirective{kind: offsetAuto}
+}
+
+// waitTimeoutForOffset mirrors the Python SDK's
+// ``wait_timeout_ms=30000 if resolved_offset else 0`` — when a
+// non-empty offset is attached we let the server block for up to
+// 30s for the applier to catch up; otherwise no wait.
+func waitTimeoutForOffset(offset string) int32 {
+	if offset == "" {
+		return 0
+	}
+	return 30000
+}
+
+// offsetAsInt64 converts a resolved string offset to the int64 the
+// GetNodeByKey RPC expects. Mirrors the Python ``get_by_key``
+// behaviour: a non-parseable / empty value degrades to 0 rather
+// than erroring.
+func offsetAsInt64(offset string) int64 {
+	if offset == "" {
+		return 0
+	}
+	n, err := strconv.ParseInt(offset, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/sdk/go/entdb/offsets_test.go
+++ b/sdk/go/entdb/offsets_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: MIT
+package entdb
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	pb "github.com/elloloop/tenant-shard-db/sdk/go/entdb/internal/pb"
+)
+
+// trackingServer is a fakeServer wired with canned read responses so
+// the read-after-write flow can be exercised end-to-end: commit,
+// then read, and assert the recorded stream_position rode along as
+// the proto after_offset.
+func newTrackingServer() *fakeServer {
+	return &fakeServer{
+		execResp: &pb.ExecuteAtomicResponse{
+			Success: true,
+			Receipt: &pb.Receipt{
+				TenantId:       "acme",
+				IdempotencyKey: "idem-1",
+				StreamPosition: "42",
+			},
+			CreatedNodeIds: []string{"node-1"},
+			AppliedStatus:  pb.ReceiptStatus_RECEIPT_STATUS_APPLIED,
+		},
+		getNodeResp: &pb.GetNodeResponse{
+			Found: true,
+			Node:  &pb.Node{TenantId: "acme", NodeId: "node-1", TypeId: 201},
+		},
+		getNodeByKeyResp: &pb.GetNodeByKeyResponse{
+			Found: true,
+			Node:  &pb.Node{TenantId: "acme", NodeId: "node-1", TypeId: 201},
+		},
+		queryResp:    &pb.QueryNodesResponse{Nodes: []*pb.Node{{NodeId: "node-1", TypeId: 201}}},
+		getNodesResp: &pb.GetNodesResponse{Nodes: []*pb.Node{{NodeId: "node-1", TypeId: 201}}},
+	}
+}
+
+// trackingTransport returns a bufconn-backed grpcTransport with a
+// live offsetTracker (startFakeServer builds the struct literal
+// without one).
+func trackingTransport(t *testing.T, svc *fakeServer) *grpcTransport {
+	t.Helper()
+	tr := startFakeServer(t, svc)
+	tr.offsets = newOffsetTracker()
+	return tr
+}
+
+// TestReadAfterWrite_AutoAttachesOffset is the core E10.2 contract:
+// a read issued right after a Commit must carry the receipt's
+// stream_position as after_offset (and the 30s wait), with zero
+// caller intervention — mirroring the Python SDK.
+func TestReadAfterWrite_AutoAttachesOffset(t *testing.T) {
+	svc := newTrackingServer()
+	tr := trackingTransport(t, svc)
+	ctx := context.Background()
+
+	if _, err := tr.ExecuteAtomic(ctx, "acme", "user:alice", "idem-1",
+		[]Operation{{Type: OpCreateNode, TypeID: 201, Alias: "a", Data: map[string]any{"1": "x"}}}); err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+
+	if _, err := tr.GetNode(ctx, "acme", "user:alice", 201, "node-1"); err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got := svc.getNodeReq.GetAfterOffset(); got != "42" {
+		t.Errorf("GetNode after_offset = %q, want \"42\"", got)
+	}
+	if got := svc.getNodeReq.GetWaitTimeoutMs(); got != 30000 {
+		t.Errorf("GetNode wait_timeout_ms = %d, want 30000", got)
+	}
+
+	if _, err := tr.QueryNodes(ctx, "acme", "user:alice", 201, nil); err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if got := svc.queryReq.GetAfterOffset(); got != "42" {
+		t.Errorf("QueryNodes after_offset = %q, want \"42\"", got)
+	}
+	if got := svc.queryReq.GetWaitTimeoutMs(); got != 30000 {
+		t.Errorf("QueryNodes wait_timeout_ms = %d, want 30000", got)
+	}
+
+	if _, _, err := tr.GetNodes(ctx, "acme", "user:alice", 201, []string{"node-1"}); err != nil {
+		t.Fatalf("GetNodes: %v", err)
+	}
+	if got := svc.getNodesReq.GetAfterOffset(); got != "42" {
+		t.Errorf("GetNodes after_offset = %q, want \"42\"", got)
+	}
+	if got := svc.getNodesReq.GetWaitTimeoutMs(); got != 30000 {
+		t.Errorf("GetNodes wait_timeout_ms = %d, want 30000", got)
+	}
+
+	if _, err := tr.GetNodeByKey(ctx, "acme", "user:alice", 201, 5, nil); err != nil {
+		t.Fatalf("GetNodeByKey: %v", err)
+	}
+	// GetNodeByKey carries after_offset as int64 (mirrors Python's
+	// int() coercion of the string offset).
+	if got := svc.getNodeByKeyReq.GetAfterOffset(); got != 42 {
+		t.Errorf("GetNodeByKey after_offset = %d, want 42", got)
+	}
+}
+
+// TestRead_NoOffsetBeforeAnyWrite verifies a read with no prior
+// write for the tenant sends no after_offset and no wait — matching
+// the Python ``_last_offsets.get(tenant_id)`` -> None path.
+func TestRead_NoOffsetBeforeAnyWrite(t *testing.T) {
+	svc := newTrackingServer()
+	tr := trackingTransport(t, svc)
+
+	if _, err := tr.GetNode(context.Background(), "acme", "user:alice", 201, "node-1"); err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got := svc.getNodeReq.GetAfterOffset(); got != "" {
+		t.Errorf("after_offset = %q, want empty (no prior write)", got)
+	}
+	if got := svc.getNodeReq.GetWaitTimeoutMs(); got != 0 {
+		t.Errorf("wait_timeout_ms = %d, want 0", got)
+	}
+}
+
+// TestOffsetTracking_PerTenantIsolation: a write for tenant A must
+// not leak into reads for tenant B.
+func TestOffsetTracking_PerTenantIsolation(t *testing.T) {
+	svc := newTrackingServer()
+	svc.execResp.Receipt.TenantId = "tenant-a"
+	tr := trackingTransport(t, svc)
+	ctx := context.Background()
+
+	if _, err := tr.ExecuteAtomic(ctx, "tenant-a", "user:alice", "idem-1",
+		[]Operation{{Type: OpCreateNode, TypeID: 201, Alias: "a", Data: map[string]any{"1": "x"}}}); err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+
+	if _, err := tr.GetNode(ctx, "tenant-b", "user:alice", 201, "node-1"); err != nil {
+		t.Fatalf("GetNode tenant-b: %v", err)
+	}
+	if got := svc.getNodeReq.GetAfterOffset(); got != "" {
+		t.Errorf("tenant-b read carried tenant-a offset %q", got)
+	}
+
+	if _, err := tr.GetNode(ctx, "tenant-a", "user:alice", 201, "node-1"); err != nil {
+		t.Fatalf("GetNode tenant-a: %v", err)
+	}
+	if got := svc.getNodeReq.GetAfterOffset(); got != "42" {
+		t.Errorf("tenant-a read after_offset = %q, want \"42\"", got)
+	}
+}
+
+// TestWithAfterOffset_ExplicitOverride: an explicit per-call offset
+// wins over the tracked one (Python explicit-string path).
+func TestWithAfterOffset_ExplicitOverride(t *testing.T) {
+	svc := newTrackingServer()
+	tr := trackingTransport(t, svc)
+	ctx := context.Background()
+
+	if _, err := tr.ExecuteAtomic(ctx, "acme", "user:alice", "idem-1",
+		[]Operation{{Type: OpCreateNode, TypeID: 201, Alias: "a", Data: map[string]any{"1": "x"}}}); err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+
+	octx := WithAfterOffset(ctx, "99")
+	if _, err := tr.GetNode(octx, "acme", "user:alice", 201, "node-1"); err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got := svc.getNodeReq.GetAfterOffset(); got != "99" {
+		t.Errorf("after_offset = %q, want \"99\" (explicit override)", got)
+	}
+}
+
+// TestWithoutOffsetTracking_OptOut: opting out suppresses the
+// after_offset even when a write was recorded (Python
+// ``after_offset=None`` path).
+func TestWithoutOffsetTracking_OptOut(t *testing.T) {
+	svc := newTrackingServer()
+	tr := trackingTransport(t, svc)
+	ctx := context.Background()
+
+	if _, err := tr.ExecuteAtomic(ctx, "acme", "user:alice", "idem-1",
+		[]Operation{{Type: OpCreateNode, TypeID: 201, Alias: "a", Data: map[string]any{"1": "x"}}}); err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+
+	octx := WithoutOffsetTracking(ctx)
+	if _, err := tr.GetNode(octx, "acme", "user:alice", 201, "node-1"); err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got := svc.getNodeReq.GetAfterOffset(); got != "" {
+		t.Errorf("after_offset = %q, want empty (opt-out)", got)
+	}
+	if got := svc.getNodeReq.GetWaitTimeoutMs(); got != 0 {
+		t.Errorf("wait_timeout_ms = %d, want 0 (opt-out)", got)
+	}
+}
+
+// TestClearOffsets drops tracked state so the next read no longer
+// pins to the prior write — mirrors Python ``clear_offsets()``.
+func TestClearOffsets(t *testing.T) {
+	svc := newTrackingServer()
+	tr := trackingTransport(t, svc)
+	client := newClientWithTransport("bufnet", tr)
+	ctx := context.Background()
+
+	if _, err := tr.ExecuteAtomic(ctx, "acme", "user:alice", "idem-1",
+		[]Operation{{Type: OpCreateNode, TypeID: 201, Alias: "a", Data: map[string]any{"1": "x"}}}); err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+
+	client.ClearOffsets()
+
+	if _, err := tr.GetNode(ctx, "acme", "user:alice", 201, "node-1"); err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got := svc.getNodeReq.GetAfterOffset(); got != "" {
+		t.Errorf("after_offset = %q, want empty after ClearOffsets", got)
+	}
+}
+
+// TestClearOffsets_NoTrackerIsNoOp: ClearOffsets must be safe on a
+// client whose transport does not implement offsetClearer (bare
+// test doubles).
+func TestClearOffsets_NoTrackerIsNoOp(t *testing.T) {
+	client := newClientWithTransport("x", &mockTransport{})
+	client.ClearOffsets() // must not panic
+}
+
+// TestOffsetTracker_Concurrency exercises the RWMutex under racing
+// record/get/clear goroutines — run with -race in CI.
+func TestOffsetTracker_Concurrency(t *testing.T) {
+	tr := newOffsetTracker()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func(n int) { defer wg.Done(); tr.record(fmt.Sprintf("t%d", n%5), fmt.Sprintf("%d", n)) }(i)
+		go func(n int) { defer wg.Done(); _ = tr.get(fmt.Sprintf("t%d", n%5)) }(i)
+		go func() { defer wg.Done(); tr.clear() }()
+	}
+	wg.Wait()
+}
+
+// TestOffsetTracker_NilSafe: methods on a nil tracker degrade
+// gracefully (transports built without newGRPCTransport).
+func TestOffsetTracker_NilSafe(t *testing.T) {
+	var tr *offsetTracker
+	tr.record("t", "1") // no panic
+	if got := tr.get("t"); got != "" {
+		t.Errorf("nil get = %q, want empty", got)
+	}
+	tr.clear() // no panic
+	if got := tr.resolve(context.Background(), "t"); got != "" {
+		t.Errorf("nil resolve = %q, want empty", got)
+	}
+}
+
+func TestOffsetAsInt64(t *testing.T) {
+	cases := map[string]int64{"": 0, "42": 42, "not-a-number": 0, "-7": -7}
+	for in, want := range cases {
+		if got := offsetAsInt64(in); got != want {
+			t.Errorf("offsetAsInt64(%q) = %d, want %d", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The Go SDK only exposed the manual `WaitForOffset` RPC wrapper. Its
`GetNode` / `GetNodeByKey` / `QueryNodes` / `GetNodes` calls never set
the proto `after_offset` field, and there was no per-tenant offset
map — so read-after-write consistency required hand-written plumbing
on every call site. The Python SDK has had automatic tracking since
#74 (`_last_offsets` / `_resolve_offset` / `clear_offsets`).

## Fix

Mirror the Python semantics exactly:

- **`offsetTracker`** — concurrency-safe per-tenant `stream_position`
  map (`RWMutex`; the Go client is safe for concurrent use, unlike
  the single-threaded asyncio Python client). Lives on
  `grpcTransport`, the single boundary both `Plan` commits and
  `Scope` reads cross. Nil-safe so bare-struct transports in tests
  degrade gracefully instead of panicking.
- **`ExecuteAtomic`** records `receipt.stream_position` per tenant on
  a successful commit (empty position ignored — matches the Python
  `if result.receipt.stream_position:` guard).
- **`GetNode` / `GetNodeByKey` / `QueryNodes` / `GetNodes`** resolve
  and attach the tracked offset as `after_offset`, with
  `wait_timeout_ms = 30000` when an offset is present and `0`
  otherwise (Python's `30000 if resolved_offset else 0`).
  `GetNodeByKey` carries it as `int64`, matching the wire field and
  Python's `int()` coercion (non-numeric → 0).
- **Per-call overrides via the request context** (Go has no kwargs /
  `_UNSET`): `WithAfterOffset(ctx, pos)` pins an explicit offset and
  `WithoutOffsetTracking(ctx)` opts out — the Go analogues of the
  Python explicit-string and `after_offset=None` paths.
- **`DbClient.ClearOffsets()`** drops tracked state (Python
  `clear_offsets()`), exposed via an optional `offsetClearer`
  capability so non-tracking test doubles are a safe no-op.

The single-shape typed read API (`Get` / `GetByKey` / `Query` /
`GetMany`) is unchanged — tracking is fully automatic; overrides ride
the context.

## Testing

`sdk/go/entdb/offsets_test.go` covers the read-after-write contract
end-to-end through the existing bufconn fake server:

- commit → read auto-attaches `after_offset` + 30s wait for all four
  read RPCs (string offset; `int64` for `GetNodeByKey`)
- no offset / no wait before any write for the tenant
- per-tenant isolation (a write to tenant A never pins reads of B)
- `WithAfterOffset` explicit override wins over the tracked offset
- `WithoutOffsetTracking` suppresses the offset and the wait
- `ClearOffsets` drops tracked state; no-op on non-tracking transports
- nil-tracker safety and a `-race` concurrency stress of the tracker
- `offsetAsInt64` coercion table

Local CI (per CLAUDE.md):

\`\`\`
$ cd sdk/go/entdb && go vet ./...        # clean
$ go test ./...                          # ok (all packages)
$ go test -race ./...                    # ok (all packages, race clean)
\`\`\`

Change is Go-SDK-only (no proto / contract harness / Python touched),
so the Python integration suite gate is not triggered by this PR.

## Epic note

Completes **Epic #73 (E10.2)** — SDK read-after-write consistency is
now automatic in the Go SDK as well. Closes #75. (Leaving #73 for the
maintainer to close.)

Closes #75