### PR TITLE
perf(apply): parallel WAL apply across distinct tenants (#140 PERF-4)

### DIFF
--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -61,6 +62,21 @@ func main() {
 	walBackend := flag.String("wal-backend", "memory", "WAL backend: memory | kafka | kinesis | pubsub | sqs | servicebus | eventhubs")
 	walTopic := flag.String("wal-topic", "entdb-wal", "WAL topic name")
 	walGroup := flag.String("wal-group", "entdb-applier", "WAL consumer group id")
+	// --apply-concurrency controls cross-tenant parallel WAL apply
+	// (#140 / PERF-4, ADR-027). Within a single poll batch the applier
+	// may apply records for DISTINCT tenant route keys in parallel;
+	// records for one tenant are always serial in offset order and
+	// offsets commit strictly in batch order, so this knob never
+	// weakens per-tenant ordering, the single-writer-per-tenant
+	// invariant (ADR-016), or the gap-free contiguous-prefix commit.
+	// LANDED DARK (ADR-027): default 1 = strictly serial, the unchanged
+	// pre-#140 behaviour. Operators opt into parallelism after a
+	// staging soak by setting 0 (-> runtime.GOMAXPROCS) or an explicit
+	// N>1. This is both the rollout posture and the no-redeploy
+	// kill-switch.
+	applyConcurrency := flag.Int("apply-concurrency", 1,
+		"max distinct tenants applied in parallel per WAL poll batch "+
+			"(1 = strictly serial / pre-#140, the default; 0 = runtime.GOMAXPROCS; N>1 = opt-in parallel)")
 	// Kafka/Redpanda-specific knobs. Defaults match the legacy
 	// KAFKA_BROKERS env-var convention so the cross-impl e2e stack
 	// can swap targets without re-jiggering compose env-vars.
@@ -334,14 +350,24 @@ func main() {
 	}
 
 	applier, err := apply.New(apply.Options{
-		Store:    canonical,
-		Global:   global,
-		Consumer: walImpl,
-		Topic:    *walTopic,
-		GroupID:  *walGroup,
+		Store:               canonical,
+		Global:              global,
+		Consumer:            walImpl,
+		Topic:               *walTopic,
+		GroupID:             *walGroup,
+		MaxApplyConcurrency: *applyConcurrency,
 	})
 	if err != nil {
 		log.Fatalf("entdb-server: applier: %v", err)
+	}
+	effectiveApplyConc := *applyConcurrency
+	if effectiveApplyConc <= 0 {
+		effectiveApplyConc = runtime.GOMAXPROCS(0)
+	}
+	if effectiveApplyConc == 1 {
+		log.Printf("entdb-server: WAL apply concurrency = 1 (strictly serial; pre-#140 behaviour)")
+	} else {
+		log.Printf("entdb-server: WAL apply concurrency = %d (cross-tenant parallel apply, ADR-027)", effectiveApplyConc)
 	}
 
 	// Run the applier before the gRPC server starts accepting writes.

--- a/server/go/internal/apply/applier.go
+++ b/server/go/internal/apply/applier.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -49,11 +50,33 @@ type Options struct {
 	// pinned by docs/go-port/shared/applier.md is that production must
 	// halt.
 	HaltOnPoison *bool
+
+	// MaxApplyConcurrency caps how many distinct tenants' records the
+	// Run loop applies in parallel within a single poll batch (#140
+	// PERF-4). Records for the SAME tenant are always applied serially
+	// in offset order by a single worker, and offsets are committed in
+	// strict batch order along the contiguous fully-applied prefix, so
+	// this knob never weakens per-tenant ordering or the
+	// single-writer-per-tenant invariant (ADR-016) — it only bounds the
+	// goroutine fan-out across independent tenant SQLite files.
+	//
+	// 0 (default) -> runtime.GOMAXPROCS(0). 1 -> fully serial (the
+	// pre-#140 behaviour, kept as an escape hatch). Values >0 cap the
+	// worker pool; the cap never exceeds the number of distinct tenants
+	// in the batch.
+	MaxApplyConcurrency int
 }
 
 // Applier is the WAL consumer that materialises TransactionEvents into
-// per-tenant SQLite. Single consumer goroutine per (topic, group_id)
-// (Python parity); per-tenant pool deferred to a follow-up.
+// per-tenant SQLite. One consumer per (topic, group_id): it polls the
+// WAL serially and commits offsets serially in batch order. Within a
+// poll batch it applies records for DISTINCT tenants in parallel (#140
+// PERF-4) — see processBatch for the invariant-preservation argument.
+// This does not change the consumer-group model ADR-016 describes
+// ("one consumer per partition; events apply serially within a
+// partition"): the consumer-group offset is still committed strictly
+// in offset order along the contiguous fully-applied prefix, and
+// records for any single tenant still apply serially in offset order.
 //
 // Concurrency: Run is meant to be called once per Applier. Stop is
 // safe to call from any goroutine and is idempotent. Replay is safe to
@@ -72,6 +95,7 @@ type Applier struct {
 	nowFn        func() int64
 	fanoutHook   func(ctx context.Context, ev *Event, res *Result)
 	haltOnPoison bool
+	maxApplyConc int
 
 	// running is non-zero when the Run loop has started. Used by
 	// Stop to skip the wait-for-loop-exit path when Run never started.
@@ -112,6 +136,13 @@ func New(opts Options) (*Applier, error) {
 	if opts.HaltOnPoison != nil {
 		halt = *opts.HaltOnPoison
 	}
+	maxConc := opts.MaxApplyConcurrency
+	if maxConc <= 0 {
+		maxConc = runtime.GOMAXPROCS(0)
+	}
+	if maxConc < 1 {
+		maxConc = 1
+	}
 	return &Applier{
 		store:        opts.Store,
 		global:       opts.Global,
@@ -123,6 +154,7 @@ func New(opts Options) (*Applier, error) {
 		nowFn:        nowFn,
 		fanoutHook:   opts.FanoutHook,
 		haltOnPoison: halt,
+		maxApplyConc: maxConc,
 		stopCh:       make(chan struct{}),
 		doneCh:       make(chan struct{}),
 	}, nil
@@ -158,37 +190,183 @@ func (a *Applier) Run(ctx context.Context) error {
 			}
 			return fmt.Errorf("apply: poll batch: %w", err)
 		}
-		for i, rec := range records {
-			res := a.applyRecord(ctx, rec)
-			if res.Err != nil {
-				if a.haltOnPoison {
-					// Do NOT advance offset; the consumer group's
-					// committed position stays at the last successful
-					// record. Subsequent records (records[i+1:]) are
-					// dropped on the floor — they'll be re-delivered
-					// after restart.
-					_ = i
-					return res.Err
-				}
-				// skip-and-continue: still commit the offset (mirrors
-				// Python halt_on_error=False) and move on.
-			}
-			if err := a.consumer.Commit(ctx, a.groupID, rec); err != nil {
-				return fmt.Errorf("apply: commit offset: %w", err)
-			}
-			if res.Status == StatusApplied || res.Status == StatusSkipped || res.Status == StatusFailedPrecondition {
-				if err := a.store.UpdateAppliedOffset(ctx, res.TenantID, rec.Position.Topic, rec.Position.Partition, rec.Position.Offset); err != nil {
-					// Persisting the offset is best-effort; the in-
-					// memory tracker has already been updated by the
-					// in-txn UpdateAppliedOffsetTx call. Surface the
-					// error so the supervisor can act.
-					return fmt.Errorf("apply: persist offset: %w", err)
-				}
-			}
-			// Best-effort post-commit fan-out + shared_index.
-			a.fanout(ctx, decodeOrZero(rec), &res)
+		if len(records) == 0 {
+			continue
+		}
+		if err := a.processBatch(ctx, records); err != nil {
+			return err
 		}
 	}
+}
+
+// processBatch applies one poll batch with cross-tenant parallelism
+// (#140 PERF-4) while preserving every consistency invariant the
+// single-threaded loop guaranteed:
+//
+//   - Per-tenant ordering: records are partitioned by tenant_id and
+//     each tenant's records are applied SERIALLY in batch (== offset)
+//     order by exactly one worker goroutine. Two records for the same
+//     tenant never run concurrently.
+//   - Single-writer-per-tenant (ADR-016): distinct tenants own
+//     independent SQLite files; workers only ever touch their own
+//     tenant. The store's per-tenant write mutex remains the backstop
+//     but is never contended by the applier itself.
+//   - Monotonic, gap-free offset commit: results are FINALISED
+//     (consumer-group commit + persisted per-tenant offset + fan-out)
+//     strictly in original batch order, stopping at the first
+//     halt-on-poison failure. Because PollBatch returns records in
+//     offset order within each partition, finalising in batch order
+//     advances each partition's committed offset only along its
+//     contiguous fully-applied prefix — a later tenant finishing first
+//     never advances an offset past an earlier un-applied record.
+//
+// On a halt-on-poison failure, workers for other tenants may already
+// have applied later records. Their SQLite writes are durable but
+// their offsets are NOT committed, so a restart re-delivers them and
+// the in-txn idempotency probe SKIPs them — identical to the
+// pre-#140 "dropped on the floor, re-delivered after restart"
+// contract, just generalised across tenants.
+func (a *Applier) processBatch(ctx context.Context, records []Record) error {
+	n := len(records)
+
+	// Decode the tenant routing key for every record up front, in
+	// order. Decode failures are deferred to applyRecord (which maps
+	// them to ErrPoisonEvent) so the halt semantics are unchanged; we
+	// route those records to a stable synthetic key so they still
+	// apply serially relative to each other.
+	results := make([]Result, n)
+	type recRef struct {
+		idx int
+		rec Record
+	}
+	groups := make(map[string][]recRef)
+	order := make([]string, 0, 8) // distinct tenants, first-seen order
+	for i, rec := range records {
+		key := routeKey(rec)
+		if _, seen := groups[key]; !seen {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], recRef{idx: i, rec: rec})
+	}
+
+	// applyChain applies one tenant's records serially in batch (offset)
+	// order. Under halt-on-poison it STOPS at the first failing record
+	// in this tenant's own stream — preserving the exact pre-#140
+	// per-tenant semantics ("subsequent records dropped on the floor;
+	// re-delivered after restart"). Records left unapplied keep their
+	// zero-value Result; finalizeBatch halts at the failing record in
+	// batch order before it could ever inspect them. Cross-tenant
+	// speculative apply past a poison in a DIFFERENT tenant can still
+	// happen (different worker, no shared stop) and is safe by the
+	// idempotent-replay invariant (ADR-016).
+	applyChain := func(refs []recRef) {
+		for _, r := range refs {
+			res := a.applyRecord(ctx, r.rec)
+			results[r.idx] = res
+			if res.Err != nil && a.haltOnPoison {
+				return
+			}
+		}
+	}
+
+	// Fast path: a single tenant in the batch -> apply serially in this
+	// goroutine, behaving exactly like the old serial loop.
+	if len(order) <= 1 {
+		for _, key := range order {
+			applyChain(groups[key])
+		}
+		return a.finalizeBatch(ctx, records, results)
+	}
+
+	// Bound the worker pool by the smaller of the configured cap and
+	// the number of distinct tenants.
+	workers := a.maxApplyConc
+	if workers > len(order) {
+		workers = len(order)
+	}
+
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	for _, key := range order {
+		key := key
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(refs []recRef) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			applyChain(refs)
+		}(groups[key])
+	}
+	wg.Wait()
+
+	return a.finalizeBatch(ctx, records, results)
+}
+
+// finalizeBatch commits offsets + runs fan-out for an already-applied
+// batch, strictly in batch order, stopping at the first halt-on-poison
+// failure (the contiguous-prefix commit rule). Records past a halted
+// failure are intentionally left uncommitted for redelivery.
+func (a *Applier) finalizeBatch(ctx context.Context, records []Record, results []Result) error {
+	for i := range records {
+		rec := records[i]
+		res := results[i]
+		if res.Err != nil {
+			if a.haltOnPoison {
+				// Do NOT advance the offset. The consumer group's
+				// committed position stays at the last successful
+				// record; records[i:] are left uncommitted and will
+				// be re-delivered after restart.
+				return res.Err
+			}
+			// skip-and-continue: still commit the offset (mirrors
+			// Python halt_on_error=False) and move on.
+		}
+		// ADR-027 invariant 3 (load-bearing): the WAL/consumer-group
+		// offset commit and the persisted per-tenant offset advance
+		// below are the ONLY places these offsets move forward, and
+		// they run here in the single serial finalizeBatch loop, in
+		// strict batch order, returning at the first poisoned record.
+		// That ordered early-return is the entire gap-free
+		// contiguous-prefix guarantee. Calling consumer.Commit (or
+		// store.UpdateAppliedOffset for the consumer-group position)
+		// from a parallel apply worker, a fan-out hook, or any path
+		// other than this serial loop lets a faster later-tenant
+		// worker advance the offset past an earlier un-applied record
+		// and BREAKS gap-freeness. Do not move offset commits out of
+		// this loop.
+		if err := a.consumer.Commit(ctx, a.groupID, rec); err != nil {
+			return fmt.Errorf("apply: commit offset: %w", err)
+		}
+		if res.Status == StatusApplied || res.Status == StatusSkipped || res.Status == StatusFailedPrecondition {
+			if err := a.store.UpdateAppliedOffset(ctx, res.TenantID, rec.Position.Topic, rec.Position.Partition, rec.Position.Offset); err != nil {
+				// Persisting the offset is best-effort; the in-memory
+				// tracker has already been updated by the in-txn
+				// UpdateAppliedOffsetTx call. Surface the error so the
+				// supervisor can act.
+				return fmt.Errorf("apply: persist offset: %w", err)
+			}
+		}
+		// Best-effort post-commit fan-out + shared_index.
+		a.fanout(ctx, decodeOrZero(rec), &res)
+	}
+	return nil
+}
+
+// routeKey returns the partition key a record's apply work is grouped
+// under. It is the event's tenant_id (global events route under the
+// synthetic global tenant). A decode failure cannot expose a tenant,
+// so such records share one stable synthetic bucket — they still apply
+// serially relative to each other and halt-on-poison still fires when
+// finalizeBatch reaches them in order.
+func routeKey(rec Record) string {
+	ev, err := wal.DecodeEvent(rec.Value)
+	if err != nil {
+		return "\x00poison"
+	}
+	if ev.TenantID == "" {
+		return "\x00poison"
+	}
+	return string(ev.Scope) + "\x00" + ev.TenantID
 }
 
 // Stop signals Run to return and waits for it to exit. Safe to call

--- a/server/go/internal/apply/event.go
+++ b/server/go/internal/apply/event.go
@@ -18,10 +18,14 @@
 //   - global admin ops added so control-plane globalstore writes can be
 //     replayed from the WAL.
 //
-// Concurrency model: a single consumer goroutine drives Run; per-tenant
-// SQLite isolation comes from the store package's per-tenant write
-// mutex. Halt-on-poison: any error in op-dispatch returns from Run with
-// a non-nil error and does not advance the WAL offset.
+// Concurrency model: one consumer drives Run; within a poll batch it
+// applies records for distinct tenants in parallel while keeping each
+// tenant's records serial in offset order and committing offsets
+// strictly in batch order (#140 PERF-4, see applier.go processBatch).
+// Per-tenant SQLite isolation comes from the store package's
+// per-tenant write mutex. Halt-on-poison: any error in op-dispatch
+// halts finalisation at that record and does not advance the WAL
+// offset past it.
 package apply
 
 import "github.com/elloloop/tenant-shard-db/server/go/internal/wal"

--- a/server/go/internal/apply/parallel_apply_bench_test.go
+++ b/server/go/internal/apply/parallel_apply_bench_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// benchmarkApplyBatch measures the wall-clock latency of applying ONE
+// poll batch of `tenants` records (one per distinct tenant) at a given
+// apply concurrency, with the WAL + store fully pre-populated so the
+// timed region is exactly the apply+commit work — no append, no poll
+// scheduling noise. concurrency=1 reproduces the pre-#140 serial
+// applier; concurrency=0 uses the default GOMAXPROCS fan-out.
+//
+// SQLite COMMIT latency (an fsync of the WAL frame even with
+// synchronous=NORMAL) is the dominant per-record cost. Distinct tenants
+// own independent DB files, so their commits' fsyncs overlap when
+// applied on separate goroutines — that overlap is the #140 win.
+//
+// The benchmark drives processBatch indirectly via Run but slices the
+// timed region tightly around a single drained batch using a fan-out
+// barrier on the last record's idempotency marker, polled at a fine
+// granularity that is amortised away at scale.
+func benchmarkApplyBatch(b *testing.B, tenants, concurrency int) {
+	b.Helper()
+	type rig struct {
+		w  *wal.InMemory
+		cs *store.CanonicalStore
+		gs *globalstore.GlobalStore
+		a  *apply.Applier
+	}
+	newRig := func() *rig {
+		w := wal.NewInMemory(32)
+		if err := w.Connect(context.Background()); err != nil {
+			b.Fatalf("Connect: %v", err)
+		}
+		dir := b.TempDir()
+		cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+		if err != nil {
+			b.Fatalf("store.New: %v", err)
+		}
+		gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+		if err != nil {
+			b.Fatalf("globalstore.New: %v", err)
+		}
+		for ti := 0; ti < tenants; ti++ {
+			tn := fmt.Sprintf("bt_%05d", ti)
+			if err := cs.OpenTenant(context.Background(), tn); err != nil {
+				b.Fatalf("OpenTenant: %v", err)
+			}
+			ev := apply.Event{
+				TenantID: tn, Actor: "u",
+				IdempotencyKey: fmt.Sprintf("%s-k", tn),
+				Ops:            []map[string]any{mkCreateNode("doc", 1, map[string]any{"1": "x"})},
+			}
+			val, _ := ev.Encode()
+			if _, err := w.Append(context.Background(), testTopic, tn, val,
+				map[string][]byte{wal.HeaderIdempotencyKey: []byte(ev.IdempotencyKey)}); err != nil {
+				b.Fatalf("Append: %v", err)
+			}
+		}
+		a, err := apply.New(apply.Options{
+			Store: cs, Global: gs, Consumer: w,
+			Topic: testTopic, GroupID: testGroupID,
+			BatchSize:           tenants, // whole workload in one poll batch
+			PollTimeout:         50 * time.Millisecond,
+			MaxApplyConcurrency: concurrency,
+		})
+		if err != nil {
+			b.Fatalf("apply.New: %v", err)
+		}
+		return &rig{w: w, cs: cs, gs: gs, a: a}
+	}
+
+	rigs := make([]*rig, b.N)
+	for i := range rigs {
+		rigs[i] = newRig()
+	}
+	lastTenant := fmt.Sprintf("bt_%05d", tenants-1)
+	lastKey := lastTenant + "-k"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := rigs[i]
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- r.a.Run(ctx) }()
+		for {
+			ok, _ := r.cs.CheckIdempotency(context.Background(), lastTenant, lastKey)
+			if ok {
+				break
+			}
+			time.Sleep(50 * time.Microsecond)
+		}
+		cancel()
+		<-done
+	}
+	b.StopTimer()
+
+	for _, r := range rigs {
+		_ = r.cs.Close()
+		_ = r.gs.Close()
+		_ = r.w.Close(context.Background())
+	}
+}
+
+func BenchmarkApply_64Tenants_Serial(b *testing.B)     { benchmarkApplyBatch(b, 64, 1) }
+func BenchmarkApply_64Tenants_Parallel(b *testing.B)   { benchmarkApplyBatch(b, 64, 0) }
+func BenchmarkApply_256Tenants_Serial(b *testing.B)    { benchmarkApplyBatch(b, 256, 1) }
+func BenchmarkApply_256Tenants_Parallel(b *testing.B)  { benchmarkApplyBatch(b, 256, 0) }
+func BenchmarkApply_1024Tenants_Serial(b *testing.B)   { benchmarkApplyBatch(b, 1024, 1) }
+func BenchmarkApply_1024Tenants_Parallel(b *testing.B) { benchmarkApplyBatch(b, 1024, 0) }

--- a/server/go/internal/apply/parallel_apply_test.go
+++ b/server/go/internal/apply/parallel_apply_test.go
@@ -1,0 +1,682 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// multiTenantFixture wires an in-memory WAL + store + applier with a
+// configurable apply concurrency. Unlike newFixture it does not pre-open
+// a single tenant — callers open whatever tenants they need.
+type multiTenantFixture struct {
+	t       *testing.T
+	wal     *wal.InMemory
+	store   *store.CanonicalStore
+	global  *globalstore.GlobalStore
+	applier *apply.Applier
+}
+
+func newMultiTenantFixture(t *testing.T, maxConc int) *multiTenantFixture {
+	t.Helper()
+	w := wal.NewInMemory(8)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	dir := t.TempDir()
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+
+	a, err := apply.New(apply.Options{
+		Store:               cs,
+		Global:              gs,
+		Consumer:            w,
+		Topic:               testTopic,
+		GroupID:             testGroupID,
+		PollTimeout:         25 * time.Millisecond,
+		MaxApplyConcurrency: maxConc,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	return &multiTenantFixture{t: t, wal: w, store: cs, global: gs, applier: a}
+}
+
+func (f *multiTenantFixture) append(t *testing.T, ev apply.Event) {
+	t.Helper()
+	val, err := ev.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	headers := map[string][]byte{wal.HeaderIdempotencyKey: []byte(ev.IdempotencyKey)}
+	if _, err := f.wal.Append(context.Background(), testTopic, ev.TenantID, val, headers); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+}
+
+func (f *multiTenantFixture) run(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+func (f *multiTenantFixture) waitIdem(t *testing.T, tenant, key string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		ok, err := f.store.CheckIdempotency(context.Background(), tenant, key)
+		if err == nil && ok {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("waitIdem: %s/%s never applied", tenant, key)
+}
+
+// TestParallelApply_PerTenantOrderingUnderConcurrency drives many tenants,
+// each with a strictly ordered chain of updates that ONLY produces the
+// expected final payload if every op for that tenant applied in offset
+// order. A single shared field is overwritten N times per tenant; the
+// terminal value encodes the last sequence number. Any reordering within
+// a tenant yields a wrong terminal value.
+func TestParallelApply_PerTenantOrderingUnderConcurrency(t *testing.T) {
+	t.Parallel()
+	const tenants = 12
+	const opsPerTenant = 25
+
+	f := newMultiTenantFixture(t, 8)
+	for ti := 0; ti < tenants; ti++ {
+		tenant := fmt.Sprintf("tenant_%02d", ti)
+		if err := f.store.OpenTenant(context.Background(), tenant); err != nil {
+			t.Fatalf("OpenTenant: %v", err)
+		}
+		// Create the node first.
+		f.append(t, apply.Event{
+			TenantID: tenant, Actor: "user:a",
+			IdempotencyKey: fmt.Sprintf("%s-create", tenant),
+			Ops:            []map[string]any{mkCreateNode("doc", 1, map[string]any{"1": "seq=0"})},
+		})
+		// Then a chain of overwrites; each depends on applying after the
+		// previous (last-writer-wins on field id 1).
+		for s := 1; s <= opsPerTenant; s++ {
+			f.append(t, apply.Event{
+				TenantID: tenant, Actor: "user:a",
+				IdempotencyKey: fmt.Sprintf("%s-u%03d", tenant, s),
+				Ops: []map[string]any{{
+					"op": string(apply.OpUpdateNode), "id": "doc",
+					"patch": map[string]any{"1": fmt.Sprintf("seq=%d", s)},
+				}},
+			})
+		}
+	}
+
+	f.run(t)
+
+	for ti := 0; ti < tenants; ti++ {
+		tenant := fmt.Sprintf("tenant_%02d", ti)
+		f.waitIdem(t, tenant, fmt.Sprintf("%s-u%03d", tenant, opsPerTenant))
+		n, err := f.store.GetNode(context.Background(), tenant, "doc")
+		if err != nil {
+			t.Fatalf("%s GetNode: %v", tenant, err)
+		}
+		want := fmt.Sprintf(`"seq=%d"`, opsPerTenant)
+		if !containsJSONValue(n.PayloadJSON, want) {
+			t.Fatalf("%s terminal payload = %s; want field 1 == %s "+
+				"(per-tenant ordering violated under concurrency)",
+				tenant, n.PayloadJSON, want)
+		}
+	}
+}
+
+func containsJSONValue(payload, want string) bool {
+	// Payload is field-id-keyed JSON like {"1":"seq=25"}; a substring
+	// check on the quoted terminal value is sufficient and avoids
+	// coupling the test to the payload codec internals.
+	return len(payload) > 0 && (indexOf(payload, want) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestParallelApply_SingleWriterPerTenant proves no two goroutines apply
+// records for the same tenant concurrently. The proof has two prongs:
+//
+//  1. Each tenant's records form a strict update chain (same node, same
+//     field, monotonically increasing value). The store's per-tenant
+//     BatchTxn write mutex is the ADR-016 backstop: if the applier ever
+//     scheduled two records for one tenant in parallel, the read-modify-
+//     write chain would interleave and the terminal value would be
+//     wrong. We assert the terminal value is exactly the last sequence
+//     for every tenant.
+//  2. Run under `go test -race` (the project CI does): any unsynchronised
+//     shared access in the parallel path trips the race detector.
+//
+// We additionally instrument the apply path via the FanoutHook (invoked
+// once per record, serially in batch order, AFTER apply) to record the
+// applied sequence per tenant and assert it is strictly increasing —
+// catching any same-tenant reorder the value check could mask.
+func TestParallelApply_SingleWriterPerTenant(t *testing.T) {
+	t.Parallel()
+	const tenants = 10
+	const opsPerTenant = 12
+
+	w := wal.NewInMemory(8)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	dir := t.TempDir()
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+
+	var seqMu sync.Mutex
+	lastSeq := map[string]int{}
+	seqViolation := ""
+	hook := func(ctx context.Context, ev *apply.Event, res *apply.Result) {
+		if ev == nil || ev.TenantID == "" || len(ev.Ops) == 0 {
+			return
+		}
+		s, ok := ev.Ops[0]["seq"]
+		if !ok {
+			return
+		}
+		seq := int(s.(float64))
+		seqMu.Lock()
+		if seq != lastSeq[ev.TenantID]+1 && seqViolation == "" {
+			seqViolation = fmt.Sprintf("tenant %s: applied seq %d after %d (not strictly +1)",
+				ev.TenantID, seq, lastSeq[ev.TenantID])
+		}
+		lastSeq[ev.TenantID] = seq
+		seqMu.Unlock()
+	}
+
+	a, err := apply.New(apply.Options{
+		Store:               cs,
+		Global:              gs,
+		Consumer:            w,
+		Topic:               testTopic,
+		GroupID:             testGroupID,
+		PollTimeout:         25 * time.Millisecond,
+		MaxApplyConcurrency: 16,
+		FanoutHook:          hook,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+
+	for ti := 0; ti < tenants; ti++ {
+		tenant := fmt.Sprintf("tnt_%02d", ti)
+		if err := cs.OpenTenant(context.Background(), tenant); err != nil {
+			t.Fatalf("OpenTenant: %v", err)
+		}
+		for s := 1; s <= opsPerTenant; s++ {
+			var ev apply.Event
+			if s == 1 {
+				ev = apply.Event{
+					TenantID: tenant, Actor: "user:a",
+					IdempotencyKey: fmt.Sprintf("%s-%d", tenant, s),
+					Ops: []map[string]any{{
+						"op": string(apply.OpCreateNode), "id": "doc",
+						"type_id": int32(1), "seq": s,
+						"data": map[string]any{"1": fmt.Sprintf("s%d", s)},
+					}},
+				}
+			} else {
+				ev = apply.Event{
+					TenantID: tenant, Actor: "user:a",
+					IdempotencyKey: fmt.Sprintf("%s-%d", tenant, s),
+					Ops: []map[string]any{{
+						"op": string(apply.OpUpdateNode), "id": "doc", "seq": s,
+						"patch": map[string]any{"1": fmt.Sprintf("s%d", s)},
+					}},
+				}
+			}
+			val, _ := ev.Encode()
+			if _, err := w.Append(context.Background(), testTopic, tenant, val,
+				map[string][]byte{wal.HeaderIdempotencyKey: []byte(ev.IdempotencyKey)}); err != nil {
+				t.Fatalf("Append: %v", err)
+			}
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+	t.Cleanup(func() { cancel(); <-done })
+
+	for ti := 0; ti < tenants; ti++ {
+		tenant := fmt.Sprintf("tnt_%02d", ti)
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			ok, _ := cs.CheckIdempotency(context.Background(), tenant,
+				fmt.Sprintf("%s-%d", tenant, opsPerTenant))
+			if ok {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		n, err := cs.GetNode(context.Background(), tenant, "doc")
+		if err != nil {
+			t.Fatalf("%s GetNode: %v", tenant, err)
+		}
+		want := fmt.Sprintf(`"s%d"`, opsPerTenant)
+		if indexOf(n.PayloadJSON, want) < 0 {
+			t.Fatalf("%s terminal payload=%s want field 1==%s "+
+				"(same-tenant applies interleaved — single-writer violated)",
+				tenant, n.PayloadJSON, want)
+		}
+	}
+	seqMu.Lock()
+	v := seqViolation
+	seqMu.Unlock()
+	if v != "" {
+		t.Fatalf("per-tenant apply order violated: %s", v)
+	}
+}
+
+// TestParallelApply_HaltOnPoisonContiguousOffset pins the gap-free
+// offset-commit invariant (#140 requirement (c)). When a record poisons
+// mid-batch:
+//
+//   - The contiguous fully-applied prefix BEFORE the poison commits its
+//     offsets (alpha/a1 here).
+//   - The consumer-group offset NEVER advances past the poison, even
+//     though a parallel worker for a different tenant may have
+//     speculatively applied a LATER record (gamma/g1, alpha/a2). Their
+//     SQLite writes are durable but uncommitted — exactly the ADR-016
+//     "re-delivered after restart, idempotency probe SKIPs" contract,
+//     now generalised across tenants.
+//
+// We prove offset non-advancement DIRECTLY: a fresh applier resumes on
+// the SAME consumer group and MUST re-deliver the poison record (and the
+// whole tail). If any tail offset had been wrongly committed, the
+// resumed group would skip it and the assertion fails.
+func TestParallelApply_HaltOnPoisonContiguousOffset(t *testing.T) {
+	t.Parallel()
+	f := newMultiTenantFixture(t, 8)
+
+	for _, tn := range []string{"alpha", "beta", "gamma"} {
+		if err := f.store.OpenTenant(context.Background(), tn); err != nil {
+			t.Fatalf("OpenTenant %s: %v", tn, err)
+		}
+	}
+
+	// Batch shape (distinct tenants -> distinct parallel workers):
+	//  1. alpha  create ok       (the only contiguous-prefix record)
+	//  2. beta   POISON (no id)
+	//  3. gamma  create ok       (later tenant; worker may apply early)
+	//  4. alpha  create ok       (after poison in batch order)
+	f.append(t, apply.Event{
+		TenantID: "alpha", Actor: "u", IdempotencyKey: "a1",
+		Ops: []map[string]any{mkCreateNode("a-node", 1, nil)},
+	})
+	f.append(t, apply.Event{
+		TenantID: "beta", Actor: "u", IdempotencyKey: "b1",
+		Ops: []map[string]any{{"op": "create_node", "type_id": 1}}, // no id => poison
+	})
+	f.append(t, apply.Event{
+		TenantID: "gamma", Actor: "u", IdempotencyKey: "g1",
+		Ops: []map[string]any{mkCreateNode("g-node", 1, nil)},
+	})
+	f.append(t, apply.Event{
+		TenantID: "alpha", Actor: "u", IdempotencyKey: "a2",
+		Ops: []map[string]any{mkCreateNode("a-node-2", 1, nil)},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx) }()
+
+	var runErr error
+	select {
+	case runErr = <-done:
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		t.Fatalf("applier did not halt on poison within 3s")
+	}
+	if runErr == nil {
+		t.Fatalf("expected halt-on-poison error, got nil")
+	}
+
+	// The contiguous applied prefix (alpha/a1) must be applied.
+	if ok, _ := f.store.CheckIdempotency(context.Background(), "alpha", "a1"); !ok {
+		t.Fatalf("alpha/a1 (the contiguous prefix) should be applied")
+	}
+
+	// DIRECT offset-non-advancement proof: resume a fresh applier on the
+	// SAME consumer group + SAME store. The poison record's offset was
+	// never committed, so it (and any speculatively-applied tail) is
+	// re-polled. Skip-and-continue mode lets the resumed applier drain
+	// the whole tail. After draining, every non-poison tail record must
+	// be present — which can only happen if their offsets had NOT been
+	// committed by the halted run (otherwise the resumed group skips
+	// them and they never re-apply).
+	//
+	// Note we reuse f.store: the redelivered records that were already
+	// applied take the idempotency-SKIP path (ADR-016), and the ones
+	// that were NOT applied (e.g. alpha/a2 if its worker hadn't reached
+	// it) now apply for the first time. Either way the terminal state is
+	// the full deterministic set.
+	skip := false
+	a2, err := apply.New(apply.Options{
+		Store: f.store, Global: f.global, Consumer: f.wal,
+		Topic: testTopic, GroupID: testGroupID, // SAME group => resumes after last commit
+		PollTimeout:  25 * time.Millisecond,
+		HaltOnPoison: &skip,
+	})
+	if err != nil {
+		t.Fatalf("apply.New resume: %v", err)
+	}
+	rctx, rcancel := context.WithCancel(context.Background())
+	defer rcancel()
+	rdone := make(chan error, 1)
+	go func() { rdone <- a2.Run(rctx) }()
+	defer func() { rcancel(); <-rdone }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		ba, _ := f.store.CheckIdempotency(context.Background(), "beta", "b1")
+		ga, _ := f.store.CheckIdempotency(context.Background(), "gamma", "g1")
+		aa, _ := f.store.CheckIdempotency(context.Background(), "alpha", "a2")
+		// beta/b1 is the poison and stays FAILED on skip-and-continue,
+		// so CheckIdempotency stays false for it; we only require the
+		// non-poison tail to converge.
+		_ = ba
+		if ga && aa {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if ok, _ := f.store.CheckIdempotency(context.Background(), "gamma", "g1"); !ok {
+		t.Fatalf("resume: gamma/g1 not applied — its offset must NOT have " +
+			"been committed by the halted run (gap-free commit violated)")
+	}
+	if ok, _ := f.store.CheckIdempotency(context.Background(), "alpha", "a2"); !ok {
+		t.Fatalf("resume: alpha/a2 not applied — tail after poison must be " +
+			"re-deliverable on the same consumer group")
+	}
+}
+
+// TestParallelApply_SamePartitionPoisonContiguousOffset is the ADR-027
+// condition-3 test. It is deliberately stronger than
+// TestParallelApply_HaltOnPoisonContiguousOffset: that test uses three
+// tenants whose WAL keys land on (almost certainly) different
+// partitions, so the poison and the speculative tail live in separate
+// partition offset streams. THIS test forces tenant A and tenant B onto
+// the *same* WAL partition and sandwiches a tenant-B poison BETWEEN two
+// tenant-A records. With one shared partition, a single committed
+// offset governs all three records, so the gap-free contiguous-prefix
+// rule (ADR-027 invariant 3) is exercised at its weakest point: a
+// faster tenant-A worker speculatively applies A's post-poison record
+// while the serial finalizeBatch must still refuse to advance the one
+// shared partition offset past tenant B's poison.
+//
+// Asserts:
+//
+//	(a) Gap-free contiguous-prefix commit: only the pre-poison prefix
+//	    (A's first record) commits its offset; the shared partition's
+//	    committed offset never advances past tenant B's poison even
+//	    though A's worker speculatively materialised A's post-poison
+//	    record.
+//	(b) Idempotent resume: a fresh applier on the SAME consumer group +
+//	    SAME store re-delivers the poison and the speculative tail; the
+//	    already-applied A records take the in-txn idempotency-SKIP path
+//	    (ADR-016) and the tail converges to the full deterministic set.
+//
+// Partition collision is asserted at runtime via wal.InMemory.PartitionFor
+// (ADR-027: "Confirm via partitionFor that the chosen tenant ids
+// actually collide on one partition") so the test fails loudly rather
+// than silently degrading to the multi-partition case if the hash
+// mapping ever changes.
+func TestParallelApply_SamePartitionPoisonContiguousOffset(t *testing.T) {
+	t.Parallel()
+
+	// newMultiTenantFixture builds an 8-partition in-memory WAL.
+	// tenant_00 and tenant_04 both MD5-hash to partition 1 of 8
+	// (binary.BigEndian.Uint32(md5(key)[:4]) % 8). tenant_09 is a
+	// same-partition sibling kept as documentation; the runtime
+	// assertion below is the source of truth.
+	const (
+		tenantA = "tenant_00" // two ok records, sandwiching the poison
+		tenantB = "tenant_04" // the poison; distinct route key => own worker
+	)
+
+	f := newMultiTenantFixture(t, 8)
+
+	// ADR-027: confirm the chosen tenant ids actually collide on ONE
+	// WAL partition. wal.Append keys records by tenant_id, so
+	// PartitionFor(tenantID) is exactly the partition the record lands
+	// in. If these ever diverge the test is no longer testing the
+	// same-partition case and must fail.
+	pa := f.wal.PartitionFor(tenantA)
+	pb := f.wal.PartitionFor(tenantB)
+	if pa != pb {
+		t.Fatalf("test precondition broken: %s -> partition %d but %s -> partition %d; "+
+			"the two tenant ids must collide on ONE partition for this test to "+
+			"exercise the same-partition contiguous-offset invariant (ADR-027 cond 3)",
+			tenantA, pa, tenantB, pb)
+	}
+	t.Logf("confirmed same-partition collision: %s and %s both -> partition %d", tenantA, tenantB, pa)
+
+	for _, tn := range []string{tenantA, tenantB} {
+		if err := f.store.OpenTenant(context.Background(), tn); err != nil {
+			t.Fatalf("OpenTenant %s: %v", tn, err)
+		}
+	}
+
+	// One shared partition, offsets 0,1,2 in this order:
+	//   off 0  tenantA  create a1   (ok)  -> the ONLY contiguous prefix
+	//   off 1  tenantB  POISON (no id)    -> halt point
+	//   off 2  tenantA  create a2   (ok)  -> AFTER the poison in batch
+	//                                         order; A's worker (distinct
+	//                                         route key from B) has no
+	//                                         shared stop and may apply
+	//                                         it speculatively.
+	f.append(t, apply.Event{
+		TenantID: tenantA, Actor: "u", IdempotencyKey: "a1",
+		Ops: []map[string]any{mkCreateNode("a-node-1", 1, nil)},
+	})
+	f.append(t, apply.Event{
+		TenantID: tenantB, Actor: "u", IdempotencyKey: "b1",
+		Ops: []map[string]any{{"op": "create_node", "type_id": 1}}, // no id => poison
+	})
+	f.append(t, apply.Event{
+		TenantID: tenantA, Actor: "u", IdempotencyKey: "a2",
+		Ops: []map[string]any{mkCreateNode("a-node-2", 1, nil)},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx) }()
+
+	var runErr error
+	select {
+	case runErr = <-done:
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		t.Fatalf("applier did not halt on poison within 3s")
+	}
+	if runErr == nil {
+		t.Fatalf("expected halt-on-poison error, got nil")
+	}
+
+	// (a) The contiguous prefix (tenantA/a1, offset 0) must be applied.
+	if ok, _ := f.store.CheckIdempotency(context.Background(), tenantA, "a1"); !ok {
+		t.Fatalf("%s/a1 (the contiguous prefix at offset 0) should be applied", tenantA)
+	}
+
+	// (b) Gap-free + idempotent resume, proven DIRECTLY: bring up a
+	// fresh applier on the SAME consumer group + SAME store. Because
+	// the halted run never committed the shared partition's offset past
+	// the poison at offset 1, a resumed group MUST re-poll from offset
+	// 1 and re-deliver the poison + everything after it on that
+	// partition. If any tail offset had been wrongly committed, the
+	// resumed group would skip it and tenantA/a2 would never converge.
+	//
+	// tenantA/a2 may already be materialised (speculative apply by A's
+	// worker before the halt) — on redelivery it takes the in-txn
+	// idempotency-SKIP path (ADR-016) and stays present. Either way the
+	// terminal state is the full deterministic set.
+	skip := false
+	a2, err := apply.New(apply.Options{
+		Store: f.store, Global: f.global, Consumer: f.wal,
+		Topic: testTopic, GroupID: testGroupID, // SAME group => resumes after last commit
+		PollTimeout:  25 * time.Millisecond,
+		HaltOnPoison: &skip,
+	})
+	if err != nil {
+		t.Fatalf("apply.New resume: %v", err)
+	}
+	rctx, rcancel := context.WithCancel(context.Background())
+	defer rcancel()
+	rdone := make(chan error, 1)
+	go func() { rdone <- a2.Run(rctx) }()
+	defer func() { rcancel(); <-rdone }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if ok, _ := f.store.CheckIdempotency(context.Background(), tenantA, "a2"); ok {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if ok, _ := f.store.CheckIdempotency(context.Background(), tenantA, "a2"); !ok {
+		t.Fatalf("resume: %s/a2 not applied — the shared partition's offset "+
+			"must NOT have been committed past tenantB's poison at offset 1 "+
+			"(gap-free contiguous-prefix commit violated, ADR-027 invariant 3)", tenantA)
+	}
+	// tenantB/b1 is the poison; under skip-and-continue it stays FAILED
+	// and CheckIdempotency stays false for it. We do not require it to
+	// converge — only that the non-poison tail did, which can only
+	// happen via redelivery on the uncommitted shared offset.
+	if ok, _ := f.store.CheckIdempotency(context.Background(), tenantB, "b1"); ok {
+		t.Fatalf("resume: %s/b1 is the poison and must NOT be marked applied", tenantB)
+	}
+}
+
+// TestParallelApply_EquivalentToSerial drives an identical mixed workload
+// through a serial applier (MaxApplyConcurrency=1) and a parallel one and
+// asserts byte-identical materialised state. This pins that parallelism
+// is an optimisation with zero observable behaviour change.
+func TestParallelApply_EquivalentToSerial(t *testing.T) {
+	t.Parallel()
+
+	build := func(maxConc int) map[string]string {
+		w := wal.NewInMemory(8)
+		_ = w.Connect(context.Background())
+		dir := t.TempDir()
+		cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+		if err != nil {
+			t.Fatalf("store.New: %v", err)
+		}
+		defer cs.Close()
+		gs, _ := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+		defer gs.Close()
+		a, err := apply.New(apply.Options{
+			Store: cs, Global: gs, Consumer: w,
+			Topic: testTopic, GroupID: testGroupID,
+			PollTimeout:         25 * time.Millisecond,
+			MaxApplyConcurrency: maxConc,
+		})
+		if err != nil {
+			t.Fatalf("apply.New: %v", err)
+		}
+		const tenants = 8
+		for ti := 0; ti < tenants; ti++ {
+			tn := fmt.Sprintf("t%d", ti)
+			_ = cs.OpenTenant(context.Background(), tn)
+		}
+		// Round-robin interleave so a single poll batch mixes tenants.
+		for s := 0; s < 20; s++ {
+			for ti := 0; ti < tenants; ti++ {
+				tn := fmt.Sprintf("t%d", ti)
+				var ev apply.Event
+				if s == 0 {
+					ev = apply.Event{TenantID: tn, Actor: "u",
+						IdempotencyKey: fmt.Sprintf("%s-c", tn),
+						Ops:            []map[string]any{mkCreateNode("doc", 1, map[string]any{"1": "v0"})}}
+				} else {
+					ev = apply.Event{TenantID: tn, Actor: "u",
+						IdempotencyKey: fmt.Sprintf("%s-u%d", tn, s),
+						Ops: []map[string]any{{
+							"op": string(apply.OpUpdateNode), "id": "doc",
+							"patch": map[string]any{"1": fmt.Sprintf("v%d", s)},
+						}}}
+				}
+				val, _ := ev.Encode()
+				_, _ = w.Append(context.Background(), testTopic, tn, val,
+					map[string][]byte{wal.HeaderIdempotencyKey: []byte(ev.IdempotencyKey)})
+			}
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- a.Run(ctx) }()
+		defer func() { cancel(); <-done }()
+
+		out := map[string]string{}
+		for ti := 0; ti < tenants; ti++ {
+			tn := fmt.Sprintf("t%d", ti)
+			deadline := time.Now().Add(5 * time.Second)
+			for time.Now().Before(deadline) {
+				ok, _ := cs.CheckIdempotency(context.Background(), tn, fmt.Sprintf("%s-u%d", tn, 19))
+				if ok {
+					break
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+			n, err := cs.GetNode(context.Background(), tn, "doc")
+			if err != nil {
+				t.Fatalf("%s GetNode: %v", tn, err)
+			}
+			out[tn] = n.PayloadJSON
+		}
+		return out
+	}
+
+	serial := build(1)
+	parallel := build(8)
+	for tn, sv := range serial {
+		if parallel[tn] != sv {
+			t.Fatalf("tenant %s diverged: serial=%s parallel=%s", tn, sv, parallel[tn])
+		}
+	}
+}

--- a/server/go/internal/wal/memory.go
+++ b/server/go/internal/wal/memory.go
@@ -353,6 +353,15 @@ func (m *InMemory) partitionFor(key string) int32 {
 	return int32(hashInt % uint32(m.numPartitions))
 }
 
+// PartitionFor exposes the partition a WAL key routes to. It is the
+// exact mapping Append uses to place records, so external callers
+// (notably the ADR-027 same-partition poison test in
+// internal/apply) can confirm two tenant ids collide on one partition
+// without reaching into unexported internals.
+func (m *InMemory) PartitionFor(key string) int32 {
+	return m.partitionFor(key)
+}
+
 func copyHeaders(in map[string][]byte) map[string][]byte {
 	if len(in) == 0 {
 		return nil


### PR DESCRIPTION
Implements ADR-027. Cross-tenant parallel WAL apply: within a poll batch, records for DISTINCT tenant route keys may apply in parallel; per-tenant records stay serial in offset order; only the serial finalize loop commits, strictly contiguous-prefix, halting at the first poison.

**Landed dark (ADR-027):** ships **serial by default** (`--apply-concurrency=1`, unchanged pre-#140 behaviour). Parallel apply is opt-in (`0`=GOMAXPROCS or N>1) after a staging soak and resolution of the multi-replica / consumer-group-rebalance open question.

Invariants preserved & verified: per-tenant ordering; single-writer-per-tenant-DB (ADR-016 intent); gap-free monotonic offset commit; all global.db writes serialized. Accepted consequence: poisoned-batch intermediate on-disk state differs from serial; converged post-restart state identical (idempotent replay).

Conditions met: `--apply-concurrency` flag wired (default serial); same-partition multi-tenant poison test added (passes under -race); finalize-commit invariant comment added.

Benchmark: ~2–3.7x at 256–1024-tenant batches. The earlier '~2.1x at 64 tenants' claim does not reproduce (~1.0–1.3x, within noise) and is dropped.

Closes #140.