### PR TITLE
audit: archive-lag metrics + WAL->S3 Object Lock e2e (part of #511)

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -18,6 +19,7 @@ import (
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
@@ -36,6 +38,7 @@ import (
 
 func main() {
 	addr := flag.String("addr", ":50051", "gRPC bind address (host:port)")
+	metricsAddr := flag.String("metrics-addr", "", "Prometheus scrape bind address (host:port); empty disables the /metrics endpoint")
 	dataDir := flag.String("data-dir", "", "directory for per-tenant SQLite + global.db")
 	tlsCert := flag.String("tls-cert", "", "server TLS certificate PEM file")
 	tlsKey := flag.String("tls-key", "", "server TLS private key PEM file")
@@ -62,6 +65,7 @@ func main() {
 	archiveGroup := flag.String("archive-group", "entdb-wal-archive", "WAL consumer group id for the archive sidecar")
 	archiveRetentionDays := flag.Int("archive-retention-days", 2557, "S3 Object Lock COMPLIANCE retention window in days")
 	archiveKMSKeyID := flag.String("archive-kms-key-id", "", "optional AWS KMS key id for archive object SSE-KMS")
+	archiveS3PathStyle := flag.Bool("archive-s3-path-style", false, "use S3 path-style addressing for the archive bucket (required for MinIO and other non-AWS S3 endpoints)")
 	archiveBatchSize := flag.Int("archive-batch-size", 128, "maximum WAL records per archive poll")
 	archiveBatchBytes := flag.Int("archive-batch-bytes", 10<<20, "approximate maximum uncompressed bytes per archive object")
 	archivePollTimeout := flag.Duration("archive-poll-timeout", time.Second, "how long the archive sidecar polls for WAL records")
@@ -217,8 +221,13 @@ func main() {
 		if err != nil {
 			log.Fatalf("entdb-server: load AWS config for archive: %v", err)
 		}
+		s3Client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+			if *archiveS3PathStyle {
+				o.UsePathStyle = true
+			}
+		})
 		archiveStore := audit.NewS3ObjectLockStore(
-			s3.NewFromConfig(awsCfg),
+			s3Client,
 			strings.TrimSpace(*archiveBucket),
 			strings.TrimSpace(*archiveKMSKeyID),
 		)
@@ -336,6 +345,31 @@ func main() {
 		log.Fatalf("entdb-server: listen %s: %v", *addr, err)
 	}
 
+	// Prometheus scrape endpoint. Off by default; production / e2e set
+	// --metrics-addr so dashboards and alert rules (entdb_archive_lag_events,
+	// entdb_grpc_*) have a target. Served on a plain HTTP listener
+	// separate from the gRPC port — scrape traffic is in-cluster.
+	var metricsSrv *http.Server
+	if strings.TrimSpace(*metricsAddr) != "" {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		metricsSrv = &http.Server{
+			Addr:              strings.TrimSpace(*metricsAddr),
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		metricsLis, err := net.Listen("tcp", metricsSrv.Addr)
+		if err != nil {
+			log.Fatalf("entdb-server: metrics listen %s: %v", metricsSrv.Addr, err)
+		}
+		go func() {
+			if err := metricsSrv.Serve(metricsLis); err != nil && err != http.ErrServerClosed {
+				log.Printf("entdb-server: metrics endpoint exited: %v", err)
+			}
+		}()
+		log.Printf("entdb-server: Prometheus metrics on %s/metrics", metricsSrv.Addr)
+	}
+
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 	if tlsReloader != nil {
@@ -362,6 +396,11 @@ func main() {
 		log.Printf("entdb-server: shutting down")
 		applier.Stop()
 		cancel()
+		if metricsSrv != nil {
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = metricsSrv.Shutdown(shutdownCtx)
+			shutdownCancel()
+		}
 		srv.GracefulStop()
 	}()
 

--- a/server/go/internal/audit/archiver.go
+++ b/server/go/internal/audit/archiver.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
 
@@ -154,6 +155,7 @@ func (a *Archiver) Run(ctx context.Context) error {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return err
 			}
+			metrics.IncArchiveErrors()
 			slog.WarnContext(ctx, "audit: archive retrying", "error", err)
 			if err := sleepContext(ctx, a.retryBackoff); err != nil {
 				return err
@@ -176,7 +178,34 @@ func (a *Archiver) RunOnce(ctx context.Context) (int, error) {
 	return a.archiveAndCommit(ctx, records)
 }
 
+// partitionKey identifies a WAL partition for the lag gauge.
+type partitionKey struct {
+	topic     string
+	partition int32
+}
+
+func (a *Archiver) partitionKeyFor(rec wal.Record) partitionKey {
+	topic := rec.Position.Topic
+	if topic == "" {
+		topic = a.topic
+	}
+	return partitionKey{topic: topic, partition: rec.Position.Partition}
+}
+
+// archiveAndCommit archives the polled records and publishes per-partition
+// lag. Lag = records polled from a partition but not yet durably written
+// to S3 Object Lock + committed. A successful round-trip drives lag to 0
+// for that partition; a put/commit failure leaves the unarchived tail as
+// lag, which is the operator alert signal in ADR-015.
 func (a *Archiver) archiveAndCommit(ctx context.Context, records []wal.Record) (int, error) {
+	pending := map[partitionKey]int{}
+	for _, rec := range records {
+		pending[a.partitionKeyFor(rec)]++
+	}
+	for pk, n := range pending {
+		metrics.SetArchiveLag(pk.topic, strconv.FormatInt(int64(pk.partition), 10), float64(n))
+	}
+
 	total := 0
 	for _, batch := range a.archiveBatches(records) {
 		obj, err := a.buildObject(ctx, batch)
@@ -190,9 +219,13 @@ func (a *Archiver) archiveAndCommit(ctx context.Context, records []wal.Record) (
 			if err := a.consumer.Commit(ctx, a.groupID, rec); err != nil {
 				return total, fmt.Errorf("audit: commit archive offset: %w", err)
 			}
+			pk := a.partitionKeyFor(rec)
+			pending[pk]--
+			metrics.SetArchiveLag(pk.topic, strconv.FormatInt(int64(pk.partition), 10), float64(pending[pk]))
 			total++
 		}
 	}
+	metrics.AddArchiveWrites(total)
 	return total, nil
 }
 

--- a/server/go/internal/audit/archiver_test.go
+++ b/server/go/internal/audit/archiver_test.go
@@ -11,9 +11,14 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
 
@@ -123,6 +128,100 @@ func TestRunOnceDoesNotCommitWhenArchiveWriteFails(t *testing.T) {
 	if len(consumer.commits) != 0 {
 		t.Fatalf("commits=%d, want 0", len(consumer.commits))
 	}
+}
+
+func TestArchiveLagMetricDrainsOnSuccessAndStaysOnFailure(t *testing.T) {
+	ctx := context.Background()
+
+	// Success path: a polled record archives + commits, so the
+	// per-partition lag gauge returns to 0.
+	okConsumer := &fakeArchiveConsumer{
+		records: []wal.Record{archiveTestRecord(t, "tenant-1", "idem-ok", 3, 11)},
+	}
+	okArchiver, err := NewArchiver(Options{
+		Consumer: okConsumer,
+		Store:    &fakeObjectLockStore{},
+		Topic:    "entdb-wal",
+		GroupID:  "archive",
+	})
+	if err != nil {
+		t.Fatalf("NewArchiver: %v", err)
+	}
+	if _, err := okArchiver.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce (ok): %v", err)
+	}
+	if got := archiveLagValue(t, "entdb-wal", "3"); got != 0 {
+		t.Fatalf("archive lag after success = %v, want 0", got)
+	}
+	if n := metricCounter(t, "entdb_archive_writes_total"); n < 1 {
+		t.Fatalf("entdb_archive_writes_total = %v, want >= 1", n)
+	}
+
+	// Failure path: S3 unavailable. The record is polled but never
+	// committed, so the lag gauge stays elevated for that partition —
+	// this is the operator alert signal in ADR-015.
+	failConsumer := &fakeArchiveConsumer{
+		records: []wal.Record{archiveTestRecord(t, "tenant-1", "idem-fail", 4, 99)},
+	}
+	failArchiver, err := NewArchiver(Options{
+		Consumer: failConsumer,
+		Store:    &fakeObjectLockStore{putErr: errors.New("s3 unavailable")},
+		Topic:    "entdb-wal",
+		GroupID:  "archive",
+	})
+	if err != nil {
+		t.Fatalf("NewArchiver: %v", err)
+	}
+	if _, err := failArchiver.RunOnce(ctx); err == nil {
+		t.Fatal("RunOnce (fail) error = nil, want put failure")
+	}
+	if got := archiveLagValue(t, "entdb-wal", "4"); got != 1 {
+		t.Fatalf("archive lag after S3 failure = %v, want 1", got)
+	}
+}
+
+func archiveLagValue(t *testing.T, topic, partition string) float64 {
+	t.Helper()
+	for _, c := range metrics.ArchiveCollectors() {
+		gv, ok := c.(*prometheus.GaugeVec)
+		if !ok {
+			continue
+		}
+		g, err := gv.GetMetricWithLabelValues(topic, partition)
+		if err != nil {
+			t.Fatalf("GetMetricWithLabelValues(%q,%q): %v", topic, partition, err)
+		}
+		return testutil.ToFloat64(g)
+	}
+	t.Fatalf("entdb_archive_lag_events gauge not found in ArchiveCollectors")
+	return 0
+}
+
+func metricCounter(t *testing.T, name string) float64 {
+	t.Helper()
+	for _, c := range metrics.ArchiveCollectors() {
+		ctr, ok := c.(prometheus.Counter)
+		if !ok {
+			continue
+		}
+		if containsName(ctr, name) {
+			return testutil.ToFloat64(ctr)
+		}
+	}
+	t.Fatalf("counter %q not found in ArchiveCollectors", name)
+	return 0
+}
+
+func containsName(c prometheus.Collector, name string) bool {
+	ch := make(chan *prometheus.Desc, 4)
+	c.Describe(ch)
+	close(ch)
+	for d := range ch {
+		if d != nil && strings.Contains(d.String(), name) {
+			return true
+		}
+	}
+	return false
 }
 
 func archiveTestRecord(t *testing.T, tenantID, idem string, partition int32, offset int64) wal.Record {

--- a/server/go/internal/metrics/archive.go
+++ b/server/go/internal/metrics/archive.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Archive metrics expose the health of the S3 Object Lock WAL archive
+// sidecar (ADR-015). The lag gauge is the primary alerting signal:
+// operators alarm on it climbing because a stalled archiver means
+// events live only in Kafka/Redpanda, outside tamper-evident storage.
+//
+// Metric names and label sets are deliberately stable so dashboards
+// and alert rules survive across releases:
+//
+//	entdb_archive_lag_events{topic,partition}     Gauge
+//	entdb_archive_writes_total                    Counter
+//	entdb_archive_errors_total                    Counter
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	archiveLag = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "entdb_archive_lag_events",
+			Help: "WAL records polled by the archive sidecar but not yet written to S3 Object Lock storage, per partition",
+		},
+		[]string{"topic", "partition"},
+	)
+
+	archiveWrites = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "entdb_archive_writes_total",
+			Help: "Total WAL records written to S3 Object Lock archive objects and committed",
+		},
+	)
+
+	archiveErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "entdb_archive_errors_total",
+			Help: "Total archive poll/build/put/commit failures observed by the archive sidecar",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(archiveLag, archiveWrites, archiveErrors)
+}
+
+// SetArchiveLag publishes the current archive lag (records polled but
+// not yet durably archived) for a (topic, partition). Called by the
+// archive sidecar after each poll/commit cycle.
+func SetArchiveLag(topic, partition string, lag float64) {
+	archiveLag.WithLabelValues(topic, partition).Set(lag)
+}
+
+// AddArchiveWrites records that n WAL records were archived and committed.
+func AddArchiveWrites(n int) {
+	if n > 0 {
+		archiveWrites.Add(float64(n))
+	}
+}
+
+// IncArchiveErrors records one archive poll/build/put/commit failure.
+func IncArchiveErrors() {
+	archiveErrors.Inc()
+}
+
+// ArchiveCollectors returns the archive collectors so tests can register
+// them against a fresh prometheus.Registry without touching the default.
+func ArchiveCollectors() []prometheus.Collector {
+	return []prometheus.Collector{archiveLag, archiveWrites, archiveErrors}
+}

--- a/tests/python/e2e/Dockerfile.archive
+++ b/tests/python/e2e/Dockerfile.archive
@@ -1,0 +1,40 @@
+# EntDB Archive E2E Test Runner
+#
+# Drives the live Go gRPC server via the Python SDK, then probes MinIO
+# (boto3) and the Prometheus /metrics endpoint to assert the
+# WAL -> S3 Object Lock archive round-trip (EPIC #511 / ADR-015).
+#
+# Separate from Dockerfile.e2e: this image adds boto3 + requests for the
+# S3 and metrics probes and only runs test_archive_*.py.
+
+FROM python:3.11-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir \
+        "grpcio>=1.60.0" \
+        "grpcio-tools>=1.60.0" \
+        "protobuf>=6.31.0" \
+        "pytest>=7.4,<9" \
+        "pytest-asyncio>=0.23,<0.25" \
+        "pytest-timeout>=2.1" \
+        "boto3>=1.34" \
+        "requests>=2.31"
+
+COPY sdk/python/entdb_sdk/ /app/entdb_sdk/
+COPY tests/python/e2e/ /app/tests/python/e2e/
+
+ENV PYTHONPATH="/app:/app/tests/python/e2e"
+
+# Only the archive round-trip test in this stack — the node/edge suite
+# runs in the main e2e stack.
+CMD ["pytest", \
+     "-v", \
+     "--tb=short", \
+     "-p", "no:cacheprovider", \
+     "-o", "asyncio_mode=auto", \
+     "--timeout=180", \
+     "/app/tests/python/e2e/test_archive_object_lock.py"]

--- a/tests/python/e2e/docker-compose.archive.yml
+++ b/tests/python/e2e/docker-compose.archive.yml
@@ -1,0 +1,142 @@
+# =============================================================================
+# EntDB Archive E2E Environment — WAL -> S3 Object Lock round-trip
+# =============================================================================
+#
+# Dedicated, opt-in stack for EPIC #511's S3 Object Lock archive
+# (ADR-015). Kept separate from docker-compose.e2e.yml so the fast
+# 22-case suite stays free of the MinIO + archive-sidecar cost; this
+# stack is the only one that boots an Object-Lock bucket.
+#
+# Topology:
+#   - redpanda     : Kafka-compatible WAL backend (same image/flags as
+#                     the main e2e stack so broker behaviour matches).
+#   - minio        : S3-compatible store. Object Lock requires the
+#                     bucket to be created WITH versioning+lock at
+#                     creation time, done by the minio-init sidecar.
+#   - minio-init   : one-shot `mc` job that creates the bucket with
+#                     Object Lock and a COMPLIANCE default retention.
+#   - server       : entdb-server with -archive-enabled pointed at
+#                     MinIO (path-style, env-provided AWS creds) and
+#                     -metrics-addr so the test can scrape the
+#                     entdb_archive_lag_events gauge.
+#   - archive-tests: pytest runner driving the SDK + an S3/HTTP probe.
+#
+# Usage:
+#   tests/python/e2e/run-archive-e2e.sh
+#
+# =============================================================================
+
+services:
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v23.3.5
+    command:
+      - redpanda
+      - start
+      - --smp=1
+      - --memory=512M
+      - --reserve-memory=0M
+      - --overprovisioned
+      - --node-id=0
+      - --kafka-addr=PLAINTEXT://0.0.0.0:9092
+      - --advertise-kafka-addr=PLAINTEXT://redpanda:9092
+    healthcheck:
+      test: ["CMD", "rpk", "cluster", "health"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
+
+  minio:
+    image: quay.io/minio/minio:RELEASE.2024-09-22T00-33-43Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: entdb
+      MINIO_ROOT_PASSWORD: entdb-secret
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
+
+  # One-shot: create the archive bucket WITH Object Lock enabled and a
+  # COMPLIANCE default-retention rule. Object Lock can only be turned on
+  # at bucket-creation time, so this MUST run before the server boots
+  # (the archiver verifies GetObjectLockConfiguration at startup and
+  # refuses to run otherwise — ADR-015 defense in depth).
+  minio-init:
+    image: quay.io/minio/minio:RELEASE.2024-09-22T00-33-43Z
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        until mc alias set m http://minio:9000 entdb entdb-secret; do
+          echo "waiting for minio..."; sleep 2;
+        done
+        mc mb --with-lock --ignore-existing m/entdb-wal-archive
+        mc retention set --default COMPLIANCE 1d m/entdb-wal-archive
+        echo "minio-init: bucket entdb-wal-archive ready with Object Lock COMPLIANCE"
+    depends_on:
+      minio:
+        condition: service_healthy
+
+  server:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+      target: server
+    image: entdb-server-go:test
+    environment:
+      AWS_ACCESS_KEY_ID: entdb
+      AWS_SECRET_ACCESS_KEY: entdb-secret
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT_URL_S3: http://minio:9000
+    command:
+      - "-addr=:50051"
+      - "-metrics-addr=:9090"
+      - "-data-dir=/var/lib/entdb"
+      - "-wal-backend=kafka"
+      - "-wal-brokers=redpanda:9092"
+      - "-wal-topic=entdb-wal-archive-e2e"
+      - "-wal-group=entdb-applier-archive-e2e"
+      - "-seed-profile=e2e"
+      - "-seed-tenant=e2e-test"
+      - "-archive-enabled=true"
+      - "-archive-bucket=entdb-wal-archive"
+      - "-archive-region=us-east-1"
+      - "-archive-group=entdb-wal-archive-sidecar"
+      - "-archive-retention-days=1"
+      - "-archive-batch-size=8"
+      - "-archive-batch-bytes=65536"
+      - "-archive-poll-timeout=1s"
+      - "-archive-retry-backoff=2s"
+      - "-archive-s3-path-style=true"
+    depends_on:
+      redpanda:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+
+  archive-tests:
+    build:
+      context: ../../..
+      dockerfile: tests/python/e2e/Dockerfile.archive
+    environment:
+      - ENTDB_HOST=server
+      - ENTDB_PORT=50051
+      - ENTDB_METRICS_URL=http://server:9090/metrics
+      - ENTDB_TENANT=e2e-test
+      - ENTDB_SERVER_TARGET=go
+      - ENTDB_S3_ENDPOINT=http://minio:9000
+      - ENTDB_S3_BUCKET=entdb-wal-archive
+      - AWS_ACCESS_KEY_ID=entdb
+      - AWS_SECRET_ACCESS_KEY=entdb-secret
+      - AWS_DEFAULT_REGION=us-east-1
+      - COMPOSE_PROJECT_NAME=e2e-archive
+    depends_on:
+      - server
+
+networks:
+  default:
+    name: entdb-e2e-archive-network

--- a/tests/python/e2e/run-archive-e2e.sh
+++ b/tests/python/e2e/run-archive-e2e.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# =============================================================================
+# EntDB Archive E2E Runner — WAL -> S3 Object Lock round-trip (EPIC #511)
+# =============================================================================
+#
+# Boots Redpanda + MinIO (Object-Lock COMPLIANCE bucket) + entdb-server
+# with -archive-enabled, then runs test_archive_object_lock.py which
+# drives the SDK and probes S3 + the Prometheus /metrics endpoint.
+#
+# Kept separate from run-e2e.sh so the fast 22-case suite doesn't pay
+# the MinIO + archive-sidecar startup cost.
+#
+# Usage:
+#   ./tests/python/e2e/run-archive-e2e.sh [--no-cache] [--keep] [--logs]
+#
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.archive.yml"
+export COMPOSE_PROJECT_NAME="e2e-archive"
+
+NO_CACHE=""
+KEEP_RUNNING=false
+SHOW_LOGS=false
+
+for arg in "$@"; do
+    case $arg in
+        --no-cache) NO_CACHE="--no-cache" ;;
+        --keep) KEEP_RUNNING=true ;;
+        --logs) SHOW_LOGS=true ;;
+    esac
+done
+
+echo "=============================================="
+echo "EntDB Archive E2E (WAL -> S3 Object Lock)"
+echo "=============================================="
+echo ""
+
+cd "$PROJECT_ROOT"
+
+echo "[1/4] Resetting existing archive-e2e containers..."
+docker compose -f "$COMPOSE_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
+
+echo ""
+echo "[2/4] Building containers..."
+docker compose -f "$COMPOSE_FILE" build $NO_CACHE
+
+echo ""
+echo "[3/4] Starting infrastructure (redpanda + minio + object-lock bucket + server)..."
+docker compose -f "$COMPOSE_FILE" up -d --wait redpanda minio
+docker compose -f "$COMPOSE_FILE" up --no-log-prefix minio-init
+docker compose -f "$COMPOSE_FILE" up -d server
+echo "Waiting briefly for the Go server to bind its listener..."
+sleep 5
+
+echo ""
+echo "[4/4] Running archive e2e tests..."
+set +e
+docker compose -f "$COMPOSE_FILE" up --exit-code-from archive-tests archive-tests
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -ne 0 ] && [ "$SHOW_LOGS" = true ]; then
+    echo ""
+    echo "[!] Tests failed. Showing server logs..."
+    docker compose -f "$COMPOSE_FILE" logs server
+    echo ""
+    echo "[!] minio-init logs..."
+    docker compose -f "$COMPOSE_FILE" logs minio-init
+fi
+
+if [ "$KEEP_RUNNING" = false ]; then
+    echo ""
+    echo "[cleanup] Cleaning up..."
+    docker compose -f "$COMPOSE_FILE" down -v
+else
+    echo ""
+    echo "[cleanup] Keeping containers running (docker compose -f $COMPOSE_FILE down -v to clean up)"
+fi
+
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "=============================================="
+    echo "Archive E2E PASSED"
+    echo "=============================================="
+else
+    echo "=============================================="
+    echo "Archive E2E FAILED (exit code: $EXIT_CODE)"
+    echo "=============================================="
+fi
+
+exit $EXIT_CODE

--- a/tests/python/e2e/test_archive_object_lock.py
+++ b/tests/python/e2e/test_archive_object_lock.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""
+EntDB Archive E2E — WAL -> S3 Object Lock round-trip (EPIC #511, ADR-015).
+
+Runs only in the dedicated archive stack (docker-compose.archive.yml):
+Redpanda + MinIO (Object-Lock COMPLIANCE bucket) + entdb-server with
+``-archive-enabled`` and a Prometheus ``/metrics`` endpoint.
+
+What this asserts (success criteria 1, 2, 5 from issue #511):
+
+1. Writing nodes through the SDK lands events on the Kafka WAL.
+2. The archive sidecar continuously copies those events into S3 with
+   ``ObjectLockMode=COMPLIANCE`` and a retain-until date.
+3. The archived object is gzip JSONL and round-trips back to the
+   events we wrote (tenant id is present in the decoded payload).
+4. The ``entdb_archive_lag_events`` Prometheus gauge is exported and
+   drains back to 0 once the archiver has caught up — the operator
+   alert signal named in ADR-015's failure-modes section.
+
+Legal-hold-on-existing-objects (criterion 4) and ops docs remain open
+checklist items on #511 and are deliberately not covered here.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import os
+import time
+
+import pytest
+
+# This module only runs inside the dedicated archive stack
+# (docker-compose.archive.yml / Dockerfile.archive). The fast 22-case
+# e2e image does NOT install boto3/requests and has no MinIO, so skip
+# the whole module cleanly when it's collected by the main suite.
+boto3 = pytest.importorskip("boto3", reason="archive e2e stack only (needs boto3)")
+requests = pytest.importorskip("requests", reason="archive e2e stack only (needs requests)")
+if not os.environ.get("ENTDB_S3_ENDPOINT"):
+    pytest.skip(
+        "archive e2e stack only — set ENTDB_S3_ENDPOINT (see "
+        "docker-compose.archive.yml / run-archive-e2e.sh)",
+        allow_module_level=True,
+    )
+
+import e2e_schema_pb2 as pb  # noqa: E402
+from botocore.config import Config  # noqa: E402
+
+S3_ENDPOINT = os.environ.get("ENTDB_S3_ENDPOINT", "http://minio:9000")
+S3_BUCKET = os.environ.get("ENTDB_S3_BUCKET", "entdb-wal-archive")
+METRICS_URL = os.environ.get("ENTDB_METRICS_URL", "http://server:9090/metrics")
+TENANT = os.environ.get("ENTDB_TENANT", "e2e-test")
+
+
+@pytest.fixture(scope="module")
+def s3():
+    return boto3.client(
+        "s3",
+        endpoint_url=S3_ENDPOINT,
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "entdb"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "entdb-secret"),
+        region_name=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+        config=Config(s3={"addressing_style": "path"}, signature_version="s3v4"),
+    )
+
+
+def _list_archive_objects(s3) -> list[dict]:
+    out: list[dict] = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=S3_BUCKET, Prefix="wal/"):
+        out.extend(page.get("Contents", []) or [])
+    return out
+
+
+def _scrape_metric_lines(name: str) -> list[str]:
+    resp = requests.get(METRICS_URL, timeout=10)
+    resp.raise_for_status()
+    return [
+        line
+        for line in resp.text.splitlines()
+        if line.startswith(name + "{") or line.startswith(name + " ")
+    ]
+
+
+async def test_wal_archives_to_s3_object_lock_compliance(s3, scope) -> None:
+    """End-to-end: SDK write -> Kafka WAL -> S3 Object Lock archive."""
+    # 1. Write a batch of nodes. Each commit is one WAL event; the
+    #    archive batch size is small (8) so the sidecar flushes quickly.
+    written_emails = set()
+    for i in range(12):
+        plan = scope.plan()
+        email = f"archive-{i}-{time.time_ns()}@example.com"
+        plan.create(pb.User(email=email, name=f"Archive User {i}"))
+        result = await plan.commit(wait_applied=True)
+        assert result.success, f"commit {i} failed: {result.error}"
+        written_emails.add(email)
+
+    # 2. Poll S3 until the archiver has flushed at least one object.
+    #    Retention is short (1 day) in the test bucket; the archiver
+    #    polls every ~1s and the batch interval is small.
+    deadline = time.time() + 90
+    objects: list[dict] = []
+    while time.time() < deadline:
+        objects = _list_archive_objects(s3)
+        if objects:
+            break
+        time.sleep(2)
+    assert objects, (
+        "no archive objects under wal/ after 90s — archiver did not flush WAL events to S3"
+    )
+
+    # Object key format: wal/<topic>/<partition>/<start>-<end>.jsonl.gz
+    key = objects[0]["Key"]
+    assert key.startswith("wal/") and key.endswith(".jsonl.gz"), f"bad key {key!r}"
+
+    # 3. Object Lock COMPLIANCE + retain-until must be set (ADR-015:
+    #    even root cannot delete within the retention window).
+    head = s3.head_object(Bucket=S3_BUCKET, Key=key)
+    assert head.get("ObjectLockMode") == "COMPLIANCE", (
+        f"ObjectLockMode={head.get('ObjectLockMode')!r}, want COMPLIANCE"
+    )
+    assert head.get("ObjectLockRetainUntilDate") is not None, (
+        "ObjectLockRetainUntilDate missing — object is not retention-locked"
+    )
+    meta = head.get("Metadata", {})
+    # S3 lowercases user metadata keys; the archiver writes entdb-* keys.
+    assert meta.get("entdb-format", "").startswith("wal-jsonl"), (
+        f"unexpected archive format metadata: {meta!r}"
+    )
+    assert int(meta.get("entdb-record-count", "0")) >= 1
+
+    # 4. The archived body is gzip JSONL and decodes back to our events.
+    body = s3.get_object(Bucket=S3_BUCKET, Key=key)["Body"].read()
+    with gzip.GzipFile(fileobj=io.BytesIO(body)) as gz:
+        lines = [ln for ln in gz.read().decode().splitlines() if ln.strip()]
+    assert lines, f"archive object {key!r} decoded to zero JSONL lines"
+    decoded = [json.loads(ln) for ln in lines]
+    for rec in decoded:
+        assert rec["topic"].startswith("entdb-wal-archive-e2e")
+        assert "offset" in rec and "partition" in rec
+    # The tenant id rides the WAL record key / event value.
+    blob = json.dumps(decoded)
+    assert TENANT in blob, "archived events do not reference the e2e tenant"
+
+    # 5. Prometheus archive-lag gauge is exported and drains to 0 once
+    #    the archiver has caught up. We just wrote 12 events that all
+    #    archived above, so steady-state lag is 0.
+    lag_lines: list[str] = []
+    drained = False
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        lag_lines = _scrape_metric_lines("entdb_archive_lag_events")
+        if lag_lines and all(float(ln.rsplit(" ", 1)[1]) == 0.0 for ln in lag_lines):
+            drained = True
+            break
+        time.sleep(3)
+    assert lag_lines, (
+        "entdb_archive_lag_events not exported on /metrics — archive lag metric missing"
+    )
+    assert drained, f"archive lag did not drain to 0; last sample: {lag_lines!r}"
+
+    # Sanity: the writes counter advanced past our batch.
+    writes = _scrape_metric_lines("entdb_archive_writes_total")
+    assert writes, "entdb_archive_writes_total not exported"
+    assert float(writes[0].rsplit(" ", 1)[1]) >= 12.0, (
+        f"entdb_archive_writes_total={writes[0]!r}, want >= 12"
+    )


### PR DESCRIPTION
## Problem

EPIC #511 (S3 Object Lock archive of the WAL, ADR-015) had two
operability gaps after the archive foundation shipped in `eda6ba9`:

1. **No archive-lag metric.** ADR-015's failure-modes section says a
   lagging/crashed archiver "leaves a window where events exist in
   Kafka but not in tamper-evident storage. Detected by:
   `entdb_archive_lag_events`." That metric did not exist, and the
   server had no `/metrics` scrape endpoint at all (the gRPC metrics
   were registered but unreachable).
2. **No MinIO+Redpanda e2e.** Success criterion 5 calls for an e2e
   test that boots server + Redpanda + MinIO with Object Lock and
   asserts the round-trip. Only Go unit tests existed.

(The EPIC body also still claimed "no Go counterparts exist" — it has
been rewritten to reflect the shipped foundation and narrowed to the
real remaining gaps.)

## Fix

**Metrics**
- New `entdb_archive_lag_events` gauge (`{topic,partition}`) plus
  `entdb_archive_writes_total` / `entdb_archive_errors_total` in
  `server/go/internal/metrics/archive.go`.
- The archiver publishes per-partition lag on every poll/commit cycle:
  lag = records polled but not yet durably archived+committed. Drains
  to 0 when caught up; stays elevated on S3 failure.
- New `-metrics-addr` flag serves the Prometheus default registry at
  `/metrics` on a separate HTTP listener (off by default).

**MinIO + Redpanda e2e**
- `docker-compose.archive.yml` + `Dockerfile.archive` +
  `run-archive-e2e.sh`: Redpanda + MinIO (Object-Lock COMPLIANCE
  bucket) + server with `-archive-enabled`. Separate from the fast
  22-case stack so it doesn't pay the MinIO/archiver startup cost.
- `test_archive_object_lock.py` drives the SDK, then asserts COMPLIANCE
  mode + retain-until on the S3 object, gzip-JSONL decodes back to the
  written events, and the lag gauge drains to 0 while the writes
  counter advances. Skips cleanly under the main stack.
- New `-archive-s3-path-style` flag so the archiver works against MinIO
  and other non-AWS S3 endpoints.

## Testing

All run locally before push:

- `cd server/go && go vet ./... && go test ./...` — all packages PASS
  (new `TestArchiveLagMetricDrainsOnSuccessAndStaysOnFailure` in
  `internal/audit`).
- `cd sdk/go/entdb && go vet ./... && go test ./...` — PASS.
- `python -m pytest tests/python/integration/ -q` — **95 passed**.
- `bash tests/python/e2e/run-archive-e2e.sh` — **1 passed** (full
  WAL→Redpanda→S3 Object Lock COMPLIANCE round-trip + lag gauge).
- `bash tests/python/e2e/run-e2e.sh --no-cache` — **22 passed,
  1 skipped** (no regression; archive test correctly skipped here).
- `uvx ruff@0.15.7 check .` / `format --check .` — clean.

## Scope

Part of #511. Two of four remaining items done; **legal-hold lift on
existing S3 objects** and **deployment/ops docs** remain open on the
EPIC, so this does not close it.
