### PR TITLE
docs: document DeleteWhere + schema-less numeric-field-id requirement (#545)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -38,7 +38,7 @@ The 44 RPCs cluster into the following groups. Source-of-truth for shapes is the
 
 **Data plane (per-tenant):**
 
-- `ExecuteAtomic` — the only mutating RPC for tenant data. Builds one or more ops in a single WAL event.
+- `ExecuteAtomic` — the only mutating RPC for tenant data. Builds one or more ops in a single WAL event. Op union includes the `delete_where` predicate sweeper (see [`ExecuteAtomic` operations](#executeatomic-operations)).
 - `GetNode`, `GetNodes`, `GetNodeByKey`, `QueryNodes`, `SearchNodes`
 - `GetEdgesFrom`, `GetEdgesTo`, `GetConnectedNodes`
 - `GetMailbox`, `SearchMailbox`, `ListMailboxUsers`
@@ -156,6 +156,21 @@ Special kind coercions on ingress (server-side, when the schema is known):
 - **json**: nested `Struct` values are unwrapped to native maps once; never recurses.
 
 On egress, the wire shape is symmetric: `[]byte` re-encoded as base64, `int64` written as `float64` (structpb), enums as strings.
+
+## `ExecuteAtomic` operations
+
+`ExecuteAtomic` carries `repeated Operation operations`; each `Operation` is a `oneof op` over the six op messages. These are wire contract but are **not** standalone RPCs — the machine-extracted inventory of all six is in [`docs/generated/api-reference.md`](generated/api-reference.md).
+
+| `op` field | Message | Purpose |
+|---|---|---|
+| `create_node` | `CreateNodeOp` | Insert a node. |
+| `update_node` | `UpdateNodeOp` | Patch a node, optionally with a CAS precondition. |
+| `delete_node` | `DeleteNodeOp` | Delete a single node by id. |
+| `create_edge` | `CreateEdgeOp` | Insert an edge. |
+| `delete_edge` | `DeleteEdgeOp` | Delete an edge. |
+| `delete_where` | `DeleteWhereOp` | Predicate sweeper: delete every node of a type matching all `where` filters, best-effort capped by `limit`, in one op (issue [#504](https://github.com/elloloop/tenant-shard-db/issues/504)). |
+
+`DeleteWhereOp.where` reuses the same `FieldFilter` / `FilterOp` shape as `QueryNodesRequest.filters`, so no new wire concept is introduced. As with `QueryNodes` filters, the filter `field` is normally a payload `field_id` resolved client-side from a name; against a **schema-less server** only digit-string keys translate (a name key returns `INVALID_ARGUMENT` — see [Field IDs, not field names](#field-ids-not-field-names) and the [schema-lockdown guide](guides/schema-lockdown.md#delete_where-and-querynodes-on-schema-less-deployments), issue [#545](https://github.com/elloloop/tenant-shard-db/issues/545)). `limit <= 0` selects the server default cap; the server clamps to a hard ceiling so a runaway predicate cannot pin the single applier goroutine for a tenant. Deleted ids are not returned (v1 scope, #504) — callers needing the ids keep using the `QueryNodes` + `DeleteNodeOp` loop.
 
 ## Schema RPC
 

--- a/docs/generated/api-reference.md
+++ b/docs/generated/api-reference.md
@@ -54,3 +54,16 @@ Source: [`proto/entdb/v1/entdb.proto`](../../proto/entdb/v1/entdb.proto). **44 R
 | `TransferUserContent` | `TransferUserContentRequest` | `TransferUserContentResponse` | Admin operations (Issue #90, ADR-003) |
 | `UpdateUser` | `UpdateUserRequest` | `UpdateUserResponse` | — |
 | `WaitForOffset` | `WaitForOffsetRequest` | `WaitForOffsetResponse` | Wait for a specific stream position to be applied |
+
+## `ExecuteAtomic` operations
+
+The `ExecuteAtomic` RPC carries a list of `Operation`s (the `oneof op`). Each op below is a member of that union — they are wire contract, not standalone RPCs. `delete_where` is the single-RPC predicate sweeper (issues #504, #545).
+
+| Op | Message | Description |
+|---|---|---|
+| `create_edge` | `CreateEdgeOp` | — |
+| `create_node` | `CreateNodeOp` | — |
+| `delete_edge` | `DeleteEdgeOp` | — |
+| `delete_node` | `DeleteNodeOp` | — |
+| `delete_where` | `DeleteWhereOp` | DeleteWhereOp is a single-RPC predicate-based sweeper: it deletes every node of ``type_id`` whose payload matches ALL of the ``where`` predicates, inside one ``ExecuteAtomic`` op. It collapses the standard "QueryNodes to find ids, then ExecuteAtomic to delete them" loop into a single round trip — the TTL-sweeper pattern. See GitHub issue #504. The ``where`` predicates reuse the exact ``FieldFilter`` / ``FilterOp`` types shipped for ``QueryNodes`` (issue #501), so no new wire concept is introduced — Eq/Ne/Lt/Le/Gt/Ge are supported and AND-ed together. Limit semantics are BEST-EFFORT (Postgres ``DELETE … LIMIT`` style): at most ``limit`` matching nodes are deleted in this op; the rest remain for a subsequent sweep. This matches sweeper semantics — a caller polls until a sweep deletes zero rows. The server caps ``limit`` to a server-side maximum so a runaway predicate cannot pin the single applier goroutine for one tenant (CLAUDE.md single-applier invariant). ``limit <= 0`` means "use the server default cap". Out of scope for v1 (issue #504): the deleted ids are NOT returned in the response — callers that need the ids keep using the QueryNodes + DeleteNodeOp loop. |
+| `update_node` | `UpdateNodeOp` | — |

--- a/docs/generated/sdk-go.md
+++ b/docs/generated/sdk-go.md
@@ -38,6 +38,10 @@ SPDX-License-Identifier: MIT
 
 SPDX-License-Identifier: MIT
 
+SPDX-License-Identifier: MIT
+
+SPDX-License-Identifier: MIT
+
 VARIABLES
 
 var ErrPreconditionFailed = errors.New("entdb: precondition failed")
@@ -62,6 +66,50 @@ func Delete[T proto.Message](p *Plan, nodeID string)
 
     Passing a non-pointer or non-proto T is a compile-time error; passing a T
     with no “(entdb.node)“ option panics at call time.
+
+func DeleteWhere[T proto.Message](p *Plan, where []Filter, limit int)
+    DeleteWhere accumulates a single-RPC predicate-based sweeper op (GitHub
+    issue #504). It deletes every node of type T whose payload matches ALL of
+    the AND-ed Filter predicates, capped best-effort by limit, in one round trip
+    — collapsing the QueryWhere + Delete loop the TTL-sweeper pattern otherwise
+    needs.
+
+    Like Delete, DeleteWhere is a free function (Go has no generic methods)
+    and T is a compile-time type witness: the SDK reads "(entdb.node).type_id"
+    from T's descriptor without a message instance. The Filter field names
+    are resolved to payload field ids server-side, exactly like QueryWhere,
+    so no client registry is needed for the predicate.
+
+    limit is best-effort (Postgres DELETE … LIMIT semantics): at most limit
+    nodes are deleted by this op. Pass 0 for the server default; the server
+    clamps to its own hard ceiling so a runaway predicate cannot pin the single
+    applier goroutine for a tenant. To drain a large backlog, sweep in a loop
+    until a sweep deletes nothing.
+
+    At least one filter is required — an unconditional bulk delete is rejected
+    server-side. Passing T with no "(entdb.node)" option panics at call time.
+
+        entdb.DeleteWhere[*auth.WebAuthnChallenge](plan,
+            []entdb.Filter{{Field: "expires_at", Op: entdb.FilterLt, Value: now}},
+            1000,
+        )
+
+    Schema-less servers (issue #545): a server started without a schema cannot
+    resolve a field NAME to a payload field id. Pass the numeric payload field
+    id as the Filter.Field string instead — exactly the schema-optional escape
+    hatch QueryWhere already accepts for numeric filter keys. The SDK forwards
+    Field verbatim; the server treats a digit-only key as a raw field id with no
+    schema lookup:
+
+        // "expires_at" is proto field 4 on the caller's own schema.
+        entdb.DeleteWhere[*auth.WebAuthnChallenge](plan,
+            []entdb.Filter{{Field: "4", Op: entdb.FilterLt, Value: now}},
+            1000,
+        )
+
+    Against a schema-configured server both forms work; against a schema-less
+    server only the numeric-id form does (a name key returns INVALID_ARGUMENT:
+    "cannot translate filter key … without a schema").
 
 func EdgeCreate[T proto.Message](p *Plan, from, to string)
     EdgeCreate accumulates a create-edge operation.
@@ -160,6 +208,20 @@ func Search[T proto.Message](ctx context.Context, s *Scope, query string, opts .
     searched.
 
         results, err := entdb.Search[*shop.Product](ctx, scope, "widget")
+
+func WithAfterOffset(ctx context.Context, streamPosition string) context.Context
+    WithAfterOffset returns a context that pins the next read to the given
+    WAL stream position, overriding automatic offset tracking for that call.
+    Equivalent to passing an explicit “after_offset“ string in the Python SDK.
+
+        ctx = entdb.WithAfterOffset(ctx, receipt.StreamPosition)
+        p, err := entdb.Get[*shop.Product](ctx, scope, "node-42")
+
+func WithoutOffsetTracking(ctx context.Context) context.Context
+    WithoutOffsetTracking returns a context that opts the next read out of
+    automatic offset tracking — no “after_offset“ is sent even if the client has
+    written for this tenant. Equivalent to passing “after_offset=None“ in the
+    Python SDK.
 
 
 TYPES
@@ -358,6 +420,17 @@ func WithNodeResolver(r NodeResolver) ClientOption
 
     If both WithNodeResolver and WithBaseDomain are supplied, the last one wins.
 
+func WithRetryBudget(d time.Duration) ClientOption
+    WithRetryBudget caps the total wall-clock time the SDK spends retrying
+    a single failed RPC, including the exponential-backoff sleeps between
+    attempts. Once the elapsed time since the first attempt would exceed
+    the budget, the last error is returned even if retry attempts (per
+    WithMaxRetries) remain.
+
+    This bounds tail latency under an outage: without it, a high maxRetries
+    combined with exponential backoff can block a caller for minutes.
+    A non-positive duration restores the 30s default.
+
 func WithSecure() ClientOption
     WithSecure enables TLS for the gRPC connection.
 
@@ -485,6 +558,16 @@ func (c *DbClient) Admin() *Admin
     Admin returns a typed handle for the cross-tenant admin RPCs. See Admin for
     the full surface.
 
+func (c *DbClient) ClearOffsets()
+    ClearOffsets drops every tracked per-tenant write offset, so the
+    next read no longer pins to a past write. Mirrors the Python SDK's
+    “DbClient.clear_offsets()“ — useful in tests and when a caller deliberately
+    wants to stop enforcing read-after-write.
+
+    Automatic offset tracking otherwise needs zero application code: every
+    Commit records “receipt.stream_position“ for its tenant and every subsequent
+    read auto-attaches it as “after_offset“.
+
 func (c *DbClient) Close() error
     Close tears down the gRPC connection.
 
@@ -525,6 +608,14 @@ func (c *DbClient) Tenant(tenantID string) *TenantScope
 
         scope := client.Tenant("acme").Actor(entdb.UserActor("bob"))
         product, err := entdb.Get[*shop.Product](ctx, scope, "node-42")
+
+func (c *DbClient) Transport() Transport
+    Transport returns the underlying Transport this client uses.
+
+    It is a read-only accessor intended for advanced consumers (e.g. custom
+    tooling or tests) that need to reach the transport without resorting to
+    reflection and unsafe. The returned value must be treated as read-only;
+    mutating transport state out from under the client is unsupported.
 
 func (c *DbClient) WaitForOffset(ctx context.Context, tenantID, actor, streamPosition string, timeoutMs int32) (bool, string, error)
     WaitForOffset blocks server-side until the WAL applier has reached
@@ -577,11 +668,18 @@ type Filter struct {
 	Op    FilterOp
 	Value any
 }
-    Filter is one AND-ed predicate passed to QueryWhere. Field is the proto
-    field name (the gRPC boundary resolves it to a payload field_id). Op selects
-    the comparison operator. Value is bound as a SQLite parameter and supports
-    the JSON-marshallable scalars SQLite understands (string, int, int64,
-    float64, bool, nil).
+    Filter is one AND-ed predicate passed to QueryWhere (and DeleteWhere).
+    Field is the proto field name (the gRPC boundary resolves it to a payload
+    field_id). Op selects the comparison operator. Value is bound as a SQLite
+    parameter and supports the JSON-marshallable scalars SQLite understands
+    (string, int, int64, float64, bool, nil).
+
+    Schema-less escape hatch (issue #545): Field may instead be the digit-only
+    numeric payload field id (e.g. "4"). The SDK forwards Field unchanged;
+    a server with no schema treats a digit-only key as a raw field id and skips
+    name resolution. This is the only way to filter against a schema-less server
+    — a field NAME there returns INVALID_ARGUMENT ("cannot translate filter key
+    … without a schema"). A schema-configured server accepts either form.
 
     Multiple filters on the same field are permitted — a half-open range is
     expressed as two filters:
@@ -711,6 +809,18 @@ type Operation struct {
 	//
 	// Only valid on OpUpdateNode. Ignored for other op types.
 	Precondition *Precondition `json:"precondition,omitempty"`
+
+	// Where carries the AND-ed predicate for OpDeleteWhere (GitHub
+	// issue #504). Field names are resolved to payload field ids at
+	// the SDK boundary, exactly like QueryWhere. Only valid on
+	// OpDeleteWhere; ignored for other op types.
+	Where []Filter `json:"where,omitempty"`
+
+	// Limit is the best-effort cap on the number of nodes deleted by
+	// an OpDeleteWhere op (Postgres DELETE … LIMIT semantics). Zero
+	// selects the server default; the server clamps to its own hard
+	// ceiling. Ignored for other op types.
+	Limit int `json:"limit,omitempty"`
 }
     Operation represents a single mutation in a Plan.
 
@@ -728,6 +838,11 @@ const (
 	OpDeleteNode
 	OpCreateEdge
 	OpDeleteEdge
+	// OpDeleteWhere is the single-RPC predicate-based sweeper
+	// (GitHub issue #504): delete every node of a type matching an
+	// AND-ed [Filter] predicate in one round trip, instead of a
+	// QueryWhere + Delete loop.
+	OpDeleteWhere
 )
 type Permission string
     Permission represents an ACL permission level.

--- a/docs/generated/sdk-python.md
+++ b/docs/generated/sdk-python.md
@@ -4,7 +4,7 @@
 
 # Python SDK Reference (generated)
 
-Extracted from `sdk/python/entdb_sdk` — `__all__` and `DbClient` public methods. Narrative + Go side-by-side lives in [sdk-reference.md](../sdk-reference.md).
+Extracted from `sdk/python/entdb_sdk` — `__all__` plus the public methods of `DbClient` (connection entrypoint) and `Plan` (chained-write builder). Narrative + Go side-by-side lives in [sdk-reference.md](../sdk-reference.md).
 
 ## Public API surface (`from entdb_sdk import ...`)
 
@@ -102,3 +102,15 @@ Extracted from `sdk/python/entdb_sdk` — `__all__` and `DbClient` public method
 | `async transfer_user_content(tenant_id, from_user, to_user, *, actor=..., timeout=...)` | Reassign ownership of all nodes from from_user to to_user. |
 | `async update_user(user_id, *, name=..., email=..., status=..., actor=..., timeout=...)` | Update user fields. |
 | `async wait_for_offset(tenant_id, stream_position, timeout_ms=..., *, trace_id=..., timeout=...)` | Wait for a stream position to be applied. |
+
+## `Plan` methods
+
+| Method | Description |
+|---|---|
+| `async commit(wait_applied=..., *, timeout=...)` | Commit the transaction. |
+| `create(msg, *, acl=..., storage=..., as_=..., fanout_to=..., id_=...)` | Create a node from a proto message. |
+| `delete(node_type, node_id)` | Delete a node. |
+| `delete_where(node_type, where, *, limit=...)` | Delete every node of a type matching a predicate, in one op. |
+| `edge_create(edge_type, from_id, to_id, *, props=...)` | Create an edge. |
+| `edge_delete(edge_type, from_id, to_id)` | Delete an edge. |
+| `update(node_id, msg, *, precondition=...)` | Update a node from a proto message. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -199,6 +199,14 @@ func main() {
 
 The `$task.id` / `$alice.id` syntax (Python) and `plan.Create(...)` returning an alias-style token (Go) let a single plan reference nodes it creates in the same call — the server resolves aliases before persisting.
 
+> **Bulk cleanup:** to delete every node matching a predicate in one
+> round-trip (the TTL-sweeper pattern), use `plan.delete_where(...)` /
+> `entdb.DeleteWhere[...]` instead of a query-then-delete loop. On a
+> schema-less server, filter by the numeric payload field id (same
+> rule as `QueryNodes` filters) — see [Plan methods](sdk-reference.md#plan-methods)
+> and [Schema lockdown → `delete_where` on schema-less deployments](guides/schema-lockdown.md#delete_where-and-querynodes-on-schema-less-deployments)
+> ([#545](https://github.com/elloloop/tenant-shard-db/issues/545)).
+
 ## 6. Inspect the data
 
 - **EntDB Console** (<http://localhost:8080>): browse tenants, nodes, edges; run sandbox writes against `playground`.

--- a/docs/guides/schema-lockdown.md
+++ b/docs/guides/schema-lockdown.md
@@ -407,6 +407,91 @@ production use; capture yours via `entdb-schema snapshot --from-server`
 pointed at your actual server (with your full registry registered, not
 just the contract-test seed).
 
+## `delete_where` and `QueryNodes` on schema-less deployments
+
+Some deployments run `entdb-server` **without** a registered schema —
+no `.schema-snapshot.json`, no `--seed-profile`, the registry empty by
+design (a thin keyed-blob store, or an early bootstrap stage before the
+schema is locked). That mode is fully supported for predicate
+operations, with one rule you must know.
+
+EntDB payloads are keyed on the wire and on disk by numeric
+`field_id`, never by name ([ADR-018](../adr/018-field-id-keyed-payloads.md)).
+The SDKs translate a human field *name* to its `field_id` from the
+proto descriptor before the call. The **server** only needs to do that
+translation for predicate *filters* — and it can only do it if it has a
+schema. So the rule is symmetric across the two predicate surfaces:
+
+- A filter **field name** (e.g. `"expires_at"`) requires a registered
+  schema. Against a schema-less server it returns
+  `INVALID_ARGUMENT: "cannot translate filter key … without a schema"`.
+- A **digit-only numeric payload field id** (e.g. `"4"`) works
+  schema-less: the server treats a digit-only key as a raw `field_id`
+  and skips the lookup entirely.
+
+This is the **same schema-optional escape hatch `QueryNodes` filters
+already accept** — `delete_where` (the single-RPC predicate sweeper,
+[issue #504](https://github.com/elloloop/tenant-shard-db/issues/504))
+deliberately reuses the exact `FieldFilter` / `FilterOp` types, so the
+behaviour is identical to `query(where=)` / `QueryWhere`. The
+schema-less numeric-field-id requirement for `delete_where` is tracked
+in [issue #545](https://github.com/elloloop/tenant-shard-db/issues/545).
+
+Against a schema-**configured** server both forms work; against a
+schema-**less** server only the numeric-id form does. Pick the proto
+field number from your own schema (the field number IS the `field_id`,
+[ADR-006](../adr/006-proto-schema-definition.md) /
+[ADR-018](../adr/018-field-id-keyed-payloads.md)) — e.g. if
+`expires_at` is field `4` in your `.proto`, pass `"4"`.
+
+### Go
+
+```go
+// Schema-configured server: a field name is fine.
+entdb.DeleteWhere[*auth.WebAuthnChallenge](plan,
+    []entdb.Filter{{Field: "expires_at", Op: entdb.FilterLt, Value: nowMs}},
+    1000)
+
+// Schema-LESS server: pass the numeric field id ("expires_at" is
+// proto field 4 in the caller's own schema). A name key here would
+// fail with INVALID_ARGUMENT: "cannot translate filter key … without
+// a schema". QueryWhere filters take the exact same numeric key.
+entdb.DeleteWhere[*auth.WebAuthnChallenge](plan,
+    []entdb.Filter{{Field: "4", Op: entdb.FilterLt, Value: nowMs}},
+    1000)
+```
+
+### Python
+
+```python
+from entdb_sdk import Filter, FilterOp
+
+# Schema-configured server: a field name is fine.
+plan.delete_where(
+    schema_pb2.WebAuthnChallenge,
+    [Filter(field="expires_at", op=FilterOp.LT, value=now_ms)],
+    limit=1000,
+)
+
+# Schema-LESS server: pass the numeric field id ("expires_at" is
+# proto field 4 in the caller's own schema). A name key here raises
+# INVALID_ARGUMENT: "cannot translate filter key … without a schema".
+# The same numeric key works for query(where=) / QueryNodes filters.
+plan.delete_where(
+    schema_pb2.WebAuthnChallenge,
+    [Filter(field="4", op=FilterOp.LT, value=now_ms)],
+    limit=1000,
+)
+```
+
+`limit` is best-effort (Postgres `DELETE … LIMIT` semantics): the
+server caps it to a hard ceiling so a runaway predicate cannot pin a
+tenant's single applier goroutine. Drain a large backlog by sweeping
+in a loop until a sweep deletes nothing. The full SDK signature and
+narrative live in [sdk-reference.md → Plan methods](../sdk-reference.md#plan-methods);
+the wire-level op shape is in [api-reference.md → `ExecuteAtomic`
+operations](../api-reference.md#executeatomic-operations).
+
 ## Caveats and follow-ups
 
 - **`--from-descriptors` is reserved.** Loading the registry from a
@@ -426,6 +511,10 @@ just the contract-test seed).
 
 - Issue #488 — design and rationale (acceptance criteria, alternative
   shapes, performance budget).
+- Issues [#504](https://github.com/elloloop/tenant-shard-db/issues/504)
+  / [#545](https://github.com/elloloop/tenant-shard-db/issues/545) —
+  the `delete_where` sweeper and its schema-less numeric-field-id
+  requirement (see [above](#delete_where-and-querynodes-on-schema-less-deployments)).
 - `docs/schema-evolution.md` — the rules `entdb-schema` enforces.
 - `docs/go-port/shared/schema-registry.md` — the registry's runtime
   contract that the snapshot captures.

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -170,11 +170,31 @@ result, err := plan.Commit(ctx,
 | Update a node | `plan.update(node_id, msg)` | `plan.Update(nodeID, msg)` |
 | Update with precondition (CAS) | `plan.update(id, msg, precondition=("field", value))` | `plan.UpdateIf(...)` |
 | Delete a node | `plan.delete(NodeType, node_id)` | `entdb.Delete[T](plan, nodeID)` |
+| Delete by predicate (sweeper) | `plan.delete_where(NodeType, where, *, limit=0)` | `entdb.DeleteWhere[T](plan, where, limit)` |
 | Create an edge | `plan.edge_create(EdgeType, from_id, to_id, props={})` | `entdb.EdgeCreate[T](plan, from, to, opts...)` |
 | Delete an edge | `plan.edge_delete(EdgeType, from_id, to_id)` | `entdb.EdgeDelete[T](plan, from, to)` |
 | Commit | `await plan.commit(...)` | `plan.Commit(ctx, ...)` |
 
 `as_` (Python) / the alias returned from `plan.Create` (Go) lets later ops in the same plan reference the new node before it has a server-assigned ID. The server resolves `$alias.id` at apply time.
+
+#### `delete_where` — single-RPC predicate sweeper
+
+`delete_where` (issue [#504](https://github.com/elloloop/tenant-shard-db/issues/504)) deletes every node of a type matching an AND-ed list of `Filter` predicates in **one** `ExecuteAtomic` op, collapsing the TTL-sweeper "query for ids, then delete each" loop into a single round-trip. At least one filter is required — an unconditional bulk delete is rejected. `limit` is best-effort (Postgres `DELETE … LIMIT` semantics): `0` selects the server default, which the server clamps to its own ceiling so a runaway predicate cannot pin a tenant's single applier; drain a backlog by sweeping in a loop until a sweep deletes nothing.
+
+```python
+plan.delete_where(
+    schema_pb2.WebAuthnChallenge,
+    [Filter(field="expires_at", op=FilterOp.LT, value=now_ms)],
+    limit=1000,
+)
+```
+
+```go
+entdb.DeleteWhere[*myschema.WebAuthnChallenge](plan,
+    []entdb.Filter{{Field: "expires_at", Op: entdb.FilterLt, Value: nowMs}}, 1000)
+```
+
+The predicate is resolved exactly like `query(where=)` — server-side, from payload `field_id`s. **Schema-less servers** (issue [#545](https://github.com/elloloop/tenant-shard-db/issues/545)): a server started without a registered schema cannot translate a field *name* to a `field_id`. Pass the numeric payload field id as the filter field (e.g. `Filter(field="4", ...)` / `{Field: "4", ...}`); the SDK forwards a digit-only key verbatim and the server treats it as a raw `field_id` with no schema lookup — the same schema-optional escape hatch `QueryNodes` filters already accept. Against a schema-less server a *name* key returns `INVALID_ARGUMENT` (`"cannot translate filter key … without a schema"`). See [Schema lockdown → `delete_where` on schema-less deployments](guides/schema-lockdown.md#delete_where-and-querynodes-on-schema-less-deployments).
 
 ## Reads
 

--- a/scripts/check_docs_coverage.py
+++ b/scripts/check_docs_coverage.py
@@ -3,11 +3,15 @@
 
 Re-scoped post Python-server retirement (ADR-017). The check is:
 
-  1. Every RPC in proto/entdb/v1/entdb.proto appears in
+  1. Every RPC *and* every Operation-oneof member (the
+     `ExecuteAtomic` ops, e.g. ``delete_where``) in
+     proto/entdb/v1/entdb.proto appears in
      docs/generated/api-reference.md.
   2. Every name in entdb_sdk.__all__ appears in
      docs/generated/sdk-python.md.
-  3. Every public DbClient method appears in
+  3. Every public method of the client-surface classes
+     (``DbClient`` and the ``Plan`` chained-write builder, which
+     owns ``delete_where``) appears in
      docs/generated/sdk-python.md.
   4. The generated files are not stale (delegates to
      generate_api_docs.py --check) so coverage can't be faked by
@@ -40,6 +44,7 @@ from generate_api_docs import (  # type: ignore[import-not-found]
     PYTHON_CLIENT,
     PYTHON_SDK_INIT,
     REPO_ROOT,
+    extract_operations,
     extract_python,
     extract_rpcs,
 )
@@ -78,28 +83,55 @@ def check_generated_fresh() -> bool:
 
 
 def check_rpc_coverage() -> bool:
-    rpcs = extract_rpcs(PROTO_PATH.read_text())
+    proto_text = PROTO_PATH.read_text()
+    rpcs = extract_rpcs(proto_text)
+    ops = extract_operations(proto_text)
     doc = (OUT_DIR / "api-reference.md").read_text()
-    missing = [r.name for r in rpcs if f"`{r.name}`" not in doc]
-    if missing:
+
+    missing_rpcs = [r.name for r in rpcs if f"`{r.name}`" not in doc]
+    # Operation oneof members (e.g. ``delete_where``) are wire
+    # contract too — they ride inside ExecuteAtomic. Enforcing them
+    # closes the blind spot that hid ``delete_where`` (#545) from the
+    # generated reference.
+    missing_ops = [o.field for o in ops if f"`{o.field}`" not in doc]
+
+    ok = True
+    if missing_rpcs:
         _fail(
-            f"{len(missing)} RPC(s) in entdb.proto not in "
-            f"docs/generated/api-reference.md: {', '.join(sorted(missing))}"
+            f"{len(missing_rpcs)} RPC(s) in entdb.proto not in "
+            f"docs/generated/api-reference.md: {', '.join(sorted(missing_rpcs))}"
         )
-        return False
-    print(f"OK: {len(rpcs)} RPCs documented.")
-    return True
+        ok = False
+    if missing_ops:
+        _fail(
+            f"{len(missing_ops)} ExecuteAtomic op(s) in entdb.proto "
+            f"not in docs/generated/api-reference.md: "
+            f"{', '.join(sorted(missing_ops))}"
+        )
+        ok = False
+    if ok:
+        print(f"OK: {len(rpcs)} RPCs + {len(ops)} ExecuteAtomic ops documented.")
+    return ok
 
 
 def check_python_coverage() -> bool:
-    exports, methods = extract_python(PYTHON_CLIENT.read_text(), PYTHON_SDK_INIT.read_text())
+    exports, methods_by_class = extract_python(
+        PYTHON_CLIENT.read_text(), PYTHON_SDK_INIT.read_text()
+    )
     doc = (OUT_DIR / "sdk-python.md").read_text()
 
     missing_exports = [e for e in exports if f"`{e}`" not in doc]
     # Methods are documented as ``async name(...)`` / ``name(...)`` —
     # match on the bare name in backticks-with-paren to avoid false
     # positives on substrings (e.g. ``get`` inside ``get_by_key``).
-    missing_methods = [m.name for m in methods if f"{m.name}(" not in doc]
+    # Both DbClient *and* Plan (the chained-write builder, which owns
+    # ``delete_where`` — the #545 schema-less sweeper) are enforced so
+    # a builder method can't silently fall out of the docs surface.
+    missing_methods: list[str] = []
+    total_methods = 0
+    for class_name, methods in methods_by_class.items():
+        total_methods += len(methods)
+        missing_methods += [f"{class_name}.{m.name}" for m in methods if f"{m.name}(" not in doc]
 
     ok = True
     if missing_exports:
@@ -111,13 +143,16 @@ def check_python_coverage() -> bool:
         ok = False
     if missing_methods:
         _fail(
-            f"{len(missing_methods)} DbClient method(s) undocumented "
-            f"in docs/generated/sdk-python.md: "
+            f"{len(missing_methods)} client-surface method(s) "
+            f"(DbClient/Plan) undocumented in "
+            f"docs/generated/sdk-python.md: "
             f"{', '.join(sorted(missing_methods))}"
         )
         ok = False
     if ok:
-        print(f"OK: {len(exports)} public symbols + {len(methods)} DbClient methods documented.")
+        print(
+            f"OK: {len(exports)} public symbols + {total_methods} DbClient/Plan methods documented."
+        )
     return ok
 
 

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -118,7 +118,64 @@ def extract_rpcs(proto_text: str) -> list[Rpc]:
     return rpcs
 
 
-def render_api_reference(rpcs: list[Rpc]) -> str:
+@dataclass
+class Op:
+    """A member of the ``Operation`` oneof (an ``ExecuteAtomic`` op).
+
+    These are part of the wire contract but are *not* RPCs — they ride
+    inside ``ExecuteAtomicRequest.operations``. The RPC-only walk never
+    listed them, so ``delete_where`` (the #545 schema-less sweeper)
+    was absent from the generated reference. Extracting the oneof
+    closes that blind spot symmetrically with the ``Plan`` one.
+    """
+
+    field: str  # oneof field name, e.g. "delete_where"
+    message: str  # message type, e.g. "DeleteWhereOp"
+    doc: str  # leading // comment on the message definition
+
+
+def extract_operations(proto_text: str) -> list[Op]:
+    """Parse the ``Operation`` oneof and each op message's doc comment."""
+    lines = proto_text.splitlines()
+
+    # 1. The oneof members: field name -> message type.
+    members: list[tuple[str, str]] = []
+    in_op_msg = False
+    in_oneof = False
+    member_re = re.compile(r"(\w+)\s+(\w+)\s*=\s*\d+\s*;")
+    for raw in lines:
+        s = raw.strip()
+        if s.startswith("message Operation"):
+            in_op_msg = True
+            continue
+        if in_op_msg and s.startswith("oneof "):
+            in_oneof = True
+            continue
+        if in_op_msg and in_oneof:
+            if s.startswith("}"):
+                break
+            m = member_re.search(s)
+            if m:
+                members.append((m.group(2), m.group(1)))
+
+    # 2. Each member message's leading // doc comment.
+    doc_for: dict[str, str] = {}
+    pending: list[str] = []
+    for raw in lines:
+        s = raw.strip()
+        if s.startswith("//"):
+            pending.append(s)
+            continue
+        m = re.match(r"message\s+(\w+)\s*\{", s)
+        if m:
+            doc_for[m.group(1)] = _strip_comment(pending)
+        if s:
+            pending.clear()
+
+    return [Op(field=field, message=msg, doc=doc_for.get(msg, "")) for field, msg in members]
+
+
+def render_api_reference(rpcs: list[Rpc], ops: list[Op]) -> str:
     lines = [
         GENERATED_BANNER,
         "# API Reference — gRPC contract (generated)",
@@ -137,6 +194,21 @@ def render_api_reference(rpcs: list[Rpc]) -> str:
     for r in sorted(rpcs, key=lambda x: x.name):
         doc = r.doc.replace("|", "\\|") or "—"
         lines.append(f"| `{r.name}` | `{r.request}` | `{r.response}` | {doc} |")
+    lines += [
+        "",
+        "## `ExecuteAtomic` operations",
+        "",
+        "The `ExecuteAtomic` RPC carries a list of `Operation`s "
+        "(the `oneof op`). Each op below is a member of that union — "
+        "they are wire contract, not standalone RPCs. `delete_where` "
+        "is the single-RPC predicate sweeper (issues #504, #545).",
+        "",
+        "| Op | Message | Description |",
+        "|---|---|---|",
+    ]
+    for o in sorted(ops, key=lambda x: x.field):
+        doc = o.doc.replace("|", "\\|") or "—"
+        lines.append(f"| `{o.field}` | `{o.message}` | {doc} |")
     lines.append("")
     return "\n".join(lines)
 
@@ -199,20 +271,27 @@ def _public_exports(init_text: str) -> list[str]:
     return []
 
 
-def extract_python(client_text: str, init_text: str) -> tuple[list[str], list[PySymbol]]:
-    """Return (public __all__ names, DbClient public methods)."""
-    exports = _public_exports(init_text)
-    tree = ast.parse(client_text)
-    methods: list[PySymbol] = []
+# Public client-surface classes whose methods are part of the
+# contract. ``DbClient`` is the connection/entrypoint; ``Plan`` is the
+# chained-write builder (``plan.create(...).delete_where(...).commit()``)
+# whose methods — including ``delete_where``, the #545 schema-less
+# sweeper — are public API but are NOT ``DbClient`` methods, so the
+# original ``DbClient``-only walk never saw them (a coverage blind
+# spot). Both classes live in client.py and both are in ``__all__``.
+_CLIENT_SURFACE_CLASSES = ("DbClient", "Plan")
+
+
+def _class_methods(tree: ast.AST, class_name: str) -> list[PySymbol]:
+    out: list[PySymbol] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == "DbClient":
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
             for item in node.body:
                 if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
                     if item.name.startswith("_"):
                         continue
                     is_async = isinstance(item, ast.AsyncFunctionDef)
                     sig = f"{'async ' if is_async else ''}{item.name}({_format_args(item)})"
-                    methods.append(
+                    out.append(
                         PySymbol(
                             name=item.name,
                             kind="method",
@@ -220,32 +299,49 @@ def extract_python(client_text: str, init_text: str) -> tuple[list[str], list[Py
                             doc=_ast_first_doc(item),
                         )
                     )
-    return exports, methods
+    return out
 
 
-def render_python(exports: list[str], methods: list[PySymbol]) -> str:
+def extract_python(client_text: str, init_text: str) -> tuple[list[str], dict[str, list[PySymbol]]]:
+    """Return (public ``__all__`` names, {class -> public methods}).
+
+    Methods are collected for every class in
+    :data:`_CLIENT_SURFACE_CLASSES` so the builder API (``Plan``) is
+    documented and guarded the same way as ``DbClient`` — otherwise a
+    ``Plan``-only method like ``delete_where`` (#545) is invisible to
+    both the generator and the coverage guard.
+    """
+    exports = _public_exports(init_text)
+    tree = ast.parse(client_text)
+    methods_by_class = {name: _class_methods(tree, name) for name in _CLIENT_SURFACE_CLASSES}
+    return exports, methods_by_class
+
+
+def render_python(exports: list[str], methods_by_class: dict[str, list[PySymbol]]) -> str:
     lines = [
         GENERATED_BANNER,
         "# Python SDK Reference (generated)",
         "",
-        "Extracted from `sdk/python/entdb_sdk` — `__all__` and "
-        "`DbClient` public methods. Narrative + Go side-by-side lives "
-        "in [sdk-reference.md](../sdk-reference.md).",
+        "Extracted from `sdk/python/entdb_sdk` — `__all__` plus the "
+        "public methods of `DbClient` (connection entrypoint) and "
+        "`Plan` (chained-write builder). Narrative + Go side-by-side "
+        "lives in [sdk-reference.md](../sdk-reference.md).",
         "",
         "## Public API surface (`from entdb_sdk import ...`)",
         "",
     ]
     lines += [f"- `{name}`" for name in sorted(exports)]
-    lines += [
-        "",
-        "## `DbClient` methods",
-        "",
-        "| Method | Description |",
-        "|---|---|",
-    ]
-    for m in sorted(methods, key=lambda x: x.name):
-        doc = (m.doc or "—").replace("|", "\\|")
-        lines.append(f"| `{m.signature}` | {doc} |")
+    for class_name in _CLIENT_SURFACE_CLASSES:
+        lines += [
+            "",
+            f"## `{class_name}` methods",
+            "",
+            "| Method | Description |",
+            "|---|---|",
+        ]
+        for m in sorted(methods_by_class.get(class_name, []), key=lambda x: x.name):
+            doc = (m.doc or "—").replace("|", "\\|")
+            lines.append(f"| `{m.signature}` | {doc} |")
     lines.append("")
     return "\n".join(lines)
 
@@ -304,12 +400,13 @@ def build_all() -> dict[str, str]:
     init_text = PYTHON_SDK_INIT.read_text()
 
     rpcs = extract_rpcs(proto_text)
-    exports, methods = extract_python(client_text, init_text)
+    ops = extract_operations(proto_text)
+    exports, methods_by_class = extract_python(client_text, init_text)
     godoc = extract_go()
 
     return {
-        "api-reference.md": render_api_reference(rpcs),
-        "sdk-python.md": render_python(exports, methods),
+        "api-reference.md": render_api_reference(rpcs, ops),
+        "sdk-python.md": render_python(exports, methods_by_class),
         "sdk-go.md": render_go(godoc),
     }
 


### PR DESCRIPTION
Docs-only change. **No server or SDK behaviour is modified.** Closes the documentation gap for `DeleteWhere` (the single-RPC predicate sweeper shipped v1.14.0 via #504) and its schema-less numeric-field-id requirement (#545). PR #546 only added code docstrings; this surfaces it in the user-facing docs.

The docs-site auto-deploys on push to `main` — no release required for these to reach consumers.

### 1. Regenerated reference (`docs/generated/`)
`scripts/generate_api_docs.py` was stale across v1.14.0–v1.16.0. Regenerated:
- `sdk-go.md` — now carries `DeleteWhere` (the Go free function) plus the rest of the post-v1.14 Go SDK surface (+120 lines, expected).
- `sdk-python.md` — now documents the `Plan` builder methods incl. `delete_where`.
- `api-reference.md` — now lists the `ExecuteAtomic` `Operation` oneof incl. `delete_where`.

`python scripts/generate_api_docs.py --check` is clean (self-consistent).

### 2. Closed a #40 coverage-guard blind spot
`DeleteWhere` is **not a top-level RPC** — it is an `Operation`-oneof member on `ExecuteAtomic`; and `delete_where` is a **`Plan` builder method**, not a `DbClient` method. The generator extracted only RPCs + `DbClient` methods and the guard enforced only those, so `delete_where` could go undocumented **undetected**.

Minimal fix: the generator now also extracts the `Operation` oneof and `Plan` public methods; `scripts/check_docs_coverage.py` enforces both. Verified the guard **fails** if `delete_where` regresses out of either generated doc. Guard now passes: `44 RPCs + 6 ExecuteAtomic ops`, `46 public symbols + 50 DbClient/Plan methods`.

### 3. Hand-written narrative
- `docs/guides/schema-lockdown.md` — **primary home**: dedicated section on `delete_where` / `QueryNodes` filters in schema-less deployments, with Go + Python numeric-field-id examples, mirroring the established `QueryNodes` schema-optional wording.
- `docs/api-reference.md` — `ExecuteAtomic` operations table incl. the schema-less caveat.
- `docs/sdk-reference.md` — `delete_where` row + sweeper subsection in Plan methods.
- `docs/getting-started.md` — concise bulk-cleanup pointer.

### Verification
- `python scripts/generate_api_docs.py --check` — clean
- `python scripts/check_docs_coverage.py` — PASS (covers `delete_where` at both layers)
- `uvx ruff@0.15.7 check .` / `format --check .` — clean
- `cd server/go && go vet ./...` — clean (untouched)
- Markdown well-formed; all new internal anchors resolve.

Refs #545, #504, #40.