### PR TITLE
Harden transient-retry policy in both SDKs (PERF-7)

### DIFF
--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -267,8 +267,20 @@ func (t *grpcTransport) Connect(_ context.Context) error {
 		}
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	}
+	// Interceptor chain, outermost first. The retry interceptor
+	// wraps the redirect interceptor so every retry attempt still
+	// follows tenant redirects (and a redirect-follow that fails
+	// transiently is itself retried). grpc.WithChainUnaryInterceptor
+	// invokes interceptors in slice order — index 0 is outermost.
+	var chain []grpc.UnaryClientInterceptor
+	if t.config.maxRetries > 0 {
+		chain = append(chain, retryInterceptor(t.config.maxRetries, t.config.retryBudget, t.config.retryJitter))
+	}
 	if interceptor := redirectInterceptor(t.config.nodeResolver, t.redirectCache); interceptor != nil {
-		opts = append(opts, grpc.WithUnaryInterceptor(interceptor))
+		chain = append(chain, interceptor)
+	}
+	if len(chain) > 0 {
+		opts = append(opts, grpc.WithChainUnaryInterceptor(chain...))
 	}
 
 	conn, err := grpc.NewClient(t.address, opts...)

--- a/sdk/go/entdb/options.go
+++ b/sdk/go/entdb/options.go
@@ -14,6 +14,15 @@ type clientConfig struct {
 	maxRetries   int
 	timeout      time.Duration
 	nodeResolver NodeResolver
+	// retryBudget bounds the total wall-clock time spent retrying a
+	// single call (backoff sleeps included). Zero means use
+	// defaultRetryWallClockBudget.
+	retryBudget time.Duration
+	// retryJitter is the randomness source for the transient-retry
+	// backoff. Left nil in production (a clock-seeded source is
+	// created on Connect); in-package tests set it to a
+	// deterministic source so backoff durations are reproducible.
+	retryJitter jitterSource
 	// dialOptions is appended to the grpc.NewClient option list on
 	// every dial — both the primary endpoint and any redirect
 	// sub-channels. Tests use it to install a contextDialer for
@@ -61,6 +70,23 @@ func WithMaxRetries(n int) ClientOption {
 func WithTimeout(d time.Duration) ClientOption {
 	return func(c *clientConfig) {
 		c.timeout = d
+	}
+}
+
+// WithRetryBudget caps the total wall-clock time the SDK spends
+// retrying a single failed RPC, including the exponential-backoff
+// sleeps between attempts. Once the elapsed time since the first
+// attempt would exceed the budget, the last error is returned even if
+// retry attempts (per [WithMaxRetries]) remain.
+//
+// This bounds tail latency under an outage: without it, a high
+// maxRetries combined with exponential backoff can block a caller for
+// minutes. A non-positive duration restores the 30s default.
+func WithRetryBudget(d time.Duration) ClientOption {
+	return func(c *clientConfig) {
+		if d > 0 {
+			c.retryBudget = d
+		}
 	}
 }
 

--- a/sdk/go/entdb/retry.go
+++ b/sdk/go/entdb/retry.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+package entdb
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Retry tuning constants. These mirror the Python SDK
+// (sdk/python/entdb_sdk/_grpc_client.py) so both clients behave
+// identically under an outage.
+const (
+	// retryBaseDelay is the base of the exponential backoff:
+	// the unjittered delay for attempt n is base * 2**n.
+	retryBaseDelay = 100 * time.Millisecond
+
+	// retryMaxDelay caps a single backoff sleep so a high
+	// maxRetries doesn't produce multi-minute waits between
+	// attempts.
+	retryMaxDelay = 5 * time.Second
+
+	// defaultRetryWallClockBudget bounds the *total* wall-clock
+	// time the SDK will spend retrying a single call (including
+	// backoff sleeps). Once the elapsed time since the first
+	// attempt would exceed this, the last error is returned even if
+	// attempts remain. This stops a slow-failing endpoint from
+	// blocking a caller far past their own deadline. Override via
+	// [WithRetryBudget].
+	defaultRetryWallClockBudget = 30 * time.Second
+)
+
+// readMethodAllowlist is the set of RPCs that are safe to retry on
+// codes.DeadlineExceeded. Every entry is a read-only / side-effect-free
+// RPC: re-issuing it after a timeout cannot duplicate a write. The
+// short method name (the segment after the final '/' in the gRPC
+// path) is used as the key.
+//
+// DEADLINE_EXCEEDED is deliberately NOT retried for mutating RPCs
+// (ExecuteAtomic, ShareNode, the admin/GDPR surface, ...): a timeout
+// means the deadline elapsed while the request was in flight, so the
+// write may already have committed server-side. Retrying would risk a
+// duplicate mutation. UNAVAILABLE is still retried for every method —
+// it is a connection-level failure where the request almost certainly
+// never reached the server.
+var readMethodAllowlist = map[string]struct{}{
+	"GetConnectedNodes": {},
+	"GetEdgesFrom":      {},
+	"GetEdgesTo":        {},
+	"GetMailbox":        {},
+	"GetNode":           {},
+	"GetNodeByKey":      {},
+	"GetNodes":          {},
+	"GetReceiptStatus":  {},
+	"GetSchema":         {},
+	"GetTenant":         {},
+	"GetTenantMembers":  {},
+	"GetTenantQuota":    {},
+	"GetUser":           {},
+	"GetUserTenants":    {},
+	"Health":            {},
+	"ListMailboxUsers":  {},
+	"ListSharedWithMe":  {},
+	"ListTenants":       {},
+	"ListUsers":         {},
+	"QueryNodes":        {},
+	"SearchMailbox":     {},
+	"SearchNodes":       {},
+	"WaitForOffset":     {},
+	"ExportUserData":    {},
+}
+
+// shortMethod returns the trailing RPC name from a full gRPC method
+// path (e.g. "/entdb.v1.EntDBService/GetNode" -> "GetNode").
+func shortMethod(fullMethod string) string {
+	if i := strings.LastIndex(fullMethod, "/"); i >= 0 {
+		return fullMethod[i+1:]
+	}
+	return fullMethod
+}
+
+// isRetryable decides whether a failed RPC may be retried.
+//
+//   - codes.Unavailable: always retryable (the request likely never
+//     reached the server).
+//   - codes.DeadlineExceeded: retryable only when the method is in
+//     the read allowlist (retrying a write after a timeout could
+//     duplicate a committed mutation).
+//
+// Any other status code is terminal.
+func isRetryable(err error, shortName string) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.Unavailable:
+		return true
+	case codes.DeadlineExceeded:
+		_, allowed := readMethodAllowlist[shortName]
+		return allowed
+	default:
+		return false
+	}
+}
+
+// jitterSource is the minimal slice of *rand.Rand the backoff needs.
+// Tests inject a deterministic implementation; production uses a
+// mutex-guarded *rand.Rand seeded from the clock.
+type jitterSource interface {
+	// Float64 returns a pseudo-random number in [0.0, 1.0).
+	Float64() float64
+}
+
+// lockedRand is the default jitterSource. math/rand's top-level
+// functions are already goroutine-safe, but a client may issue
+// concurrent RPCs through one transport, so we guard an explicit
+// source to keep the jitter reproducible under -race when a seed is
+// pinned in tests.
+type lockedRand struct {
+	mu sync.Mutex
+	r  *rand.Rand
+}
+
+func newLockedRand() *lockedRand {
+	return &lockedRand{r: rand.New(rand.NewSource(time.Now().UnixNano()))}
+}
+
+func (l *lockedRand) Float64() float64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.r.Float64()
+}
+
+// fullJitterBackoff returns the sleep duration before the given
+// attempt (0-indexed). It implements the "full jitter" strategy from
+// AWS's exponential-backoff guidance: pick a uniformly random delay
+// in [0, min(cap, base*2**attempt)). Full jitter de-correlates the
+// retry schedules of many clients recovering from the same outage,
+// avoiding a thundering herd.
+func fullJitterBackoff(attempt int, src jitterSource) time.Duration {
+	ceiling := retryBaseDelay << uint(attempt) // base * 2**attempt
+	if ceiling <= 0 || ceiling > retryMaxDelay {
+		ceiling = retryMaxDelay
+	}
+	return time.Duration(src.Float64() * float64(ceiling))
+}
+
+// retryInterceptor returns a unary client interceptor that retries
+// transient failures with full-jitter exponential backoff, bounded by
+// both maxRetries and a wall-clock budget.
+//
+// It is installed *outside* the redirect interceptor so each retry
+// attempt still gets the full redirect-follow behaviour. When
+// maxRetries <= 0 the interceptor is a no-op pass-through (callers can
+// also just skip installing it). A budget <= 0 falls back to
+// [defaultRetryWallClockBudget].
+func retryInterceptor(maxRetries int, budget time.Duration, src jitterSource) grpc.UnaryClientInterceptor {
+	if src == nil {
+		src = newLockedRand()
+	}
+	if budget <= 0 {
+		budget = defaultRetryWallClockBudget
+	}
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		short := shortMethod(method)
+		start := time.Now()
+		var err error
+		for attempt := 0; ; attempt++ {
+			err = invoker(ctx, method, req, reply, cc, opts...)
+			if err == nil {
+				return nil
+			}
+			if attempt >= maxRetries || !isRetryable(err, short) {
+				return err
+			}
+
+			sleep := fullJitterBackoff(attempt, src)
+
+			// Wall-clock budget: stop if the next sleep would push
+			// total elapsed time past the budget. Returning the
+			// last error here (rather than sleeping anyway) keeps
+			// the SDK from blocking a caller well past their own
+			// deadline on a persistently slow endpoint.
+			if time.Since(start)+sleep > budget {
+				return err
+			}
+
+			// Respect a caller-supplied context deadline: never
+			// sleep past it.
+			select {
+			case <-ctx.Done():
+				return err
+			case <-time.After(sleep):
+			}
+		}
+	}
+}

--- a/sdk/go/entdb/retry_test.go
+++ b/sdk/go/entdb/retry_test.go
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: MIT
+package entdb
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	pb "github.com/elloloop/tenant-shard-db/sdk/go/entdb/internal/pb"
+)
+
+// fixedJitter is a deterministic jitterSource so backoff durations
+// are reproducible in tests. It always returns the same fraction.
+type fixedJitter struct{ v float64 }
+
+func (f fixedJitter) Float64() float64 { return f.v }
+
+func TestShortMethod(t *testing.T) {
+	cases := map[string]string{
+		"/entdb.v1.EntDBService/GetNode": "GetNode",
+		"/entdb.v1.EntDBService/ExecuteAtomic": "ExecuteAtomic",
+		"GetNode": "GetNode",
+		"":        "",
+	}
+	for in, want := range cases {
+		if got := shortMethod(in); got != want {
+			t.Errorf("shortMethod(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsRetryable_Unavailable_AllMethods(t *testing.T) {
+	err := status.Error(codes.Unavailable, "down")
+	// UNAVAILABLE retries for reads AND writes — the request
+	// almost certainly never reached the server.
+	for _, m := range []string{"GetNode", "ExecuteAtomic", "ShareNode", "DeleteUser"} {
+		if !isRetryable(err, m) {
+			t.Errorf("isRetryable(UNAVAILABLE, %q) = false, want true", m)
+		}
+	}
+}
+
+func TestIsRetryable_DeadlineExceeded_ReadAllowlistOnly(t *testing.T) {
+	err := status.Error(codes.DeadlineExceeded, "slow")
+
+	// Reads in the allowlist: retryable on timeout.
+	for _, m := range []string{"GetNode", "QueryNodes", "SearchNodes", "Health", "WaitForOffset", "ExportUserData"} {
+		if !isRetryable(err, m) {
+			t.Errorf("isRetryable(DEADLINE_EXCEEDED, %q) = false, want true (read allowlist)", m)
+		}
+	}
+
+	// Writes / mutations: NEVER retried on timeout — the write may
+	// already have committed server-side.
+	for _, m := range []string{"ExecuteAtomic", "ShareNode", "DeleteUser", "CreateTenant", "TransferOwnership", "AddGroupMember"} {
+		if isRetryable(err, m) {
+			t.Errorf("isRetryable(DEADLINE_EXCEEDED, %q) = true, want false (mutation must not retry)", m)
+		}
+	}
+}
+
+func TestIsRetryable_TerminalCodes(t *testing.T) {
+	for _, c := range []codes.Code{codes.NotFound, codes.PermissionDenied, codes.InvalidArgument, codes.AlreadyExists, codes.Internal} {
+		if isRetryable(status.Error(c, "x"), "GetNode") {
+			t.Errorf("isRetryable(%s) = true, want false (terminal)", c)
+		}
+	}
+	if isRetryable(nil, "GetNode") {
+		t.Error("isRetryable(nil) = true, want false")
+	}
+}
+
+func TestFullJitterBackoff_BoundedByCeiling(t *testing.T) {
+	// At fraction 1.0 the sleep is the full ceiling; the ceiling
+	// for attempt n is base*2**n, capped at retryMaxDelay.
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, retryBaseDelay},      // 100ms * 1
+		{1, 2 * retryBaseDelay},  // 100ms * 2
+		{2, 4 * retryBaseDelay},  // 100ms * 4
+		{3, 8 * retryBaseDelay},  // 100ms * 8
+		{10, retryMaxDelay},      // capped
+		{40, retryMaxDelay},      // shift overflow guard -> capped
+	}
+	for _, c := range cases {
+		got := fullJitterBackoff(c.attempt, fixedJitter{1.0})
+		// Float math: allow a 1ms slack.
+		if got < c.want-time.Millisecond || got > c.want+time.Millisecond {
+			t.Errorf("fullJitterBackoff(%d, 1.0) = %v, want ~%v", c.attempt, got, c.want)
+		}
+	}
+}
+
+func TestFullJitterBackoff_ZeroFractionIsZero(t *testing.T) {
+	if got := fullJitterBackoff(5, fixedJitter{0.0}); got != 0 {
+		t.Errorf("fullJitterBackoff with 0.0 fraction = %v, want 0", got)
+	}
+}
+
+func TestFullJitterBackoff_HalfFraction(t *testing.T) {
+	// Full jitter picks uniformly in [0, ceiling); a 0.5 fraction
+	// yields exactly half the ceiling.
+	got := fullJitterBackoff(1, fixedJitter{0.5}) // ceiling = 200ms
+	want := retryBaseDelay // 100ms
+	if got < want-time.Millisecond || got > want+time.Millisecond {
+		t.Errorf("fullJitterBackoff(1, 0.5) = %v, want ~%v", got, want)
+	}
+}
+
+// retryFakeServer fails the first failN GetNode/ExecuteAtomic calls
+// with errCode, then serves normally. It counts every hit.
+type retryFakeServer struct {
+	pb.UnimplementedEntDBServiceServer
+	errCode      codes.Code
+	failN        int32
+	getNodeHits  atomic.Int32
+	execHits     atomic.Int32
+}
+
+func (s *retryFakeServer) GetNode(_ context.Context, req *pb.GetNodeRequest) (*pb.GetNodeResponse, error) {
+	n := s.getNodeHits.Add(1)
+	if n <= s.failN {
+		return nil, status.Errorf(s.errCode, "transient %d", n)
+	}
+	return &pb.GetNodeResponse{
+		Found: true,
+		Node:  &pb.Node{TenantId: req.GetContext().GetTenantId(), NodeId: req.GetNodeId()},
+	}, nil
+}
+
+func (s *retryFakeServer) ExecuteAtomic(_ context.Context, _ *pb.ExecuteAtomicRequest) (*pb.ExecuteAtomicResponse, error) {
+	n := s.execHits.Add(1)
+	if n <= s.failN {
+		return nil, status.Errorf(s.errCode, "transient %d", n)
+	}
+	return &pb.ExecuteAtomicResponse{Success: true}, nil
+}
+
+// startRetryTransport wires a grpcTransport with the retry
+// interceptor installed (via Connect) pointed at an in-process
+// server. Jitter is pinned to 0.0 so backoff sleeps are
+// instantaneous and the test is fast + deterministic.
+func startRetryTransport(t *testing.T, svc *retryFakeServer, maxRetries int) *grpcTransport {
+	t.Helper()
+	lis := bufconn.Listen(1 << 16)
+	srv := grpc.NewServer()
+	pb.RegisterEntDBServiceServer(srv, svc)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() { srv.Stop() })
+
+	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+
+	cfg := defaultConfig()
+	cfg.maxRetries = maxRetries
+	cfg.retryJitter = fixedJitter{0.0}
+	cfg.dialOptions = []grpc.DialOption{
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	tr := newGRPCTransport("passthrough:///bufnet", cfg)
+	if err := tr.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = tr.Close() })
+	return tr
+}
+
+func TestRetryInterceptor_UnavailableRetriesThenSucceeds(t *testing.T) {
+	svc := &retryFakeServer{errCode: codes.Unavailable, failN: 2}
+	tr := startRetryTransport(t, svc, 3)
+
+	node, err := tr.GetNode(context.Background(), "acme", "user:alice", 1, "n1")
+	if err != nil {
+		t.Fatalf("GetNode after 2 transient UNAVAILABLE: %v", err)
+	}
+	if node == nil {
+		t.Fatal("expected node, got nil")
+	}
+	if got := svc.getNodeHits.Load(); got != 3 {
+		t.Errorf("server saw %d calls, want 3 (2 fail + 1 success)", got)
+	}
+}
+
+func TestRetryInterceptor_ExhaustsMaxRetries(t *testing.T) {
+	svc := &retryFakeServer{errCode: codes.Unavailable, failN: 100}
+	tr := startRetryTransport(t, svc, 2)
+
+	_, err := tr.GetNode(context.Background(), "acme", "user:alice", 1, "n1")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	// 1 initial + 2 retries = 3 attempts.
+	if got := svc.getNodeHits.Load(); got != 3 {
+		t.Errorf("server saw %d calls, want 3 (1 initial + 2 retries)", got)
+	}
+}
+
+func TestRetryInterceptor_ExecuteAtomicNotRetriedOnDeadlineExceeded(t *testing.T) {
+	// ExecuteAtomic is a write — DEADLINE_EXCEEDED must NOT retry.
+	svc := &retryFakeServer{errCode: codes.DeadlineExceeded, failN: 100}
+	tr := startRetryTransport(t, svc, 5)
+
+	_, err := tr.ExecuteAtomic(context.Background(), "acme", "user:alice", "idem-1", nil)
+	if err == nil {
+		t.Fatal("expected DEADLINE_EXCEEDED error, got nil")
+	}
+	if got := svc.execHits.Load(); got != 1 {
+		t.Errorf("ExecuteAtomic was called %d times, want exactly 1 (no retry on DEADLINE_EXCEEDED for a write)", got)
+	}
+}
+
+func TestRetryInterceptor_ExecuteAtomicRetriesOnUnavailable(t *testing.T) {
+	// UNAVAILABLE is still retryable even for a write — the request
+	// almost certainly never reached the server.
+	svc := &retryFakeServer{errCode: codes.Unavailable, failN: 1}
+	tr := startRetryTransport(t, svc, 3)
+
+	res, err := tr.ExecuteAtomic(context.Background(), "acme", "user:alice", "idem-1", nil)
+	if err != nil {
+		t.Fatalf("ExecuteAtomic after 1 transient UNAVAILABLE: %v", err)
+	}
+	if !res.Success {
+		t.Error("expected Success=true")
+	}
+	if got := svc.execHits.Load(); got != 2 {
+		t.Errorf("ExecuteAtomic was called %d times, want 2 (1 fail + 1 success)", got)
+	}
+}
+
+func TestRetryInterceptor_ReadRetriedOnDeadlineExceeded(t *testing.T) {
+	// GetNode is in the read allowlist — DEADLINE_EXCEEDED retries.
+	svc := &retryFakeServer{errCode: codes.DeadlineExceeded, failN: 1}
+	tr := startRetryTransport(t, svc, 3)
+
+	node, err := tr.GetNode(context.Background(), "acme", "user:alice", 1, "n1")
+	if err != nil {
+		t.Fatalf("GetNode after 1 transient DEADLINE_EXCEEDED: %v", err)
+	}
+	if node == nil {
+		t.Fatal("expected node, got nil")
+	}
+	if got := svc.getNodeHits.Load(); got != 2 {
+		t.Errorf("server saw %d calls, want 2 (1 fail + 1 success)", got)
+	}
+}
+
+func TestRetryInterceptor_DisabledWhenMaxRetriesZero(t *testing.T) {
+	svc := &retryFakeServer{errCode: codes.Unavailable, failN: 100}
+	tr := startRetryTransport(t, svc, 0)
+
+	_, err := tr.GetNode(context.Background(), "acme", "user:alice", 1, "n1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := svc.getNodeHits.Load(); got != 1 {
+		t.Errorf("server saw %d calls, want 1 (retries disabled)", got)
+	}
+}
+
+func TestRetryInterceptor_WallClockBudgetStopsEarly(t *testing.T) {
+	// With a non-zero jitter the per-attempt sleep grows; the
+	// wall-clock budget must cut retries off well before
+	// maxRetries=50 is reached. A tiny 500ms budget keeps the test
+	// fast while still exercising the budget logic.
+	const budget = 500 * time.Millisecond
+	svc := &retryFakeServer{errCode: codes.Unavailable, failN: 1000}
+	lis := bufconn.Listen(1 << 16)
+	srv := grpc.NewServer()
+	pb.RegisterEntDBServiceServer(srv, svc)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() { srv.Stop() })
+	dialer := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+
+	cfg := defaultConfig()
+	cfg.maxRetries = 50
+	cfg.retryBudget = budget
+	cfg.retryJitter = fixedJitter{1.0} // full ceiling each time
+	cfg.dialOptions = []grpc.DialOption{
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	tr := newGRPCTransport("passthrough:///bufnet", cfg)
+	if err := tr.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = tr.Close() })
+
+	start := time.Now()
+	_, err := tr.GetNode(context.Background(), "acme", "user:alice", 1, "n1")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after budget exhaustion, got nil")
+	}
+	// The loop returns the moment the next sleep would exceed the
+	// budget, so total elapsed stays under budget + generous slack.
+	// It must NOT run the full 50-attempt schedule.
+	if elapsed > budget+5*time.Second {
+		t.Errorf("call took %v, expected to stop near the %v wall-clock budget", elapsed, budget)
+	}
+	if got := svc.getNodeHits.Load(); got >= 50 {
+		t.Errorf("server saw %d calls — budget did not cut retries short", got)
+	}
+}

--- a/sdk/python/entdb_sdk/_grpc_client.py
+++ b/sdk/python/entdb_sdk/_grpc_client.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import random
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -249,7 +251,117 @@ _RETRYABLE_STATUS_CODES = frozenset(
     {grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED}
 )
 
+# Retry tuning. Kept in lock-step with the Go SDK
+# (sdk/go/entdb/retry.go) so both clients behave identically under
+# an outage.
+#
+# - base of the exponential backoff (seconds): unjittered delay for
+#   attempt n is _RETRY_BASE_DELAY * 2**n.
+_RETRY_BASE_DELAY: float = 0.1
+# - cap on a single backoff sleep so a high max_retries doesn't
+#   produce multi-minute waits between attempts.
+_RETRY_MAX_DELAY: float = 5.0
+# - total wall-clock seconds the SDK will spend retrying one call
+#   (backoff sleeps included). Once the elapsed time since the first
+#   attempt would exceed this, the last error is raised even if
+#   retry attempts remain. Stops a slow-failing endpoint from
+#   blocking a caller far past their own deadline.
+_RETRY_WALL_CLOCK_BUDGET: float = 30.0
+
+# RPCs that are safe to retry on DEADLINE_EXCEEDED. Every entry is a
+# read-only / side-effect-free RPC: re-issuing it after a timeout
+# cannot duplicate a write.
+#
+# DEADLINE_EXCEEDED is deliberately NOT retried for mutating RPCs
+# (ExecuteAtomic, ShareNode, the admin/GDPR surface, ...): a timeout
+# means the deadline elapsed while the request was in flight, so the
+# write may already have committed server-side and a retry would risk
+# a duplicate mutation. UNAVAILABLE is still retried for every method
+# — it is a connection-level failure where the request almost
+# certainly never reached the server.
+_DEADLINE_RETRYABLE_METHODS = frozenset(
+    {
+        "GetConnectedNodes",
+        "GetEdgesFrom",
+        "GetEdgesTo",
+        "GetMailbox",
+        "GetNode",
+        "GetNodeByKey",
+        "GetNodes",
+        "GetReceiptStatus",
+        "GetSchema",
+        "GetTenant",
+        "GetTenantMembers",
+        "GetTenantQuota",
+        "GetUser",
+        "GetUserTenants",
+        "Health",
+        "ListMailboxUsers",
+        "ListSharedWithMe",
+        "ListTenants",
+        "ListUsers",
+        "QueryNodes",
+        "SearchMailbox",
+        "SearchNodes",
+        "WaitForOffset",
+        "ExportUserData",
+    }
+)
+
 _DEFAULT_TIMEOUT: float = 30.0
+
+
+def _short_method(fn: Any) -> str:
+    """Return the trailing RPC name from a bound stub multicallable.
+
+    grpc.aio binds each RPC's ``_method`` to its full path, e.g.
+    ``b"/entdb.v1.EntDBService/GetNode"``. We key the
+    DEADLINE_EXCEEDED allowlist off the trailing segment
+    (``"GetNode"``). Returns ``""`` for callables we can't introspect
+    (e.g. a test fake) so the caller treats them as non-allowlisted —
+    fail closed: an unknown method does not get DEADLINE retries.
+    """
+    method = getattr(fn, "_method", None)
+    if method is None:
+        return ""
+    if isinstance(method, (bytes, bytearray)):
+        method = method.decode()
+    return method.rsplit("/", 1)[-1]
+
+
+def _is_retryable(code: grpc.StatusCode, short_method: str) -> bool:
+    """Decide whether a failed RPC may be retried.
+
+    - UNAVAILABLE: always retryable (the request likely never
+      reached the server).
+    - DEADLINE_EXCEEDED: retryable only when the method is in the
+      read allowlist (retrying a write after a timeout could
+      duplicate a committed mutation).
+
+    Any other status code is terminal.
+    """
+    if code == grpc.StatusCode.UNAVAILABLE:
+        return True
+    if code == grpc.StatusCode.DEADLINE_EXCEEDED:
+        return short_method in _DEADLINE_RETRYABLE_METHODS
+    return False
+
+
+def _full_jitter_backoff(attempt: int, rng: random.Random | None = None) -> float:
+    """Return the backoff sleep (seconds) before ``attempt``.
+
+    Implements the "full jitter" strategy from AWS's
+    exponential-backoff guidance: a uniformly random delay in
+    ``[0, min(cap, base * 2**attempt))``. Full jitter de-correlates
+    the retry schedules of many clients recovering from the same
+    outage, avoiding a thundering herd.
+
+    ``rng`` is injectable so tests can pin the jitter and assert
+    exact sleep durations.
+    """
+    ceiling = min(_RETRY_MAX_DELAY, _RETRY_BASE_DELAY * (2**attempt))
+    r = rng if rng is not None else random
+    return r.uniform(0.0, ceiling)
 
 
 def _multicallable_rebinder(fn: Any):
@@ -491,6 +603,8 @@ class GrpcClient:
         credentials: grpc.ChannelCredentials | None = None,
         api_key: str | None = None,
         max_retries: int = 3,
+        retry_budget: float = _RETRY_WALL_CLOCK_BUDGET,
+        retry_rng: random.Random | None = None,
         registry: Any = None,
         node_resolver: Any | None = None,
     ) -> None:
@@ -503,6 +617,15 @@ class GrpcClient:
             credentials: Optional TLS credentials
             api_key: Optional API key for authentication
             max_retries: Maximum number of retries for transient failures
+            retry_budget: Total wall-clock seconds the SDK will spend
+                retrying a single call, backoff sleeps included. Once
+                the elapsed time since the first attempt would exceed
+                this, the last error is raised even if retry attempts
+                remain. A non-positive value restores the 30s default.
+            retry_rng: Optional :class:`random.Random` used as the
+                jitter source for the backoff. Injected by tests so
+                sleep durations are reproducible; production leaves it
+                ``None`` (module-global RNG).
             registry: Optional schema registry used to translate the
                 id-keyed wire payload back to user-facing field names.
             node_resolver: Optional :class:`NodeResolver` used to map
@@ -517,6 +640,8 @@ class GrpcClient:
         self._credentials = credentials
         self._api_key = api_key
         self._max_retries = max_retries
+        self._retry_budget = retry_budget if retry_budget > 0 else _RETRY_WALL_CLOCK_BUDGET
+        self._retry_rng = retry_rng
         self._registry = registry
         self._channel: grpc_aio.Channel | None = None
         self._stub: EntDBServiceStub | None = None
@@ -650,6 +775,11 @@ class GrpcClient:
                 rebind = _multicallable_rebinder(fn)
 
         retries = max_retries if max_retries is not None else self._max_retries
+        # Method name keys the DEADLINE_EXCEEDED allowlist. Resolved
+        # from the *original* bound multicallable so a redirect
+        # rebind (same RPC, different channel) keeps the same name.
+        short_method = _short_method(fn)
+        retry_start = time.monotonic()
         last_error: grpc.RpcError | None = None
         for attempt in range(retries + 1):
             try:
@@ -695,10 +825,28 @@ class GrpcClient:
                     and fn_channel is not primary_channel
                 ):
                     await self._redirect_cache.evict(tenant_id)
-                if e.code() not in _RETRYABLE_STATUS_CODES or attempt == retries:
+                # Terminal status, exhausted attempts, or a
+                # DEADLINE_EXCEEDED on a non-allowlisted (mutating)
+                # method: never retry — re-issuing a write after a
+                # timeout could duplicate a committed mutation.
+                if attempt == retries or not _is_retryable(e.code(), short_method):
                     raise
                 last_error = e
-                await asyncio.sleep(0.1 * (2**attempt))
+
+                # Full-jitter exponential backoff: de-correlates the
+                # retry schedules of many clients recovering from the
+                # same outage (no thundering herd).
+                sleep = _full_jitter_backoff(attempt, self._retry_rng)
+
+                # Wall-clock budget: if the next sleep would push
+                # total elapsed time past the budget, give up now and
+                # raise the last error rather than blocking the caller
+                # well past their own deadline on a slow endpoint.
+                elapsed = time.monotonic() - retry_start
+                if elapsed + sleep > self._retry_budget:
+                    raise
+
+                await asyncio.sleep(sleep)
         raise last_error  # type: ignore[misc]
 
     async def execute_atomic(

--- a/sdk/python/entdb_sdk/client.py
+++ b/sdk/python/entdb_sdk/client.py
@@ -705,6 +705,7 @@ class DbClient:
         api_key: str | None = None,
         credentials: Any | None = None,
         max_retries: int = 3,
+        retry_budget: float = 30.0,
         registry: SchemaRegistry | None = None,
         schema_module: Any | None = None,
         schema_fingerprint: str | None = None,
@@ -720,6 +721,11 @@ class DbClient:
             credentials: Optional gRPC channel credentials. When set,
                 `secure` should also be true.
             max_retries: Maximum number of retries for transient gRPC failures
+            retry_budget: Total wall-clock seconds spent retrying a single
+                failed RPC, backoff sleeps included. Bounds tail latency
+                under an outage: once elapsed time would exceed this, the
+                last error is raised even if retry attempts remain. A
+                non-positive value restores the 30s default.
             registry: Optional schema registry
             schema_module: Optional generated schema module (e.g. the module
                 produced by ``entdb codegen``). If provided and it exposes a
@@ -760,6 +766,7 @@ class DbClient:
             credentials=credentials,
             api_key=api_key,
             max_retries=max_retries,
+            retry_budget=retry_budget,
             registry=self.registry,
             node_resolver=node_resolver,
         )

--- a/tests/python/unit/test_grpc_retry.py
+++ b/tests/python/unit/test_grpc_retry.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""
+Unit tests for the Python SDK's transient-retry policy
+(``GrpcClient._retry`` and its helpers in ``_grpc_client.py``).
+
+Covers the three properties added for issue #143 (PERF-7):
+
+  * full-jitter exponential backoff (no thundering herd),
+  * a per-call wall-clock retry budget,
+  * a DEADLINE_EXCEEDED read-method allowlist (writes such as
+    ExecuteAtomic must NEVER be retried on a timeout).
+
+The jitter source is injected as a seeded ``random.Random`` so the
+backoff durations asserted here are deterministic. ``asyncio.sleep``
+is monkeypatched so the tests don't actually wait.
+"""
+
+from __future__ import annotations
+
+import random
+
+import grpc
+import pytest
+
+from entdb_sdk._grpc_client import (
+    _DEADLINE_RETRYABLE_METHODS,
+    GrpcClient,
+    _full_jitter_backoff,
+    _is_retryable,
+    _short_method,
+)
+
+# ── Fake gRPC error / multicallable ─────────────────────────────────
+
+
+class FakeRpcError(grpc.RpcError):
+    """Minimal stand-in for grpc.aio.AioRpcError.
+
+    ``_retry`` only needs ``.code()`` and (via
+    ``extract_redirect_node``) ``.trailing_metadata()``.
+    """
+
+    def __init__(self, code: grpc.StatusCode) -> None:
+        self._code = code
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+    def trailing_metadata(self):  # noqa: D401 - matches grpc API
+        return []
+
+
+class FakeCall:
+    """An awaitable bound-multicallable substitute.
+
+    Raises ``FakeRpcError(code)`` for the first ``fail_n`` calls,
+    then returns ``"ok"``. Records how many times it was invoked.
+    Exposes ``_method`` so ``_short_method`` resolves the allowlist
+    key just like a real grpc.aio multicallable.
+    """
+
+    def __init__(self, code: grpc.StatusCode, fail_n: int, method: str) -> None:
+        self._code = code
+        self._fail_n = fail_n
+        self._method = f"/entdb.v1.EntDBService/{method}"
+        self.calls = 0
+
+    async def __call__(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self._fail_n:
+            raise FakeRpcError(self._code)
+        return "ok"
+
+
+def _make_client(**kw) -> GrpcClient:
+    # Seeded RNG -> deterministic jitter. No real network.
+    return GrpcClient(retry_rng=random.Random(1234), **kw)
+
+
+# ── _short_method ───────────────────────────────────────────────────
+
+
+class TestShortMethod:
+    def test_strips_path(self):
+        fn = FakeCall(grpc.StatusCode.OK, 0, "GetNode")
+        assert _short_method(fn) == "GetNode"
+
+    def test_bytes_method(self):
+        fn = FakeCall(grpc.StatusCode.OK, 0, "ExecuteAtomic")
+        fn._method = fn._method.encode()
+        assert _short_method(fn) == "ExecuteAtomic"
+
+    def test_unknown_callable_returns_empty(self):
+        assert _short_method(object()) == ""
+
+
+# ── _is_retryable ───────────────────────────────────────────────────
+
+
+class TestIsRetryable:
+    def test_unavailable_retryable_for_reads_and_writes(self):
+        for m in ("GetNode", "ExecuteAtomic", "ShareNode", "DeleteUser"):
+            assert _is_retryable(grpc.StatusCode.UNAVAILABLE, m) is True
+
+    def test_deadline_exceeded_retryable_only_for_read_allowlist(self):
+        for m in ("GetNode", "QueryNodes", "Health", "WaitForOffset", "ExportUserData"):
+            assert _is_retryable(grpc.StatusCode.DEADLINE_EXCEEDED, m) is True
+        for m in ("ExecuteAtomic", "ShareNode", "DeleteUser", "CreateTenant"):
+            assert _is_retryable(grpc.StatusCode.DEADLINE_EXCEEDED, m) is False
+
+    def test_terminal_codes_never_retryable(self):
+        for c in (
+            grpc.StatusCode.NOT_FOUND,
+            grpc.StatusCode.PERMISSION_DENIED,
+            grpc.StatusCode.INVALID_ARGUMENT,
+            grpc.StatusCode.ALREADY_EXISTS,
+            grpc.StatusCode.INTERNAL,
+        ):
+            assert _is_retryable(c, "GetNode") is False
+
+    def test_execute_atomic_not_in_read_allowlist(self):
+        assert "ExecuteAtomic" not in _DEADLINE_RETRYABLE_METHODS
+        assert "ShareNode" not in _DEADLINE_RETRYABLE_METHODS
+        assert "GetNode" in _DEADLINE_RETRYABLE_METHODS
+
+
+# ── _full_jitter_backoff ────────────────────────────────────────────
+
+
+class _FixedFractionRandom(random.Random):
+    """random.Random whose ``random()`` always returns ``frac``.
+
+    ``Random.uniform(a, b)`` is ``a + (b - a) * self.random()``, so
+    pinning ``random()`` pins the jitter draw without monkeypatching
+    ``uniform`` (which trips ARG lint on the unused signature).
+    """
+
+    def __init__(self, frac: float) -> None:
+        super().__init__()
+        self._frac = frac
+
+    def random(self) -> float:  # noqa: D401 - matches Random API
+        return self._frac
+
+
+class TestFullJitterBackoff:
+    def test_bounded_by_ceiling(self):
+        # Worst case (rng -> ~1.0) is essentially the per-attempt
+        # ceiling: uniform(0, c) with random()=frac yields c*frac.
+        rng = _FixedFractionRandom(1.0)
+        for attempt, ceiling in ((0, 0.1), (1, 0.2), (2, 0.4), (3, 0.8)):
+            assert _full_jitter_backoff(attempt, rng) == pytest.approx(ceiling)
+
+    def test_capped_at_max_delay(self):
+        rng = _FixedFractionRandom(1.0)
+        # attempt 10 would be 0.1*1024=102.4s unjittered; must cap.
+        assert _full_jitter_backoff(10, rng) == pytest.approx(5.0)
+
+    def test_zero_fraction_is_zero(self):
+        rng = _FixedFractionRandom(0.0)
+        assert _full_jitter_backoff(5, rng) == 0.0
+
+    def test_is_randomised_not_fixed(self):
+        # Distinct seeds -> distinct draws: proves jitter is applied
+        # (the pre-#143 code used a fixed 0.1*2**n with no jitter).
+        a = _full_jitter_backoff(3, random.Random(1))
+        b = _full_jitter_backoff(3, random.Random(2))
+        assert a != b
+        assert 0.0 <= a < 0.8
+        assert 0.0 <= b < 0.8
+
+
+# ── _retry: end-to-end behaviour ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestRetryLoop:
+    async def test_unavailable_retries_then_succeeds(self, monkeypatch):
+        slept: list[float] = []
+
+        async def fake_sleep(d):
+            slept.append(d)
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.asyncio.sleep", fake_sleep)
+        client = _make_client(max_retries=3)
+        fn = FakeCall(grpc.StatusCode.UNAVAILABLE, 2, "GetNode")
+
+        result = await client._retry(fn)
+
+        assert result == "ok"
+        assert fn.calls == 3  # 2 failures + 1 success
+        assert len(slept) == 2  # one backoff per retry
+        # Full jitter: every sleep is within its attempt ceiling.
+        assert 0.0 <= slept[0] < 0.1
+        assert 0.0 <= slept[1] < 0.2
+
+    async def test_exhausts_max_retries_and_raises(self, monkeypatch):
+        async def fake_sleep(_d):
+            pass
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.asyncio.sleep", fake_sleep)
+        client = _make_client(max_retries=2)
+        fn = FakeCall(grpc.StatusCode.UNAVAILABLE, 99, "GetNode")
+
+        with pytest.raises(grpc.RpcError):
+            await client._retry(fn)
+        assert fn.calls == 3  # 1 initial + 2 retries
+
+    async def test_execute_atomic_not_retried_on_deadline_exceeded(self, monkeypatch):
+        async def fake_sleep(_d):
+            raise AssertionError("must not sleep — write must not retry")
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.asyncio.sleep", fake_sleep)
+        client = _make_client(max_retries=5)
+        fn = FakeCall(grpc.StatusCode.DEADLINE_EXCEEDED, 99, "ExecuteAtomic")
+
+        with pytest.raises(grpc.RpcError):
+            await client._retry(fn)
+        # Exactly one attempt: a write timing out is NOT retried.
+        assert fn.calls == 1
+
+    async def test_execute_atomic_still_retries_on_unavailable(self, monkeypatch):
+        async def fake_sleep(_d):
+            pass
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.asyncio.sleep", fake_sleep)
+        client = _make_client(max_retries=3)
+        fn = FakeCall(grpc.StatusCode.UNAVAILABLE, 1, "ExecuteAtomic")
+
+        result = await client._retry(fn)
+        assert result == "ok"
+        assert fn.calls == 2  # UNAVAILABLE retried even for a write
+
+    async def test_read_retried_on_deadline_exceeded(self, monkeypatch):
+        async def fake_sleep(_d):
+            pass
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.asyncio.sleep", fake_sleep)
+        client = _make_client(max_retries=3)
+        fn = FakeCall(grpc.StatusCode.DEADLINE_EXCEEDED, 1, "GetNode")
+
+        result = await client._retry(fn)
+        assert result == "ok"
+        assert fn.calls == 2
+
+    async def test_terminal_status_not_retried(self, monkeypatch):
+        async def fake_sleep(_d):
+            raise AssertionError("must not sleep on a terminal status")
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.asyncio.sleep", fake_sleep)
+        client = _make_client(max_retries=5)
+        fn = FakeCall(grpc.StatusCode.NOT_FOUND, 99, "GetNode")
+
+        with pytest.raises(grpc.RpcError):
+            await client._retry(fn)
+        assert fn.calls == 1
+
+    async def test_wall_clock_budget_stops_early(self, monkeypatch):
+        # A monotonic clock that jumps 100s per call makes the budget
+        # (default 30s) trip on the first backoff decision, so even
+        # though max_retries=50 the loop bails after a single retry
+        # decision rather than running the full schedule.
+        ticks = iter([0.0, 100.0, 200.0, 300.0, 400.0])
+        monkeypatch.setattr("entdb_sdk._grpc_client.time.monotonic", lambda: next(ticks))
+
+        async def fake_sleep(_d):
+            raise AssertionError("budget should trip before sleeping")
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.asyncio.sleep", fake_sleep)
+        client = _make_client(max_retries=50)
+        fn = FakeCall(grpc.StatusCode.UNAVAILABLE, 99, "GetNode")
+
+        with pytest.raises(grpc.RpcError):
+            await client._retry(fn)
+        # 1 initial attempt; budget tripped before the first sleep.
+        assert fn.calls == 1
+
+    async def test_custom_budget_allows_more_attempts(self, monkeypatch):
+        # With a generous budget the loop runs the full retry count.
+        monkeypatch.setattr("entdb_sdk._grpc_client.time.monotonic", lambda: 0.0)
+
+        async def fake_sleep(_d):
+            pass
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.asyncio.sleep", fake_sleep)
+        client = _make_client(max_retries=4, retry_budget=999.0)
+        fn = FakeCall(grpc.StatusCode.UNAVAILABLE, 99, "GetNode")
+
+        with pytest.raises(grpc.RpcError):
+            await client._retry(fn)
+        assert fn.calls == 5  # 1 initial + 4 retries
+
+    async def test_non_positive_budget_falls_back_to_default(self):
+        client = _make_client(retry_budget=0.0)
+        assert client._retry_budget == 30.0
+        client2 = _make_client(retry_budget=-5.0)
+        assert client2._retry_budget == 30.0


### PR DESCRIPTION
## Problem

The SDK retry layer had three weaknesses that compound during an outage (issue #143, PERF-7):

- **No jitter.** The exponential backoff was a fixed `0.1 * 2**attempt`. Every client recovering from the same outage retried in lockstep — a thundering herd that prolongs the outage.
- **DEADLINE_EXCEEDED retried unconditionally**, including for `ExecuteAtomic` and the other mutating RPCs. A timeout means the deadline elapsed while the request was in flight, so the write may already have committed server-side; a blind retry risks a **duplicate mutation**.
- **No wall-clock budget.** A high `max_retries` combined with exponential backoff could block a caller for minutes, far past their own deadline.
- The **Go SDK** configured `WithMaxRetries` but never consumed it — there was no transient-retry loop at all.

## Fix

Both SDKs now share identical retry semantics:

- **Full-jitter exponential backoff** — uniformly random delay in `[0, min(cap, base*2**attempt))`, base `100ms`, cap `5s`. De-correlates retry schedules across clients. RNG is injectable for deterministic tests.
- **Per-call wall-clock budget** (default `30s`): if the next backoff sleep would push total elapsed time past the budget, the last error is returned/raised immediately instead of sleeping. Configurable via `DbClient(retry_budget=...)` (Python) and `entdb.WithRetryBudget(...)` (Go).
- **DEADLINE_EXCEEDED read-method allowlist** — only side-effect-free reads (`Get*`/`List*`/`Search*`/`QueryNodes`/`Health`/`WaitForOffset`/`ExportUserData`) are retried on a timeout. Writes (`ExecuteAtomic`, `ShareNode`, the admin/GDPR surface, ...) are **never** retried on `DEADLINE_EXCEEDED`. `UNAVAILABLE` still retries every method — it is a connection-level failure where the request almost certainly never reached the server.

Python: changes in `sdk/python/entdb_sdk/_grpc_client.py` (`_retry` loop + new helpers) and `client.py` (plumb `retry_budget`).

Go: new `sdk/go/entdb/retry.go` installs a unary client interceptor with the same semantics, chained *outside* the redirect interceptor so every retry attempt still follows tenant redirects. `WithRetryBudget` option added in `options.go` for parity.

Per project convention, both SDKs ship in this single PR.

## Testing

Full local CI, all green:

- **Go SDK** — `go vet ./...` clean; `go test ./...` ok (incl. new `retry_test.go`: jitter bounds/cap, allowlist, `ExecuteAtomic` not retried on DEADLINE_EXCEEDED but is on UNAVAILABLE, max-retry exhaustion, wall-clock budget cut-off, retries-disabled). Also passes under `-race`.
- **Python** — new `tests/python/unit/test_grpc_retry.py` (20 cases) green; full unit suite 389 passed; integration contract suite vs the Go server **95 passed**.
- **Ruff** — `check` and `format --check` both clean repo-wide.

Closes #143