### PR TITLE
docs: ADR-026 (read/write conn split) + ADR-027 (parallel WAL apply)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ Quick orientation (one-liners, not normative — the ADR is normative):
 - [ADR-023](docs/adr/023-declarative-query-indexes.md) — non-unique expression indexes declared via `(entdb.field).indexed = true`
 - [ADR-024](docs/adr/024-three-layer-rate-limit-model.md) — three-layer rate-limit model; Phase 1 (monthly quotas) is the implementation start
 - [ADR-025](docs/adr/025-single-shape-sdk-api.md) — single-shape SDK API (proto messages everywhere, typed unique-key tokens via codegen, expression-index uniqueness)
+- [ADR-026](docs/adr/026-per-tenant-read-write-connection-split.md) — per-tenant read/write SQLite connection split (Accepted; implementation #536 gated on the broadcast-ordering fix — see ADR)
+- [ADR-027](docs/adr/027-parallel-wal-apply-across-tenants.md) — parallel WAL apply across distinct tenants; amends ADR-016's no-fan-out clause (Accepted; implementation #541 gated on conditions — see ADR)
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,8 @@ Quick orientation (one-liners, not normative — the ADR is normative):
 - [ADR-023](docs/adr/023-declarative-query-indexes.md) — non-unique expression indexes declared via `(entdb.field).indexed = true`
 - [ADR-024](docs/adr/024-three-layer-rate-limit-model.md) — three-layer rate-limit model; Phase 1 (monthly quotas) is the implementation start
 - [ADR-025](docs/adr/025-single-shape-sdk-api.md) — single-shape SDK API (proto messages everywhere, typed unique-key tokens via codegen, expression-index uniqueness)
-- [ADR-026](docs/adr/026-per-tenant-read-write-connection-split.md) — per-tenant read/write SQLite connection split (Accepted; implementation #536 gated on the broadcast-ordering fix — see ADR)
-- [ADR-027](docs/adr/027-parallel-wal-apply-across-tenants.md) — parallel WAL apply across distinct tenants; amends ADR-016's no-fan-out clause (Accepted; implementation #541 gated on conditions — see ADR)
+- [ADR-026](docs/adr/026-per-tenant-read-write-connection-split.md) — per-tenant read/write SQLite connection split (Accepted; landed dark — split off by default `--read-pool-size=1`; the post-commit broadcast fix is always active)
+- [ADR-027](docs/adr/027-parallel-wal-apply-across-tenants.md) — parallel WAL apply across distinct tenants; amends ADR-016's no-fan-out clause (Accepted; landed dark — serial by default `--apply-concurrency=1`)
 
 ## Project Structure
 

--- a/docs/adr/026-per-tenant-read-write-connection-split.md
+++ b/docs/adr/026-per-tenant-read-write-connection-split.md
@@ -1,0 +1,158 @@
+# ADR-026: Per-tenant read/write SQLite connection split
+
+**Status:** Accepted — implementation (PR #536, issue #137 / PERF-1) is
+**gated on the blocking conditions in §Conditions** and MUST NOT merge
+until they are met.
+**Decided:** 2026-05-17
+**Tags:** store, concurrency, performance, sqlite, read-after-write
+**Implementation:** `server/go/internal/store/{pool,canonical}.go`;
+SELECT-only methods in `nodes.go, access.go, acl.go, visibility.go,
+edges.go, offset.go, fts.go, idempotency.go`; `--read-pool-size` flag
+in `server/go/cmd/entdb-server/main.go`. Tracked by PR #536.
+
+## Decision
+
+Each per-tenant SQLite database is opened with **two** `*sql.DB`
+handles:
+
+- The existing **write handle** — `SetMaxOpenConns(1)` + `writeMu` +
+  `BEGIN IMMEDIATE`, unchanged byte-for-byte. It remains the sole
+  writer. [ADR-016](016-handlers-append-applier-writes.md) (only the
+  applier writes SQLite) is fully preserved.
+- A new **read handle** — a pooled, physically read-only connection
+  set (`SetMaxOpenConns(readPoolSize)`), opened with SQLite
+  `mode=ro` + `PRAGMA query_only=ON` on the modernc path and
+  `&mode=ro&_query_only=true` on the SQLCipher path (the per-tenant
+  key is still supplied).
+
+Pure-SELECT store methods route to the read handle; every
+`INSERT/UPDATE/DELETE` and all DDL stay on the write handle. The split
+activates only when `WALMode && readPoolSize > 1`; otherwise the read
+handle is nil and reads fall back to the single write handle (behaviour
+identical to pre-#137).
+
+## Context
+
+`pool.go` opened each tenant `*sql.DB` with `SetMaxOpenConns(1)`,
+shared by the applier and all readers. The applier holds that one
+connection for the whole `BatchTxn` (`BEGIN IMMEDIATE` … `COMMIT`), so
+**same-tenant reads serialise** — behind each other and behind any
+in-flight write. SQLite WAL mode natively supports one writer plus many
+concurrent readers, so this leaves throughput on the floor.
+`docs/go-port/shared/canonical-store.md` open-question 5 marked the
+`SetMaxOpenConns(1)` vs N decision **benchmark-gated** ("decide via
+benchmark, not vibes") and flagged the specific hazard: `INSERT OR
+REPLACE` + lazy DDL under concurrent readers.
+
+Measured (Apple M4 Max, same-tenant parallel `GetNode`,
+reproduced independently): **~2.8× read throughput**
+(≈10.4 µs/op → ≈3.7 µs/op), stable across runs. The win is real and
+the design direction is sound.
+
+Two correctness facts were verified against driver source and the
+apply path, and they hold:
+
+- The read handle is **physically read-only** on both drivers
+  (`mode=ro` honoured at the VFS; `query_only` parsed to
+  `PRAGMA query_only=1`). Concurrent readers therefore cannot race
+  `INSERT OR REPLACE` — they cannot write at all. Open-question-5's
+  hazard is genuinely closed.
+- The applier reads its own uncommitted writes **only** through
+  `tx.Conn()` (the write-txn connection), never through a re-routed
+  SELECT method. No in-flight uncommitted row is ever read via the
+  read pool inside an apply transaction.
+
+## The correctness regression this unmasks (first-class consequence)
+
+The split removes an **implicit connection-serialisation** that was
+masking a pre-existing latent race in the read-after-write path:
+
+`applyEvent` calls `UpdateAppliedOffsetTx`, which executes
+`offsetCond.Broadcast()` (waking `WaitForOffset(N)` waiters) **before**
+`tx.Commit()`. The code itself notes a strictly-correct implementation
+would defer the notify to commit.
+
+- **Pre-#536:** a woken reader used the single write connection, which
+  the applier's `BatchTxn` held until post-`COMMIT` cleanup. The
+  reader physically blocked until the write committed, then saw the
+  data. The early broadcast was harmless — the connection bottleneck
+  masked it.
+- **Post-#536:** the woken reader uses an independent read connection
+  and runs its `SELECT` immediately. If it lands in the
+  broadcast→commit window, its WAL snapshot **excludes the uncommitted
+  write** → the client reads its own confirmed write back as **stale
+  or `Found=false`**.
+
+This is **not an edge case**: the Python SDK auto-attaches the last
+write's offset as `after_offset` on every subsequent
+`GetNode`/`GetNodeByKey`/`GetNodes`, and those handlers do a bare
+`WaitForOffset` with **no idempotency poll**. It is the default
+read-your-write path. CI is green only because write RPCs
+(`ExecuteAtomic`) additionally poll an idempotency record that commits
+in the *same* `BatchTxn` as the data, and every integration/e2e test
+uses that protected write path; the exposed read path has no test.
+
+## Conditions (blocking — PR #536 does not merge until all are met)
+
+1. **Move `offsetCond.Broadcast()` to after `BatchTxn.Commit()`**
+   (root-cause fix; also fixes the pre-existing latent bug). Until this
+   lands, default `--read-pool-size` to `1` (split off).
+2. **Add a regression test**: a write driven through the WAL→applier
+   path, fenced by `after_offset`/`WaitForOffset`, asserting the
+   re-routed `GetNode` observes the write under concurrent apply. It
+   must fail on the pre-fix branch and pass after condition 1.
+3. **Correct the narrative.** The split ships **on by default**
+   (`--read-pool-size=8`; it is opt-*out*, not opt-in as the PR
+   states). Read-your-writes via bare `WaitForOffset` is *weakened and
+   then re-fixed by condition 1* — not "preserved".
+
+## Alternatives considered
+
+- **Keep `SetMaxOpenConns(1)`.** Rejected — leaves a measured ~2.8×
+  same-tenant read win unrealised; the open question explicitly asked
+  for the benchmark, which now exists.
+- **Route only `after_offset`-fenced reads back to the write handle**
+  (keep the masking). Rejected — that defeats the perf win on exactly
+  the reads people fence, and preserves the latent bug instead of
+  fixing it.
+- **Ship the split now, fix the broadcast race later.** Rejected — it
+  is a live, default-path read-after-write correctness regression; the
+  fix is small and must land with it.
+
+## Consequences
+
+**Locks in:** per-tenant resource cost rises — each materialised read
+connection is an extra OS file descriptor and carries its own
+`PRAGMA cache_size = -64000` (up to 64 MiB page cache). With no
+idle-tenant eviction (canonical-store.md open-question 2 is still
+unresolved — handles live for the process lifetime), worst case is
+~9 FDs and up to several hundred MiB page-cache **per active tenant**.
+
+**Makes easy:** concurrent same-tenant reads (dashboards, fan-out
+queries, list endpoints) no longer queue behind each other or behind
+the applier.
+
+**Makes harder / follow-ups (tracked in this ADR, non-blocking):**
+
+- Pair with the long-deferred idle-tenant LRU eviction
+  (canonical-store.md OQ-2) before large-tenant-count GA; reconsider
+  the default pool size and per-read-conn `cache_size`.
+- `go test -race ./internal/api/` hangs on a pre-existing
+  `transferFixture` nil-channel send (unrelated to this change).
+  "Full CI green under `-race`" cannot be claimed until that fixture
+  is fixed; track separately.
+
+**Failure modes:** if condition 1 is not met, the documented
+read-after-write regression is live by default. With condition 1 met,
+`WaitForOffset(N)` signals only once offset N's data is committed and
+visible on any connection, closing the window for both the read pool
+and the pre-existing latent path.
+
+## References
+
+- [ADR-016](016-handlers-append-applier-writes.md) — only the applier
+  writes SQLite; the write path is untouched by this ADR.
+- `docs/go-port/shared/canonical-store.md` — open-question 5
+  (read/write split, benchmark-gated) and open-question 2 (idle-tenant
+  eviction).
+- Issue #137 (PERF-1); PR #536.

--- a/docs/adr/026-per-tenant-read-write-connection-split.md
+++ b/docs/adr/026-per-tenant-read-write-connection-split.md
@@ -1,8 +1,11 @@
 # ADR-026: Per-tenant read/write SQLite connection split
 
-**Status:** Accepted — implementation (PR #536, issue #137 / PERF-1) is
-**gated on the blocking conditions in §Conditions** and MUST NOT merge
-until they are met.
+**Status:** Accepted — implemented (PR #536, issue #137 / PERF-1); the
+conditions in §Conditions are met. **Landed dark:** the split ships
+**off by default** (`--read-pool-size=1`); enabling it in production is
+an explicit operator opt-in, gated on idle-tenant eviction
+(canonical-store open-question 2). The root-cause broadcast-ordering
+fix (condition 1) is unconditional and always active.
 **Decided:** 2026-05-17
 **Tags:** store, concurrency, performance, sqlite, read-after-write
 **Implementation:** `server/go/internal/store/{pool,canonical}.go`;
@@ -92,19 +95,24 @@ read-your-write path. CI is green only because write RPCs
 in the *same* `BatchTxn` as the data, and every integration/e2e test
 uses that protected write path; the exposed read path has no test.
 
-## Conditions (blocking — PR #536 does not merge until all are met)
+## Conditions (met before merge)
 
 1. **Move `offsetCond.Broadcast()` to after `BatchTxn.Commit()`**
-   (root-cause fix; also fixes the pre-existing latent bug). Until this
-   lands, default `--read-pool-size` to `1` (split off).
+   (root-cause fix; also fixes the pre-existing latent bug).
+   Unconditional and always active regardless of `--read-pool-size`.
 2. **Add a regression test**: a write driven through the WAL→applier
    path, fenced by `after_offset`/`WaitForOffset`, asserting the
    re-routed `GetNode` observes the write under concurrent apply. It
    must fail on the pre-fix branch and pass after condition 1.
-3. **Correct the narrative.** The split ships **on by default**
-   (`--read-pool-size=8`; it is opt-*out*, not opt-in as the PR
-   states). Read-your-writes via bare `WaitForOffset` is *weakened and
-   then re-fixed by condition 1* — not "preserved".
+3. **Accurate rollout posture.** The split ships **off by default**
+   (`--read-pool-size=1`) — a deliberate dark landing. Read-after-write
+   correctness is fixed by condition 1, but the resource envelope
+   (extra FDs + page cache per tenant, no idle-tenant eviction —
+   canonical-store OQ-2) is unresolved, so the split is an explicit
+   operator opt-in pending that work. Flag help and PR narrative state
+   off-by-default / opt-in, and that read-your-writes via
+   `WaitForOffset` is *weakened then re-fixed by condition 1* — not
+   "preserved".
 
 ## Alternatives considered
 

--- a/docs/adr/027-parallel-wal-apply-across-tenants.md
+++ b/docs/adr/027-parallel-wal-apply-across-tenants.md
@@ -1,8 +1,12 @@
 # ADR-027: Parallel WAL apply across distinct tenants
 
-**Status:** Accepted — implementation (PR #541, issue #140 / PERF-4) is
-**gated on the blocking conditions in §Conditions** and MUST NOT merge
-until they are met.
+**Status:** Accepted — implemented (PR #541, issue #140 / PERF-4); the
+conditions in §Conditions are met. **Landed dark:** ships
+**serial by default** (`--apply-concurrency=1`); parallel apply is an
+explicit operator opt-in, enabled only after a staging soak and
+resolution of the multi-replica / consumer-group-rebalance open
+question (see §Open question). The applier code path is unchanged
+behaviour at the default.
 **Decided:** 2026-05-17
 **Tags:** apply, wal, concurrency, performance, consistency
 **Amends:** [ADR-016](016-handlers-append-applier-writes.md) — the
@@ -16,8 +20,9 @@ flag in `server/go/cmd/entdb-server/main.go`. Tracked by PR #541.
 
 Within a single WAL poll batch, the applier MAY apply records in
 **parallel across distinct tenant route keys**, bounded by
-`--apply-concurrency` (default `GOMAXPROCS`; `1` reproduces the old
-strictly-serial loop). `routeKey = scope + "\x00" + tenant_id`, so all
+`--apply-concurrency` (**default `1` = strictly-serial, the unchanged
+legacy behaviour**; operators opt into parallelism by setting it
+higher, e.g. `GOMAXPROCS`). `routeKey = scope + "\x00" + tenant_id`, so all
 records for one tenant — and all global-scope records — each collapse
 to a single key and a single worker.
 
@@ -86,14 +91,15 @@ This is acceptable because, per
 view with no external consumer reading it mid-halt. Recorded here as a
 deliberate, accepted behavioural change (not a footnote).
 
-## Conditions (blocking — PR #541 does not merge until all are met)
+## Conditions (met before merge)
 
 1. **This ADR** recording the ADR-016 amendment, the four invariants,
    and the accepted consequence. (Done.)
-2. **Wire `--apply-concurrency`** in `cmd/entdb-server/main.go`
-   (default `GOMAXPROCS`, `1` = serial) so operators have a
-   no-redeploy kill-switch for a consistency-sensitive default-on
-   change. Today it is only an `Options` field.
+2. **Wire `--apply-concurrency`** in `cmd/entdb-server/main.go` with
+   **default `1` (serial — dark landing)**; operators explicitly opt
+   into parallelism (`GOMAXPROCS` or a chosen N) after a staging soak.
+   This is both the rollout posture and the no-redeploy kill-switch
+   for a consistency-sensitive change.
 3. **Add a same-partition multi-tenant poison test**: two tenants that
    hash to the *same* WAL partition with a poison from tenant B
    sandwiched between tenant A records, asserting contiguous-prefix

--- a/docs/adr/027-parallel-wal-apply-across-tenants.md
+++ b/docs/adr/027-parallel-wal-apply-across-tenants.md
@@ -1,0 +1,157 @@
+# ADR-027: Parallel WAL apply across distinct tenants
+
+**Status:** Accepted — implementation (PR #541, issue #140 / PERF-4) is
+**gated on the blocking conditions in §Conditions** and MUST NOT merge
+until they are met.
+**Decided:** 2026-05-17
+**Tags:** apply, wal, concurrency, performance, consistency
+**Amends:** [ADR-016](016-handlers-append-applier-writes.md) — the
+"events apply serially within a partition; no fan-out within the
+consumer" clause is narrowed by this ADR (see §Decision).
+**Implementation:** `server/go/internal/apply/applier.go`
+(`processBatch` / `finalizeBatch` / `routeKey`); `--apply-concurrency`
+flag in `server/go/cmd/entdb-server/main.go`. Tracked by PR #541.
+
+## Decision
+
+Within a single WAL poll batch, the applier MAY apply records in
+**parallel across distinct tenant route keys**, bounded by
+`--apply-concurrency` (default `GOMAXPROCS`; `1` reproduces the old
+strictly-serial loop). `routeKey = scope + "\x00" + tenant_id`, so all
+records for one tenant — and all global-scope records — each collapse
+to a single key and a single worker.
+
+This **amends [ADR-016](016-handlers-append-applier-writes.md)**: its
+"events apply serially within a partition … no fan-out within the
+consumer" wording is narrowed to *"events for a given tenant route key
+apply serially in offset order; fan-out across distinct route keys is
+permitted; offset commit remains serial and contiguous-prefix."* The
+single-writer-per-tenant-DB and gap-free-offset invariants are
+preserved by the mechanism below, not by serial execution.
+
+## Context
+
+The applier applied every record in a poll batch serially in one
+goroutine regardless of tenant. Per-tenant SQLite files are fully
+independent ([ADR-001](001-storage-architecture.md),
+[ADR-014](014-physical-storage-layout.md)) with independent write
+mutexes, and the per-record cost is dominated by the SQLite `COMMIT`
+fsync, which parallelises trivially across distinct files. So apply
+latency scaled with the number of distinct tenants per batch for no
+structural reason. This is issue #140 (PERF-4).
+
+Measured (independently reproduced): a real **~2–3.7× speedup at
+256–1024-tenant batches**. The PR's "~2.1× at 64 tenants" claim **did
+not reproduce** (~1.0–1.3×, within noise); the benchmark harness is
+methodologically weak (non-independent timed iterations, busy-wait
+barrier) and must not be cited for small-batch numbers.
+
+## Invariants (must hold; verified for PR #541 at review time)
+
+1. **Per-tenant ordering.** One route key → one `groups` entry → one
+   worker; `applyChain` consumes that key's records sequentially in
+   batch (= partition offset) order. The WAL keys by `tenant_id`, so a
+   tenant's records are totally ordered within a partition and
+   `PollBatch` returns them in offset order.
+2. **Single-writer-per-tenant-DB** ([ADR-016](016-handlers-append-applier-writes.md)
+   intent). No two goroutines ever touch the same `tenant_<id>.db`;
+   `store.BeginBatch` still takes `poolEntry.writeMu` as an unchanged
+   backstop the applier simply never contends.
+3. **Gap-free monotonic offset commit.** Only the **serial**
+   `finalizeBatch` calls `consumer.Commit` / `UpdateAppliedOffset`,
+   strictly in original batch order, and returns at the first
+   poisoned record without committing it or anything after it. The
+   committed set is therefore exactly the contiguous batch prefix; a
+   faster later-tenant worker cannot advance the consumer-group offset
+   early because workers never commit. Gap-freeness is provided
+   entirely by this ordered early-return — **no apply work may ever
+   call `consumer.Commit` from a worker.**
+4. **Serialised `global.db` writes.** All cross-tenant/global writes
+   funnel through either the single `__global__` route or the serial
+   `finalizeBatch`/fanout path. `globalstore` has no write mutex
+   (relies on `MaxOpenConns(1)`), so this serialisation is
+   **load-bearing**: a future change that parallelises fanout, or
+   moves a globalstore write into a parallel tenant txn, silently
+   breaks cross-tenant consistency. Stated here as a hard invariant.
+
+## Accepted consequence
+
+On a **poisoned batch**, the intermediate on-disk SQLite state differs
+from the old serial loop: speculatively-applied later-tenant records
+are materialised before the halt. The **converged post-restart state
+is identical** — the consumer-group offset sits at the poison, the
+speculative tail is re-delivered and idempotency-SKIPped on replay.
+This is acceptable because, per
+[ADR-016](016-handlers-append-applier-writes.md), SQLite is a derived
+view with no external consumer reading it mid-halt. Recorded here as a
+deliberate, accepted behavioural change (not a footnote).
+
+## Conditions (blocking — PR #541 does not merge until all are met)
+
+1. **This ADR** recording the ADR-016 amendment, the four invariants,
+   and the accepted consequence. (Done.)
+2. **Wire `--apply-concurrency`** in `cmd/entdb-server/main.go`
+   (default `GOMAXPROCS`, `1` = serial) so operators have a
+   no-redeploy kill-switch for a consistency-sensitive default-on
+   change. Today it is only an `Options` field.
+3. **Add a same-partition multi-tenant poison test**: two tenants that
+   hash to the *same* WAL partition with a poison from tenant B
+   sandwiched between tenant A records, asserting contiguous-prefix
+   commit and idempotent resume.
+4. **Restate the benchmark honestly** in the PR: ~2–3.7× at
+   256–1024-tenant batches; **drop the "~2.1× at 64 tenants" claim**
+   (did not reproduce).
+
+## Open question (non-blocking; track with an e2e follow-up)
+
+Multi-replica / consumer-group **rebalance** mid-batch: on rebalance,
+partitions can move to another applier replica that re-polls from the
+last broker-committed offset; in-flight speculative applies become the
+other replica's redelivery. This stays idempotent (same SKIP path) and
+per-tenant ordering holds **only because per-tenant records never split
+across partitions** — but that argument now spans two appliers and is
+**untested** (the e2e suite uses a single applier). Safe for today's
+single-applier deployment; must be validated before multi-replica
+appliers ship.
+
+## Alternatives considered
+
+- **Keep strictly-serial apply.** Rejected — leaves a real 2–3.7×
+  at-scale win unrealised for no correctness benefit.
+- **Parallelise within a tenant** (multiple workers per tenant DB).
+  Rejected — breaks per-tenant ordering and the single-writer
+  invariant.
+- **Abort the whole batch on first poison** (instead of committing the
+  contiguous good prefix). Rejected — would discard already-applied
+  independent-tenant work and cost most of the parallelism; the
+  contiguous-prefix + idempotent-replay model is strictly better and
+  is the existing serial contract generalised across tenants.
+
+## Consequences
+
+**Locks in:** the rule that *commit happens only in the serial
+finalize loop, in batch order, halting at the first poison* — this is
+the single load-bearing decision; a code comment at the finalize
+commit site MUST state that committing from anywhere else breaks
+gap-freeness.
+
+**Makes easy:** apply throughput scales with available cores on
+many-tenant batches without weakening per-tenant ordering or the
+single-writer guarantee.
+
+**Makes harder:** future changes near `global.db` writes or the
+commit path must respect invariants 3–4 explicitly; the implicit
+serialisation that previously made them safe by construction is gone.
+
+## References
+
+- [ADR-016](016-handlers-append-applier-writes.md) — amended by this
+  ADR (fan-out clause narrowed); single-writer + handlers-append
+  intent preserved.
+- [ADR-001](001-storage-architecture.md),
+  [ADR-014](014-physical-storage-layout.md) — per-tenant SQLite files
+  are independent, which is what makes cross-tenant parallel apply
+  sound.
+- [ADR-005](005-event-sourcing-wal.md) — WAL partitioning by
+  `tenant_id` underpins per-tenant ordering.
+- Issue #140 (PERF-4); PR #541.


### PR DESCRIPTION
Authored from the principal-engineer deep review of the two draft perf PRs.

- **ADR-026** — per-tenant read/write SQLite connection split (#137 / PR #536). Accepted; **implementation gated**: PR #536 must not merge until `offsetCond.Broadcast()` is moved after `tx.Commit()` (+ regression test, + corrected default/narrative). Documents the read-after-write regression the split unmasks.
- **ADR-027** — parallel WAL apply across distinct tenants (#140 / PR #541). Accepted; **amends ADR-016**'s no-fan-out clause. Gated: PR #541 needs the `--apply-concurrency` kill-switch flag, a same-partition poison test, and an honest benchmark restatement. Records the four load-bearing invariants + accepted poisoned-batch consequence + the multi-replica-rebalance open question.

Decision records only — no code change. CLAUDE.md gains the two index pointers per ADR-019.