### PR TITLE
fix(testseed): seed contract fixture through the real producer→applier path

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -295,7 +295,10 @@ func main() {
 		}
 		switch profile {
 		case "contract":
-			if err := testseed.SeedTenantContract(ctx, global, canonical, *seedTenant); err != nil {
+			// Seed through the shared producer; the applier goroutine
+			// started above consumes the event and writes the receipt +
+			// offset rows (GitHub issue #505).
+			if err := testseed.SeedTenantContract(ctx, global, canonical, walImpl, *walTopic, *seedTenant); err != nil {
 				log.Fatalf("entdb-server: seed tenant %q (contract): %v", *seedTenant, err)
 			}
 			log.Printf("entdb-server: seeded tenant %q with contract profile (alice=owner, bob=member, seed node + receipt)", *seedTenant)

--- a/server/go/internal/api/execute_atomic.go
+++ b/server/go/internal/api/execute_atomic.go
@@ -269,13 +269,22 @@ func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest
 		waitCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutMs)*time.Millisecond)
 		if err := s.store.WaitForOffset(waitCtx, tenantID, parseStreamOffset(posStr)); err == nil {
 			// Poll briefly for the idempotency row to be present.
-			// WaitForOffset's in-memory tracker can be advanced by
-			// non-event paths (e.g. the contract seed pre-bumps the
-			// offset), so the wait alone does not guarantee the
-			// applier has finalised THIS event's idempotency record.
-			// Polling closes the race without changing the wait
-			// semantics that the rest of the codebase relies on.
-			// GitHub issue #500.
+			// WaitForOffset's in-memory tracker is advanced from
+			// UpdateAppliedOffsetTx BEFORE the applier's batch txn
+			// commits (see store/offset.go: the cond broadcast is
+			// pre-commit), so the wait returning does NOT guarantee
+			// THIS event's applied_events row is committed/visible on
+			// a fresh read connection. Polling the idempotency record
+			// closes that residual race without changing the wait
+			// semantics the rest of the codebase relies on.
+			//
+			// NOTE (GitHub issue #505): the original trigger — the
+			// contract seed pre-bumping the in-memory offset via a
+			// WAL-bypassing CreateNodeRaw — has been removed; the seed
+			// now goes through the real producer→applier path. This
+			// poll is retained because the pre-commit broadcast above
+			// is an independent source of the same race and is not
+			// addressed by the seed fix. GitHub issues #500, #503, #505.
 			rec := waitForIdempotencyRecord(ctx, s.store, tenantID, idem, time.Duration(timeoutMs)*time.Millisecond)
 			switch {
 			case rec.Present && rec.Status == store.IdempotencyStatusFailedPrecondition:

--- a/server/go/internal/testseed/seed.go
+++ b/server/go/internal/testseed/seed.go
@@ -17,24 +17,26 @@
 //     a single `e2e-runner` user as tenant owner. No seed node — the
 //     e2e suite creates all its own state.
 //
-// CLAUDE.md invariant #1 says all writes go through the WAL. This
-// package is the documented exception: it is a test-only seed for
-// the cross-impl harnesses, gated by `--seed-profile`, and never
-// reachable from a production code path. The seed writes the same
-// applied_events + applied_offsets rows the applier would have written
-// had the seed run through ExecuteAtomic, so post-seed reads behave
-// identically.
+// CLAUDE.md invariant #1 says all writes go through the WAL, and as of
+// GitHub issue #505 this seed honours it: the seed node is written by
+// appending a real WAL event through the producer and letting the
+// already-running applier materialise it (idempotency + offset rows
+// included). The seed path and the runtime ExecuteAtomic path are now
+// byte-identical, so there is no longer a parallel-universe state and
+// no in-memory offset pre-bump to poison WaitForOffset.
 package testseed
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 	"google.golang.org/grpc/codes"
 )
 
@@ -210,24 +212,46 @@ func RegisterE2ESchema(reg *schema.Registry) error {
 	return nil
 }
 
+// seedWaitTimeout bounds how long SeedTenantContract waits for the
+// running applier to materialise the seed event. Generous enough to
+// cover a slow CI box; the applier normally catches up in single-digit
+// milliseconds on the in-memory WAL.
+const seedWaitTimeout = 30 * time.Second
+
 // SeedTenantContract applies the contract-fixture seed for tenantID.
 // Order mirrors the Python conftest:
 //
 //  1. tenant_registry row (tenantID, "Acme Corp", region default).
 //  2. user_registry rows: alice + bob.
 //  3. tenant_members: alice=owner, bob=member.
-//  4. canonical store: OpenTenant + seeded-node + seed-1 receipt +
-//     applied_offsets row.
+//  4. canonical store: OpenTenant, then the seeded-node + seed-1
+//     receipt + applied_offsets row are produced by appending a real
+//     WAL event and letting the running applier materialise it.
 //
-// All steps are best-effort idempotent: an already-existing row is
-// treated as success so repeated harness boots against the same
-// data-dir don't fail.
-func SeedTenantContract(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, tenantID string) error {
+// The producer/topic MUST be the same producer the gRPC server and the
+// running applier share, so the appended event is consumed by the
+// applier that is already running (see cmd/entdb-server/main.go: the
+// applier goroutine is started before the seed runs). This makes the
+// seed path identical to the runtime ExecuteAtomic path — GitHub issue
+// #505.
+//
+// All steps are best-effort idempotent: an already-existing globalstore
+// row is treated as success, and the WAL event carries idempotency key
+// "seed-1" so a repeated harness boot against the same data-dir dedupes
+// at both the producer (same key → same StreamPos) and the applier
+// (in-txn idempotency probe → StatusSkipped) layers.
+func SeedTenantContract(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, producer wal.Producer, topic, tenantID string) error {
 	if g == nil {
 		return errors.New("testseed: nil globalstore")
 	}
 	if s == nil {
 		return errors.New("testseed: nil canonical store")
+	}
+	if producer == nil {
+		return errors.New("testseed: nil wal producer")
+	}
+	if topic == "" {
+		return errors.New("testseed: empty wal topic")
 	}
 	if tenantID == "" {
 		return errors.New("testseed: empty tenantID")
@@ -253,30 +277,77 @@ func SeedTenantContract(ctx context.Context, g *globalstore.GlobalStore, s *stor
 		return fmt.Errorf("testseed: open tenant: %w", err)
 	}
 
-	// Seed node — payload is field-id-keyed (CLAUDE.md invariant #6).
-	// Field 1 = email, Field 2 = name (per RegisterContractSchema).
-	if _, err := s.CreateNodeRaw(ctx, tenantID, store.NodeInput{
-		NodeID:     SeedNodeID,
-		TypeID:     UserTypeID,
-		Payload:    map[string]any{"1": "seeded@example.com", "2": "Seeded"},
-		OwnerActor: AliceActor,
-	}); err != nil && !isUniqueOrAlreadyExists(err) {
-		return fmt.Errorf("testseed: create seed node: %w", err)
+	// Seed node — written through the real producer→applier path so
+	// the applier itself records the seed-1 idempotency row and the
+	// applied_offsets row (CLAUDE.md invariant #1; GitHub issue #505).
+	// Payload is field-id-keyed (CLAUDE.md invariant #6): field 1 =
+	// email, field 2 = name (per RegisterContractSchema). The event
+	// actor IS the materialised owner_actor (see apply/ops_create_node.go),
+	// so it must be AliceActor to satisfy the contract fixture.
+	event := wal.Event{
+		TenantID:       tenantID,
+		Actor:          AliceActor,
+		IdempotencyKey: SeedReceipt,
+		TsMs:           time.Now().UnixMilli(),
+		Ops: []map[string]any{
+			{
+				"op":      "create_node",
+				"id":      SeedNodeID,
+				"type_id": UserTypeID,
+				"data":    map[string]any{"1": "seeded@example.com", "2": "Seeded"},
+			},
+		},
+	}
+	payloadBytes, err := event.Encode()
+	if err != nil {
+		return fmt.Errorf("testseed: encode seed event: %w", err)
+	}
+	headers := map[string][]byte{
+		wal.HeaderIdempotencyKey: []byte(SeedReceipt),
+	}
+	if _, err := producer.Append(ctx, topic, tenantID, payloadBytes, headers); err != nil {
+		return fmt.Errorf("testseed: append seed event: %w", err)
 	}
 
-	// seed-1 receipt so GetReceiptStatus(seed-1) returns APPLIED.
-	if err := s.RecordIdempotency(ctx, tenantID, SeedReceipt, "entdb-wal:0:0"); err != nil && !isIdempotencyViolation(err) {
-		return fmt.Errorf("testseed: record receipt seed-1: %w", err)
-	}
-
-	// applied_offsets: mark partition 0 of entdb-wal as having processed
-	// offset 1 (one event — the seed node). WaitForOffset(target=0)
-	// returns immediately because the in-memory map now has tenantID >= 0.
-	if err := s.UpdateAppliedOffset(ctx, tenantID, SeedTopic, 0, 1); err != nil {
-		return fmt.Errorf("testseed: update applied offset: %w", err)
+	// Block until the running applier has finalised the seed event.
+	// We poll the idempotency record (not WaitForOffset) because the
+	// receipt row is the precise post-condition the contract suite
+	// asserts on (GetReceiptStatus(seed-1) == APPLIED) and it is
+	// written in the same applier transaction as the node + offset.
+	if err := waitForSeedApplied(ctx, s, tenantID, SeedReceipt); err != nil {
+		return fmt.Errorf("testseed: wait for seed event to apply: %w", err)
 	}
 
 	return nil
+}
+
+// waitForSeedApplied blocks until (tenantID, idem) is present in
+// applied_events, the seed-wait budget elapses, or ctx is cancelled.
+// The seed event is consumed by the applier goroutine that main.go
+// starts before the seed runs, so this typically returns within a few
+// milliseconds.
+func waitForSeedApplied(ctx context.Context, s *store.CanonicalStore, tenantID, idem string) error {
+	waitCtx, cancel := context.WithTimeout(ctx, seedWaitTimeout)
+	defer cancel()
+
+	delay := 1 * time.Millisecond
+	for {
+		rec, err := s.CheckIdempotencyStatus(waitCtx, tenantID, idem)
+		if err != nil {
+			return err
+		}
+		if rec.Present {
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("timed out after %s waiting for seed receipt %q", seedWaitTimeout, idem)
+		case <-time.After(delay):
+		}
+		if delay < 25*time.Millisecond {
+			delay *= 2
+		}
+	}
 }
 
 // SeedTenant is a deprecated alias for SeedTenantContract kept until
@@ -284,8 +355,8 @@ func SeedTenantContract(ctx context.Context, g *globalstore.GlobalStore, s *stor
 // profile-aware variant.
 //
 // Deprecated: use SeedTenantContract.
-func SeedTenant(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, tenantID string) error {
-	return SeedTenantContract(ctx, g, s, tenantID)
+func SeedTenant(ctx context.Context, g *globalstore.GlobalStore, s *store.CanonicalStore, producer wal.Producer, topic, tenantID string) error {
+	return SeedTenantContract(ctx, g, s, producer, topic, tenantID)
 }
 
 // SeedTenantE2E applies the e2e-fixture seed for tenantID. Order:
@@ -331,15 +402,4 @@ func SeedTenantE2E(ctx context.Context, g *globalstore.GlobalStore, s *store.Can
 
 func isAlreadyExists(err error) bool {
 	return errs.Code(err) == codes.AlreadyExists
-}
-
-func isUniqueOrAlreadyExists(err error) bool {
-	if isAlreadyExists(err) {
-		return true
-	}
-	return errors.Is(err, store.ErrUniqueConstraint)
-}
-
-func isIdempotencyViolation(err error) bool {
-	return errors.Is(err, store.ErrIdempotencyViolation)
 }

--- a/server/go/internal/testseed/seed_test.go
+++ b/server/go/internal/testseed/seed_test.go
@@ -3,13 +3,27 @@ package testseed
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
 
-func newStores(t *testing.T) (*globalstore.GlobalStore, *store.CanonicalStore, *schema.Registry) {
+// testTopic / testGroupID mirror the server defaults; the seed event
+// is keyed by tenant_id so a single in-memory partition is enough.
+const (
+	testTopic   = "entdb-wal"
+	testGroupID = "entdb-applier"
+)
+
+// newStores builds the globalstore + canonical store + a connected
+// in-memory WAL with the applier already running, mirroring how
+// cmd/entdb-server/main.go wires the seed (the applier consumes the
+// seed event the seed appends — GitHub issue #505).
+func newStores(t *testing.T) (*globalstore.GlobalStore, *store.CanonicalStore, *schema.Registry, wal.Producer) {
 	t.Helper()
 	dir := t.TempDir()
 	g, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: false})
@@ -32,14 +46,38 @@ func newStores(t *testing.T) (*globalstore.GlobalStore, *store.CanonicalStore, *
 	}
 	t.Cleanup(func() { _ = s.Close() })
 
-	return g, s, reg
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+
+	applier, err := apply.New(apply.Options{
+		Store:       s,
+		Global:      g,
+		Consumer:    w,
+		Topic:       testTopic,
+		GroupID:     testGroupID,
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- applier.Run(runCtx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	return g, s, reg, w
 }
 
 func TestSeedTenant_PopulatesContractFixture(t *testing.T) {
 	ctx := context.Background()
-	g, s, _ := newStores(t)
+	g, s, _, w := newStores(t)
 
-	if err := SeedTenant(ctx, g, s, "acme"); err != nil {
+	if err := SeedTenant(ctx, g, s, w, testTopic, "acme"); err != nil {
 		t.Fatalf("SeedTenant: %v", err)
 	}
 
@@ -94,8 +132,11 @@ func TestSeedTenant_PopulatesContractFixture(t *testing.T) {
 		t.Fatalf("CheckIdempotency seed-1 = false, want true")
 	}
 
-	// WaitForOffset returns immediately for target=0 since the applied
-	// offset map is populated.
+	// The applier (not a pre-bump) advanced the offset for the seed
+	// event, which is the first in-memory record (offset 0). The
+	// in-memory tracker is therefore populated honestly, so a
+	// WaitForOffset for an offset we have already passed returns
+	// without blocking — the GitHub-issue-#505 invariant.
 	if err := s.WaitForOffset(ctx, "acme", 0); err != nil {
 		t.Fatalf("WaitForOffset(0): %v", err)
 	}
@@ -103,12 +144,12 @@ func TestSeedTenant_PopulatesContractFixture(t *testing.T) {
 
 func TestSeedTenant_Idempotent(t *testing.T) {
 	ctx := context.Background()
-	g, s, _ := newStores(t)
+	g, s, _, w := newStores(t)
 
-	if err := SeedTenant(ctx, g, s, "acme"); err != nil {
+	if err := SeedTenant(ctx, g, s, w, testTopic, "acme"); err != nil {
 		t.Fatalf("first SeedTenant: %v", err)
 	}
-	if err := SeedTenant(ctx, g, s, "acme"); err != nil {
+	if err := SeedTenant(ctx, g, s, w, testTopic, "acme"); err != nil {
 		t.Fatalf("second SeedTenant (should be idempotent): %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

`server/go/internal/testseed/seed.go` `SeedTenantContract` seeded the
contract fixture out-of-band:

- `CreateNodeRaw` wrote the seed node directly to SQLite, bypassing the WAL.
- `RecordIdempotency` hand-wrote the `seed-1` receipt.
- `UpdateAppliedOffset(...,0,1)` pre-bumped the **in-memory** applied-offset
  tracker that `WaitForOffset` consults.

The pre-bump made `WaitForOffset(target ≤ 1)` return *before* the applier
had processed any event. The seed and runtime write paths lived in two
different universes; the `#500` CAS work hit this directly (read-after-write
in the same request saw stale state) and was worked around in `#503` with a
handler-side polling loop. The underlying poison was untouched (issue #505).

## Fix

Reroute the seed through the exact path every real mutation takes:

1. Build a `wal.Event` — `create_node` op, idempotency key `seed-1`, actor
   `user:alice` (the event actor becomes the materialised `owner_actor`).
2. `producer.Append(...)` it onto the shared WAL.
3. Block until the **already-running** applier materialises it, polling
   `CheckIdempotencyStatus` for the `seed-1` receipt the applier writes
   itself (same txn as the node + `applied_offsets` row).

The applier now owns the `applied_events` / `applied_offsets` writes — no
WAL-bypassing write, no offset pre-bump, no parallel-universe state. The
seed path is byte-identical to `ExecuteAtomic`.

Idempotency across repeated harness boots is preserved for free: the same
idempotency key dedupes at the producer (returns the original `StreamPos`)
and at the applier's in-txn idempotency probe (`StatusSkipped`).

`SeedTenantContract` / `SeedTenant` now take a `wal.Producer` + topic;
`cmd/entdb-server/main.go` passes the shared producer (the applier
goroutine is already started before the seed runs). `seed_test.go` wires an
in-memory WAL + running applier to mirror the server. Dead helpers removed.

### The #503 workaround is intentionally NOT removed

The issue scoped its removal to *"only if tests prove it's safe — otherwise
leave it and note why."* It is **not** safe to remove:
`WaitForOffset`'s in-memory tracker is broadcast from
`UpdateAppliedOffsetTx` **before** the applier's batch txn commits (see
`store/offset.go` — the cond broadcast is pre-commit). So `WaitForOffset`
returning still does not guarantee `THIS` event's `applied_events` row is
committed/visible on a fresh read connection. That pre-commit broadcast is
an **independent** source of the same race the seed pre-bump used to
trigger; the seed fix does not address it. Removing
`waitForIdempotencyRecord` would reintroduce the `#500` CAS flake. Its
comment is updated to attribute the cause correctly (pre-commit broadcast,
not the now-removed seed pre-bump).

## Testing (local, all green)

- `cd server/go && go vet ./... && go test ./...` — all packages pass
- `cd sdk/go/entdb && go vet ./... && go test ./...` — all pass
- `python -m pytest tests/python/integration/ -q` — **95 passed**
- `bash tests/python/e2e/run-e2e.sh` — **22 passed** (Redpanda stack)
- `uvx ruff@0.15.7 check .` / `format --check .` — clean

Closes #505