### PR TITLE
Sanitize internal error responses (SEC-5, #136)

### DIFF
--- a/server/go/internal/api/add_tenant_member.go
+++ b/server/go/internal/api/add_tenant_member.go
@@ -117,7 +117,7 @@ func (s *Server) AddTenantMember(
 		role, err := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
 		if err != nil {
 			status = "error"
-			return nil, errs.Errorf(codes.Internal, "lookup member role: %v", err)
+			return nil, errs.Internal(ctx, "lookup member role", err)
 		}
 		if role != "owner" && role != "admin" {
 			status = "error"

--- a/server/go/internal/api/change_member_role.go
+++ b/server/go/internal/api/change_member_role.go
@@ -91,7 +91,7 @@ func (s *Server) ChangeMemberRole(
 		callerRole, err := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
 		if err != nil {
 			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
-			return nil, errs.Errorf(codes.Internal, "list tenant members: %v", err)
+			return nil, errs.Internal(ctx, "list tenant members", err)
 		}
 		if callerRole != "owner" && callerRole != "admin" {
 			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
@@ -103,7 +103,7 @@ func (s *Server) ChangeMemberRole(
 	members, err := s.global.GetTenantMembers(ctx, req.GetTenantId())
 	if err != nil {
 		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
-		return nil, errs.Errorf(codes.Internal, "list tenant members: %v", err)
+		return nil, errs.Internal(ctx, "list tenant members", err)
 	}
 	var targetJoinedAt int64
 	targetFound := false

--- a/server/go/internal/api/create_tenant.go
+++ b/server/go/internal/api/create_tenant.go
@@ -100,7 +100,7 @@ func (s *Server) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) 
 
 	if existing, err := s.global.GetTenant(ctx, req.GetTenantId()); err != nil {
 		resultStatus = "error"
-		return nil, errs.Errorf(codes.Internal, "get tenant: %v", err)
+		return nil, errs.Internal(ctx, "get tenant", err)
 	} else if existing != nil {
 		resultStatus = "error"
 		return nil, errs.Errorf(codes.AlreadyExists,

--- a/server/go/internal/api/create_user.go
+++ b/server/go/internal/api/create_user.go
@@ -99,7 +99,7 @@ func (s *Server) CreateUser(ctx context.Context, req *pb.CreateUserRequest) (*pb
 
 	if existing, err := s.global.GetUser(ctx, req.GetUserId()); err != nil {
 		outcome = "error"
-		return nil, errs.Errorf(codes.Internal, "get user: %v", err)
+		return nil, errs.Internal(ctx, "get user", err)
 	} else if existing != nil {
 		outcome = "error"
 		return nil, errs.Errorf(codes.AlreadyExists,
@@ -107,7 +107,7 @@ func (s *Server) CreateUser(ctx context.Context, req *pb.CreateUserRequest) (*pb
 	}
 	if existing, err := s.global.GetUserByEmail(ctx, req.GetEmail()); err != nil {
 		outcome = "error"
-		return nil, errs.Errorf(codes.Internal, "get user by email: %v", err)
+		return nil, errs.Internal(ctx, "get user by email", err)
 	} else if existing != nil {
 		outcome = "error"
 		return nil, errs.Errorf(codes.AlreadyExists,

--- a/server/go/internal/api/error_sanitization_test.go
+++ b/server/go/internal/api/error_sanitization_test.go
@@ -1,0 +1,184 @@
+// SEC-5 / issue #136: internal store/DB/driver errors must NOT leak to
+// the client, but MUST be logged server-side.
+//
+// Before the errs.Internal chokepoint, handlers wrapped the underlying
+// error with %v into a client-visible codes.Internal status, e.g.
+//
+//	errs.Errorf(codes.Internal, "get user: %v", err)
+//
+// which shipped strings like `globalstore: get user "alice": sql:
+// database is closed` back to the caller -- enough to fingerprint the
+// schema/driver and confirm record existence.
+//
+// This test drives a real handler (CreateUser) into a real driver
+// failure by closing the backing globalstore, then asserts:
+//
+//   - the gRPC status code stays codes.Internal (SDK behavior unchanged),
+//   - the client-visible message is the fixed generic string and
+//     contains NONE of the SQLite/driver/internal substrings,
+//   - the full underlying detail IS captured by the server-side slog
+//     logger.
+
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// syncBuffer is a goroutine-safe io.Writer so the slog handler can be
+// read back after the handler call without a data race (slog writes may
+// happen on a different goroutine in other handlers; CreateUser is
+// synchronous but we stay defensive).
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// captureSlog redirects slog.Default to a buffer for the duration of the
+// test and restores the original logger on cleanup.
+func captureSlog(t *testing.T) *syncBuffer {
+	t.Helper()
+	orig := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(orig) })
+	sb := &syncBuffer{}
+	slog.SetDefault(slog.New(slog.NewTextHandler(sb, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+	return sb
+}
+
+// leakSubstrings are fragments of the underlying driver/store error that
+// MUST NOT appear in any client-visible message.
+var leakSubstrings = []string{
+	"sql:",          // database/sql sentinel text
+	"database is closed",
+	"sqlite",        // driver name / table-name fingerprinting
+	"globalstore:",  // internal package context
+	"get user",      // internal op label (logged, never sent)
+}
+
+// TestCreateUser_InternalErrorIsSanitized is the SEC-5 regression pin.
+func TestCreateUser_InternalErrorIsSanitized(t *testing.T) {
+	logBuf := captureSlog(t)
+
+	gs, err := globalstore.New(globalstore.Options{DataDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	// Close the store so the very next driver call inside the handler
+	// (GetUser) fails with a real `sql: database is closed` error.
+	if cerr := gs.Close(); cerr != nil {
+		t.Fatalf("gs.Close: %v", cerr)
+	}
+
+	srv := api.New(api.WithGlobalStore(gs))
+
+	// admin:root passes the privilege gate (no interceptor on ctx, so
+	// the claimed actor is authoritative), so the handler proceeds to
+	// the GetUser existence check and trips the closed-DB error.
+	_, herr := srv.CreateUser(context.Background(), &pb.CreateUserRequest{
+		Actor:  "admin:root",
+		UserId: "alice",
+		Email:  "alice@example.com",
+		Name:   "Alice",
+	})
+	if herr == nil {
+		t.Fatalf("CreateUser: expected an internal error, got nil")
+	}
+
+	// 1. Code is still Internal — observability/retry contract unchanged.
+	if got := errs.Code(herr); got != codes.Internal {
+		t.Fatalf("code: got %v, want Internal (err=%v)", got, herr)
+	}
+
+	// 2. The client-visible message is the fixed generic string and
+	//    leaks none of the underlying detail.
+	st, _ := status.FromError(herr)
+	clientMsg := st.Message()
+	if clientMsg != "internal error" {
+		t.Errorf("client message: got %q, want %q", clientMsg, "internal error")
+	}
+	lowMsg := strings.ToLower(clientMsg)
+	for _, frag := range leakSubstrings {
+		if strings.Contains(lowMsg, strings.ToLower(frag)) {
+			t.Errorf("client message %q leaks internal substring %q", clientMsg, frag)
+		}
+	}
+
+	// 3. The full detail WAS logged server-side. The slog record must
+	//    carry both the op label and the raw driver text so an operator
+	//    can still diagnose the failure.
+	logged := logBuf.String()
+	if logged == "" {
+		t.Fatalf("expected a server-side slog record, got empty buffer")
+	}
+	if !strings.Contains(logged, "internal error sanitized for client") {
+		t.Errorf("slog record missing sanitizer marker; got: %s", logged)
+	}
+	if !strings.Contains(logged, "get user") {
+		t.Errorf("slog record missing op label %q; got: %s", "get user", logged)
+	}
+	if !strings.Contains(logged, "database is closed") {
+		t.Errorf("slog record missing underlying driver detail; got: %s", logged)
+	}
+}
+
+// TestErrsInternal_Unit is a focused unit test of the chokepoint itself:
+// it returns codes.Internal with the fixed message and logs the detail,
+// independent of any handler wiring.
+func TestErrsInternal_Unit(t *testing.T) {
+	logBuf := captureSlog(t)
+
+	underlying := status.Error(codes.Unknown, "raw sqlite: no such table: secret_nodes")
+	got := errs.Internal(context.Background(), "probe op", underlying)
+
+	if code := errs.Code(got); code != codes.Internal {
+		t.Fatalf("code: got %v, want Internal", code)
+	}
+	st, _ := status.FromError(got)
+	if st.Message() != "internal error" {
+		t.Fatalf("message: got %q, want %q", st.Message(), "internal error")
+	}
+	if strings.Contains(st.Message(), "secret_nodes") || strings.Contains(st.Message(), "sqlite") {
+		t.Fatalf("client message leaked underlying detail: %q", st.Message())
+	}
+	logged := logBuf.String()
+	if !strings.Contains(logged, "probe op") || !strings.Contains(logged, "secret_nodes") {
+		t.Fatalf("slog record missing op label or detail; got: %s", logged)
+	}
+
+	// InternalNoCtx behaves identically without a context.
+	got2 := errs.InternalNoCtx("noctx op", underlying)
+	if errs.Code(got2) != codes.Internal {
+		t.Fatalf("InternalNoCtx code: got %v, want Internal", errs.Code(got2))
+	}
+	st2, _ := status.FromError(got2)
+	if st2.Message() != "internal error" {
+		t.Fatalf("InternalNoCtx message: got %q, want %q", st2.Message(), "internal error")
+	}
+}

--- a/server/go/internal/api/execute_atomic.go
+++ b/server/go/internal/api/execute_atomic.go
@@ -760,7 +760,7 @@ func (s *Server) checkTenantWriteAccess(ctx context.Context, tenantID string, ac
 
 	t, err := s.global.GetTenant(ctx, tenantID)
 	if err != nil {
-		return errs.Errorf(codes.Internal, "tenant lookup: %v", err)
+		return errs.Internal(ctx, "tenant lookup", err)
 	}
 	if t == nil {
 		return errs.Errorf(codes.NotFound, "tenant %q does not exist", tenantID)
@@ -788,7 +788,7 @@ func (s *Server) checkTenantWriteAccess(ctx context.Context, tenantID string, ac
 
 	members, err := s.global.GetTenantMembers(ctx, tenantID)
 	if err != nil {
-		return errs.Errorf(codes.Internal, "membership lookup: %v", err)
+		return errs.Internal(ctx, "membership lookup", err)
 	}
 	var role string
 	for _, m := range members {

--- a/server/go/internal/api/freeze_gate.go
+++ b/server/go/internal/api/freeze_gate.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
 )
 
@@ -121,7 +122,7 @@ func (s *Server) checkFreezeGate(ctx context.Context, fullMethod string) error {
 		// Globalstore IO error — surface as Internal so the operator
 		// can detect it. Do NOT swallow as "passed" — that would let
 		// a flaky DB silently disable the gate.
-		return status.Errorf(codes.Internal, "freeze-gate: lookup user %q: %v", trusted.ID(), err)
+		return errs.Internal(ctx, "freeze-gate: lookup user", err)
 	}
 	if user == nil {
 		// Unknown user — fail closed (Python does the same: an

--- a/server/go/internal/api/get_tenant_quota.go
+++ b/server/go/internal/api/get_tenant_quota.go
@@ -91,8 +91,7 @@ func (s *Server) GetTenantQuota(
 		role, err := s.lookupMemberRole(ctx, tenantID, trusted.ID())
 		if err != nil {
 			outcome = "error"
-			return nil, errs.Errorf(codes.Internal,
-				"GetTenantQuota: lookup member role: %v", err)
+			return nil, errs.Internal(ctx, "GetTenantQuota: lookup member role", err)
 		}
 		if role != "owner" && role != "admin" {
 			outcome = "error"
@@ -104,14 +103,12 @@ func (s *Server) GetTenantQuota(
 	cfg, err := s.global.GetTenantQuota(ctx, tenantID)
 	if err != nil {
 		outcome = "error"
-		return nil, errs.Errorf(codes.Internal,
-			"GetTenantQuota: read quota config: %v", err)
+		return nil, errs.Internal(ctx, "GetTenantQuota: read quota config", err)
 	}
 	usage, err := s.global.GetUsage(ctx, tenantID)
 	if err != nil {
 		outcome = "error"
-		return nil, errs.Errorf(codes.Internal,
-			"GetTenantQuota: read usage: %v", err)
+		return nil, errs.Internal(ctx, "GetTenantQuota: read usage", err)
 	}
 
 	// period_end_ms is computed locally — never read from the DB row.

--- a/server/go/internal/api/helpers.go
+++ b/server/go/internal/api/helpers.go
@@ -225,8 +225,7 @@ func edgePropsToStruct(propsJSON string) *structpb.Struct {
 func (s *Server) storeNodeToProto(typeName string, n *store.Node) (*pb.Node, error) {
 	idPayload, err := decodeIDKeyedPayload(n.PayloadJSON)
 	if err != nil {
-		return nil, errs.Errorf(codes.Internal,
-			"parse payload for %s: %v", n.NodeID, err)
+		return nil, errs.InternalNoCtx("parse node payload", err)
 	}
 	pStruct, err := payload.PayloadToStruct(s.registry, typeName, idPayload)
 	if err != nil {
@@ -234,8 +233,7 @@ func (s *Server) storeNodeToProto(typeName string, n *store.Node) (*pb.Node, err
 	}
 	aclEntries, err := decodeACLEntries(n.ACLJSON)
 	if err != nil {
-		return nil, errs.Errorf(codes.Internal,
-			"parse acl for %s: %v", n.NodeID, err)
+		return nil, errs.InternalNoCtx("parse node acl", err)
 	}
 	return &pb.Node{
 		TenantId:   n.TenantID,
@@ -435,7 +433,7 @@ func (s *Server) appendGlobalAdminOp(ctx context.Context, actor string, op map[s
 	}
 	idem, err := newIdempotencyKey()
 	if err != nil {
-		return wal.StreamPos{}, "", errs.Errorf(codes.Internal, "%v", err)
+		return wal.StreamPos{}, "", errs.Internal(ctx, "generate idempotency key", err)
 	}
 	ev := wal.Event{
 		TenantID:       wal.GlobalTenantID,
@@ -447,14 +445,14 @@ func (s *Server) appendGlobalAdminOp(ctx context.Context, actor string, op map[s
 	}
 	value, err := ev.Encode()
 	if err != nil {
-		return wal.StreamPos{}, "", errs.Errorf(codes.Internal, "encode global admin event: %v", err)
+		return wal.StreamPos{}, "", errs.Internal(ctx, "encode global admin event", err)
 	}
 	headers := map[string][]byte{
 		wal.HeaderIdempotencyKey: []byte(idem),
 	}
 	pos, err := s.producer.Append(ctx, s.walTopic(), wal.GlobalTenantID, value, headers)
 	if err != nil {
-		return wal.StreamPos{}, "", errs.Errorf(codes.Internal, "append global admin event: %v", err)
+		return wal.StreamPos{}, "", errs.Internal(ctx, "append global admin event", err)
 	}
 
 	if err := s.waitForAdminApplied(ctx, wal.GlobalTenantID, pos.Offset, idem, "global admin event"); err != nil {

--- a/server/go/internal/api/query_nodes.go
+++ b/server/go/internal/api/query_nodes.go
@@ -136,7 +136,7 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	})
 	if err != nil {
 		resultStatus = "error"
-		return nil, errs.Errorf(codes.Internal, "store: query nodes: %v", err)
+		return nil, errs.Internal(ctx, "store: query nodes", err)
 	}
 
 	// ACL post-filter (cross-tenant readers). Same-tenant member access
@@ -358,7 +358,7 @@ func (s *Server) applyQueryACLFilter(ctx context.Context, tenantID string, a aut
 	}
 	visible, err := filter.FilterReadable(ctx, tenantID, aclActor, ids)
 	if err != nil {
-		return nil, errs.Errorf(codes.Internal, "QueryNodes: acl filter: %v", err)
+		return nil, errs.Internal(ctx, "QueryNodes: acl filter", err)
 	}
 	visibleSet := make(map[string]struct{}, len(visible))
 	for _, id := range visible {

--- a/server/go/internal/api/remove_group_member.go
+++ b/server/go/internal/api/remove_group_member.go
@@ -138,8 +138,7 @@ func (s *Server) RemoveGroupMember(
 		role, err := s.lookupMemberRole(ctx, tenantID, trusted.ID())
 		if err != nil {
 			status = "error"
-			return nil, errs.Errorf(codes.Internal,
-				"RemoveGroupMember: lookup caller role: %v", err)
+			return nil, errs.Internal(ctx, "RemoveGroupMember: lookup caller role", err)
 		}
 		if role != "owner" && role != "admin" {
 			status = "error"

--- a/server/go/internal/api/remove_tenant_member.go
+++ b/server/go/internal/api/remove_tenant_member.go
@@ -109,7 +109,7 @@ func (s *Server) RemoveTenantMember(
 		role, err := s.getTenantMemberRole(ctx, req.GetTenantId(), trusted.ID())
 		if err != nil {
 			status = "error"
-			return nil, errs.Errorf(codes.Internal, "RemoveTenantMember: lookup caller role: %v", err)
+			return nil, errs.Internal(ctx, "RemoveTenantMember: lookup caller role", err)
 		}
 		if role != "owner" && role != "admin" {
 			status = "error"
@@ -123,7 +123,7 @@ func (s *Server) RemoveTenantMember(
 	members, err := s.global.GetTenantMembers(ctx, req.GetTenantId())
 	if err != nil {
 		status = "error"
-		return nil, errs.Errorf(codes.Internal, "RemoveTenantMember: list members: %v", err)
+		return nil, errs.Internal(ctx, "RemoveTenantMember: list members", err)
 	}
 	var (
 		target     *string // role of the target user, nil if not a member

--- a/server/go/internal/api/revoke_all_user_access.go
+++ b/server/go/internal/api/revoke_all_user_access.go
@@ -126,8 +126,7 @@ func (s *Server) RevokeAllUserAccess(
 			r, err := s.getTenantMemberRole(ctx, req.GetTenantId(), trusted.ID())
 			if err != nil {
 				status = "error"
-				return nil, errs.Errorf(codes.Internal,
-					"RevokeAllUserAccess: lookup caller role: %v", err)
+				return nil, errs.Internal(ctx, "RevokeAllUserAccess: lookup caller role", err)
 			}
 			role = r
 		}
@@ -157,8 +156,7 @@ func (s *Server) RevokeAllUserAccess(
 	)
 	if err != nil {
 		status = "error"
-		return nil, errs.Errorf(codes.Internal,
-			"RevokeAllUserAccess: count rows: %v", err)
+		return nil, errs.Internal(ctx, "RevokeAllUserAccess: count rows", err)
 	}
 	revokedShared := s.countSharedIndexRows(ctx, req.GetUserId(), req.GetTenantId())
 
@@ -187,8 +185,7 @@ func (s *Server) RevokeAllUserAccess(
 	encoded, err := ev.Encode()
 	if err != nil {
 		status = "error"
-		return nil, errs.Errorf(codes.Internal,
-			"RevokeAllUserAccess: encode event: %v", err)
+		return nil, errs.Internal(ctx, "RevokeAllUserAccess: encode event", err)
 	}
 	headers := map[string][]byte{
 		wal.HeaderIdempotencyKey: []byte(idempKey),
@@ -198,8 +195,7 @@ func (s *Server) RevokeAllUserAccess(
 	)
 	if err != nil {
 		status = "error"
-		return nil, errs.Errorf(codes.Internal,
-			"RevokeAllUserAccess: wal append: %v", err)
+		return nil, errs.Internal(ctx, "RevokeAllUserAccess: wal append", err)
 	}
 	if err := s.waitForAdminApplied(ctx, req.GetTenantId(), pos.Offset, idempKey, "revoke all user access event"); err != nil {
 		status = "error"

--- a/server/go/internal/api/transfer_ownership.go
+++ b/server/go/internal/api/transfer_ownership.go
@@ -161,7 +161,7 @@ func (s *Server) TransferOwnership(
 			return nil, errs.Errorf(codes.NotFound, "node %q not found", req.GetNodeId())
 		}
 		statusLabel = "error"
-		return nil, errs.Errorf(codes.Internal, "read node: %v", err)
+		return nil, errs.Internal(ctx, "read node", err)
 	}
 
 	// 5. Current-owner-only authorization. The trusted actor's full
@@ -182,7 +182,7 @@ func (s *Server) TransferOwnership(
 	idempKey, err := newIdempotencyKey()
 	if err != nil {
 		statusLabel = "error"
-		return nil, errs.Errorf(codes.Internal, "generate idempotency key: %v", err)
+		return nil, errs.Internal(ctx, "generate idempotency key", err)
 	}
 	evt := wal.Event{
 		TenantID:       tenantID,
@@ -200,14 +200,14 @@ func (s *Server) TransferOwnership(
 		value, encErr := evt.Encode()
 		if encErr != nil {
 			statusLabel = "error"
-			return nil, errs.Errorf(codes.Internal, "encode wal event: %v", encErr)
+			return nil, errs.Internal(ctx, "encode wal event", encErr)
 		}
 		headers := map[string][]byte{
 			wal.HeaderIdempotencyKey: []byte(idempKey),
 		}
 		if _, appendErr := s.producer.Append(ctx, transferOwnershipTopic, tenantID, value, headers); appendErr != nil {
 			statusLabel = "error"
-			return nil, errs.Errorf(codes.Internal, "wal append: %v", appendErr)
+			return nil, errs.Internal(ctx, "wal append", appendErr)
 		}
 	}
 
@@ -222,7 +222,7 @@ func (s *Server) TransferOwnership(
 			return nil, errs.Errorf(codes.NotFound, "node %q not found", req.GetNodeId())
 		}
 		statusLabel = "error"
-		return nil, errs.Errorf(codes.Internal, "apply transfer_ownership: %v", err)
+		return nil, errs.Internal(ctx, "apply transfer_ownership", err)
 	}
 
 	return &pb.TransferOwnershipResponse{Found: true}, nil

--- a/server/go/internal/api/transfer_user_content.go
+++ b/server/go/internal/api/transfer_user_content.go
@@ -153,8 +153,7 @@ func (s *Server) TransferUserContent(
 		role, err := s.getTenantMemberRole(ctx, req.GetTenantId(), trusted.ID())
 		if err != nil {
 			statusLabel = "error"
-			return nil, errs.Errorf(codes.Internal,
-				"TransferUserContent: lookup caller role: %v", err)
+			return nil, errs.Internal(ctx, "TransferUserContent: lookup caller role", err)
 		}
 		if role != "owner" && role != "admin" {
 			statusLabel = "error"

--- a/server/go/internal/errs/sanitize.go
+++ b/server/go/internal/errs/sanitize.go
@@ -1,0 +1,81 @@
+// Internal-error sanitization chokepoint (SEC-5, issue #136).
+//
+// Handlers that wrap an underlying store / DB / driver error into a
+// client-visible codes.Internal status used to do:
+//
+//	return errs.Errorf(codes.Internal, "get user: %v", err)
+//
+// That ships the raw SQLite driver text, table names and internal file
+// paths back to the caller -- an info leak that helps an attacker
+// fingerprint the schema and confirm record existence (defeating the
+// generic 404 on GetUser). It also defeats the point of the typed
+// sentinels, since the wrapped detail is free-form in proto's
+// `string error = N`.
+//
+// errs.Internal and errs.InternalNoCtx replace that pattern: the full
+// detail (op label + underlying err) is logged server-side via slog at
+// ERROR level, and the client receives only a fixed, opaque message
+// (genericInternalMessage). The gRPC code stays codes.Internal so the
+// SDK's retry/observability behavior is unchanged.
+//
+// Typed sentinels (NotFound / AlreadyExists / InvalidArgument /
+// PermissionDenied / FailedPrecondition / ...) and their human-meaningful
+// messages are deliberately NOT routed through here -- those messages are
+// part of the contract and carry no server internals. Only Internal /
+// Unknown (wrapped naked errors) are sanitized.
+package errs
+
+import (
+	"context"
+	"log/slog"
+
+	"google.golang.org/grpc/codes"
+)
+
+// genericInternalMessage is the only thing a client ever sees for a
+// sanitized internal error. It carries no schema, path, or driver
+// detail. Keep it stable -- contract tests assert on it and changing it
+// is a (minor) wire-visible change.
+const genericInternalMessage = "internal error"
+
+// Internal logs the full underlying error server-side and returns a
+// codes.Internal status carrying only the fixed generic message.
+//
+// op is a short, static, non-sensitive label for the failing operation
+// (e.g. "get user", "wal append") used purely for server-side log
+// correlation. It MUST NOT contain request data; pass a literal.
+//
+// Usage -- replace
+//
+//	return errs.Errorf(codes.Internal, "get user: %v", err)
+//
+// with
+//
+//	return errs.Internal(ctx, "get user", err)
+//
+// If err is nil, Internal still returns a non-nil codes.Internal error
+// (callers only reach this path on a real failure); the log records a
+// nil error for traceability.
+func Internal(ctx context.Context, op string, err error) error {
+	logInternal(ctx, op, err)
+	return &codeError{code: codes.Internal, msg: genericInternalMessage}
+}
+
+// InternalNoCtx is Internal for the handful of pure helper functions
+// that have no context.Context in scope (e.g. proto-conversion helpers).
+// It logs without request-scoped attributes; prefer Internal whenever a
+// ctx is available.
+func InternalNoCtx(op string, err error) error {
+	logInternal(context.Background(), op, err)
+	return &codeError{code: codes.Internal, msg: genericInternalMessage}
+}
+
+// logInternal centralizes the server-side record of a sanitized error so
+// the detail is never lost. ERROR level: these are by definition
+// unexpected store/DB/driver failures.
+func logInternal(ctx context.Context, op string, err error) {
+	slog.ErrorContext(ctx, "internal error sanitized for client",
+		"op", op,
+		"error", err,
+	)
+}

--- a/server/go/internal/errs/sanitize_test.go
+++ b/server/go/internal/errs/sanitize_test.go
@@ -1,0 +1,94 @@
+package errs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// withCapturedSlog swaps slog.Default for a buffer-backed text handler
+// and restores it on cleanup.
+func withCapturedSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	orig := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(orig) })
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+	return &buf
+}
+
+func TestInternal_ReturnsGenericInternalAndLogsDetail(t *testing.T) {
+	buf := withCapturedSlog(t)
+
+	underlying := errors.New("sqlite: no such table: tenant_secrets")
+	err := Internal(context.Background(), "get user", underlying)
+
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code: got %v, want Internal", status.Code(err))
+	}
+	st, _ := status.FromError(err)
+	if st.Message() != genericInternalMessage {
+		t.Fatalf("client message: got %q, want %q", st.Message(), genericInternalMessage)
+	}
+	// errors.Is must still classify it as the Internal sentinel so
+	// handler-side assertions keep working.
+	if !errors.Is(err, ErrInternal) {
+		t.Fatalf("errors.Is(Internal(...), ErrInternal) = false")
+	}
+
+	for _, leak := range []string{"sqlite", "tenant_secrets", "no such table"} {
+		if strings.Contains(st.Message(), leak) {
+			t.Fatalf("client message %q leaked %q", st.Message(), leak)
+		}
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "get user") {
+		t.Fatalf("log missing op label; got: %s", logged)
+	}
+	if !strings.Contains(logged, "tenant_secrets") {
+		t.Fatalf("log missing underlying detail; got: %s", logged)
+	}
+}
+
+func TestInternalNoCtx_SameContract(t *testing.T) {
+	buf := withCapturedSlog(t)
+
+	err := InternalNoCtx("parse node payload", errors.New("driver crash 0xdeadbeef"))
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code: got %v, want Internal", status.Code(err))
+	}
+	st, _ := status.FromError(err)
+	if st.Message() != genericInternalMessage {
+		t.Fatalf("message: got %q, want %q", st.Message(), genericInternalMessage)
+	}
+	if strings.Contains(st.Message(), "0xdeadbeef") {
+		t.Fatalf("client message leaked detail: %q", st.Message())
+	}
+	if !strings.Contains(buf.String(), "0xdeadbeef") {
+		t.Fatalf("log missing underlying detail; got: %s", buf.String())
+	}
+}
+
+func TestInternal_NilUnderlyingStillSanitizes(t *testing.T) {
+	withCapturedSlog(t)
+	err := Internal(context.Background(), "op", nil)
+	if err == nil {
+		t.Fatalf("Internal(nil) returned nil; must always yield a non-nil status")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code: got %v, want Internal", status.Code(err))
+	}
+	st, _ := status.FromError(err)
+	if st.Message() != genericInternalMessage {
+		t.Fatalf("message: got %q, want %q", st.Message(), genericInternalMessage)
+	}
+}


### PR DESCRIPTION
## Problem

Many handlers wrapped the underlying store/DB/driver error with `%v` into a client-visible `codes.Internal` status, e.g.

```go
return nil, errs.Errorf(codes.Internal, "get user: %v", err)
```

A closed/broken globalstore made `CreateUser` ship `globalstore: get user "alice": sql: database is closed` straight back to the caller. That raw text leaks the SQLite driver, internal package context, and (via the `%q` actor id in the freeze gate) the caller's own identity — enough to fingerprint the schema/driver and confirm record existence, defeating the deliberately-generic 404 on `GetUser`. No sanitization chokepoint existed (SEC-5, low severity).

## Fix

- New chokepoint in `server/go/internal/errs/sanitize.go`: `errs.Internal(ctx, op, err)` and `errs.InternalNoCtx(op, err)`. They log the static op label + full underlying error server-side via `slog.ErrorContext` at ERROR level, and return a `codes.Internal` status carrying only the fixed generic message `"internal error"`. The gRPC **code stays `codes.Internal`** so SDK retry/observability behavior is unchanged, and `errors.Is(err, errs.ErrInternal)` still works.
- Routed all **32** internal-wrap call sites through it: 31 `errs.Errorf(codes.Internal, "...: %v", err)` sites across the `internal/api` handlers plus the one `status.Errorf(codes.Internal, ...)` in `freeze_gate.go` (which also leaked `trusted.ID()`).
- Typed sentinels (`NotFound` / `AlreadyExists` / `InvalidArgument` / `PermissionDenied` / `FailedPrecondition` / `Unimplemented` / ...) and their contractful, server-internal-free messages are left **untouched** — only `Internal`/`Unknown` wrapped errors are sanitized.

Contract impact: only free-form `string error = N` text changes; no code (Go SDK, Python SDK, or contract tests) consumes the old internal text. Confirmed by grep + the green Python contract suite.

## Testing

Full local CI, all green:

```
go vet ./...        (server/go)            clean
go test ./...       (server/go)            all packages ok
go vet  ./...        (sdk/go/entdb)        clean
go test ./...       (sdk/go/entdb)         ok
python -m pytest tests/python/integration/ 95 passed in 101.67s
uvx ruff@0.15.7 check .                    All checks passed!
uvx ruff@0.15.7 format --check .           55 files already formatted
```

New tests:
- `internal/api/error_sanitization_test.go` — handler-level regression: `CreateUser` against a **closed** globalstore returns `codes.Internal` with client message `"internal error"` and zero leak substrings (`sql:`, `database is closed`, `sqlite`, `globalstore:`, `get user`), while the slog buffer **does** contain the op label and the raw `database is closed` driver text.
- `internal/errs/sanitize_test.go` — focused unit tests of `Internal` / `InternalNoCtx` (generic message, code preserved, `errors.Is(ErrInternal)`, detail logged, nil-underlying still sanitizes).

Closes #136
