### PR TITLE
fix: DeleteWhere usable in schemaless mode via numeric field id (#545)

### DIFF
--- a/sdk/go/entdb/filter.go
+++ b/sdk/go/entdb/filter.go
@@ -28,11 +28,20 @@ const (
 	FilterGe FilterOp = "ge"
 )
 
-// Filter is one AND-ed predicate passed to [QueryWhere]. Field is
-// the proto field name (the gRPC boundary resolves it to a payload
-// field_id). Op selects the comparison operator. Value is bound as
-// a SQLite parameter and supports the JSON-marshallable scalars
-// SQLite understands (string, int, int64, float64, bool, nil).
+// Filter is one AND-ed predicate passed to [QueryWhere] (and
+// [DeleteWhere]). Field is the proto field name (the gRPC boundary
+// resolves it to a payload field_id). Op selects the comparison
+// operator. Value is bound as a SQLite parameter and supports the
+// JSON-marshallable scalars SQLite understands (string, int, int64,
+// float64, bool, nil).
+//
+// Schema-less escape hatch (issue #545): Field may instead be the
+// digit-only numeric payload field id (e.g. "4"). The SDK forwards
+// Field unchanged; a server with no schema treats a digit-only key as
+// a raw field id and skips name resolution. This is the only way to
+// filter against a schema-less server — a field NAME there returns
+// INVALID_ARGUMENT ("cannot translate filter key … without a
+// schema"). A schema-configured server accepts either form.
 //
 // Multiple filters on the same field are permitted — a half-open
 // range is expressed as two filters:

--- a/sdk/go/entdb/plan.go
+++ b/sdk/go/entdb/plan.go
@@ -210,6 +210,24 @@ func Delete[T proto.Message](p *Plan, nodeID string) {
 //	    []entdb.Filter{{Field: "expires_at", Op: entdb.FilterLt, Value: now}},
 //	    1000,
 //	)
+//
+// Schema-less servers (issue #545): a server started without a schema
+// cannot resolve a field NAME to a payload field id. Pass the numeric
+// payload field id as the [Filter].Field string instead — exactly the
+// schema-optional escape hatch QueryWhere already accepts for numeric
+// filter keys. The SDK forwards Field verbatim; the server treats a
+// digit-only key as a raw field id with no schema lookup:
+//
+//	// "expires_at" is proto field 4 on the caller's own schema.
+//	entdb.DeleteWhere[*auth.WebAuthnChallenge](plan,
+//	    []entdb.Filter{{Field: "4", Op: entdb.FilterLt, Value: now}},
+//	    1000,
+//	)
+//
+// Against a schema-configured server both forms work; against a
+// schema-less server only the numeric-id form does (a name key
+// returns INVALID_ARGUMENT: "cannot translate filter key … without a
+// schema").
 func DeleteWhere[T proto.Message](p *Plan, where []Filter, limit int) {
 	p.ensureNotCommitted()
 	msg := newZeroMessage[T]()

--- a/sdk/go/entdb/plan_test.go
+++ b/sdk/go/entdb/plan_test.go
@@ -313,6 +313,51 @@ func TestPlan_DeleteWhere(t *testing.T) {
 	}
 }
 
+// TestPlan_DeleteWhere_SchemalessNumericFieldID is the SDK half of
+// issue #545: a Filter whose Field is the digit-only numeric payload
+// field id must reach the wire VERBATIM (no client-side name
+// resolution, no rewrite), so a schema-less server can resolve it
+// without a schema — the same escape hatch QueryWhere already gives
+// numeric filter keys. This pins that the SDK never mangles a numeric
+// Field, so the documented schema-less workflow keeps working.
+func TestPlan_DeleteWhere_SchemalessNumericFieldID(t *testing.T) {
+	mock := &mockTransport{}
+	plan := newPlan(mock, "t1", "user:alice", "key-1")
+
+	// "4" is the caller's own (server-unknown) expires_at field id.
+	DeleteWhere[*testpb.Product](plan, []Filter{
+		{Field: "4", Op: FilterLt, Value: int64(1700000000000)},
+	}, 1000)
+
+	ops := plan.Operations()
+	if len(ops) != 1 || ops[0].Type != OpDeleteWhere {
+		t.Fatalf("ops = %#v, want one OpDeleteWhere", ops)
+	}
+	if ops[0].Where[0].Field != "4" {
+		t.Fatalf("Field = %q, want %q (must NOT be name-resolved client-side)",
+			ops[0].Where[0].Field, "4")
+	}
+
+	protoOps, err := operationsToProto(ops)
+	if err != nil {
+		t.Fatalf("operationsToProto: %v", err)
+	}
+	dw := protoOps[0].GetDeleteWhere()
+	if dw == nil {
+		t.Fatalf("expected DeleteWhere proto op, got %#v", protoOps[0].GetOp())
+	}
+	if len(dw.GetWhere()) != 1 {
+		t.Fatalf("proto Where len = %d, want 1", len(dw.GetWhere()))
+	}
+	if got := dw.GetWhere()[0].GetField(); got != "4" {
+		t.Fatalf("wire field = %q, want %q — the numeric id must travel "+
+			"unchanged so a schema-less server resolves it without a schema", got, "4")
+	}
+	if dw.GetWhere()[0].GetOp() != pb.FilterOp_LT {
+		t.Errorf("wire op = %v, want LT", dw.GetWhere()[0].GetOp())
+	}
+}
+
 func TestPlan_CreateEdge(t *testing.T) {
 	mock := &mockTransport{}
 	plan := newPlan(mock, "t1", "user:alice", "key-1")

--- a/sdk/python/entdb_sdk/client.py
+++ b/sdk/python/entdb_sdk/client.py
@@ -579,6 +579,17 @@ class Plan:
         #501), so the same six comparison operators are available and
         AND-ed together.
 
+        Schema-less servers (issue #545): a server started without a
+        schema cannot resolve a field NAME to a payload field id.
+        Pass the numeric payload field id as ``Filter.field`` (e.g.
+        ``Filter(field="4", op=FilterOp.LT, value=now)``) — the SDK
+        forwards it verbatim and the schema-less server treats a
+        digit-only key as a raw field id with no schema lookup. This
+        is the same schema-optional escape hatch ``query(where=)``
+        already accepts for numeric filter keys. Against a
+        schema-less server a field NAME raises ``INVALID_ARGUMENT``
+        ("cannot translate filter key … without a schema").
+
         Args:
             node_type: The proto message *class* (e.g.
                 ``schema_pb2.WebAuthnChallenge``) whose descriptor

--- a/sdk/python/entdb_sdk/filter.py
+++ b/sdk/python/entdb_sdk/filter.py
@@ -46,13 +46,23 @@ class FilterOp(str, Enum):
 
 @dataclass(frozen=True)
 class Filter:
-    """One AND-ed predicate passed to :meth:`DbClient.query`.
+    """One AND-ed predicate passed to :meth:`DbClient.query` and
+    :meth:`Plan.delete_where`.
 
     ``field`` is the proto field name (the gRPC boundary resolves it
     to a payload field id). ``op`` selects the comparison operator.
     ``value`` is bound as a SQLite parameter and accepts the same
     scalar types as the existing equality filter (str, int, float,
     bool, ``None``).
+
+    Schema-less escape hatch (issue #545): ``field`` may instead be
+    the digit-only numeric payload field id (e.g. ``"4"``). The SDK
+    forwards ``field`` verbatim on the wire; a server started without
+    a schema treats a digit-only key as a raw field id and skips
+    name resolution. This is the only way to filter against a
+    schema-less server — passing a field NAME there raises
+    ``INVALID_ARGUMENT`` ("cannot translate filter key … without a
+    schema"). A schema-configured server accepts either form.
     """
 
     field: str

--- a/server/go/internal/api/execute_atomic.go
+++ b/server/go/internal/api/execute_atomic.go
@@ -507,6 +507,21 @@ func (s *Server) convertOperations(operations []*pb.Operation) ([]map[string]any
 			// Resolve the developer-facing FieldFilter names to stable
 			// field_ids using the EXACT same path QueryNodes uses
 			// (issue #501) so the predicate is schema-less on the WAL.
+			//
+			// Schema-OPTIONAL, exactly like QueryNodes (issue #545): a
+			// nil registry is the server's schema-less mode and is
+			// tolerated here just as it is in query_nodes.go. When the
+			// registry is nil, typeName stays "" and
+			// fieldFiltersToStoreFilters -> payload.FilterNamesToIDs
+			// takes its schema-less branch: digit-only FieldFilter.field
+			// keys parse to raw payload field ids, and a non-digit field
+			// NAME surfaces as INVALID_ARGUMENT with the same wording as
+			// the QueryNodes path ("payload: cannot translate filter key
+			// %q without a schema"). Do NOT add a hard reject for a
+			// missing schema here — that is the exact bug #545 fixes and
+			// would diverge from the QueryNodes contract. Schema-mode
+			// behaviour (registry configured) is unchanged: an unknown
+			// type_id is still INVALID_ARGUMENT.
 			typeName := ""
 			if s.registry != nil {
 				nt := s.registry.NodeTypeByID(dw.GetTypeId())

--- a/server/go/internal/api/execute_atomic_test.go
+++ b/server/go/internal/api/execute_atomic_test.go
@@ -1366,3 +1366,202 @@ func TestExecuteAtomic_DeleteWhereRoundTrip(t *testing.T) {
 		t.Fatalf("predicate field_id: got %v want 2 (name->id resolved)", pm["field_id"])
 	}
 }
+
+// TestExecuteAtomic_DeleteWhereSchemalessNumericFieldID is the issue
+// #545 contract: a schema-less server (nil registry) MUST accept a
+// DeleteWhere whose FieldFilter.field is a digit-only numeric field id
+// and sweep exactly the matching nodes — the same schema-optional
+// escape hatch QueryNodes already gives numeric-string filter keys.
+// No client schema registry is required.
+func TestExecuteAtomic_DeleteWhereSchemalessNumericFieldID(t *testing.T) {
+	t.Parallel()
+	f := newSchemalessXAFixture(t)
+	f.runApplier(t)
+	ctx := context.Background()
+
+	// Seed three nodes of an unregistered type via the raw store
+	// (schema-less: payloads are id-keyed). field_id 4 == "expires_at"
+	// on the caller's own (server-unknown) schema.
+	for _, tc := range []struct {
+		id  string
+		exp int64
+	}{
+		{"sweep-a", 10},
+		{"sweep-b", 20},
+		{"keep-c", 9999},
+	} {
+		if _, err := f.store.CreateNodeRaw(ctx, xaTenant, store.NodeInput{
+			NodeID:     tc.id,
+			TypeID:     525,
+			OwnerActor: xaActorStr,
+			Payload:    map[string]any{"4": tc.exp},
+		}); err != nil {
+			t.Fatalf("CreateNodeRaw %s: %v", tc.id, err)
+		}
+	}
+
+	// Sweep everything with field 4 (expires_at) < 100 by NUMERIC
+	// field id — no schema on the server, no registry on the client.
+	resp, err := f.srv.ExecuteAtomic(ctx, &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "dw-schemaless-num",
+		WaitApplied:    true,
+		WaitTimeoutMs:  2000,
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_DeleteWhere{DeleteWhere: &pb.DeleteWhereOp{
+				TypeId: 525,
+				Where: []*pb.FieldFilter{
+					{Field: "4", Op: pb.FilterOp_LT, Value: newValue(t, int64(100))},
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("schemaless numeric DeleteWhere: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success=false (error=%q code=%q) — schemaless numeric DeleteWhere must work",
+			resp.GetError(), resp.GetErrorCode())
+	}
+	f.waitForIdempKey(t, "dw-schemaless-num")
+
+	for _, id := range []string{"sweep-a", "sweep-b"} {
+		if _, err := f.store.GetNode(ctx, xaTenant, id); err == nil {
+			t.Fatalf("node %q should have been swept by the schemaless numeric predicate", id)
+		}
+	}
+	if _, err := f.store.GetNode(ctx, xaTenant, "keep-c"); err != nil {
+		t.Fatalf("keep-c must survive (exp 9999 not < 100): %v", err)
+	}
+
+	// The WAL carries the id-keyed predicate verbatim — field "4"
+	// parsed straight to field_id 4 with no schema involved.
+	recs := f.wal.GetAllRecords(xaTopic)
+	var ev wal.Event
+	if err := json.Unmarshal(recs[len(recs)-1].Value, &ev); err != nil {
+		t.Fatalf("decode sweep event: %v", err)
+	}
+	where, ok := ev.Ops[0]["where"].([]any)
+	if !ok || len(where) != 1 {
+		t.Fatalf("where: got %#v want one predicate", ev.Ops[0]["where"])
+	}
+	pm, _ := where[0].(map[string]any)
+	if fid, _ := pm["field_id"].(float64); int(fid) != 4 {
+		t.Fatalf("predicate field_id: got %v want 4 (numeric key, no schema)", pm["field_id"])
+	}
+}
+
+// TestExecuteAtomic_DeleteWhereSchemalessNameKeyRejected pins the
+// other half of the #545 contract: on a schema-less server a non-digit
+// field NAME is genuinely unresolvable, so DeleteWhere must return a
+// clear INVALID_ARGUMENT with the SAME wording family the QueryNodes /
+// payload.FilterNamesToIDs schema-less path uses. The numeric escape
+// hatch is the only schema-less route; a name key is not silently
+// accepted.
+func TestExecuteAtomic_DeleteWhereSchemalessNameKeyRejected(t *testing.T) {
+	t.Parallel()
+	f := newSchemalessXAFixture(t)
+
+	_, err := f.srv.ExecuteAtomic(context.Background(), &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "dw-schemaless-name",
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_DeleteWhere{DeleteWhere: &pb.DeleteWhereOp{
+				TypeId: 525,
+				Where: []*pb.FieldFilter{
+					{Field: "expires_at", Op: pb.FilterOp_LT, Value: newValue(t, int64(100))},
+				},
+			}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("schemaless DeleteWhere with a name key must error")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("code=%v want InvalidArgument", st.Code())
+	}
+	// Exact wording family shared with QueryNodes /
+	// payload.FilterNamesToIDs (translate.go:222-223).
+	if !strings.Contains(st.Message(), "cannot translate filter key") ||
+		!strings.Contains(st.Message(), "without a schema") {
+		t.Fatalf("message %q: want the shared "+
+			`"cannot translate filter key %%q without a schema" wording`, st.Message())
+	}
+}
+
+// TestExecuteAtomic_DeleteWhereSchemaModeNameStillResolves pins that
+// the #545 schema-optional change did NOT regress schema mode: with a
+// registry configured, a field NAME still resolves to its field_id and
+// an unknown type_id is still INVALID_ARGUMENT.
+func TestExecuteAtomic_DeleteWhereSchemaModeNameStillResolves(t *testing.T) {
+	t.Parallel()
+	f := newXAFixture(t) // registry has User(type 1): email=1, name=2
+	f.runApplier(t)
+	ctx := context.Background()
+
+	seed, err := f.srv.ExecuteAtomic(ctx, &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "dw-schema-seed",
+		Operations: []*pb.Operation{
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "s-1",
+				Data: newStruct(t, map[string]any{"email": "x@x", "name": "drop"}),
+			}}},
+			{Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 1, Id: "s-2",
+				Data: newStruct(t, map[string]any{"email": "y@y", "name": "stay"}),
+			}}},
+		},
+	})
+	if err != nil || !seed.GetSuccess() {
+		t.Fatalf("seed: err=%v resp=%+v", err, seed)
+	}
+	f.waitForIdempKey(t, "dw-schema-seed")
+
+	resp, err := f.srv.ExecuteAtomic(ctx, &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "dw-schema-sweep",
+		WaitApplied:    true,
+		WaitTimeoutMs:  2000,
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_DeleteWhere{DeleteWhere: &pb.DeleteWhereOp{
+				TypeId: 1,
+				Where: []*pb.FieldFilter{
+					{Field: "name", Op: pb.FilterOp_EQ, Value: newValue(t, "drop")},
+				},
+			}},
+		}},
+	})
+	if err != nil || !resp.GetSuccess() {
+		t.Fatalf("schema-mode name sweep: err=%v resp=%+v", err, resp)
+	}
+	f.waitForIdempKey(t, "dw-schema-sweep")
+	if _, err := f.store.GetNode(ctx, xaTenant, "s-1"); err == nil {
+		t.Fatal("s-1 (name=drop) should have been swept in schema mode")
+	}
+	if _, err := f.store.GetNode(ctx, xaTenant, "s-2"); err != nil {
+		t.Fatalf("s-2 (name=stay) must survive: %v", err)
+	}
+
+	// Unknown type_id in schema mode is still INVALID_ARGUMENT.
+	_, err = f.srv.ExecuteAtomic(ctx, &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: "dw-schema-unknown",
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_DeleteWhere{DeleteWhere: &pb.DeleteWhereOp{
+				TypeId: 9999,
+				Where: []*pb.FieldFilter{
+					{Field: "name", Op: pb.FilterOp_EQ, Value: newValue(t, "drop")},
+				},
+			}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("unknown type_id in schema mode must error")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("code=%v want InvalidArgument for unknown type_id", st.Code())
+	}
+}

--- a/tests/python/integration/conftest.py
+++ b/tests/python/integration/conftest.py
@@ -161,8 +161,17 @@ ALICE = "user:alice"
 SEED_NODE_ID = "seeded-node"
 
 
-async def _start_go_server(tmp_path_factory) -> AsyncIterator[int]:
-    """Go subprocess harness — yields the bound port."""
+async def _start_go_server(tmp_path_factory, *, profile: str = "contract") -> AsyncIterator[int]:
+    """Go subprocess harness — yields the bound port.
+
+    ``profile`` selects the ``--seed-profile``. The default
+    ``"contract"`` (registry configured + seeded ``acme`` tenant) is
+    what every existing fixture relies on. ``"none"`` boots the server
+    schema-less (nil registry, no seeded tenant) — used by the issue
+    #545 schema-less DeleteWhere regression; a schema-less server
+    auto-opens a tenant on first write so no ``--seed-tenant`` is
+    passed.
+    """
     binary = _build_go_binary()
     data_dir = tmp_path_factory.mktemp("entdb-go-data")
     log_path = tmp_path_factory.mktemp("entdb-go-logs") / "server.log"
@@ -184,10 +193,10 @@ async def _start_go_server(tmp_path_factory) -> AsyncIterator[int]:
             "--wal-backend",
             "memory",
             "--seed-profile",
-            "contract",
-            "--seed-tenant",
-            TENANT,
+            profile,
         ]
+        if profile != "none":
+            cmd += ["--seed-tenant", TENANT]
         log_fh = open(log_path, "ab", buffering=0)  # noqa: SIM115 - lifetime tied to subprocess
         proc = subprocess.Popen(
             cmd,
@@ -251,3 +260,29 @@ async def live_server(tmp_path_factory):
 def grpc_endpoint(live_server) -> str:
     """``"127.0.0.1:<port>"`` form of :func:`live_server`."""
     return f"127.0.0.1:{live_server}"
+
+
+@pytest.fixture
+async def schemaless_live_server(tmp_path_factory):
+    """A live server booted schema-less (``--seed-profile none``).
+
+    Used by the issue #545 regression: a schema-less server cannot
+    resolve a field NAME, so DeleteWhere must be driven by the numeric
+    payload field id. No tenant is seeded — the applier auto-opens a
+    tenant on first write.
+    """
+    agen = _start_go_server(tmp_path_factory, profile="none")
+    port = await agen.__anext__()
+    try:
+        yield port
+    finally:
+        try:
+            await agen.__anext__()
+        except StopAsyncIteration:
+            pass
+
+
+@pytest.fixture
+def schemaless_grpc_endpoint(schemaless_live_server) -> str:
+    """``"127.0.0.1:<port>"`` form of :func:`schemaless_live_server`."""
+    return f"127.0.0.1:{schemaless_live_server}"

--- a/tests/python/integration/test_delete_where.py
+++ b/tests/python/integration/test_delete_where.py
@@ -171,3 +171,167 @@ async def test_delete_where_limit_is_best_effort(stub) -> None:
         if await _exists(stub, f"{p}-{n}"):
             remaining += 1
     assert remaining == 0, f"second sweep should drain all, got {remaining}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #545 — DeleteWhere against a schema-less server
+# ---------------------------------------------------------------------------
+#
+# A server started without a schema (``--seed-profile none``) cannot
+# resolve a FieldFilter.field NAME to a payload field id. The
+# documented contract (mirroring QueryNodes' schema-optional path) is:
+# a digit-only numeric field id works without a schema; a field NAME
+# returns a clear INVALID_ARGUMENT. These exercise that end-to-end
+# against a live schema-less Go subprocess.
+
+SL_TENANT = "sl-545"
+SL_TYPE_ID = 525  # caller's own (server-unknown) node type
+SL_ADMIN = "system:admin"
+
+
+def _sl_ctx() -> pb.RequestContext:
+    # system:/admin: actors bypass tenant-membership checks
+    # (execute_atomic.go:826); this test pins field-id resolution,
+    # not ACL, so drive it as the tenant's creating admin.
+    return pb.RequestContext(tenant_id=SL_TENANT, actor=SL_ADMIN)
+
+
+async def _sl_provision_tenant(stub: EntDBServiceStub) -> None:
+    """Create SL_TENANT on the schema-less server (no --seed-tenant).
+
+    CreateTenant flows through the global WAL + applier asynchronously,
+    so poll GetTenant until it materialises before any write.
+    """
+    import asyncio
+
+    resp = await stub.CreateTenant(
+        pb.CreateTenantRequest(actor=SL_ADMIN, tenant_id=SL_TENANT, name="SL 545")
+    )
+    assert resp.success, resp
+    for _ in range(100):
+        g = await stub.GetTenant(pb.GetTenantRequest(actor=SL_ADMIN, tenant_id=SL_TENANT))
+        if g.found:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"tenant {SL_TENANT!r} never materialised")
+
+
+def _int_value(v: int) -> struct_pb2.Value:
+    out = struct_pb2.Value()
+    out.number_value = v
+    return out
+
+
+@pytest.fixture
+async def schemaless_stub(schemaless_grpc_endpoint):
+    async with grpc_aio.insecure_channel(schemaless_grpc_endpoint) as ch:
+        stub = EntDBServiceStub(ch)
+        await _sl_provision_tenant(stub)
+        yield stub
+
+
+async def _sl_seed(stub: EntDBServiceStub, rows: dict[str, int]) -> None:
+    """Create id-keyed nodes on the schema-less server (field 4 = expires_at)."""
+    ops = []
+    for node_id, expires_at in rows.items():
+        data = struct_pb2.Struct()
+        # Schema-less => the payload itself is id-keyed ("4", not "expires_at").
+        json_format.ParseDict({"4": expires_at}, data)
+        ops.append(
+            pb.Operation(create_node=pb.CreateNodeOp(type_id=SL_TYPE_ID, id=node_id, data=data))
+        )
+    resp = await stub.ExecuteAtomic(
+        pb.ExecuteAtomicRequest(
+            context=_sl_ctx(),
+            idempotency_key=f"sl-seed-{uuid.uuid4().hex[:8]}",
+            operations=ops,
+            wait_applied=True,
+            wait_timeout_ms=5000,
+        )
+    )
+    assert resp.success, resp.error
+
+
+async def _sl_exists(stub: EntDBServiceStub, node_id: str) -> bool:
+    resp = await stub.GetNode(
+        pb.GetNodeRequest(context=_sl_ctx(), type_id=SL_TYPE_ID, node_id=node_id)
+    )
+    return resp.found
+
+
+async def test_delete_where_schemaless_by_numeric_field_id(schemaless_stub) -> None:
+    """Schema-less server: DeleteWhere by NUMERIC field id sweeps the matches.
+
+    Proves the issue #545 escape hatch works end-to-end: no schema on
+    the server, no client registry — the digit-only ``field="4"`` is
+    resolved to a raw payload field id and exactly the matching nodes
+    are swept.
+    """
+    p = f"sln-{uuid.uuid4().hex[:6]}"
+    await _sl_seed(
+        schemaless_stub,
+        {f"{p}-stale-1": 10, f"{p}-stale-2": 20, f"{p}-keep": 9999},
+    )
+
+    resp = await schemaless_stub.ExecuteAtomic(
+        pb.ExecuteAtomicRequest(
+            context=_sl_ctx(),
+            idempotency_key=f"sl-sweep-{uuid.uuid4().hex[:8]}",
+            operations=[
+                pb.Operation(
+                    delete_where=pb.DeleteWhereOp(
+                        type_id=SL_TYPE_ID,
+                        where=[
+                            # NUMERIC field id — no schema needed.
+                            pb.FieldFilter(
+                                field="4",
+                                op=pb.FilterOp.LT,
+                                value=_int_value(100),
+                            )
+                        ],
+                    )
+                )
+            ],
+            wait_applied=True,
+            wait_timeout_ms=5000,
+        )
+    )
+    assert resp.success, resp.error
+
+    assert not await _sl_exists(schemaless_stub, f"{p}-stale-1")
+    assert not await _sl_exists(schemaless_stub, f"{p}-stale-2")
+    assert await _sl_exists(schemaless_stub, f"{p}-keep")
+
+
+async def test_delete_where_schemaless_field_name_rejected(schemaless_stub) -> None:
+    """Schema-less server: a field NAME is a clear INVALID_ARGUMENT.
+
+    The numeric id is the only schema-less route; a non-digit name is
+    genuinely unresolvable and must surface the shared
+    "cannot translate filter key … without a schema" wording.
+    """
+    with pytest.raises(grpc_aio.AioRpcError) as exc:
+        await schemaless_stub.ExecuteAtomic(
+            pb.ExecuteAtomicRequest(
+                context=_sl_ctx(),
+                idempotency_key=f"sl-name-{uuid.uuid4().hex[:8]}",
+                operations=[
+                    pb.Operation(
+                        delete_where=pb.DeleteWhereOp(
+                            type_id=SL_TYPE_ID,
+                            where=[
+                                pb.FieldFilter(
+                                    field="expires_at",
+                                    op=pb.FilterOp.LT,
+                                    value=_int_value(100),
+                                )
+                            ],
+                        )
+                    )
+                ],
+            )
+        )
+    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    msg = exc.value.details() or ""
+    assert "cannot translate filter key" in msg
+    assert "without a schema" in msg

--- a/tests/python/unit/test_delete_where_schemaless.py
+++ b/tests/python/unit/test_delete_where_schemaless.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+"""SDK-side regression for issue #545: schema-less DeleteWhere.
+
+A server started without a schema cannot resolve a field NAME to a
+payload field id. The documented workaround is to pass the digit-only
+numeric payload field id as ``Filter.field`` — exactly the
+schema-optional escape hatch the query path already accepts. These
+tests pin that the Python SDK forwards a numeric ``Filter.field``
+VERBATIM to the wire (no client-side name resolution, no rewrite), so
+the schema-less workflow keeps working end-to-end. The matching
+server-side behaviour is pinned in
+``tests/python/integration/test_delete_where.py`` against a live
+schema-less Go server.
+"""
+
+from __future__ import annotations
+
+from entdb_sdk._grpc_client import GrpcClient
+from entdb_sdk.filter import Filter, FilterOp, filters_to_filter_dict
+
+
+def test_filters_to_filter_dict_preserves_numeric_field_key() -> None:
+    """A numeric field id survives the MongoDB-style lowering unchanged."""
+    out = filters_to_filter_dict([Filter(field="4", op=FilterOp.LT, value=1700000000000)])
+    assert out == {"4": {"$lt": 1700000000000}}
+
+
+def test_delete_where_numeric_field_id_reaches_wire_verbatim() -> None:
+    """delete_where with Filter(field="4") emits FieldFilter(field="4").
+
+    The numeric id must NOT be name-resolved client-side — the
+    schema-less server resolves a digit-only key to a raw payload
+    field id with no schema lookup (issue #545).
+    """
+    client = GrpcClient(host="127.0.0.1", port=1)  # no connect()
+
+    # "4" is the caller's own (server-unknown) expires_at field id.
+    where_dict = filters_to_filter_dict([Filter(field="4", op=FilterOp.LT, value=1700000000000)])
+    proto_ops = client._convert_operations(
+        [{"delete_where": {"type_id": 525, "where": where_dict, "limit": 1000}}]
+    )
+
+    assert len(proto_ops) == 1
+    dw = proto_ops[0].delete_where
+    assert dw.type_id == 525
+    assert dw.limit == 1000
+    assert len(dw.where) == 1
+    # The decisive assertion: the numeric id travels unchanged so a
+    # schema-less server can resolve it without a schema.
+    assert dw.where[0].field == "4"
+    # {"$lt": v} rides through as a Value; the server's inlined-operator
+    # decoder fans it into the LT comparison (issue #501).
+    inner = dw.where[0].value.struct_value
+    assert "$lt" in inner.fields
+    assert inner.fields["$lt"].number_value == 1700000000000
+
+
+def test_delete_where_field_name_also_passes_through() -> None:
+    """A field NAME is still forwarded verbatim (schema-mode path).
+
+    The SDK never resolves names client-side — a schema-configured
+    server resolves the name; a schema-less server rejects it with
+    INVALID_ARGUMENT. Either way the SDK's job is to pass it through.
+    """
+    client = GrpcClient(host="127.0.0.1", port=1)
+    where_dict = filters_to_filter_dict([Filter(field="expires_at", op=FilterOp.LT, value=100)])
+    proto_ops = client._convert_operations(
+        [{"delete_where": {"type_id": 525, "where": where_dict, "limit": 0}}]
+    )
+    assert proto_ops[0].delete_where.where[0].field == "expires_at"


### PR DESCRIPTION
## Problem

`OpDeleteWhere` (shipped v1.14.0, #540) was unusable in **schemaless mode**. A server started without a schema cannot resolve `FieldFilter.field` (a proto field NAME) to a payload field id, so `entdb.DeleteWhere` failed with:

```
entdb VALIDATION_ERROR: payload: cannot translate filter key "expires_at" without a schema
```

The pre-v1.14.0 `QueryNodes(filter map[string]any{"4": {...}})` path already worked schemaless because the caller passes the numeric field id as the key string. `DeleteWhere` had no documented or tested equivalent, blocking the documented "embed an identity service on top of tenant-shard-db" deployment shape.

## Root cause

The `DeleteWhere` handler (`server/go/internal/api/execute_atomic.go`, `case *pb.Operation_DeleteWhere:`) is in fact **already schema-optional, exactly like `QueryNodes`** (`server/go/internal/api/query_nodes.go`): when `s.registry == nil` it skips the registry block, leaves `typeName == ""`, and routes through `s.fieldFiltersToStoreFilters("", …)` → `payload.FilterNamesToIDs(nil, "", …)`, whose schemaless branch (`server/go/internal/payload/translate.go`) resolves digit-only keys via `parseFieldID` and returns a clear `INVALID_ARGUMENT` for genuine name keys. Both SDKs already forward `Filter.Field` verbatim onto the wire, so `Filter{Field: "4"}` reaches the server unchanged.

Verified empirically on `origin/main`: a schemaless `DeleteWhere` with `Field:"4"` succeeds; with `Field:"expires_at"` it returns the clear `cannot translate filter key … without a schema` error. The real gap was that this schema-optional contract was **undocumented and unpinned** — callers did not know the numeric-id route was the supported escape hatch, and nothing guarded it against a future regression (e.g. someone "fixing" the handler by adding a hard reject for a missing schema, which would diverge from `QueryNodes`).

## Fix (mirrors the QueryNodes schema-optional contract; no new API shape)

- **Server**: documented the schema-optional contract directly on the `DeleteWhere` handler so it stays aligned with `QueryNodes` and is not regressed into a hard reject. Behaviour unchanged.
- **Go + Python SDKs** (one PR, per project rule): documented the numeric-field-id escape hatch on `DeleteWhere`/`delete_where` and `Filter`. No API change — the existing `Filter.Field`/`field` already passes through, consistent with ADR-025's single-shape API (no second parallel method added).
- **Tests**:
  - Server unit (`server/go/internal/api/execute_atomic_test.go`): `TestExecuteAtomic_DeleteWhereSchemalessNumericFieldID` (schemaless numeric id sweeps exactly the matches; WAL carries the id-keyed predicate), `TestExecuteAtomic_DeleteWhereSchemalessNameKeyRejected` (schemaless name key → `INVALID_ARGUMENT` with the shared "cannot translate filter key … without a schema" wording), `TestExecuteAtomic_DeleteWhereSchemaModeNameStillResolves` (schema mode name resolution + unknown type_id still `INVALID_ARGUMENT`).
  - Go SDK (`sdk/go/entdb/plan_test.go`): `TestPlan_DeleteWhere_SchemalessNumericFieldID` — numeric `Field` reaches the wire verbatim, no client-side name resolution.
  - Python SDK (`tests/python/unit/test_delete_where_schemaless.py`): numeric key survives `filters_to_filter_dict`; `delete_where` emits `FieldFilter(field="4")` verbatim; a name key is also forwarded unchanged.
  - Python integration (`tests/python/integration/test_delete_where.py` + a schemaless server fixture in `conftest.py`): live schemaless Go server — numeric id sweeps end-to-end; name key → `INVALID_ARGUMENT`.

## Testing

Full local CI, all green:
- `cd server/go && go vet ./... && go test ./...` — all packages `ok`
- `cd sdk/go/entdb && go vet ./... && go test ./...` — all packages `ok`
- `python -m pytest tests/python/integration/ -q` — 103 passed
- `python -m pytest tests/python/unit/test_delete_where_schemaless.py -q` — 3 passed
- `uvx ruff@0.15.7 check .` / `format --check .` — clean
- `bash tests/python/e2e/run-e2e.sh` — 22 passed, 1 skipped

Closes #545
