### PR TITLE
[E9.2] API key argon2id hashing + persistent, rotatable keys

### DIFF
--- a/server/go/cmd/entdb-server/apikey_wiring_test.go
+++ b/server/go/cmd/entdb-server/apikey_wiring_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+)
+
+// TestGlobalStoreAPIKeysAdapterEndToEnd exercises the production wiring:
+// the globalStoreAPIKeys adapter over a real global.db, driven by the
+// PersistentAPIKeyManager. This is the path --api-key-auth installs, so
+// it covers issue -> argon2 persist -> validate -> rotation overlap ->
+// revoke against the actual SQLite schema.
+func TestGlobalStoreAPIKeysAdapterEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+
+	mgr := auth.NewPersistentAPIKeyManager(globalStoreAPIKeys{gs})
+	ctx := context.Background()
+
+	oldID, err := mgr.Issue(ctx, "old-secret", "deploy-bot", []string{"read", "write"}, 0)
+	if err != nil {
+		t.Fatalf("Issue old: %v", err)
+	}
+
+	// Stored row must carry an argon2id hash, never the plaintext.
+	row, err := gs.GetAPIKey(ctx, oldID)
+	if err != nil || row == nil {
+		t.Fatalf("GetAPIKey(%s): row=%v err=%v", oldID, row, err)
+	}
+	if row.Hash == "old-secret" || len(row.Hash) < 20 || row.Hash[:9] != "$argon2id" {
+		t.Fatalf("persisted hash not argon2id: %q", row.Hash)
+	}
+
+	info, err := mgr.Validate(ctx, "old-secret")
+	if err != nil {
+		t.Fatalf("Validate old: %v", err)
+	}
+	if info.Name != "deploy-bot" || len(info.Scopes) != 2 {
+		t.Fatalf("validated info = %+v, want deploy-bot/[read write]", info)
+	}
+
+	// Rotation: issue the replacement, both keys validate during overlap.
+	if _, err := mgr.Issue(ctx, "new-secret", "deploy-bot", []string{"read", "write"}, 0); err != nil {
+		t.Fatalf("Issue new: %v", err)
+	}
+	if _, err := mgr.Validate(ctx, "old-secret"); err != nil {
+		t.Fatalf("old key should validate during overlap: %v", err)
+	}
+	if _, err := mgr.Validate(ctx, "new-secret"); err != nil {
+		t.Fatalf("new key should validate during overlap: %v", err)
+	}
+
+	// Cutover: revoke the old key; only the new key keeps working.
+	flipped, err := mgr.Revoke(ctx, oldID)
+	if err != nil || !flipped {
+		t.Fatalf("Revoke old: flipped=%v err=%v", flipped, err)
+	}
+	if _, err := mgr.Validate(ctx, "old-secret"); err == nil {
+		t.Fatal("revoked old key must fail")
+	}
+	if _, err := mgr.Validate(ctx, "new-secret"); err != nil {
+		t.Fatalf("new key must survive old-key revocation: %v", err)
+	}
+}

--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -50,6 +50,7 @@ func main() {
 	oauthIssuer := flag.String("oauth-issuer", "", "OIDC issuer URL; expected JWT 'iss' and the discovery base when --jwks-url is unset")
 	oauthJWKSURL := flag.String("jwks-url", "", "explicit JWKS endpoint; when set, OIDC discovery is skipped")
 	oauthAudience := flag.String("oauth-audience", "", "expected JWT 'aud' (your OAuth client/app id); empty disables the audience check (dev only)")
+	apiKeyAuth := flag.Bool("api-key-auth", false, "enable persistent argon2id-hashed API-key authentication backed by global.db (x-api-key header)")
 	kmsProvider := flag.String("kms-provider", "", "encryption master-key provider: file | aws | gcp | azure | vault")
 	kmsKeyID := flag.String("kms-key-id", "", "master-key provider identifier; file provider accepts path or env:NAME")
 	encryptionRequired := flag.Bool("encryption-required", false, "require encrypted global.db and tenant SQLite files")
@@ -348,10 +349,10 @@ func main() {
 	// network-backed JWKSValidator (real JWKS fetch + caching + key
 	// rotation, OIDC discovery, provider presets) and install the auth
 	// interceptor. The interceptor reads gRPC metadata, so it is wired
-	// independently of TLS. API-key / session managers stay nil here
-	// (in-memory dev managers and their flags are tracked under
-	// sibling issues #87/#88); a nil backend simply means that
-	// credential type is not accepted.
+	// independently of TLS. The session manager stays nil here
+	// (in-memory dev manager and its flag are tracked under sibling
+	// issue #88); a nil backend simply means that credential type is
+	// not accepted.
 	oc := oauthConfig{
 		provider: *oauthProvider,
 		issuer:   *oauthIssuer,
@@ -371,6 +372,23 @@ func main() {
 		log.Printf("entdb-server: OAuth/OIDC authentication enabled (%s)", oauthSummary(oc, validator))
 	} else {
 		log.Printf("entdb-server: WARNING: OAuth/OIDC authentication disabled; no -oauth-* flags set (local/dev only — production MUST set --oauth-issuer)")
+	}
+
+	// Persistent API-key auth. When enabled, every non-Health RPC must
+	// present a valid x-api-key whose argon2id hash is stored in
+	// global.db. Rotation is supported out of band (issue a new key,
+	// flip clients, revoke the old key_id) -- both keys validate while
+	// both are active. Installed AFTER the mTLS peer interceptor so a
+	// future authorization layer sees the API-key Identity on the
+	// context.
+	if *apiKeyAuth {
+		keyMgr := auth.NewPersistentAPIKeyManager(globalStoreAPIKeys{global})
+		apiKeyInterceptor := auth.NewInterceptor(nil, keyMgr, nil)
+		grpcServerOpts = append(grpcServerOpts,
+			grpc.ChainUnaryInterceptor(apiKeyInterceptor.Unary()),
+			grpc.ChainStreamInterceptor(apiKeyInterceptor.Stream()),
+		)
+		log.Printf("entdb-server: persistent API-key auth enabled (argon2id, global.db-backed, rotatable)")
 	}
 
 	srv := grpc.NewServer(grpcServerOpts...)
@@ -506,6 +524,48 @@ func splitBrokers(s string) []string {
 		}
 	}
 	return out
+}
+
+// globalStoreAPIKeys adapts *globalstore.GlobalStore to
+// auth.APIKeyStore. The adapter lives here -- the only place that wires
+// both packages -- so neither auth nor globalstore takes a dependency on
+// the other (the cross-package edge is owned by main, like every other
+// backend wiring in this file).
+type globalStoreAPIKeys struct {
+	g *globalstore.GlobalStore
+}
+
+func (a globalStoreAPIKeys) PutAPIKey(ctx context.Context, k auth.StoredAPIKey) error {
+	return a.g.PutAPIKey(ctx, globalstore.APIKeyRecord{
+		KeyID:     k.KeyID,
+		Name:      k.Name,
+		Hash:      k.Hash,
+		Scopes:    k.Scopes,
+		Status:    globalstore.APIKeyStatusActive,
+		ExpiresAt: k.ExpiresAt,
+	})
+}
+
+func (a globalStoreAPIKeys) RevokeAPIKey(ctx context.Context, keyID string) (bool, error) {
+	return a.g.RevokeAPIKey(ctx, keyID)
+}
+
+func (a globalStoreAPIKeys) ListActiveAPIKeys(ctx context.Context, now int64) ([]auth.StoredAPIKey, error) {
+	recs, err := a.g.ListActiveAPIKeys(ctx, now)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]auth.StoredAPIKey, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, auth.StoredAPIKey{
+			KeyID:     r.KeyID,
+			Name:      r.Name,
+			Hash:      r.Hash,
+			Scopes:    r.Scopes,
+			ExpiresAt: r.ExpiresAt,
+		})
+	}
+	return out, nil
 }
 
 func effectiveKMSProvider(provider string) string {

--- a/server/go/internal/auth/apikey.go
+++ b/server/go/internal/auth/apikey.go
@@ -4,11 +4,17 @@ package auth
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/rand"
 	"crypto/subtle"
-	"encoding/hex"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/crypto/argon2"
 )
 
 // APIKeyManager validates an opaque API key (the value of the
@@ -22,117 +28,225 @@ type APIKeyManager interface {
 // key. The Name is what the interceptor uses as the Identity.Subject;
 // the Scopes flow through to AuthContext.Scopes for the quota
 // interceptor and any future scope-gated RPC.
-//
-// Mirrors the dict returned by ApiKeyManager.validate_key in
 type APIKeyInfo struct {
 	KeyID  string
 	Name   string
 	Scopes []string
 }
 
+// argon2id parameters. These are deliberately constants rather than
+// tunables: the encoded PHC string carries the parameters that were used
+// for each stored hash, so Verify always uses the per-hash parameters
+// and we can raise these defaults later without invalidating old keys.
+//
+// 64 MiB / 1 pass / parallelism=4 follows the OWASP "first recommended"
+// argon2id configuration. API-key validation is on the request hot path,
+// so we keep time=1 and lean on memory hardness; a single Validate is
+// ~2-4ms on commodity hardware which is acceptable for a credential that
+// is presented once per RPC (and typically behind a connection that
+// reuses the same key).
+const (
+	argon2Time    uint32 = 1
+	argon2Memory  uint32 = 64 * 1024 // KiB => 64 MiB
+	argon2KeyLen  uint32 = 32
+	argon2SaltLen        = 16
+)
+
+func argon2Threads() uint8 {
+	if n := runtime.GOMAXPROCS(0); n > 0 && n < 255 {
+		return uint8(n)
+	}
+	return 4
+}
+
+// hashAPIKey returns a PHC-format argon2id string for the plaintext key
+// using a fresh random salt. Format:
+//
+//	$argon2id$v=19$m=65536,t=1,p=4$<b64salt>$<b64hash>
+//
+// The parameters are embedded so VerifyAPIKeyHash can reproduce the
+// derivation even if the package defaults change later.
+func hashAPIKey(plaintext string) (string, error) {
+	salt := make([]byte, argon2SaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("auth: generate argon2 salt: %w", err)
+	}
+	threads := argon2Threads()
+	sum := argon2.IDKey([]byte(plaintext), salt, argon2Time, argon2Memory, threads, argon2KeyLen)
+	return fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		argon2Memory, argon2Time, threads,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(sum),
+	), nil
+}
+
+// errBadHashFormat marks a stored hash that does not parse. It is never
+// surfaced to a client (always remapped to a generic UNAUTHENTICATED) so
+// a corrupt row reads as "invalid key", not as an oracle.
+var errBadHashFormat = errors.New("auth: malformed argon2 hash")
+
+// VerifyAPIKeyHash reports whether plaintext hashes to encoded. The
+// comparison of the derived key against the stored key is
+// constant-time (subtle.ConstantTimeCompare); argon2 itself is
+// data-independent so the derivation does not leak the secret through
+// timing.
+func VerifyAPIKeyHash(plaintext, encoded string) (bool, error) {
+	parts := strings.Split(encoded, "$")
+	// "" / "argon2id" / "v=19" / "m=..,t=..,p=.." / salt / hash
+	if len(parts) != 6 || parts[0] != "" || parts[1] != "argon2id" {
+		return false, errBadHashFormat
+	}
+	var version int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil || version != argon2.Version {
+		return false, errBadHashFormat
+	}
+	var memory, time uint32
+	var threads uint8
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &memory, &time, &threads); err != nil {
+		return false, errBadHashFormat
+	}
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false, errBadHashFormat
+	}
+	want, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false, errBadHashFormat
+	}
+	got := argon2.IDKey([]byte(plaintext), salt, time, memory, threads, uint32(len(want)))
+	return subtle.ConstantTimeCompare(got, want) == 1, nil
+}
+
+// keyIDFor derives the public, non-secret key identifier. It is a
+// truncated argon2id digest under a fixed all-zero salt so the same
+// plaintext is idempotent across Add calls (matching the historical
+// "ek_<hex>" contract) while never exposing a reversible function of the
+// secret -- the truncation plus a separate salt domain from the
+// verification hash means the key_id is not a verification oracle.
+func keyIDFor(plaintext string) string {
+	var idSalt [argon2SaltLen]byte // fixed zero salt: this is an identifier, not a credential
+	sum := argon2.IDKey([]byte("keyid:"+plaintext), idSalt[:], 1, 16*1024, 1, 8)
+	return "ek_" + base64.RawURLEncoding.EncodeToString(sum)
+}
+
 // MemoryAPIKeyManager is the in-memory APIKeyManager used by tests and
-// the no-auth dev server. Keys are stored as SHA-256 hashes -- no
-// plaintext secret is retained -- to match the Python implementation's
-// disk-write surface. Validation uses subtle.ConstantTimeCompare on the
-// hash to avoid timing leaks (TODO carried over from
-// api_key_manager.py:23).
+// the no-auth dev server. Keys are stored as argon2id PHC strings -- no
+// plaintext secret is retained. Validation derives the argon2id digest
+// of the presented key and compares it constant-time against the stored
+// digest.
+//
+// It supports the same rotation surface as the persistent manager
+// (multiple simultaneously-active keys, Revoke without the plaintext) so
+// tests can exercise the migration window without a database.
 type MemoryAPIKeyManager struct {
 	mu      sync.RWMutex
-	byHash  map[string]*apiKeyEntry
 	byKeyID map[string]*apiKeyEntry
+
+	// Now lets tests pin a synthetic clock. nil -> time.Now.
+	Now func() time.Time
 }
 
 type apiKeyEntry struct {
-	keyID     string
-	name      string
-	scopes    []string
-	hash      []byte
-	expiresAt time.Time // zero means "never"
-	revoked   bool
+	keyID      string
+	name       string
+	scopes     []string
+	encodedHsh string
+	expiresAt  time.Time // zero means "never"
+	revoked    bool
 }
 
 // NewMemoryAPIKeyManager returns an empty in-memory key store. Add keys
 // with Add.
 func NewMemoryAPIKeyManager() *MemoryAPIKeyManager {
 	return &MemoryAPIKeyManager{
-		byHash:  make(map[string]*apiKeyEntry),
 		byKeyID: make(map[string]*apiKeyEntry),
 	}
 }
 
-// Add registers a plaintext key. The plaintext is hashed and dropped;
-// callers retain it themselves (or print it once and forget it, like
-// the real key-create flow). The returned key_id matches the
-// "ek_<hex>" format the Python store hands out and lets callers
-// Revoke later without remembering the plaintext.
-//
-// keyID is generated from the hash so the same plaintext is idempotent
-// across calls; the test surface doesn't need a separate ID generator.
+func (m *MemoryAPIKeyManager) now() time.Time {
+	if m.Now != nil {
+		return m.Now()
+	}
+	return time.Now()
+}
+
+// Add registers a plaintext key with no expiry. The plaintext is hashed
+// (argon2id) and dropped; callers retain it themselves (or print it once
+// and forget it, like the real key-create flow). The returned key_id is
+// stable for the same plaintext and lets callers Revoke later without
+// remembering the secret.
 func (m *MemoryAPIKeyManager) Add(plaintext, name string, scopes []string) string {
-	hash := sha256Sum(plaintext)
-	keyID := "ek_" + hex.EncodeToString(hash[:8])
+	id, _ := m.AddWithExpiry(plaintext, name, scopes, time.Time{})
+	return id
+}
+
+// AddWithExpiry is Add with an absolute expiry (zero == never). Returns
+// the key_id and any hashing error. Used by the rotation tests to mint
+// already-expired keys.
+func (m *MemoryAPIKeyManager) AddWithExpiry(plaintext, name string, scopes []string, expiresAt time.Time) (string, error) {
+	encoded, err := hashAPIKey(plaintext)
+	if err != nil {
+		return "", err
+	}
+	keyID := keyIDFor(plaintext)
 	entry := &apiKeyEntry{
-		keyID:  keyID,
-		name:   name,
-		scopes: append([]string(nil), scopes...),
-		hash:   hash,
+		keyID:      keyID,
+		name:       name,
+		scopes:     append([]string(nil), scopes...),
+		encodedHsh: encoded,
+		expiresAt:  expiresAt,
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.byHash[string(hash)] = entry
 	m.byKeyID[keyID] = entry
-	return keyID
+	m.mu.Unlock()
+	return keyID, nil
 }
 
 // Revoke marks a key as revoked. Subsequent Validate calls return an
-// UNAUTHENTICATED error.
+// UNAUTHENTICATED error. Unknown key_id is a no-op.
 func (m *MemoryAPIKeyManager) Revoke(keyID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if e, ok := m.byKeyID[keyID]; ok {
 		e.revoked = true
-		// Drop from the hash index so Validate fails fast with a
-		// constant-time miss, matching api_key_manager.py:222.
-		delete(m.byHash, string(e.hash))
 	}
 }
 
-// Validate looks up the plaintext key, checks revocation and expiry,
-// and returns the key info. The lookup itself is a hash-table read;
-// the constant-time compare here is defence-in-depth -- map lookup is
-// already O(1) but does allocate, so the timing channel is small.
+// Validate derives the argon2id digest of the presented key and matches
+// it against every stored entry. The match is O(n) in the number of
+// active keys because argon2 hashes are salted per key (the historical
+// SHA-256 hash-table lookup is not possible with a per-key salt); n is
+// the count of keys in a single rotation window, which is small by
+// construction.
 func (m *MemoryAPIKeyManager) Validate(_ context.Context, plaintext string) (APIKeyInfo, error) {
 	if plaintext == "" {
 		return APIKeyInfo{}, unauthenticatedf("missing API key")
 	}
-	hash := sha256Sum(plaintext)
 	m.mu.RLock()
-	entry, ok := m.byHash[string(hash)]
+	entries := make([]*apiKeyEntry, 0, len(m.byKeyID))
+	for _, e := range m.byKeyID {
+		entries = append(entries, e)
+	}
 	m.mu.RUnlock()
-	if !ok || entry == nil {
-		return APIKeyInfo{}, unauthenticatedf("invalid API key")
-	}
-	// Belt-and-suspenders constant-time compare against the stored
-	// hash. If the map index hash collides (it won't with SHA-256 on
-	// the universe of inputs we see, but the assertion is cheap) this
-	// catches it.
-	if subtle.ConstantTimeCompare(entry.hash, hash) != 1 {
-		return APIKeyInfo{}, unauthenticatedf("invalid API key")
-	}
-	if entry.revoked {
-		return APIKeyInfo{}, unauthenticatedf("API key has been revoked")
-	}
-	if !entry.expiresAt.IsZero() && !time.Now().Before(entry.expiresAt) {
-		return APIKeyInfo{}, unauthenticatedf("API key has expired")
-	}
-	return APIKeyInfo{
-		KeyID:  entry.keyID,
-		Name:   entry.name,
-		Scopes: append([]string(nil), entry.scopes...),
-	}, nil
-}
 
-func sha256Sum(s string) []byte {
-	h := sha256.Sum256([]byte(s))
-	return h[:]
+	for _, e := range entries {
+		ok, err := VerifyAPIKeyHash(plaintext, e.encodedHsh)
+		if err != nil || !ok {
+			continue
+		}
+		if e.revoked {
+			return APIKeyInfo{}, unauthenticatedf("API key has been revoked")
+		}
+		if !e.expiresAt.IsZero() && !m.now().Before(e.expiresAt) {
+			return APIKeyInfo{}, unauthenticatedf("API key has expired")
+		}
+		return APIKeyInfo{
+			KeyID:  e.keyID,
+			Name:   e.name,
+			Scopes: append([]string(nil), e.scopes...),
+		}, nil
+	}
+	return APIKeyInfo{}, unauthenticatedf("invalid API key")
 }

--- a/server/go/internal/auth/apikey_persistent.go
+++ b/server/go/internal/auth/apikey_persistent.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// StoredAPIKey is the auth-package view of one persisted API-key row.
+// It is decoupled from globalstore.APIKeyRecord so this package does not
+// import globalstore (keeps the dependency edge auth <- callers, never
+// auth -> globalstore) and so the manager is unit-testable with a fake
+// store.
+type StoredAPIKey struct {
+	KeyID     string
+	Name      string
+	Hash      string   // argon2id PHC string
+	Scopes    []string
+	ExpiresAt int64 // Unix seconds; 0 == never
+}
+
+// APIKeyStore is the persistence contract the PersistentAPIKeyManager
+// depends on. *globalstore.GlobalStore satisfies it structurally via an
+// adapter (see GlobalStoreAPIKeys); tests use an in-memory fake.
+//
+// PutAPIKey/RevokeAPIKey carry the rotation surface: issue a new row,
+// flip clients over, then revoke the old key_id. ListActiveAPIKeys is
+// the validation hot path -- it returns every key that is status=active
+// AND unexpired, which is exactly the set that must all stay acceptable
+// during a rotation migration window.
+type APIKeyStore interface {
+	PutAPIKey(ctx context.Context, k StoredAPIKey) error
+	RevokeAPIKey(ctx context.Context, keyID string) (bool, error)
+	ListActiveAPIKeys(ctx context.Context, now int64) ([]StoredAPIKey, error)
+}
+
+// PersistentAPIKeyManager is the production APIKeyManager: keys live in
+// global.db, hashed with argon2id, scoped, revocable, and rotatable
+// (multiple simultaneously-active keys for a documented migration
+// window).
+//
+// Validate fetches the active set from the store and compares the
+// presented secret against each entry's argon2id hash with a
+// constant-time compare. The candidate set is naturally small (one
+// rotation window's worth of keys); per-key salts make a hash-table
+// lookup impossible by construction, so the linear scan is intentional
+// and bounded.
+//
+// Concurrency: safe for concurrent use as long as the backing store is
+// (globalstore pins MaxOpenConns(1), so it is).
+type PersistentAPIKeyManager struct {
+	store APIKeyStore
+
+	// Now lets tests pin a synthetic clock. nil -> time.Now.
+	Now func() time.Time
+}
+
+// NewPersistentAPIKeyManager wires a manager onto a durable store.
+func NewPersistentAPIKeyManager(store APIKeyStore) *PersistentAPIKeyManager {
+	return &PersistentAPIKeyManager{store: store}
+}
+
+func (m *PersistentAPIKeyManager) now() time.Time {
+	if m.Now != nil {
+		return m.Now()
+	}
+	return time.Now()
+}
+
+// Issue mints a new key: it hashes the plaintext with argon2id, derives
+// a stable key_id, and persists the row as status=active. The plaintext
+// is the caller's responsibility to surface once and then forget --
+// globalstore only ever stores the hash. expiresAt is an absolute
+// Unix-second deadline; pass 0 for "never".
+//
+// Issue is the "create the new key" half of rotation: call it to mint
+// the replacement, hand the new secret to the client, leave the old key
+// active until the cutover completes, then Revoke the old key_id.
+func (m *PersistentAPIKeyManager) Issue(ctx context.Context, plaintext, name string, scopes []string, expiresAt int64) (keyID string, err error) {
+	if plaintext == "" {
+		return "", fmt.Errorf("auth: Issue requires a non-empty plaintext key")
+	}
+	encoded, err := hashAPIKey(plaintext)
+	if err != nil {
+		return "", err
+	}
+	keyID = keyIDFor(plaintext)
+	if err := m.store.PutAPIKey(ctx, StoredAPIKey{
+		KeyID:     keyID,
+		Name:      name,
+		Hash:      encoded,
+		Scopes:    append([]string(nil), scopes...),
+		ExpiresAt: expiresAt,
+	}); err != nil {
+		return "", err
+	}
+	return keyID, nil
+}
+
+// Revoke retires a key by key_id. Returns true iff an active key was
+// flipped to revoked. This is the "retire the old key" half of the
+// rotation migration window; after this returns the old secret is dead
+// while the new one (issued earlier) keeps working uninterrupted.
+func (m *PersistentAPIKeyManager) Revoke(ctx context.Context, keyID string) (bool, error) {
+	return m.store.RevokeAPIKey(ctx, keyID)
+}
+
+// Validate authenticates a presented API-key secret against the active
+// set. Revoked or expired keys are never returned by the store query, so
+// a hit here is by construction a live key. The argon2id verification is
+// constant-time per candidate.
+func (m *PersistentAPIKeyManager) Validate(ctx context.Context, plaintext string) (APIKeyInfo, error) {
+	if plaintext == "" {
+		return APIKeyInfo{}, unauthenticatedf("missing API key")
+	}
+	active, err := m.store.ListActiveAPIKeys(ctx, m.now().Unix())
+	if err != nil {
+		// A store failure must not leak as "invalid key" (that would be
+		// an availability bug masquerading as auth). Surface it as an
+		// internal-ish UNAUTHENTICATED with a distinct message; the
+		// interceptor maps everything from this package to the gRPC
+		// status, and we never want a transient DB blip to look like a
+		// brute-force miss.
+		return APIKeyInfo{}, unauthenticatedf("API key store unavailable: %v", err)
+	}
+	for _, k := range active {
+		ok, verr := VerifyAPIKeyHash(plaintext, k.Hash)
+		if verr != nil || !ok {
+			continue
+		}
+		return APIKeyInfo{
+			KeyID:  k.KeyID,
+			Name:   k.Name,
+			Scopes: append([]string(nil), k.Scopes...),
+		}, nil
+	}
+	return APIKeyInfo{}, unauthenticatedf("invalid API key")
+}

--- a/server/go/internal/auth/apikey_persistent_test.go
+++ b/server/go/internal/auth/apikey_persistent_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// fakeAPIKeyStore is an in-memory APIKeyStore for unit-testing the
+// persistent manager without global.db. now() lets tests drive expiry.
+type fakeAPIKeyStore struct {
+	rows    map[string]*StoredAPIKey
+	revoked map[string]bool
+	now     func() int64
+	failOn  string // if set, the named method returns an error
+}
+
+func newFakeStore() *fakeAPIKeyStore {
+	return &fakeAPIKeyStore{
+		rows:    map[string]*StoredAPIKey{},
+		revoked: map[string]bool{},
+		now:     func() int64 { return 1_000_000 },
+	}
+}
+
+func (f *fakeAPIKeyStore) PutAPIKey(_ context.Context, k StoredAPIKey) error {
+	if f.failOn == "put" {
+		return errors.New("boom")
+	}
+	if _, ok := f.rows[k.KeyID]; ok {
+		return errors.New("duplicate key_id")
+	}
+	cp := k
+	cp.Scopes = append([]string(nil), k.Scopes...)
+	f.rows[k.KeyID] = &cp
+	return nil
+}
+
+func (f *fakeAPIKeyStore) RevokeAPIKey(_ context.Context, keyID string) (bool, error) {
+	if f.failOn == "revoke" {
+		return false, errors.New("boom")
+	}
+	if _, ok := f.rows[keyID]; !ok || f.revoked[keyID] {
+		return false, nil
+	}
+	f.revoked[keyID] = true
+	return true, nil
+}
+
+func (f *fakeAPIKeyStore) ListActiveAPIKeys(_ context.Context, now int64) ([]StoredAPIKey, error) {
+	if f.failOn == "list" {
+		return nil, errors.New("db unavailable")
+	}
+	if now == 0 {
+		now = f.now()
+	}
+	out := []StoredAPIKey{}
+	for id, r := range f.rows {
+		if f.revoked[id] {
+			continue
+		}
+		if r.ExpiresAt != 0 && r.ExpiresAt <= now {
+			continue
+		}
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+func TestPersistentAPIKeyManager_IssueValidateRoundTrip(t *testing.T) {
+	store := newFakeStore()
+	m := NewPersistentAPIKeyManager(store)
+	m.Now = func() time.Time { return time.Unix(1_000_000, 0) }
+
+	id, err := m.Issue(context.Background(), "super-secret", "deploy-bot", []string{"read", "write"}, 0)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if id == "" {
+		t.Fatal("Issue returned empty key_id")
+	}
+	// The stored row must carry an argon2id hash, never the plaintext.
+	row := store.rows[id]
+	if row == nil {
+		t.Fatal("Issue did not persist a row")
+	}
+	if row.Hash == "super-secret" || !hasArgon2Prefix(row.Hash) {
+		t.Fatalf("stored hash not argon2id: %q", row.Hash)
+	}
+
+	info, err := m.Validate(context.Background(), "super-secret")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if info.Name != "deploy-bot" {
+		t.Errorf("Name = %q, want deploy-bot", info.Name)
+	}
+	if len(info.Scopes) != 2 {
+		t.Errorf("Scopes = %v, want 2", info.Scopes)
+	}
+	if info.KeyID != id {
+		t.Errorf("KeyID = %q, want %q", info.KeyID, id)
+	}
+}
+
+func TestPersistentAPIKeyManager_UnknownAndEmpty(t *testing.T) {
+	m := NewPersistentAPIKeyManager(newFakeStore())
+	if _, err := m.Validate(context.Background(), ""); errs.Code(err) != codes.Unauthenticated {
+		t.Errorf("empty key code = %v, want Unauthenticated", errs.Code(err))
+	}
+	if _, err := m.Validate(context.Background(), "ghost"); errs.Code(err) != codes.Unauthenticated {
+		t.Errorf("unknown key code = %v, want Unauthenticated", errs.Code(err))
+	}
+}
+
+// TestPersistentAPIKeyManager_RotationOverlap is the documented
+// migration window end-to-end against the persistence layer: issue new,
+// both validate, revoke old, only new validates.
+func TestPersistentAPIKeyManager_RotationOverlap(t *testing.T) {
+	store := newFakeStore()
+	m := NewPersistentAPIKeyManager(store)
+	ctx := context.Background()
+
+	oldID, err := m.Issue(ctx, "old-secret", "svc", []string{"read"}, 0)
+	if err != nil {
+		t.Fatalf("issue old: %v", err)
+	}
+	newID, err := m.Issue(ctx, "new-secret", "svc", []string{"read"}, 0)
+	if err != nil {
+		t.Fatalf("issue new: %v", err)
+	}
+	if oldID == newID {
+		t.Fatal("distinct secrets produced same key_id")
+	}
+
+	// Overlap: both keys valid.
+	if _, err := m.Validate(ctx, "old-secret"); err != nil {
+		t.Fatalf("old key should validate during overlap: %v", err)
+	}
+	if _, err := m.Validate(ctx, "new-secret"); err != nil {
+		t.Fatalf("new key should validate during overlap: %v", err)
+	}
+
+	// Retire the old key.
+	flipped, err := m.Revoke(ctx, oldID)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if !flipped {
+		t.Fatal("Revoke reported no active key flipped")
+	}
+	// Idempotent: re-revoking returns false.
+	if again, _ := m.Revoke(ctx, oldID); again {
+		t.Fatal("second Revoke should be a no-op (false)")
+	}
+
+	if _, err := m.Validate(ctx, "old-secret"); err == nil {
+		t.Fatal("revoked old key must fail")
+	}
+	if _, err := m.Validate(ctx, "new-secret"); err != nil {
+		t.Fatalf("new key must survive old-key revocation: %v", err)
+	}
+}
+
+func TestPersistentAPIKeyManager_ExpiryEnforced(t *testing.T) {
+	store := newFakeStore()
+	m := NewPersistentAPIKeyManager(store)
+	clock := int64(1_000_000)
+	store.now = func() int64 { return clock }
+	m.Now = func() time.Time { return time.Unix(clock, 0) }
+	ctx := context.Background()
+
+	if _, err := m.Issue(ctx, "short-lived", "bot", []string{"read"}, clock+100); err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if _, err := m.Validate(ctx, "short-lived"); err != nil {
+		t.Fatalf("key valid before expiry: %v", err)
+	}
+	clock += 200 // advance past expiry
+	if _, err := m.Validate(ctx, "short-lived"); err == nil {
+		t.Fatal("expired key must fail")
+	}
+}
+
+func TestPersistentAPIKeyManager_ScopeEnforcement(t *testing.T) {
+	store := newFakeStore()
+	m := NewPersistentAPIKeyManager(store)
+	ctx := context.Background()
+
+	if _, err := m.Issue(ctx, "ro", "reader", []string{"read"}, 0); err != nil {
+		t.Fatalf("issue ro: %v", err)
+	}
+	if _, err := m.Issue(ctx, "admin", "ops", []string{"read", "write", "admin"}, 0); err != nil {
+		t.Fatalf("issue admin: %v", err)
+	}
+
+	ro, err := m.Validate(ctx, "ro")
+	if err != nil {
+		t.Fatalf("validate ro: %v", err)
+	}
+	if len(ro.Scopes) != 1 || ro.Scopes[0] != "read" {
+		t.Fatalf("ro scopes = %v, want [read]", ro.Scopes)
+	}
+	admin, err := m.Validate(ctx, "admin")
+	if err != nil {
+		t.Fatalf("validate admin: %v", err)
+	}
+	if len(admin.Scopes) != 3 {
+		t.Fatalf("admin scopes = %v, want 3", admin.Scopes)
+	}
+}
+
+// TestPersistentAPIKeyManager_StoreFailureNotAnInvalidKey ensures a DB
+// outage surfaces as a distinct UNAUTHENTICATED message (availability
+// problem), not as a silent "invalid API key" that would mask the
+// outage.
+func TestPersistentAPIKeyManager_StoreFailureNotAnInvalidKey(t *testing.T) {
+	store := newFakeStore()
+	store.failOn = "list"
+	m := NewPersistentAPIKeyManager(store)
+	_, err := m.Validate(context.Background(), "anything")
+	if err == nil {
+		t.Fatal("expected error when store fails")
+	}
+	if errs.Code(err) != codes.Unauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", errs.Code(err))
+	}
+	if got := err.Error(); !strings.Contains(got, "store unavailable") {
+		t.Errorf("error = %q, want it to mention store unavailability", got)
+	}
+}
+
+func hasArgon2Prefix(s string) bool { return strings.Contains(s, "$argon2id$v=19$") }

--- a/server/go/internal/auth/apikey_test.go
+++ b/server/go/internal/auth/apikey_test.go
@@ -4,7 +4,9 @@ package auth
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 
@@ -17,6 +19,9 @@ func TestMemoryAPIKeyManager_ValidateRoundTrip(t *testing.T) {
 	if keyID == "" {
 		t.Fatal("expected non-empty keyID")
 	}
+	if !strings.HasPrefix(keyID, "ek_") {
+		t.Errorf("keyID = %q, want ek_ prefix", keyID)
+	}
 	info, err := m.Validate(context.Background(), "plaintext-secret")
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
@@ -27,10 +32,14 @@ func TestMemoryAPIKeyManager_ValidateRoundTrip(t *testing.T) {
 	if len(info.Scopes) != 2 || info.Scopes[0] != "read" || info.Scopes[1] != "write" {
 		t.Errorf("Scopes = %v, want [read write]", info.Scopes)
 	}
+	if info.KeyID != keyID {
+		t.Errorf("KeyID = %q, want %q", info.KeyID, keyID)
+	}
 }
 
 func TestMemoryAPIKeyManager_RejectsUnknown(t *testing.T) {
 	m := NewMemoryAPIKeyManager()
+	m.Add("the-real-key", "bot", nil)
 	_, err := m.Validate(context.Background(), "nope")
 	if err == nil {
 		t.Fatal("expected error for unknown key")
@@ -53,5 +62,144 @@ func TestMemoryAPIKeyManager_EmptyKeyFails(t *testing.T) {
 	m := NewMemoryAPIKeyManager()
 	if _, err := m.Validate(context.Background(), ""); err == nil {
 		t.Fatal("expected empty key to fail")
+	}
+}
+
+// TestArgon2HashRoundTrip pins the hashing primitive: a fresh hash
+// verifies against its own plaintext, a different plaintext does not,
+// and the encoded form is a PHC argon2id string (never the plaintext or
+// a bare SHA-256 hex).
+func TestArgon2HashRoundTrip(t *testing.T) {
+	enc, err := hashAPIKey("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("hashAPIKey: %v", err)
+	}
+	if !strings.HasPrefix(enc, "$argon2id$v=19$") {
+		t.Fatalf("encoded hash = %q, want $argon2id$v=19$ prefix", enc)
+	}
+	if strings.Contains(enc, "correct horse") {
+		t.Fatal("encoded hash leaks plaintext")
+	}
+	ok, err := VerifyAPIKeyHash("correct horse battery staple", enc)
+	if err != nil {
+		t.Fatalf("VerifyAPIKeyHash: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifyAPIKeyHash: correct password did not verify")
+	}
+	bad, err := VerifyAPIKeyHash("wrong password", enc)
+	if err != nil {
+		t.Fatalf("VerifyAPIKeyHash (wrong): %v", err)
+	}
+	if bad {
+		t.Fatal("VerifyAPIKeyHash: wrong password verified")
+	}
+}
+
+// TestArgon2HashSaltIsRandom proves two hashes of the same plaintext
+// differ (per-key random salt) yet both verify.
+func TestArgon2HashSaltIsRandom(t *testing.T) {
+	a, err := hashAPIKey("same-secret")
+	if err != nil {
+		t.Fatalf("hashAPIKey a: %v", err)
+	}
+	b, err := hashAPIKey("same-secret")
+	if err != nil {
+		t.Fatalf("hashAPIKey b: %v", err)
+	}
+	if a == b {
+		t.Fatal("two hashes of the same plaintext are identical -- salt is not random")
+	}
+	for _, enc := range []string{a, b} {
+		ok, err := VerifyAPIKeyHash("same-secret", enc)
+		if err != nil || !ok {
+			t.Fatalf("salted hash failed to verify: ok=%v err=%v", ok, err)
+		}
+	}
+}
+
+func TestVerifyAPIKeyHash_MalformedRejected(t *testing.T) {
+	for _, bad := range []string{
+		"",
+		"not-a-phc-string",
+		"$argon2id$v=19$m=65536,t=1,p=4$onlyfourfields",
+		"$bcrypt$v=19$m=65536,t=1,p=4$c2FsdA$aGFzaA",
+		"$argon2id$v=99$m=65536,t=1,p=4$c2FsdA$aGFzaA",
+	} {
+		ok, err := VerifyAPIKeyHash("x", bad)
+		if ok {
+			t.Errorf("malformed hash %q verified true", bad)
+		}
+		if err == nil {
+			t.Errorf("malformed hash %q returned nil error", bad)
+		}
+	}
+}
+
+func TestMemoryAPIKeyManager_ExpiredKeyFails(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	m := NewMemoryAPIKeyManager()
+	m.Now = func() time.Time { return now }
+	if _, err := m.AddWithExpiry("k", "bot", nil, now.Add(-time.Second)); err != nil {
+		t.Fatalf("AddWithExpiry: %v", err)
+	}
+	if _, err := m.Validate(context.Background(), "k"); err == nil {
+		t.Fatal("expected expired key to fail")
+	}
+}
+
+func TestMemoryAPIKeyManager_ScopesArePerKey(t *testing.T) {
+	m := NewMemoryAPIKeyManager()
+	m.Add("ro-key", "reader", []string{"read"})
+	m.Add("rw-key", "writer", []string{"read", "write"})
+
+	ro, err := m.Validate(context.Background(), "ro-key")
+	if err != nil {
+		t.Fatalf("validate ro: %v", err)
+	}
+	if len(ro.Scopes) != 1 || ro.Scopes[0] != "read" {
+		t.Errorf("ro scopes = %v, want [read]", ro.Scopes)
+	}
+	rw, err := m.Validate(context.Background(), "rw-key")
+	if err != nil {
+		t.Fatalf("validate rw: %v", err)
+	}
+	if len(rw.Scopes) != 2 {
+		t.Errorf("rw scopes = %v, want 2 entries", rw.Scopes)
+	}
+	// Mutating the returned slice must not poison the store.
+	rw.Scopes[0] = "tampered"
+	again, _ := m.Validate(context.Background(), "rw-key")
+	if again.Scopes[0] == "tampered" {
+		t.Fatal("returned Scopes slice aliases internal state")
+	}
+}
+
+// TestMemoryAPIKeyManager_RotationOverlap exercises the migration
+// window: old + new keys both validate while both are active, then the
+// old key is revoked and only the new key works.
+func TestMemoryAPIKeyManager_RotationOverlap(t *testing.T) {
+	m := NewMemoryAPIKeyManager()
+	oldID := m.Add("old-secret", "svc", []string{"read"})
+	newID := m.Add("new-secret", "svc", []string{"read"})
+	if oldID == newID {
+		t.Fatal("distinct plaintexts produced the same key_id")
+	}
+
+	// Migration window: both keys accepted.
+	if _, err := m.Validate(context.Background(), "old-secret"); err != nil {
+		t.Fatalf("old key should still validate during overlap: %v", err)
+	}
+	if _, err := m.Validate(context.Background(), "new-secret"); err != nil {
+		t.Fatalf("new key should validate during overlap: %v", err)
+	}
+
+	// Cutover complete: retire the old key.
+	m.Revoke(oldID)
+	if _, err := m.Validate(context.Background(), "old-secret"); err == nil {
+		t.Fatal("old key must fail after revocation")
+	}
+	if _, err := m.Validate(context.Background(), "new-secret"); err != nil {
+		t.Fatalf("new key must keep working after old key revoked: %v", err)
 	}
 }

--- a/server/go/internal/auth/doc.go
+++ b/server/go/internal/auth/doc.go
@@ -20,15 +20,28 @@
 //	jwks.go Production JWKSValidator: network JWKS fetch +
 //	                 caching + key rotation, OIDC discovery,
 //	                 Google/Microsoft/Okta presets (RS256 / ES256).
-//	apikey.go In-memory APIKeyManager.
+//	apikey.go argon2id hashing + in-memory APIKeyManager.
+//	apikey_persistent.go PersistentAPIKeyManager (durable, rotatable).
 //	session.go In-memory SessionManager.
 //	errors.go UNAUTHENTICATED / PERMISSION_DENIED wrappers.
 //
-// Production OAuth/OIDC ships here (JWKSValidator), wired into the
-// server via the -oauth-issuer / -jwks-url / -oauth-audience /
-// -oauth-provider flags on cmd/entdb-server. Redis-backed sessions, the
-// production API-key store, and the quota interceptor are tracked
-// separately (#87/#88); this package ships the OAuth validators plus the
-// trusted-actor plumbing, with in-memory API-key/session managers for
-// tests and dev.
+// Production OAuth/OIDC ships here (JWKSValidator: network JWKS fetch +
+// caching + key rotation, OIDC discovery, Google/Microsoft/Okta
+// presets), wired into the server via the -oauth-issuer / -jwks-url /
+// -oauth-audience / -oauth-provider flags on cmd/entdb-server.
+//
+// API keys are hashed with argon2id (golang.org/x/crypto/argon2) in a
+// PHC-format string with a per-key random salt; verification is a
+// constant-time compare of the derived key. The PersistentAPIKeyManager
+// stores those hashes in global.db (via the APIKeyStore interface, so
+// auth never imports globalstore) and supports rotation: multiple
+// simultaneously-active keys for a documented migration window (issue
+// the new key, flip clients over, then revoke the old key_id). It is
+// wired into cmd/entdb-server behind the --api-key-auth flag.
+//
+// Redis-backed sessions and the quota interceptor are tracked
+// separately (#88); this package ships the production OAuth validators
+// and the argon2id API-key managers (in-memory + persistent), plus the
+// trusted-actor plumbing, with an in-memory session manager for tests
+// and dev.
 package auth

--- a/server/go/internal/globalstore/apikeys.go
+++ b/server/go/internal/globalstore/apikeys.go
@@ -1,0 +1,263 @@
+// api_keys CRUD. Backs auth.PersistentAPIKeyManager: durable, rotatable,
+// scopeable, revocable API keys.
+//
+// globalstore stores only the argon2id PHC hash (produced by the auth
+// package) -- never the plaintext secret. This file is pure persistence;
+// hashing and constant-time verification live in
+// server/go/internal/auth/apikey.go.
+//
+// Rotation model: multiple rows can be status='active' for the same
+// tenant/name at once. The migration window is "issue the new key,
+// flip clients over, then RevokeAPIKey the old key_id". ListActiveAPIKeys
+// returns every still-valid key so the auth layer can accept any of them
+// during the overlap.
+
+package globalstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// encodeScopes joins a scope slice into the comma-separated TEXT column.
+// Empty/whitespace scopes are dropped so a round-trip is stable.
+func encodeScopes(scopes []string) string {
+	out := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return strings.Join(out, ",")
+}
+
+// decodeScopes splits the stored TEXT column back into a slice. The
+// empty string decodes to a nil slice (not []string{""}).
+func decodeScopes(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// PutAPIKey inserts a new API-key row. The key_id is the primary key;
+// re-inserting an existing key_id is a UNIQUE violation surfaced as an
+// error (callers generate a fresh key_id per issued key, so a collision
+// is a bug, not a re-issue path). Hash is the argon2id PHC string;
+// globalstore does not validate its shape.
+func (g *GlobalStore) PutAPIKey(ctx context.Context, rec APIKeyRecord) error {
+	if rec.KeyID == "" {
+		return errors.New("globalstore: PutAPIKey requires key_id")
+	}
+	if rec.Hash == "" {
+		return errors.New("globalstore: PutAPIKey requires hash")
+	}
+	status := rec.Status
+	if status == "" {
+		status = APIKeyStatusActive
+	}
+	created := rec.CreatedAt
+	if created == 0 {
+		created = g.now()
+	}
+	_, err := g.db.ExecContext(ctx,
+		`INSERT INTO api_keys
+		     (key_id, tenant_id, name, hash, scopes, status,
+		      created_at, expires_at, revoked_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		rec.KeyID, rec.TenantID, rec.Name, rec.Hash,
+		encodeScopes(rec.Scopes), status,
+		created, rec.ExpiresAt, rec.RevokedAt,
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return fmt.Errorf("globalstore: api key %q already exists: %w", rec.KeyID, err)
+		}
+		return fmt.Errorf("globalstore: put api key %q: %w", rec.KeyID, err)
+	}
+	return nil
+}
+
+// GetAPIKey returns the row for key_id, or (nil, nil) if absent.
+func (g *GlobalStore) GetAPIKey(ctx context.Context, keyID string) (*APIKeyRecord, error) {
+	row := g.db.QueryRowContext(ctx,
+		`SELECT key_id, tenant_id, name, hash, scopes, status,
+		        created_at, expires_at, revoked_at
+		 FROM api_keys WHERE key_id = ?`,
+		keyID,
+	)
+	rec, err := scanAPIKeyRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("globalstore: get api key %q: %w", keyID, err)
+	}
+	return rec, nil
+}
+
+// ListAPIKeys returns every api_keys row, newest first. tenantID == ""
+// lists across all tenants (the persistent manager loads the full set
+// into memory at boot, then re-syncs on demand). limit <= 0 -> unlimited.
+func (g *GlobalStore) ListAPIKeys(ctx context.Context, tenantID string, limit int) ([]*APIKeyRecord, error) {
+	if limit <= 0 {
+		limit = -1
+	}
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if tenantID == "" {
+		rows, err = g.db.QueryContext(ctx,
+			`SELECT key_id, tenant_id, name, hash, scopes, status,
+			        created_at, expires_at, revoked_at
+			 FROM api_keys ORDER BY created_at DESC LIMIT ?`,
+			limit,
+		)
+	} else {
+		rows, err = g.db.QueryContext(ctx,
+			`SELECT key_id, tenant_id, name, hash, scopes, status,
+			        created_at, expires_at, revoked_at
+			 FROM api_keys WHERE tenant_id = ?
+			 ORDER BY created_at DESC LIMIT ?`,
+			tenantID, limit,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("globalstore: list api keys (tenant=%q): %w", tenantID, err)
+	}
+	defer rows.Close()
+
+	out := []*APIKeyRecord{}
+	for rows.Next() {
+		rec, scanErr := scanAPIKeyRows(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("globalstore: scan api key row: %w", scanErr)
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("globalstore: iterate api key rows: %w", err)
+	}
+	return out, nil
+}
+
+// ListActiveAPIKeys returns the rows the auth layer should accept right
+// now: status='active' AND not past expiry. This is the set the rotation
+// migration window relies on -- old + new keys both come back while both
+// are active, so a client cutover never sees a gap. now is the caller's
+// notion of "current second"; pass 0 to use the store clock.
+func (g *GlobalStore) ListActiveAPIKeys(ctx context.Context, now int64) ([]*APIKeyRecord, error) {
+	if now == 0 {
+		now = g.now()
+	}
+	rows, err := g.db.QueryContext(ctx,
+		`SELECT key_id, tenant_id, name, hash, scopes, status,
+		        created_at, expires_at, revoked_at
+		 FROM api_keys
+		 WHERE status = ?
+		   AND (expires_at = 0 OR expires_at > ?)
+		 ORDER BY created_at DESC`,
+		APIKeyStatusActive, now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("globalstore: list active api keys: %w", err)
+	}
+	defer rows.Close()
+
+	out := []*APIKeyRecord{}
+	for rows.Next() {
+		rec, scanErr := scanAPIKeyRows(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("globalstore: scan api key row: %w", scanErr)
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("globalstore: iterate active api key rows: %w", err)
+	}
+	return out, nil
+}
+
+// RevokeAPIKey flips a key to status='revoked' and stamps revoked_at.
+// Returns true iff a still-active row was flipped (idempotent: revoking
+// an already-revoked or unknown key returns false, nil). This is the
+// "retire the old key" half of the rotation migration window.
+func (g *GlobalStore) RevokeAPIKey(ctx context.Context, keyID string) (bool, error) {
+	res, err := g.db.ExecContext(ctx,
+		`UPDATE api_keys
+		 SET status = ?, revoked_at = ?
+		 WHERE key_id = ? AND status = ?`,
+		APIKeyStatusRevoked, g.now(), keyID, APIKeyStatusActive,
+	)
+	if err != nil {
+		return false, fmt.Errorf("globalstore: revoke api key %q: %w", keyID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("globalstore: rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
+// DeleteAPIKey hard-deletes a key row. Used by GDPR / ops cleanup; the
+// normal retire path is RevokeAPIKey (keeps the audit trail). Returns
+// true iff a row was removed.
+func (g *GlobalStore) DeleteAPIKey(ctx context.Context, keyID string) (bool, error) {
+	res, err := g.db.ExecContext(ctx,
+		`DELETE FROM api_keys WHERE key_id = ?`, keyID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("globalstore: delete api key %q: %w", keyID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("globalstore: rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
+// scanAPIKeyRow scans a single *sql.Row into an APIKeyRecord.
+func scanAPIKeyRow(row *sql.Row) (*APIKeyRecord, error) {
+	var (
+		rec    APIKeyRecord
+		scopes string
+	)
+	if err := row.Scan(
+		&rec.KeyID, &rec.TenantID, &rec.Name, &rec.Hash, &scopes,
+		&rec.Status, &rec.CreatedAt, &rec.ExpiresAt, &rec.RevokedAt,
+	); err != nil {
+		return nil, err
+	}
+	rec.Scopes = decodeScopes(scopes)
+	return &rec, nil
+}
+
+// scanAPIKeyRows scans the current *sql.Rows cursor row.
+func scanAPIKeyRows(rows *sql.Rows) (*APIKeyRecord, error) {
+	var (
+		rec    APIKeyRecord
+		scopes string
+	)
+	if err := rows.Scan(
+		&rec.KeyID, &rec.TenantID, &rec.Name, &rec.Hash, &scopes,
+		&rec.Status, &rec.CreatedAt, &rec.ExpiresAt, &rec.RevokedAt,
+	); err != nil {
+		return nil, err
+	}
+	rec.Scopes = decodeScopes(scopes)
+	return &rec, nil
+}

--- a/server/go/internal/globalstore/apikeys_test.go
+++ b/server/go/internal/globalstore/apikeys_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package globalstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+)
+
+func TestAPIKeyPutGetRoundTrip(t *testing.T) {
+	gs := newStore(t, func() int64 { return 1_700_000_000 })
+	ctx := context.Background()
+
+	rec := globalstore.APIKeyRecord{
+		KeyID:    "ek_abc",
+		TenantID: "acme",
+		Name:     "ci-bot",
+		Hash:     "$argon2id$v=19$m=65536,t=1,p=4$c2FsdHNhbHQ$aGFzaA",
+		Scopes:   []string{"read", "write"},
+	}
+	if err := gs.PutAPIKey(ctx, rec); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+
+	got, err := gs.GetAPIKey(ctx, "ek_abc")
+	if err != nil {
+		t.Fatalf("GetAPIKey: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetAPIKey returned nil for an inserted key")
+	}
+	if got.Name != "ci-bot" || got.Hash != rec.Hash {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	if got.Status != globalstore.APIKeyStatusActive {
+		t.Errorf("Status = %q, want active", got.Status)
+	}
+	if len(got.Scopes) != 2 || got.Scopes[0] != "read" || got.Scopes[1] != "write" {
+		t.Errorf("Scopes = %v, want [read write]", got.Scopes)
+	}
+	if got.CreatedAt != 1_700_000_000 {
+		t.Errorf("CreatedAt = %d, want store clock", got.CreatedAt)
+	}
+}
+
+func TestAPIKeyGetMissingReturnsNil(t *testing.T) {
+	gs := newStore(t, nil)
+	got, err := gs.GetAPIKey(context.Background(), "ek_nope")
+	if err != nil {
+		t.Fatalf("GetAPIKey: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for missing key, got %+v", got)
+	}
+}
+
+func TestAPIKeyDuplicateRejected(t *testing.T) {
+	gs := newStore(t, nil)
+	ctx := context.Background()
+	rec := globalstore.APIKeyRecord{KeyID: "ek_dup", Name: "n", Hash: "h"}
+	if err := gs.PutAPIKey(ctx, rec); err != nil {
+		t.Fatalf("first PutAPIKey: %v", err)
+	}
+	if err := gs.PutAPIKey(ctx, rec); err == nil {
+		t.Fatal("expected duplicate key_id to be rejected")
+	}
+}
+
+func TestAPIKeyRequiresKeyIDAndHash(t *testing.T) {
+	gs := newStore(t, nil)
+	ctx := context.Background()
+	if err := gs.PutAPIKey(ctx, globalstore.APIKeyRecord{Hash: "h"}); err == nil {
+		t.Error("expected error when key_id missing")
+	}
+	if err := gs.PutAPIKey(ctx, globalstore.APIKeyRecord{KeyID: "ek_x"}); err == nil {
+		t.Error("expected error when hash missing")
+	}
+}
+
+// TestAPIKeyListActiveFiltersRevokedAndExpired is the rotation-window
+// contract: only active, unexpired keys come back, so the auth layer
+// accepts exactly the keys that should still work.
+func TestAPIKeyListActiveFiltersRevokedAndExpired(t *testing.T) {
+	clock := int64(2_000_000)
+	gs := newStore(t, func() int64 { return clock })
+	ctx := context.Background()
+
+	mustPut := func(id string, expires int64) {
+		t.Helper()
+		if err := gs.PutAPIKey(ctx, globalstore.APIKeyRecord{
+			KeyID: id, Name: "svc", Hash: "h-" + id, ExpiresAt: expires,
+		}); err != nil {
+			t.Fatalf("PutAPIKey %s: %v", id, err)
+		}
+	}
+	mustPut("ek_live", 0)               // never expires
+	mustPut("ek_future", clock+10_000)  // not yet expired
+	mustPut("ek_expired", clock-1)      // already expired
+	mustPut("ek_revoked", 0)            // will be revoked below
+
+	flipped, err := gs.RevokeAPIKey(ctx, "ek_revoked")
+	if err != nil {
+		t.Fatalf("RevokeAPIKey: %v", err)
+	}
+	if !flipped {
+		t.Fatal("RevokeAPIKey reported no active row flipped")
+	}
+
+	active, err := gs.ListActiveAPIKeys(ctx, 0)
+	if err != nil {
+		t.Fatalf("ListActiveAPIKeys: %v", err)
+	}
+	got := map[string]bool{}
+	for _, k := range active {
+		got[k.KeyID] = true
+	}
+	if !got["ek_live"] || !got["ek_future"] {
+		t.Errorf("active set missing live/future keys: %v", got)
+	}
+	if got["ek_expired"] {
+		t.Error("expired key leaked into active set")
+	}
+	if got["ek_revoked"] {
+		t.Error("revoked key leaked into active set")
+	}
+}
+
+func TestAPIKeyRevokeIsIdempotent(t *testing.T) {
+	gs := newStore(t, nil)
+	ctx := context.Background()
+	if err := gs.PutAPIKey(ctx, globalstore.APIKeyRecord{KeyID: "ek_r", Name: "n", Hash: "h"}); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	first, err := gs.RevokeAPIKey(ctx, "ek_r")
+	if err != nil || !first {
+		t.Fatalf("first RevokeAPIKey: flipped=%v err=%v", first, err)
+	}
+	second, err := gs.RevokeAPIKey(ctx, "ek_r")
+	if err != nil {
+		t.Fatalf("second RevokeAPIKey: %v", err)
+	}
+	if second {
+		t.Fatal("second RevokeAPIKey should report no active row flipped")
+	}
+	missing, err := gs.RevokeAPIKey(ctx, "ek_does_not_exist")
+	if err != nil {
+		t.Fatalf("RevokeAPIKey unknown: %v", err)
+	}
+	if missing {
+		t.Fatal("revoking an unknown key should report false")
+	}
+
+	got, err := gs.GetAPIKey(ctx, "ek_r")
+	if err != nil {
+		t.Fatalf("GetAPIKey: %v", err)
+	}
+	if got.Status != globalstore.APIKeyStatusRevoked || got.RevokedAt == 0 {
+		t.Errorf("revoked key state = %+v, want status=revoked & revoked_at set", got)
+	}
+}
+
+func TestAPIKeyListAndDelete(t *testing.T) {
+	gs := newStore(t, nil)
+	ctx := context.Background()
+	for _, id := range []string{"ek_1", "ek_2", "ek_3"} {
+		if err := gs.PutAPIKey(ctx, globalstore.APIKeyRecord{
+			KeyID: id, TenantID: "t1", Name: "n", Hash: "h",
+		}); err != nil {
+			t.Fatalf("PutAPIKey %s: %v", id, err)
+		}
+	}
+	// Different tenant -- must not show up in the t1-scoped list.
+	if err := gs.PutAPIKey(ctx, globalstore.APIKeyRecord{
+		KeyID: "ek_other", TenantID: "t2", Name: "n", Hash: "h",
+	}); err != nil {
+		t.Fatalf("PutAPIKey other-tenant: %v", err)
+	}
+
+	t1, err := gs.ListAPIKeys(ctx, "t1", 0)
+	if err != nil {
+		t.Fatalf("ListAPIKeys t1: %v", err)
+	}
+	if len(t1) != 3 {
+		t.Fatalf("ListAPIKeys t1 = %d rows, want 3", len(t1))
+	}
+	all, err := gs.ListAPIKeys(ctx, "", 0)
+	if err != nil {
+		t.Fatalf("ListAPIKeys all: %v", err)
+	}
+	if len(all) != 4 {
+		t.Fatalf("ListAPIKeys all = %d rows, want 4", len(all))
+	}
+
+	removed, err := gs.DeleteAPIKey(ctx, "ek_1")
+	if err != nil || !removed {
+		t.Fatalf("DeleteAPIKey: removed=%v err=%v", removed, err)
+	}
+	if again, _ := gs.DeleteAPIKey(ctx, "ek_1"); again {
+		t.Fatal("second DeleteAPIKey should report false")
+	}
+	got, err := gs.GetAPIKey(ctx, "ek_1")
+	if err != nil {
+		t.Fatalf("GetAPIKey after delete: %v", err)
+	}
+	if got != nil {
+		t.Fatal("deleted key still present")
+	}
+}
+
+// TestAPIKeyPersistenceSurvivesReopen proves durability: keys written
+// before Close are still readable after re-opening global.db.
+func TestAPIKeyPersistenceSurvivesReopen(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	gs1, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	if err := gs1.PutAPIKey(ctx, globalstore.APIKeyRecord{
+		KeyID: "ek_durable", Name: "svc", Hash: "$argon2id$v=19$m=1$s$h", Scopes: []string{"read"},
+	}); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	if err := gs1.Close(); err != nil {
+		t.Fatalf("close 1: %v", err)
+	}
+
+	gs2, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	t.Cleanup(func() { _ = gs2.Close() })
+
+	got, err := gs2.GetAPIKey(ctx, "ek_durable")
+	if err != nil {
+		t.Fatalf("GetAPIKey after reopen: %v", err)
+	}
+	if got == nil || got.Name != "svc" || len(got.Scopes) != 1 {
+		t.Fatalf("key did not survive reopen: %+v", got)
+	}
+}

--- a/server/go/internal/globalstore/schema.go
+++ b/server/go/internal/globalstore/schema.go
@@ -89,6 +89,22 @@ CREATE TABLE IF NOT EXISTS tenant_usage (
     writes_count    INTEGER NOT NULL DEFAULT 0,
     updated_at      INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    key_id      TEXT PRIMARY KEY,
+    tenant_id   TEXT NOT NULL DEFAULT '',
+    name        TEXT NOT NULL,
+    hash        TEXT NOT NULL,
+    scopes      TEXT NOT NULL DEFAULT '',
+    status      TEXT NOT NULL DEFAULT 'active',
+    created_at  INTEGER NOT NULL,
+    expires_at  INTEGER NOT NULL DEFAULT 0,
+    revoked_at  INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_api_keys_tenant
+    ON api_keys(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_status
+    ON api_keys(status);
 `
 
 // initSchema runs schemaDDL and the table-info-guarded ALTERs. Safe to

--- a/server/go/internal/globalstore/types.go
+++ b/server/go/internal/globalstore/types.go
@@ -89,6 +89,29 @@ type Usage struct {
 	UpdatedAt     int64
 }
 
+// APIKeyRecord is one row of api_keys. The Hash is an argon2id PHC
+// string produced by the auth package; globalstore never sees the
+// plaintext secret. Scopes is the decoded scope list (stored as a
+// comma-separated TEXT column on disk). ExpiresAt / RevokedAt are
+// Unix-epoch seconds; 0 means "unset" (never expires / not revoked).
+type APIKeyRecord struct {
+	KeyID     string
+	TenantID  string
+	Name      string
+	Hash      string
+	Scopes    []string
+	Status    string // "active" | "revoked"
+	CreatedAt int64
+	ExpiresAt int64 // 0 == never
+	RevokedAt int64 // 0 == not revoked
+}
+
+// API-key status values. Strings are part of the on-disk contract.
+const (
+	APIKeyStatusActive  = "active"
+	APIKeyStatusRevoked = "revoked"
+)
+
 // TransferResult is the outcome of TransferUserContent.
 type TransferResult struct {
 	TenantID          string


### PR DESCRIPTION
## Problem

`MemoryAPIKeyManager` hashed API keys with **SHA-256** and was **in-memory only**. Per issue #87 triage, two requirements were unmet:

1. Keys must be hashed with **argon2id** (ADR-011: "stored hashed (bcrypt/argon2; never plaintext)").
2. It was in-memory only — **no persistence**, **no documented rotation / multiple-active-keys migration window**, and **not wired into `cmd/entdb-server`** (no `-api-key` flag).

## Fix

- **argon2id hashing** (`golang.org/x/crypto/argon2`, already a direct dep) in a PHC-format string (`$argon2id$v=19$m=65536,t=1,p=N$<salt>$<hash>`) with a **per-key random salt**. Verification derives the key and compares with `subtle.ConstantTimeCompare` — the **constant-time guarantee is preserved**. PHC params are embedded per hash, so the cost defaults can be raised later without invalidating existing keys.
- **Persistence**: new `api_keys` table in `global.db` (`hash`, `scopes`, `status`, `created_at`, `expires_at`, `revoked_at`) with full CRUD in `globalstore/apikeys.go`. The table uses `CREATE TABLE IF NOT EXISTS`, so existing `global.db` files upgrade **non-destructively** (no guarded ALTER needed for a new table).
- **Rotation / multiple simultaneously-active keys**: new `PersistentAPIKeyManager`. Multiple keys can be `status=active` at once for a **documented migration window** — *issue the new key → flip clients over → revoke the old `key_id`*. `ListActiveAPIKeys` returns every still-valid (active AND unexpired) key so the cutover never sees a gap. The manager depends on an `APIKeyStore` interface, so `auth` never imports `globalstore`.
- **Flag wiring**: new `--api-key-auth` flag in `entdb-server` installs the API-key interceptor backed by `global.db`. **Opt-in, default off**, so the contract/e2e harnesses are unaffected. A `globalStoreAPIKeys` adapter in `main` bridges the two packages without a cross-import.

Scope is confined to `apikey.go` + its new persistence + flag wiring. `oauth.go` and `session.go` are untouched.

## Testing

New tests covering every required behavior:

- **argon2 verify**: round-trip, wrong-password rejection, salt randomness, malformed/wrong-version/wrong-algorithm PHC rejection.
- **persistence round-trip**: put/get, duplicate rejection, list/delete, **reopen durability** (keys survive `global.db` close+reopen).
- **rotation overlap**: old+new both validate during the window, then old revoked → only new validates. Verified at three layers (in-memory manager, persistent manager with a fake store, and **end-to-end through a real `global.db`** via the production adapter).
- **scope enforcement**: per-key scopes returned correctly; returned slice is a defensive copy.
- **revocation**: idempotent; revoked keys excluded from the active set.
- Plus expiry enforcement and store-failure handling (DB outage surfaces as a distinct UNAUTHENTICATED, never a silent "invalid key").

Full local CI green:

```
go vet ./...                                  clean (server)
go test ./...                                 ALL PASS (server, every package)
sdk/go/entdb: go vet + go test                ALL PASS
python -m pytest tests/python/integration/    95 passed
bash tests/python/e2e/run-e2e.sh              22 passed, exit 0
uvx ruff check . / format --check .           clean
go mod tidy                                   no-op (no go.mod/go.sum churn)
```

Advances Epic #85 (does not close it).

Closes #87