### PR TITLE
[E9.1] Production OAuth/OIDC: network JWKS, discovery, ES256, server flags

### DIFF
--- a/server/go/cmd/entdb-server/auth.go
+++ b/server/go/cmd/entdb-server/auth.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+)
+
+// oauthConfig is the operator-facing OAuth/OIDC configuration parsed
+// from the -oauth-* flags. When provider is set it seeds issuer / JWKS
+// URL from a known IdP preset; explicit -oauth-issuer / -jwks-url always
+// win over the preset.
+type oauthConfig struct {
+	provider string // "" | google | microsoft | okta
+	issuer   string
+	jwksURL  string
+	audience string
+}
+
+// enabled reports whether the operator asked for production OIDC auth.
+// Any one of provider / issuer / jwks-url being set turns it on.
+func (c oauthConfig) enabled() bool {
+	return strings.TrimSpace(c.provider) != "" ||
+		strings.TrimSpace(c.issuer) != "" ||
+		strings.TrimSpace(c.jwksURL) != ""
+}
+
+// buildOAuthValidator resolves the flag set into a production
+// JWKSValidator. Resolution order:
+//
+//  1. If -oauth-provider names a known preset, seed issuer + JWKS URL
+//     from it (Google has both; Microsoft/Okta are tenant/org-specific
+//     so the preset only marks them as discovery-driven and the
+//     operator MUST pass -oauth-issuer).
+//  2. Explicit -oauth-issuer / -jwks-url override the preset.
+//  3. With a JWKS URL, discovery is skipped. Without one, OIDC discovery
+//     runs against the issuer (<issuer>/.well-known/openid-configuration).
+//
+// The returned validator has already warmed its JWKS cache, so a
+// misconfigured issuer fails here at boot rather than on the first
+// request.
+func buildOAuthValidator(ctx context.Context, c oauthConfig) (*auth.JWKSValidator, error) {
+	issuer := strings.TrimSpace(c.issuer)
+	jwksURL := strings.TrimSpace(c.jwksURL)
+
+	if name := strings.TrimSpace(c.provider); name != "" {
+		preset, ok := auth.PresetProvider(name)
+		if !ok {
+			return nil, fmt.Errorf("--oauth-provider %q is not recognised (want one of %s)",
+				name, strings.Join(auth.KnownProviders(), ", "))
+		}
+		if issuer == "" {
+			issuer = preset.Issuer
+		}
+		if jwksURL == "" {
+			jwksURL = preset.JWKSURL
+		}
+		if issuer == "" {
+			// Microsoft / Okta: tenant/org-specific issuer the preset
+			// cannot know. Force the operator to supply it.
+			return nil, fmt.Errorf("--oauth-provider %q is tenant/org-specific; also pass --oauth-issuer with the concrete issuer URL", name)
+		}
+	}
+
+	if issuer == "" {
+		return nil, fmt.Errorf("OAuth requires --oauth-issuer (or a --oauth-provider preset that supplies one)")
+	}
+
+	v, err := auth.NewJWKSValidator(ctx, auth.JWKSOptions{
+		Issuer:   issuer,
+		Audience: strings.TrimSpace(c.audience),
+		JWKSURL:  jwksURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// oauthSummary is a one-line, secret-free description for the boot log.
+func oauthSummary(c oauthConfig, v *auth.JWKSValidator) string {
+	prov := strings.TrimSpace(c.provider)
+	if prov == "" {
+		prov = "custom"
+	}
+	aud := strings.TrimSpace(c.audience)
+	if aud == "" {
+		aud = "(unchecked — set --oauth-audience in production)"
+	}
+	return fmt.Sprintf("provider=%s issuer=%s jwks=%s audience=%s", prov, c.issuerOrPreset(), v.JWKSURL(), aud)
+}
+
+// issuerOrPreset reports the effective issuer for logging, falling back
+// to the preset name when the operator relied purely on -oauth-provider.
+func (c oauthConfig) issuerOrPreset() string {
+	if s := strings.TrimSpace(c.issuer); s != "" {
+		return s
+	}
+	if name := strings.TrimSpace(c.provider); name != "" {
+		if p, ok := auth.PresetProvider(name); ok && p.Issuer != "" {
+			return p.Issuer
+		}
+	}
+	return "(discovery)"
+}

--- a/server/go/cmd/entdb-server/auth_test.go
+++ b/server/go/cmd/entdb-server/auth_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOAuthConfigEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		c    oauthConfig
+		want bool
+	}{
+		{"empty", oauthConfig{}, false},
+		{"provider", oauthConfig{provider: "google"}, true},
+		{"issuer", oauthConfig{issuer: "https://x"}, true},
+		{"jwks", oauthConfig{jwksURL: "https://x/jwks"}, true},
+		{"audience-only is not enough", oauthConfig{audience: "a"}, false},
+	}
+	for _, tc := range cases {
+		if got := tc.c.enabled(); got != tc.want {
+			t.Errorf("%s: enabled() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestBuildOAuthValidator_RejectsUnknownProvider(t *testing.T) {
+	_, err := buildOAuthValidator(context.Background(), oauthConfig{provider: "facebook"})
+	if err == nil || !strings.Contains(err.Error(), "not recognised") {
+		t.Fatalf("err = %v, want unrecognised-provider error", err)
+	}
+}
+
+func TestBuildOAuthValidator_TenantSpecificProviderNeedsIssuer(t *testing.T) {
+	// microsoft/okta presets carry no static issuer; the operator must
+	// supply --oauth-issuer.
+	for _, p := range []string{"microsoft", "okta"} {
+		_, err := buildOAuthValidator(context.Background(), oauthConfig{provider: p})
+		if err == nil || !strings.Contains(err.Error(), "--oauth-issuer") {
+			t.Errorf("provider=%s err = %v, want must-pass-issuer error", p, err)
+		}
+	}
+}
+
+func TestBuildOAuthValidator_RequiresIssuer(t *testing.T) {
+	_, err := buildOAuthValidator(context.Background(), oauthConfig{audience: "a"})
+	if err == nil || !strings.Contains(err.Error(), "--oauth-issuer") {
+		t.Fatalf("err = %v, want requires-issuer error", err)
+	}
+}
+
+func TestBuildOAuthValidator_DiscoversAndWarmsCache(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":   srv.URL,
+			"jwks_uri": srv.URL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		eBytes := big.NewInt(int64(priv.PublicKey.E)).Bytes()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{{
+				"kty": "RSA", "kid": "k", "alg": "RS256", "use": "sig",
+				"n": base64.RawURLEncoding.EncodeToString(priv.PublicKey.N.Bytes()),
+				"e": base64.RawURLEncoding.EncodeToString(eBytes),
+			}},
+		})
+	})
+
+	v, err := buildOAuthValidator(context.Background(), oauthConfig{
+		issuer:   srv.URL,
+		audience: "entdb",
+	})
+	if err != nil {
+		t.Fatalf("buildOAuthValidator: %v", err)
+	}
+	if v.JWKSURL() != srv.URL+"/jwks" {
+		t.Errorf("resolved JWKS URL = %q, want %q", v.JWKSURL(), srv.URL+"/jwks")
+	}
+}
+
+func TestBuildOAuthValidator_FailsClosedOnBadIssuer(t *testing.T) {
+	// Discovery against a dead host must fail at boot, not silently
+	// produce an always-reject validator.
+	_, err := buildOAuthValidator(context.Background(), oauthConfig{
+		issuer: "http://127.0.0.1:0/no-such-issuer",
+	})
+	if err == nil {
+		t.Fatal("expected boot failure for unreachable issuer")
+	}
+}

--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -43,6 +43,10 @@ func main() {
 	tlsMinVersion := flag.String("tls-min-version", "1.3", "minimum TLS version: 1.3 | 1.2")
 	requireTLS := flag.Bool("require-tls", false, "refuse to start unless TLS is configured")
 	requireClientCert := flag.Bool("require-client-cert", false, "require and verify client certificates (mTLS; requires --tls-ca)")
+	oauthProvider := flag.String("oauth-provider", "", "OIDC provider preset: google | microsoft | okta (microsoft/okta also need --oauth-issuer)")
+	oauthIssuer := flag.String("oauth-issuer", "", "OIDC issuer URL; expected JWT 'iss' and the discovery base when --jwks-url is unset")
+	oauthJWKSURL := flag.String("jwks-url", "", "explicit JWKS endpoint; when set, OIDC discovery is skipped")
+	oauthAudience := flag.String("oauth-audience", "", "expected JWT 'aud' (your OAuth client/app id); empty disables the audience check (dev only)")
 	kmsProvider := flag.String("kms-provider", "", "encryption master-key provider: file | aws | gcp | azure | vault")
 	kmsKeyID := flag.String("kms-key-id", "", "master-key provider identifier; file provider accepts path or env:NAME")
 	encryptionRequired := flag.Bool("encryption-required", false, "require encrypted global.db and tenant SQLite files")
@@ -326,6 +330,35 @@ func main() {
 		log.Printf("entdb-server: TLS enabled (min-version=%s client-auth=%s)", *tlsMinVersion, clientAuthMode(*tlsCA, *requireClientCert))
 	} else {
 		log.Printf("entdb-server: WARNING: TLS disabled; plaintext gRPC listener is for local/dev use only")
+	}
+
+	// Production OAuth/OIDC. When any -oauth-* flag is set we build a
+	// network-backed JWKSValidator (real JWKS fetch + caching + key
+	// rotation, OIDC discovery, provider presets) and install the auth
+	// interceptor. The interceptor reads gRPC metadata, so it is wired
+	// independently of TLS. API-key / session managers stay nil here
+	// (in-memory dev managers and their flags are tracked under
+	// sibling issues #87/#88); a nil backend simply means that
+	// credential type is not accepted.
+	oc := oauthConfig{
+		provider: *oauthProvider,
+		issuer:   *oauthIssuer,
+		jwksURL:  *oauthJWKSURL,
+		audience: *oauthAudience,
+	}
+	if oc.enabled() {
+		validator, err := buildOAuthValidator(ctx, oc)
+		if err != nil {
+			log.Fatalf("entdb-server: OAuth config: %v", err)
+		}
+		authInterceptor := auth.NewInterceptor(validator, nil, nil)
+		grpcServerOpts = append(grpcServerOpts,
+			grpc.ChainUnaryInterceptor(authInterceptor.Unary()),
+			grpc.ChainStreamInterceptor(authInterceptor.Stream()),
+		)
+		log.Printf("entdb-server: OAuth/OIDC authentication enabled (%s)", oauthSummary(oc, validator))
+	} else {
+		log.Printf("entdb-server: WARNING: OAuth/OIDC authentication disabled; no -oauth-* flags set (local/dev only — production MUST set --oauth-issuer)")
 	}
 
 	srv := grpc.NewServer(grpcServerOpts...)

--- a/server/go/internal/auth/doc.go
+++ b/server/go/internal/auth/doc.go
@@ -16,13 +16,19 @@
 //	identity.go Identity struct + context.Context plumbing.
 //	authoritative.go Authoritative() -- the SINGLE trusted-actor chokepoint.
 //	interceptor.go Unary + Stream gRPC interceptors; Health bypass list.
-//	oauth.go In-memory OAuthValidator (HS256 / RS256).
+//	oauth.go In-memory OAuthValidator (HS256 / RS256 / ES256).
+//	jwks.go Production JWKSValidator: network JWKS fetch +
+//	                 caching + key rotation, OIDC discovery,
+//	                 Google/Microsoft/Okta presets (RS256 / ES256).
 //	apikey.go In-memory APIKeyManager.
 //	session.go In-memory SessionManager.
 //	errors.go UNAUTHENTICATED / PERMISSION_DENIED wrappers.
 //
-// Production OAuth (real JWKS rotation, network discovery), Redis-backed
-// sessions, and the quota interceptor are tracked separately; this
-// package ships the in-memory validators plus the trusted-actor
-// plumbing.
+// Production OAuth/OIDC ships here (JWKSValidator), wired into the
+// server via the -oauth-issuer / -jwks-url / -oauth-audience /
+// -oauth-provider flags on cmd/entdb-server. Redis-backed sessions, the
+// production API-key store, and the quota interceptor are tracked
+// separately (#87/#88); this package ships the OAuth validators plus the
+// trusted-actor plumbing, with in-memory API-key/session managers for
+// tests and dev.
 package auth

--- a/server/go/internal/auth/jwks.go
+++ b/server/go/internal/auth/jwks.go
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// JWKSValidator is the production OAuthValidator. It validates RS256 /
+// ES256 OIDC bearer tokens against a JWKS document fetched over the
+// network, with the document cached in-process and refreshed lazily on a
+// kid miss (key rotation) or after a TTL.
+//
+// HS256 is intentionally NOT accepted here: a JWKS endpoint only ever
+// publishes asymmetric public keys, so an HS256 token reaching this
+// validator is the classic algorithm-confusion attack (signing a token
+// with the RSA/EC public bytes treated as an HMAC secret). It is
+// rejected outright, the same guard MemoryOAuthValidator enforces.
+//
+// Concurrency: the cached key set is guarded by a RWMutex; refreshes are
+// coalesced through a single-flight latch keyed by JWKS URL so a burst
+// of requests on an unknown kid triggers exactly one network fetch (the
+// "thundering herd" risk called out in
+// docs/go-port/shared/auth-interceptor.md).
+type JWKSValidator struct {
+	issuer   string
+	audience string
+	jwksURL  string
+
+	httpClient *http.Client
+	// cacheTTL bounds how long a fetched JWKS is trusted before a
+	// proactive refresh; a kid miss forces a refresh regardless.
+	cacheTTL time.Duration
+
+	mu        sync.RWMutex
+	keys      map[string]parsedJWK
+	fetchedAt time.Time
+
+	// flight serialises concurrent refreshes for this validator so a
+	// kid miss does not fan out N network calls. Mirrors the
+	// singleflight pattern without pulling in golang.org/x/sync.
+	flightMu sync.Mutex
+	flight   *refreshCall
+
+	// Now lets tests pin a synthetic clock for exp/nbf and the cache
+	// TTL. nil -> time.Now.
+	Now func() time.Time
+}
+
+// parsedJWK is a verification key materialised from one JWKS entry. The
+// alg is pinned at parse time so the verify path can enforce the
+// algorithm-confusion guard (a token's header alg must match the key's
+// declared alg, never cross RSA<->EC<->HMAC).
+type parsedJWK struct {
+	alg string
+	rsa *rsa.PublicKey
+	ec  *ecdsa.PublicKey
+}
+
+type refreshCall struct {
+	done chan struct{}
+	err  error
+}
+
+// JWKSOptions configures a JWKSValidator. Exactly one of JWKSURL or
+// IssuerDiscovery must drive key discovery: pass JWKSURL to skip the
+// .well-known round-trip, or leave it empty and let NewJWKSValidator run
+// OIDC discovery against Issuer.
+type JWKSOptions struct {
+	// Issuer is the expected `iss` claim AND, when JWKSURL is empty,
+	// the OIDC issuer whose .well-known/openid-configuration is
+	// fetched to discover jwks_uri. Required.
+	Issuer string
+	// Audience is the expected `aud` claim. Empty disables the
+	// audience check (dev only; production MUST set it).
+	Audience string
+	// JWKSURL, when set, is used verbatim and discovery is skipped.
+	JWKSURL string
+	// HTTPClient is used for discovery + JWKS fetches. nil -> a client
+	// with a 10s timeout.
+	HTTPClient *http.Client
+	// CacheTTL bounds how long a fetched JWKS is trusted before a
+	// proactive refresh. Zero -> 15 minutes. A kid miss always forces
+	// an immediate refresh regardless of TTL.
+	CacheTTL time.Duration
+}
+
+// oidcDiscovery is the subset of the OpenID Provider Metadata
+// (RFC 8414 / OpenID Connect Discovery 1.0) we consume.
+type oidcDiscovery struct {
+	Issuer  string `json:"issuer"`
+	JWKSURI string `json:"jwks_uri"`
+}
+
+// NewJWKSValidator builds a production validator. If opts.JWKSURL is
+// empty it performs OIDC discovery against opts.Issuer
+// (<issuer>/.well-known/openid-configuration) to resolve jwks_uri, and
+// verifies the discovered issuer matches (a discovery document that
+// claims a different issuer is an attack and is rejected). It then warms
+// the JWKS cache with one fetch so the first real request is fast and
+// boot fails loudly on a misconfigured issuer.
+func NewJWKSValidator(ctx context.Context, opts JWKSOptions) (*JWKSValidator, error) {
+	if strings.TrimSpace(opts.Issuer) == "" {
+		return nil, fmt.Errorf("jwks validator: Issuer is required")
+	}
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	ttl := opts.CacheTTL
+	if ttl <= 0 {
+		ttl = 15 * time.Minute
+	}
+
+	jwksURL := strings.TrimSpace(opts.JWKSURL)
+	if jwksURL == "" {
+		disc, err := discoverOIDC(ctx, httpClient, opts.Issuer)
+		if err != nil {
+			return nil, err
+		}
+		if disc.Issuer != "" && disc.Issuer != opts.Issuer {
+			return nil, fmt.Errorf("oidc discovery: document issuer %q does not match configured issuer %q", disc.Issuer, opts.Issuer)
+		}
+		if disc.JWKSURI == "" {
+			return nil, fmt.Errorf("oidc discovery: %s did not return a jwks_uri", opts.Issuer)
+		}
+		jwksURL = disc.JWKSURI
+	}
+
+	v := &JWKSValidator{
+		issuer:     opts.Issuer,
+		audience:   opts.Audience,
+		jwksURL:    jwksURL,
+		httpClient: httpClient,
+		cacheTTL:   ttl,
+		keys:       map[string]parsedJWK{},
+	}
+	// Warm the cache so a bad issuer/JWKS URL fails at boot, not on the
+	// first request.
+	if err := v.refresh(ctx); err != nil {
+		return nil, fmt.Errorf("jwks validator: initial JWKS fetch: %w", err)
+	}
+	return v, nil
+}
+
+func (v *JWKSValidator) now() time.Time {
+	if v.Now != nil {
+		return v.Now()
+	}
+	return time.Now()
+}
+
+// JWKSURL returns the resolved JWKS endpoint (post-discovery). Useful
+// for boot logging.
+func (v *JWKSValidator) JWKSURL() string { return v.jwksURL }
+
+// Validate implements OAuthValidator. It parses the JWT, resolves the
+// kid against the cached JWKS (refreshing once on a miss to pick up
+// rotated keys), verifies the signature with the algorithm pinned by the
+// JWKS entry, and enforces exp / nbf / iss / aud.
+func (v *JWKSValidator) Validate(ctx context.Context, token string) (map[string]any, error) {
+	hdr, claims, signed, sigB, err := parseJWT(token)
+	if err != nil {
+		return nil, err
+	}
+	if hdr.Kid == "" {
+		return nil, unauthenticatedf("JWT missing 'kid' header")
+	}
+	switch hdr.Alg {
+	case "RS256", "ES256":
+		// asymmetric -- a JWKS can verify these.
+	default:
+		// HS256 / none / anything else. An HS256 token at a JWKS
+		// endpoint is the algorithm-confusion attack.
+		return nil, unauthenticatedf("unsupported JWT algorithm for JWKS validation: %q", hdr.Alg)
+	}
+
+	key, ok := v.lookupKey(hdr.Kid)
+	if !ok {
+		// Unknown kid: the IdP may have rotated signing keys. Force a
+		// single coalesced refresh and retry once.
+		if err := v.refreshOnce(ctx); err != nil {
+			return nil, unauthenticatedf("no JWKS key for kid %q and refresh failed: %v", hdr.Kid, err)
+		}
+		key, ok = v.lookupKey(hdr.Kid)
+		if !ok {
+			return nil, unauthenticatedf("no JWKS key found for kid %q", hdr.Kid)
+		}
+	}
+	if key.alg != hdr.Alg {
+		// Algorithm-confusion guard: the JWKS entry pins the alg; a
+		// token claiming a different alg for the same kid is rejected.
+		return nil, unauthenticatedf("algorithm mismatch: token=%s, key=%s", hdr.Alg, key.alg)
+	}
+
+	switch hdr.Alg {
+	case "RS256":
+		if key.rsa == nil {
+			return nil, unauthenticatedf("kid %q is not an RSA key", hdr.Kid)
+		}
+		if err := verifyRS256(key.rsa, signed, sigB); err != nil {
+			return nil, unauthenticatedf("invalid JWT signature: %v", err)
+		}
+	case "ES256":
+		if key.ec == nil {
+			return nil, unauthenticatedf("kid %q is not an EC key", hdr.Kid)
+		}
+		if err := verifyES256(key.ec, signed, sigB); err != nil {
+			return nil, unauthenticatedf("invalid JWT signature: %v", err)
+		}
+	}
+
+	if err := verifyStandardClaims(claims, v.now(), v.issuer, v.audience); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+func (v *JWKSValidator) lookupKey(kid string) (parsedJWK, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	k, ok := v.keys[kid]
+	return k, ok
+}
+
+// refreshOnce coalesces concurrent refreshes: the first caller performs
+// the fetch, every other caller that arrives while it is in flight waits
+// on the same result instead of issuing its own network call. This is
+// the singleflight behaviour the spec calls for, implemented with a
+// latch so we don't add a dependency.
+func (v *JWKSValidator) refreshOnce(ctx context.Context) error {
+	v.flightMu.Lock()
+	if v.flight != nil {
+		call := v.flight
+		v.flightMu.Unlock()
+		select {
+		case <-call.done:
+			return call.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	call := &refreshCall{done: make(chan struct{})}
+	v.flight = call
+	v.flightMu.Unlock()
+
+	call.err = v.refresh(ctx)
+
+	v.flightMu.Lock()
+	v.flight = nil
+	v.flightMu.Unlock()
+	close(call.done)
+	return call.err
+}
+
+// refresh fetches the JWKS document and atomically swaps the cached key
+// set. A fetch that yields zero usable keys is treated as an error so we
+// don't blow away a good cache with an empty one.
+func (v *JWKSValidator) refresh(ctx context.Context) error {
+	keys, err := fetchJWKS(ctx, v.httpClient, v.jwksURL)
+	if err != nil {
+		return err
+	}
+	if len(keys) == 0 {
+		return fmt.Errorf("jwks: %s returned no usable keys", v.jwksURL)
+	}
+	v.mu.Lock()
+	v.keys = keys
+	v.fetchedAt = v.now()
+	v.mu.Unlock()
+	return nil
+}
+
+// MaybeRefresh proactively refreshes if the cache is older than the TTL.
+// The interceptor does not call this on the hot path -- the kid-miss
+// refresh covers correctness; this exists for an optional background
+// ticker an operator may wire up later. Kept un-wired for now.
+func (v *JWKSValidator) MaybeRefresh(ctx context.Context) error {
+	v.mu.RLock()
+	stale := v.now().Sub(v.fetchedAt) >= v.cacheTTL
+	v.mu.RUnlock()
+	if !stale {
+		return nil
+	}
+	return v.refreshOnce(ctx)
+}
+
+// discoverOIDC fetches <issuer>/.well-known/openid-configuration and
+// returns the parsed metadata. The well-known path is appended to the
+// issuer with exactly one slash, per OpenID Connect Discovery 1.0 sec 4.
+func discoverOIDC(ctx context.Context, c *http.Client, issuer string) (oidcDiscovery, error) {
+	url := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return oidcDiscovery{}, fmt.Errorf("oidc discovery: build request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return oidcDiscovery{}, fmt.Errorf("oidc discovery: GET %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return oidcDiscovery{}, fmt.Errorf("oidc discovery: GET %s: status %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return oidcDiscovery{}, fmt.Errorf("oidc discovery: read body: %w", err)
+	}
+	var d oidcDiscovery
+	if err := json.Unmarshal(body, &d); err != nil {
+		return oidcDiscovery{}, fmt.Errorf("oidc discovery: decode %s: %w", url, err)
+	}
+	return d, nil
+}
+
+// jwksDoc / jwkEntry mirror the JWK Set structure (RFC 7517). Only the
+// fields needed to materialise RSA / EC verification keys are decoded.
+type jwksDoc struct {
+	Keys []jwkEntry `json:"keys"`
+}
+
+type jwkEntry struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	// RSA
+	N string `json:"n"`
+	E string `json:"e"`
+	// EC
+	Crv string `json:"crv"`
+	X   string `json:"x"`
+	Y   string `json:"y"`
+}
+
+// fetchJWKS GETs the JWKS document and materialises every RSA/EC signing
+// key into a kid-indexed map. Entries that are malformed or of an
+// unsupported type are skipped (an IdP may publish encryption keys or
+// future algorithms alongside the signing keys we use); the caller
+// errors only if NOTHING usable came back.
+func fetchJWKS(ctx context.Context, c *http.Client, jwksURL string) (map[string]parsedJWK, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: build request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: GET %s: %w", jwksURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("jwks: GET %s: status %d", jwksURL, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("jwks: read body: %w", err)
+	}
+	var doc jwksDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("jwks: decode %s: %w", jwksURL, err)
+	}
+
+	out := make(map[string]parsedJWK, len(doc.Keys))
+	for _, k := range doc.Keys {
+		if k.Kid == "" {
+			continue // we route by kid; an entry without one is unusable
+		}
+		// Skip explicit encryption keys; we only verify signatures.
+		if k.Use != "" && k.Use != "sig" {
+			continue
+		}
+		switch k.Kty {
+		case "RSA":
+			pub, err := parseRSAJWK(k)
+			if err != nil {
+				continue
+			}
+			alg := k.Alg
+			if alg == "" {
+				alg = "RS256"
+			}
+			if alg != "RS256" {
+				continue // only RS256 supported
+			}
+			out[k.Kid] = parsedJWK{alg: alg, rsa: pub}
+		case "EC":
+			pub, err := parseECJWK(k)
+			if err != nil {
+				continue
+			}
+			alg := k.Alg
+			if alg == "" {
+				alg = "ES256"
+			}
+			if alg != "ES256" {
+				continue // only ES256 (P-256) supported
+			}
+			out[k.Kid] = parsedJWK{alg: alg, ec: pub}
+		default:
+			continue
+		}
+	}
+	return out, nil
+}
+
+func parseRSAJWK(k jwkEntry) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("rsa jwk: bad modulus: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("rsa jwk: bad exponent: %w", err)
+	}
+	if len(nBytes) == 0 || len(eBytes) == 0 {
+		return nil, fmt.Errorf("rsa jwk: empty modulus or exponent")
+	}
+	e := new(big.Int).SetBytes(eBytes)
+	if !e.IsInt64() || e.Int64() <= 0 {
+		return nil, fmt.Errorf("rsa jwk: implausible exponent")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: int(e.Int64()),
+	}, nil
+}
+
+func parseECJWK(k jwkEntry) (*ecdsa.PublicKey, error) {
+	if k.Crv != "P-256" {
+		return nil, fmt.Errorf("ec jwk: unsupported curve %q (only P-256/ES256)", k.Crv)
+	}
+	xBytes, err := base64.RawURLEncoding.DecodeString(k.X)
+	if err != nil {
+		return nil, fmt.Errorf("ec jwk: bad x: %w", err)
+	}
+	yBytes, err := base64.RawURLEncoding.DecodeString(k.Y)
+	if err != nil {
+		return nil, fmt.Errorf("ec jwk: bad y: %w", err)
+	}
+	pub := &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     new(big.Int).SetBytes(xBytes),
+		Y:     new(big.Int).SetBytes(yBytes),
+	}
+	if !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+		return nil, fmt.Errorf("ec jwk: point is not on P-256")
+	}
+	return pub, nil
+}
+
+// OIDCProvider is a known IdP whose issuer + JWKS URL are well-known, so
+// an operator can configure auth with a single -oauth-provider flag plus
+// the audience (client id) instead of hand-copying URLs.
+type OIDCProvider struct {
+	// Issuer is the canonical `iss` value the IdP stamps into tokens.
+	Issuer string
+	// JWKSURL is the IdP's published JWKS endpoint. When set, the
+	// validator skips OIDC discovery and uses it directly.
+	JWKSURL string
+}
+
+// providerPresets maps a short name to a known IdP. Microsoft's issuer
+// is tenant-specific (`https://login.microsoftonline.com/<tenant>/v2.0`)
+// so it is intentionally NOT a static preset -- use -oauth-issuer with
+// the concrete tenant and let discovery resolve the JWKS URL.
+var providerPresets = map[string]OIDCProvider{
+	"google": {
+		Issuer:  "https://accounts.google.com",
+		JWKSURL: "https://www.googleapis.com/oauth2/v3/certs",
+	},
+	"okta": {
+		// Okta is org-specific; the issuer must be supplied by the
+		// operator. The preset only records that discovery is the
+		// resolution path (no static JWKS URL).
+	},
+	"microsoft": {
+		// Tenant-specific issuer; resolved via discovery from
+		// -oauth-issuer. No static JWKS URL.
+	},
+}
+
+// PresetProvider returns the preset for a known provider name
+// ("google", "microsoft", "okta"). The bool is false for an unknown
+// name. A returned preset with an empty Issuer means "discovery only --
+// the operator must supply -oauth-issuer" (Okta/Microsoft are
+// org/tenant-specific).
+func PresetProvider(name string) (OIDCProvider, bool) {
+	p, ok := providerPresets[strings.ToLower(strings.TrimSpace(name))]
+	return p, ok
+}
+
+// KnownProviders lists the recognised -oauth-provider preset names.
+func KnownProviders() []string {
+	return []string{"google", "microsoft", "okta"}
+}

--- a/server/go/internal/auth/jwks_test.go
+++ b/server/go/internal/auth/jwks_test.go
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// --- JWKS document helpers -------------------------------------------------
+
+func rsaJWK(kid string, pub *rsa.PublicKey) jwkEntry {
+	eBytes := big.NewInt(int64(pub.E)).Bytes()
+	return jwkEntry{
+		Kty: "RSA",
+		Kid: kid,
+		Alg: "RS256",
+		Use: "sig",
+		N:   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(eBytes),
+	}
+}
+
+func ecJWK(kid string, pub *ecdsa.PublicKey) jwkEntry {
+	return jwkEntry{
+		Kty: "EC",
+		Kid: kid,
+		Alg: "ES256",
+		Use: "sig",
+		Crv: "P-256",
+		X:   base64.RawURLEncoding.EncodeToString(pub.X.Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(pub.Y.Bytes()),
+	}
+}
+
+func jwksJSON(t *testing.T, keys ...jwkEntry) []byte {
+	t.Helper()
+	b, err := json.Marshal(jwksDoc{Keys: keys})
+	if err != nil {
+		t.Fatalf("marshal jwks: %v", err)
+	}
+	return b
+}
+
+// --- Tests -----------------------------------------------------------------
+
+func TestJWKSValidator_RS256_Valid(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	var hits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		_, _ = w.Write(jwksJSON(t, rsaJWK("kid-rsa", &priv.PublicKey)))
+	}))
+	defer srv.Close()
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:   "https://issuer.test",
+		Audience: "entdb",
+		JWKSURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator: %v", err)
+	}
+	tok, _ := SignRS256ForTest(priv, "kid-rsa", map[string]any{
+		"sub": "alice",
+		"iss": "https://issuer.test",
+		"aud": "entdb",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	claims, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims["sub"] != "alice" {
+		t.Errorf("sub = %v, want alice", claims["sub"])
+	}
+	// One fetch at construction; cached afterward.
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Errorf("JWKS fetched %d times, want 1 (cache miss)", got)
+	}
+}
+
+func TestJWKSValidator_ES256_Valid(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(jwksJSON(t, ecJWK("kid-ec", &priv.PublicKey)))
+	}))
+	defer srv.Close()
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:  "https://issuer.test",
+		JWKSURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator: %v", err)
+	}
+	tok, _ := SignES256ForTest(priv, "kid-ec", map[string]any{
+		"sub": "bob",
+		"iss": "https://issuer.test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	claims, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims["sub"] != "bob" {
+		t.Errorf("sub = %v, want bob", claims["sub"])
+	}
+}
+
+func TestJWKSValidator_CachesAcrossRequests(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	var hits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		_, _ = w.Write(jwksJSON(t, rsaJWK("k1", &priv.PublicKey)))
+	}))
+	defer srv.Close()
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:  "https://issuer.test",
+		JWKSURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		tok, _ := SignRS256ForTest(priv, "k1", map[string]any{
+			"sub": "alice",
+			"iss": "https://issuer.test",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+		if _, err := v.Validate(context.Background(), tok); err != nil {
+			t.Fatalf("Validate #%d: %v", i, err)
+		}
+	}
+	// 20 validations, known kid each time -> still just the warm-up
+	// fetch.
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Errorf("JWKS fetched %d times, want 1 (cached)", got)
+	}
+}
+
+func TestJWKSValidator_KeyRotationRefetchesOnKidMiss(t *testing.T) {
+	oldKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	newKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	var rotated atomic.Bool
+	var hits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		if rotated.Load() {
+			// After rotation the IdP serves the new kid only.
+			_, _ = w.Write(jwksJSON(t, rsaJWK("kid-new", &newKey.PublicKey)))
+			return
+		}
+		_, _ = w.Write(jwksJSON(t, rsaJWK("kid-old", &oldKey.PublicKey)))
+	}))
+	defer srv.Close()
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:  "https://issuer.test",
+		JWKSURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator: %v", err)
+	}
+
+	// Old key validates with the warm cache (1 fetch so far).
+	oldTok, _ := SignRS256ForTest(oldKey, "kid-old", map[string]any{
+		"sub": "alice", "iss": "https://issuer.test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), oldTok); err != nil {
+		t.Fatalf("pre-rotation Validate: %v", err)
+	}
+
+	// IdP rotates. A token signed by the new key has an unknown kid;
+	// the validator must refetch and then succeed.
+	rotated.Store(true)
+	newTok, _ := SignRS256ForTest(newKey, "kid-new", map[string]any{
+		"sub": "alice", "iss": "https://issuer.test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), newTok); err != nil {
+		t.Fatalf("post-rotation Validate (should refetch): %v", err)
+	}
+	if got := atomic.LoadInt64(&hits); got != 2 {
+		t.Errorf("JWKS fetched %d times, want 2 (warm-up + rotation refetch)", got)
+	}
+
+	// The refreshed cache still serves the new kid without another
+	// fetch.
+	if _, err := v.Validate(context.Background(), newTok); err != nil {
+		t.Fatalf("second post-rotation Validate: %v", err)
+	}
+	if got := atomic.LoadInt64(&hits); got != 2 {
+		t.Errorf("JWKS fetched %d times after re-validate, want 2 (cached)", got)
+	}
+}
+
+func TestJWKSValidator_KidMissRefreshIsCoalesced(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	var hits int64
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt64(&hits, 1)
+		if n >= 2 {
+			// Block concurrent refetches so they pile up on the
+			// singleflight latch instead of racing past it.
+			<-release
+		}
+		_, _ = w.Write(jwksJSON(t, rsaJWK("kid-1", &key.PublicKey)))
+	}))
+	defer srv.Close()
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:  "https://issuer.test",
+		JWKSURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator: %v", err)
+	}
+
+	// Unknown kid -> every concurrent caller triggers refreshOnce; only
+	// one network call should be in flight.
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tok, _ := SignRS256ForTest(key, "ghost-kid", map[string]any{
+				"sub": "x", "iss": "https://issuer.test",
+				"exp": time.Now().Add(time.Hour).Unix(),
+			})
+			_, _ = v.Validate(context.Background(), tok)
+		}()
+	}
+	// Give the goroutines time to converge on the latch, then release.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	// Warm-up fetch (1) + at most one coalesced refetch for the burst.
+	if got := atomic.LoadInt64(&hits); got > 2 {
+		t.Errorf("JWKS fetched %d times, want <=2 (singleflight coalesced the burst)", got)
+	}
+}
+
+func TestJWKSValidator_RejectsAlgConfusion_HS256AtJWKS(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(jwksJSON(t, rsaJWK("kid-1", &priv.PublicKey)))
+	}))
+	defer srv.Close()
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:  "https://issuer.test",
+		JWKSURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator: %v", err)
+	}
+	// Attacker forges an HS256 token for a kid that the JWKS publishes
+	// as RSA. A naive verifier that fed the RSA public bytes to HMAC
+	// would accept it; we must reject before any signature math.
+	tok, _ := SignHS256ForTest([]byte("rsa-public-bytes-as-hmac-secret"), "kid-1", map[string]any{
+		"sub": "attacker", "iss": "https://issuer.test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	_, err = v.Validate(context.Background(), tok)
+	if err == nil || errs.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected UNAUTHENTICATED alg-confusion rejection, got err=%v code=%v", err, errs.Code(err))
+	}
+}
+
+func TestJWKSValidator_RejectsNoneAlg(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(jwksJSON(t, rsaJWK("kid-1", &priv.PublicKey)))
+	}))
+	defer srv.Close()
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:  "https://issuer.test",
+		JWKSURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator: %v", err)
+	}
+	// header {"alg":"none","kid":"kid-1"}, empty payload, empty sig.
+	tok := "eyJhbGciOiJub25lIiwia2lkIjoia2lkLTEifQ.e30."
+	if _, err := v.Validate(context.Background(), tok); err == nil {
+		t.Fatal("expected rejection of alg=none at JWKS validator")
+	}
+}
+
+func TestJWKSValidator_RejectsExpiredAndBadIssuer(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(jwksJSON(t, rsaJWK("k", &priv.PublicKey)))
+	}))
+	defer srv.Close()
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:   "https://right.test",
+		Audience: "aud",
+		JWKSURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator: %v", err)
+	}
+
+	expired, _ := SignRS256ForTest(priv, "k", map[string]any{
+		"sub": "alice", "iss": "https://right.test", "aud": "aud",
+		"exp": time.Now().Add(-time.Minute).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), expired); err == nil {
+		t.Error("expected expired-token rejection")
+	}
+
+	wrongIss, _ := SignRS256ForTest(priv, "k", map[string]any{
+		"sub": "alice", "iss": "https://evil.test", "aud": "aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), wrongIss); err == nil {
+		t.Error("expected issuer rejection")
+	}
+
+	wrongAud, _ := SignRS256ForTest(priv, "k", map[string]any{
+		"sub": "alice", "iss": "https://right.test", "aud": "other",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), wrongAud); err == nil {
+		t.Error("expected audience rejection")
+	}
+}
+
+func TestJWKSValidator_OIDCDiscovery(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	mux := http.NewServeMux()
+	var jwksHits int64
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(oidcDiscovery{
+			Issuer:  srv.URL, // discovery doc issuer must match configured issuer
+			JWKSURI: srv.URL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&jwksHits, 1)
+		_, _ = w.Write(jwksJSON(t, rsaJWK("disc-kid", &priv.PublicKey)))
+	})
+
+	v, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer: srv.URL, // no JWKSURL -> discovery resolves jwks_uri
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSValidator (discovery): %v", err)
+	}
+	if v.JWKSURL() != srv.URL+"/jwks" {
+		t.Errorf("resolved JWKS URL = %q, want %q", v.JWKSURL(), srv.URL+"/jwks")
+	}
+	tok, _ := SignRS256ForTest(priv, "disc-kid", map[string]any{
+		"sub": "alice", "iss": srv.URL,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), tok); err != nil {
+		t.Fatalf("Validate after discovery: %v", err)
+	}
+	if atomic.LoadInt64(&jwksHits) != 1 {
+		t.Errorf("jwks endpoint hit %d times, want 1", jwksHits)
+	}
+}
+
+func TestJWKSValidator_DiscoveryIssuerMismatchRejected(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		// A discovery doc that claims a different issuer than the one
+		// we asked for is an attack (issuer substitution).
+		_ = json.NewEncoder(w).Encode(oidcDiscovery{
+			Issuer:  "https://attacker.example",
+			JWKSURI: srv.URL + "/jwks",
+		})
+	})
+	_, err := NewJWKSValidator(context.Background(), JWKSOptions{Issuer: srv.URL})
+	if err == nil {
+		t.Fatal("expected discovery issuer-mismatch rejection")
+	}
+}
+
+func TestJWKSValidator_RequiresIssuer(t *testing.T) {
+	if _, err := NewJWKSValidator(context.Background(), JWKSOptions{JWKSURL: "http://x"}); err == nil {
+		t.Fatal("expected error when Issuer is empty")
+	}
+}
+
+func TestJWKSValidator_BootFailsOnUnreachableJWKS(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	_, err := NewJWKSValidator(context.Background(), JWKSOptions{
+		Issuer:  "https://issuer.test",
+		JWKSURL: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected boot failure on unreachable/erroring JWKS endpoint")
+	}
+}
+
+func TestPresetProvider(t *testing.T) {
+	g, ok := PresetProvider("google")
+	if !ok {
+		t.Fatal("google preset missing")
+	}
+	if g.Issuer != "https://accounts.google.com" || g.JWKSURL == "" {
+		t.Errorf("google preset = %+v, want issuer+jwks set", g)
+	}
+	// Microsoft / Okta are tenant/org-specific: recognised, but no
+	// static issuer (discovery from operator-supplied -oauth-issuer).
+	ms, ok := PresetProvider("microsoft")
+	if !ok || ms.Issuer != "" || ms.JWKSURL != "" {
+		t.Errorf("microsoft preset = %+v, want recognised-but-discovery-only", ms)
+	}
+	if _, ok := PresetProvider("not-a-provider"); ok {
+		t.Error("unknown provider should not resolve")
+	}
+	if len(KnownProviders()) != 3 {
+		t.Errorf("KnownProviders() = %v, want 3", KnownProviders())
+	}
+}
+
+// sanity: the helper-built JWKS round-trips through the real parser.
+func TestParseJWK_RoundTrip(t *testing.T) {
+	rsaPriv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	ecPriv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	keys, err := func() (map[string]parsedJWK, error) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(jwksJSON(t,
+				rsaJWK("r", &rsaPriv.PublicKey),
+				ecJWK("e", &ecPriv.PublicKey),
+			))
+		}))
+		defer srv.Close()
+		return fetchJWKS(context.Background(), http.DefaultClient, srv.URL)
+	}()
+	if err != nil {
+		t.Fatalf("fetchJWKS: %v", err)
+	}
+	if k, ok := keys["r"]; !ok || k.rsa == nil || k.alg != "RS256" {
+		t.Errorf("rsa key not parsed: %+v", keys["r"])
+	}
+	if k, ok := keys["e"]; !ok || k.ec == nil || k.alg != "ES256" {
+		t.Errorf("ec key not parsed: %+v", keys["e"])
+	}
+}

--- a/server/go/internal/auth/oauth.go
+++ b/server/go/internal/auth/oauth.go
@@ -5,13 +5,17 @@ package auth
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/hmac"
+	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 	"sync"
 	"time"
@@ -27,26 +31,30 @@ import (
 //   - Verify signature, expiry, issuer, and audience.
 //   - Return an error wrapping codes.Unauthenticated on any failure.
 //
-// Today only the in-memory implementation below is shipped. Real JWKS
-// rotation, network discovery, and ES256 are tracked separately -- see
-// docs/go-port/shared/auth-interceptor.md "Open questions / risks"
-// items "JWKS rotation thundering herd" and "sub collisions across
-// providers".
+// Two implementations ship:
+//
+//   - MemoryOAuthValidator (this file) -- a static kid -> key map used by
+//     tests and the no-auth dev server. HS256 / RS256 / ES256.
+//   - JWKSValidator (jwks.go) -- production OIDC: real JWKS fetched over
+//     the network with caching and key rotation, OIDC discovery, and
+//     Google / Microsoft / Okta presets. RS256 / ES256.
+//
+// The algorithm-confusion guards (a JWKS RSA/EC key may never verify an
+// HS* token, and vice versa) are enforced by both.
 type OAuthValidator interface {
 	Validate(ctx context.Context, token string) (map[string]any, error)
 }
 
 // JWKKey is one entry in an in-memory JWKS used by the in-memory
-// validator. Exactly one of HS256Secret or RS256Public is populated; the
-// validator picks the algorithm based on the JWT header.
+// validator. Exactly one of HS256Secret / RS256Public / ES256Public is
+// populated; the validator picks the algorithm based on the JWT header.
 //
 // This is deliberately simpler than the JWK spec -- no kty, no crv, no
 // PEM parsing -- because the in-memory validator is only used by tests
 // and dev-mode servers. Production OAuth (real JWKS fetched over the
-// network) is Phase 2.
+// network) lives in jwks.go.
 type JWKKey struct {
-	// Alg is "HS256" or "RS256". ES256 is tracked separately for a
-	// follow-up.
+	// Alg is "HS256", "RS256", or "ES256".
 	Alg string
 	// HS256Secret is the shared secret for HS256 verification.
 	// Populated iff Alg == "HS256".
@@ -54,6 +62,9 @@ type JWKKey struct {
 	// RS256Public is the RSA public key for RS256 verification.
 	// Populated iff Alg == "RS256".
 	RS256Public *rsa.PublicKey
+	// ES256Public is the ECDSA P-256 public key for ES256
+	// verification. Populated iff Alg == "ES256".
+	ES256Public *ecdsa.PublicKey
 }
 
 // MemoryOAuthValidator is the in-memory OAuthValidator used by tests
@@ -61,9 +72,8 @@ type JWKKey struct {
 // and a static map of kid -> JWKKey. Concurrent reads are safe; writes
 // (AddKey) take a write lock.
 //
-// It supports HS256 and RS256. ES256 is deferred to Phase 2 with the
-// rest of the production OAuth surface -- see
-// docs/go-port/shared/auth-interceptor.md "Open questions / risks".
+// It supports HS256, RS256, and ES256. Production OIDC (network JWKS,
+// discovery, provider presets) lives in JWKSValidator (jwks.go).
 type MemoryOAuthValidator struct {
 	issuer   string
 	audience string
@@ -106,40 +116,17 @@ func (v *MemoryOAuthValidator) now() time.Time {
 // unsupported algorithm, unknown kid, bad signature, expired, wrong
 // issuer/audience) it returns an error that wraps
 // codes.Unauthenticated.
-//
-// Mirrors OAuthValidator.validate_token in
 func (v *MemoryOAuthValidator) Validate(_ context.Context, token string) (map[string]any, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return nil, unauthenticatedf("malformed JWT: expected 3 segments, got %d", len(parts))
-	}
-	headerB, err := decodeSegment(parts[0])
+	hdr, claims, signed, sigB, err := parseJWT(token)
 	if err != nil {
-		return nil, unauthenticatedf("malformed JWT header: %v", err)
-	}
-	payloadB, err := decodeSegment(parts[1])
-	if err != nil {
-		return nil, unauthenticatedf("malformed JWT payload: %v", err)
-	}
-	sigB, err := decodeSegment(parts[2])
-	if err != nil {
-		return nil, unauthenticatedf("malformed JWT signature: %v", err)
-	}
-
-	var hdr struct {
-		Alg string `json:"alg"`
-		Kid string `json:"kid"`
-		Typ string `json:"typ"`
-	}
-	if err := json.Unmarshal(headerB, &hdr); err != nil {
-		return nil, unauthenticatedf("malformed JWT header: %v", err)
+		return nil, err
 	}
 	if hdr.Kid == "" {
 		return nil, unauthenticatedf("JWT missing 'kid' header")
 	}
-	if hdr.Alg != "HS256" && hdr.Alg != "RS256" {
+	if hdr.Alg != "HS256" && hdr.Alg != "RS256" && hdr.Alg != "ES256" {
 		// Reject "none" explicitly along with everything else we
-		// don't understand. ES256 is deferred to Phase 2.
+		// don't understand.
 		return nil, unauthenticatedf("unsupported JWT algorithm: %q", hdr.Alg)
 	}
 
@@ -157,7 +144,6 @@ func (v *MemoryOAuthValidator) Validate(_ context.Context, token string) (map[st
 		return nil, unauthenticatedf("algorithm mismatch: token=%s, key=%s", hdr.Alg, key.Alg)
 	}
 
-	signed := []byte(parts[0] + "." + parts[1])
 	switch hdr.Alg {
 	case "HS256":
 		if !verifyHS256(key.HS256Secret, signed, sigB) {
@@ -170,37 +156,85 @@ func (v *MemoryOAuthValidator) Validate(_ context.Context, token string) (map[st
 		if err := verifyRS256(key.RS256Public, signed, sigB); err != nil {
 			return nil, unauthenticatedf("invalid JWT signature: %v", err)
 		}
+	case "ES256":
+		if key.ES256Public == nil {
+			return nil, unauthenticatedf("kid %q has no ES256 public key", hdr.Kid)
+		}
+		if err := verifyES256(key.ES256Public, signed, sigB); err != nil {
+			return nil, unauthenticatedf("invalid JWT signature: %v", err)
+		}
 	}
 
-	var claims map[string]any
-	if err := json.Unmarshal(payloadB, &claims); err != nil {
-		return nil, unauthenticatedf("malformed JWT claims: %v", err)
+	if err := verifyStandardClaims(claims, v.now(), v.issuer, v.audience); err != nil {
+		return nil, err
 	}
+	return claims, nil
+}
 
-	now := v.now()
+// jwtHeader is the decoded JOSE header. typ is parsed but unused -- some
+// IdPs omit it and the spec makes it optional.
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+	Typ string `json:"typ"`
+}
+
+// parseJWT splits a compact-serialisation JWT, base64url-decodes the
+// three segments, and unmarshals the header + claims. It performs NO
+// signature or claim verification -- callers do that. signed is the
+// exact bytes the signature covers (header.payload).
+func parseJWT(token string) (hdr jwtHeader, claims map[string]any, signed, sig []byte, err error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return hdr, nil, nil, nil, unauthenticatedf("malformed JWT: expected 3 segments, got %d", len(parts))
+	}
+	headerB, e := decodeSegment(parts[0])
+	if e != nil {
+		return hdr, nil, nil, nil, unauthenticatedf("malformed JWT header: %v", e)
+	}
+	payloadB, e := decodeSegment(parts[1])
+	if e != nil {
+		return hdr, nil, nil, nil, unauthenticatedf("malformed JWT payload: %v", e)
+	}
+	sigB, e := decodeSegment(parts[2])
+	if e != nil {
+		return hdr, nil, nil, nil, unauthenticatedf("malformed JWT signature: %v", e)
+	}
+	if e := json.Unmarshal(headerB, &hdr); e != nil {
+		return hdr, nil, nil, nil, unauthenticatedf("malformed JWT header: %v", e)
+	}
+	if e := json.Unmarshal(payloadB, &claims); e != nil {
+		return hdr, nil, nil, nil, unauthenticatedf("malformed JWT claims: %v", e)
+	}
+	return hdr, claims, []byte(parts[0] + "." + parts[1]), sigB, nil
+}
+
+// verifyStandardClaims enforces exp / nbf / iss / aud. Empty wantIssuer
+// or wantAudience skips that check (dev mode). now is the validator's
+// clock so tests can pin it.
+func verifyStandardClaims(claims map[string]any, now time.Time, wantIssuer, wantAudience string) error {
 	if exp, ok := numericClaim(claims, "exp"); ok {
 		if now.Unix() >= exp {
-			return nil, unauthenticatedf("token has expired")
+			return unauthenticatedf("token has expired")
 		}
 	}
 	if nbf, ok := numericClaim(claims, "nbf"); ok {
 		if now.Unix() < nbf {
-			return nil, unauthenticatedf("token not yet valid")
+			return unauthenticatedf("token not yet valid")
 		}
 	}
-	if v.issuer != "" {
+	if wantIssuer != "" {
 		iss, _ := claims["iss"].(string)
-		if iss != v.issuer {
-			return nil, unauthenticatedf("invalid issuer: got %q, want %q", iss, v.issuer)
+		if iss != wantIssuer {
+			return unauthenticatedf("invalid issuer: got %q, want %q", iss, wantIssuer)
 		}
 	}
-	if v.audience != "" {
-		if !audienceMatches(claims["aud"], v.audience) {
-			return nil, unauthenticatedf("invalid audience: want %q", v.audience)
+	if wantAudience != "" {
+		if !audienceMatches(claims["aud"], wantAudience) {
+			return unauthenticatedf("invalid audience: want %q", wantAudience)
 		}
 	}
-
-	return claims, nil
+	return nil
 }
 
 // audienceMatches accepts either a string aud or a list-of-strings aud,
@@ -263,6 +297,30 @@ func verifyRS256(pub *rsa.PublicKey, signed, sig []byte) error {
 	return nil
 }
 
+// verifyES256 verifies an ES256 (ECDSA on P-256 with SHA-256) signature.
+//
+// The JWS ES256 signature is the fixed-width R || S concatenation (RFC
+// 7518 sec 3.4), each 32 bytes for P-256 -- NOT the ASN.1 DER form that
+// ecdsa.VerifyASN1 expects. We split it and verify with ecdsa.Verify.
+// A signature of the wrong length is rejected outright; this also slams
+// the door on the curve-confusion family of attacks.
+func verifyES256(pub *ecdsa.PublicKey, signed, sig []byte) error {
+	if pub.Curve != elliptic.P256() {
+		return errors.New("ES256 key is not on the P-256 curve")
+	}
+	const keyBytes = 32 // P-256 field size
+	if len(sig) != 2*keyBytes {
+		return fmt.Errorf("ES256 signature is %d bytes, want %d (R||S)", len(sig), 2*keyBytes)
+	}
+	r := new(big.Int).SetBytes(sig[:keyBytes])
+	s := new(big.Int).SetBytes(sig[keyBytes:])
+	h := sha256.Sum256(signed)
+	if !ecdsa.Verify(pub, h[:], r, s) {
+		return errors.New("ecdsa verify failed")
+	}
+	return nil
+}
+
 // SignHS256ForTest is a tiny helper that produces a compact-serialisation
 // HS256 JWT given the raw header and claims. It exists so the package's
 // own unit tests can mint tokens without pulling in a third-party JWT
@@ -309,5 +367,33 @@ func SignRS256ForTest(priv *rsa.PrivateKey, kid string, claims map[string]any) (
 	if err != nil {
 		return "", fmt.Errorf("sign rs256: %w", err)
 	}
+	return signed + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// SignES256ForTest mints an ES256 JWT (ECDSA P-256, SHA-256) with the
+// JWS-mandated fixed-width R||S signature. Tests / dev only -- production
+// code MUST NOT call it.
+func SignES256ForTest(priv *ecdsa.PrivateKey, kid string, claims map[string]any) (string, error) {
+	hdr := map[string]any{"alg": "ES256", "kid": kid, "typ": "JWT"}
+	hdrB, err := json.Marshal(hdr)
+	if err != nil {
+		return "", fmt.Errorf("marshal header: %w", err)
+	}
+	payloadB, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal claims: %w", err)
+	}
+	encHdr := base64.RawURLEncoding.EncodeToString(hdrB)
+	encPayload := base64.RawURLEncoding.EncodeToString(payloadB)
+	signed := encHdr + "." + encPayload
+	h := sha256.Sum256([]byte(signed))
+	r, s, err := ecdsa.Sign(cryptorand.Reader, priv, h[:])
+	if err != nil {
+		return "", fmt.Errorf("sign es256: %w", err)
+	}
+	const keyBytes = 32
+	sig := make([]byte, 2*keyBytes)
+	r.FillBytes(sig[:keyBytes])
+	s.FillBytes(sig[keyBytes:])
 	return signed + "." + base64.RawURLEncoding.EncodeToString(sig), nil
 }

--- a/server/go/internal/auth/oauth_test.go
+++ b/server/go/internal/auth/oauth_test.go
@@ -4,6 +4,8 @@ package auth
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
@@ -60,6 +62,68 @@ func TestMemoryOAuthValidator_RS256_Valid(t *testing.T) {
 	}
 	if claims["sub"] != "bob" {
 		t.Errorf("sub = %v, want bob", claims["sub"])
+	}
+}
+
+func TestMemoryOAuthValidator_ES256_Valid(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	v := NewMemoryOAuthValidator("https://issuer.test", "entdb-test")
+	v.AddKey("kid-ec", JWKKey{Alg: "ES256", ES256Public: &priv.PublicKey})
+
+	tok, err := SignES256ForTest(priv, "kid-ec", map[string]any{
+		"sub": "carol",
+		"iss": "https://issuer.test",
+		"aud": "entdb-test",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	claims, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims["sub"] != "carol" {
+		t.Errorf("sub = %v, want carol", claims["sub"])
+	}
+}
+
+func TestMemoryOAuthValidator_ES256_RejectsTamperedSig(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	other, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	v := NewMemoryOAuthValidator("iss", "aud")
+	// Register the wrong public key so a correctly-formed ES256 sig
+	// fails verification.
+	v.AddKey("k", JWKKey{Alg: "ES256", ES256Public: &other.PublicKey})
+	tok, _ := SignES256ForTest(priv, "k", map[string]any{
+		"sub": "carol",
+		"iss": "iss",
+		"aud": "aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	_, err := v.Validate(context.Background(), tok)
+	if err == nil || errs.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected UNAUTHENTICATED, got err=%v code=%v", err, errs.Code(err))
+	}
+}
+
+func TestMemoryOAuthValidator_ES256_RejectsAlgConfusion(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	v := NewMemoryOAuthValidator("iss", "aud")
+	// Key registered as ES256; token claims HS256 -> reject before any
+	// signature math.
+	v.AddKey("k", JWKKey{Alg: "ES256", ES256Public: &priv.PublicKey})
+	tok, _ := SignHS256ForTest([]byte("anything"), "k", map[string]any{
+		"sub": "carol",
+		"iss": "iss",
+		"aud": "aud",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.Validate(context.Background(), tok); err == nil {
+		t.Fatal("expected algorithm-confusion rejection (ES256 key, HS256 token)")
 	}
 }
 


### PR DESCRIPTION
## Problem

`MemoryOAuthValidator` ships HS256/RS256 with the algorithm-confusion
guards, but issue #86's core asks were explicitly deferred: there is no
production OAuth path. Specifically — no network JWKS fetch, no key
rotation, no OIDC discovery, no ES256, no provider presets, and the
auth interceptor is **not wired into `cmd/entdb-server`** (only the
mTLS peer interceptor is, and there are no `-oauth-*` flags). A
production deployment had no way to turn on real OIDC token validation.

## Fix

**`server/go/internal/auth/jwks.go` — new `JWKSValidator`:**

- Fetches a JWKS document over HTTP, parses RSA + EC (P-256) signing
  keys, indexes by `kid`.
- In-process cache; lazy refresh on a **kid miss** (picks up rotated
  signing keys) and an optional TTL-based `MaybeRefresh`.
- Refreshes coalesced through a single-flight latch keyed per validator
  — a burst of requests on an unknown kid triggers exactly **one**
  network fetch (the "thundering herd" risk from the auth-interceptor
  spec), implemented without adding `golang.org/x/sync`.
- **OIDC discovery**: when no explicit JWKS URL is given, fetches
  `<issuer>/.well-known/openid-configuration`, resolves `jwks_uri`, and
  rejects a discovery document whose `issuer` doesn't match the
  configured one (issuer-substitution guard).
- **Fail-closed boot**: warms the cache during construction, so a bad
  issuer/JWKS URL fails at startup, not silently on every request.
- **Provider presets**: `google` (static issuer + JWKS URL);
  `microsoft` / `okta` are recognised but tenant/org-specific, so they
  require an explicit `-oauth-issuer` and resolve via discovery.
- Algorithm-confusion guards preserved/extended: HS256 is rejected
  outright at the JWKS path (symmetric token at an asymmetric
  endpoint), the JWKS entry pins each kid's algorithm, and `alg=none`
  is rejected.

**`server/go/internal/auth/oauth.go` — ES256 added:**

- ES256 (ECDSA P-256, SHA-256) verification with JWS fixed-width
  `R||S` signature handling and a P-256 curve check, available to both
  `MemoryOAuthValidator` (new `JWKKey.ES256Public`) and the JWKS
  validator. Shared JWT parsing + standard-claims (`exp`/`nbf`/`iss`/
  `aud`) helpers extracted so both validators stay in lockstep.

**`server/go/cmd/entdb-server/` — flag wiring:**

- New flags: `-oauth-provider`, `-oauth-issuer`, `-jwks-url`,
  `-oauth-audience`. The auth interceptor installs whenever any
  `-oauth-*` flag is set, independent of TLS (it reads gRPC metadata).
- `buildOAuthValidator` resolves provider preset → explicit flags →
  discovery, with clear boot errors. API-key/session managers stay
  `nil` here (in-memory dev managers + their flags are tracked under
  siblings #87/#88; this PR touches only OAuth/OIDC code, not
  `apikey.go`/`session.go`).
- No-flag path is unchanged: existing dev/test boots and the
  cross-impl harness are unaffected (verified — see Testing).

## Testing

Full local CI, all green:

```
cd server/go && go vet ./... && go test ./...     # all packages ok
go test -race ./internal/auth/ ./cmd/entdb-server/ # race-clean
cd sdk/go/entdb && go vet ./... && go test ./...   # all ok
python -m pytest tests/python/integration/ -q      # 95 passed
bash tests/python/e2e/run-e2e.sh                   # 22 passed (e2e-tests-1 exit 0)
uvx ruff@0.15.7 check .                             # All checks passed!
uvx ruff@0.15.7 format --check .                    # 55 files already formatted
```

New tests cover: JWKS RS256/ES256 verify, cache-hit across 20
requests, key-rotation refetch on kid miss, single-flight coalescing
under 16-goroutine concurrency, `alg=none` + HS256-at-JWKS rejection,
expiry/issuer/audience enforcement, OIDC discovery + issuer-mismatch
rejection, fail-closed boot, provider presets, and ES256 +
alg-confusion cases for `MemoryOAuthValidator`. The Python integration
contract suite (boots the Go server) passing confirms the no-flag
default path is behaviourally unchanged. The e2e run reported
`22 passed ... e2e-tests-1 exited with code 0`; the script's non-zero
overall exit was a Docker Desktop teardown/cleanup flake (SIGKILL
during container removal), not a test failure, and is unrelated to
this change.

## Deferred / caveats

- **Microsoft/Okta static presets**: not shipped as zero-config presets
  because their issuers are tenant/org-specific. They are recognised by
  `-oauth-provider` but require `-oauth-issuer`; JWKS resolves via OIDC
  discovery. A static Google preset is included.
- **Multi-IdP `sub` namespacing** (`user:<iss>#<sub>`): out of scope —
  it changes every persisted WAL actor (breaking change), flagged in
  the auth-interceptor spec for a later decision. Single-issuer per
  server today.
- **`MaybeRefresh` background ticker**: the method exists for an
  optional operator-wired refresh loop but is intentionally left
  un-wired; correctness is covered by the kid-miss refresh.
- API-key/session production stores and their flags are out of scope
  (siblings #87/#88).

This advances Epic #85 (production-auth) but does not close it.

Closes #86