### PR TITLE
fix(wal): Service Bus backend uses session receivers for per-tenant ordering (#543)

### DIFF
--- a/docs/adr/005-event-sourcing-wal.md
+++ b/docs/adr/005-event-sourcing-wal.md
@@ -231,6 +231,24 @@ key.
   Python source semantics: covered by the e2e crash-recovery tests
   in `tests/python/e2e/` (Kafka backend today; other backends gain
   coverage as they port via #518).
+- In-memory consumer state on the cloud backends: the Kinesis /
+  Event Hubs checkpoints and the SQS / Service Bus pending-ack maps
+  are process memory only. A server restart loses them, so every
+  received-but-uncommitted record is re-replayed after restart. This
+  is safe — the contract is at-least-once and the applier dedupes on
+  `(tenant_id, idempotency_key)` — but operators should expect a
+  bounded burst of re-applied (no-op) events on restart for these
+  backends. Kafka/Redpanda persists offsets in the broker and does
+  not have this restart re-replay window.
+- Non-unique `StreamPos.Offset` within a millisecond: the Pub/Sub,
+  Service Bus, and Event Hubs `Append` receipts derive `Offset` from
+  a wall-clock millisecond, so two appends in the same millisecond
+  can return the same `StreamPos`. The receipt is a durability
+  acknowledgement, not a unique cursor, on these backends; ordering
+  and dedupe rely on the per-key/per-session stream and the
+  idempotency key, never on `StreamPos` uniqueness. SDK/operator
+  code must not treat the returned position string as a unique id on
+  these backends (Kafka's broker offset *is* unique per partition).
 
 ## References
 

--- a/server/go/internal/wal/servicebus.go
+++ b/server/go/internal/wal/servicebus.go
@@ -19,7 +19,21 @@ package wal
 //                            as StreamPos.Offset.
 //   - Complete            -> commit. Commit calls CompleteMessage (the
 //                            Service Bus ack); an uncompleted message
-//                            is redelivered after the lock expires.
+//                            is redelivered after the session lock
+//                            expires.
+//
+// Session receivers (issue #543): the producer stamps every message
+// with SessionId = tenant key, and a session-enabled Service Bus queue
+// REQUIRES a *session* receiver — a plain `Client.NewReceiverForQueue`
+// receiver fails at runtime ("entity requires sessions") and, even if
+// it did not, could not preserve per-session FIFO. We therefore drive
+// the consumer through `Client.AcceptNextSessionForQueue`, servicing
+// one tenant session at a time and rotating fairly across sessions so
+// no tenant starves. Per-session FIFO == per-tenant ordering; ordering
+// across sessions is not promised by Service Bus and is not required by
+// the WAL contract (per-key order only). The ServiceBusAPI seam below
+// is deliberately session-shaped: there is no queue-wide Receive, so a
+// non-session receiver is structurally unrepresentable.
 //
 // Service Bus has no partitions; StreamPos.Partition is always 0.
 //
@@ -32,8 +46,9 @@ package wal
 // event surfaces at the applier (CLAUDE.md: WAL is the source of
 // truth).
 //
-// Testing: ServiceBusAPI is the seam. A thin adapter wraps the SDK
-// client/sender/receiver; unit tests inject a fake — no live Azure.
+// Testing: ServiceBusAPI / serviceBusSession are the seams. A thin
+// adapter wraps the SDK client/sender/session-receiver; unit tests
+// inject a fake that models sessions — no live Azure.
 
 import (
 	"context"
@@ -47,19 +62,57 @@ import (
 )
 
 // ServiceBusAPI is the slice of Service Bus operations the WAL backend
-// needs. The adapter in defaultNewClient wraps the SDK; tests fake it.
+// needs. It is deliberately session-shaped on the consume side: the
+// only way to read is to AcceptNextSession (a *session* receiver), so a
+// non-session receiver — the #543 bug — cannot be expressed through
+// this interface. The adapter in defaultNewClient wraps the SDK; tests
+// fake it.
 type ServiceBusAPI interface {
 	// Send sends one message to the queue with the given session id +
 	// application properties.
 	Send(ctx context.Context, sessionID string, body []byte, props map[string]string) error
-	// Receive receives up to maxMessages, waiting at most wait.
-	Receive(ctx context.Context, maxMessages int, wait time.Duration) ([]serviceBusMessage, error)
-	// Complete acks (completes) a previously-received message by its
-	// sequence number.
-	Complete(ctx context.Context, sequenceNumber int64) error
+	// AcceptNextSession accepts the next available session on the queue
+	// and returns a receiver scoped to exactly that session. It blocks
+	// up to wait for a session to become available; when none is
+	// available within wait it returns errNoSession (a normal "nothing
+	// to do right now" signal, not a failure). Per Azure semantics each
+	// accepted session is held (locked) until the returned
+	// serviceBusSession is Closed, at which point another consumer —
+	// or this one, on the next accept — may take it.
+	AcceptNextSession(ctx context.Context, wait time.Duration) (serviceBusSession, error)
 	// Close releases the client.
 	Close(ctx context.Context) error
 }
+
+// serviceBusSession is a receiver bound to a single Service Bus session
+// (one tenant). Messages it returns are in per-session FIFO order;
+// Complete acks a message by sequence number on this session's link.
+// There is no cross-session receive here by construction.
+type serviceBusSession interface {
+	// SessionID is the session this receiver is locked to.
+	SessionID() string
+	// Receive receives up to maxMessages from this session, waiting at
+	// most wait. An empty slice with a nil error means "no more right
+	// now" (the session is drained or the wait elapsed).
+	Receive(ctx context.Context, maxMessages int, wait time.Duration) ([]serviceBusMessage, error)
+	// Complete acks (completes) a previously-received message by its
+	// sequence number on this session's link.
+	Complete(ctx context.Context, sequenceNumber int64) error
+	// Pending reports how many received-but-not-yet-completed messages
+	// this session receiver still holds. Zero means every delivered
+	// message has been settled, so the consumer may release the session
+	// lock (close it) and let the accept-next loop rotate to the next
+	// tenant — keeping the queue fully drainable without starving any
+	// tenant.
+	Pending() int
+	// Close releases the session lock so another accept can take it.
+	Close(ctx context.Context) error
+}
+
+// errNoSession is returned by AcceptNextSession when no session became
+// available within the wait window. It is an internal control signal
+// (an empty poll), never surfaced to WAL callers as an error.
+var errNoSession = errors.New("servicebus: no session available")
 
 // serviceBusMessage is the transport-neutral shape Receive returns.
 type serviceBusMessage struct {
@@ -80,14 +133,20 @@ type ServiceBusConfig struct {
 	QueueName string
 	// MaxWaitTime bounds a single Receive call. Python default 5s.
 	MaxWaitTime time.Duration
+	// SessionAcceptTimeout bounds a single AcceptNextSession call. If a
+	// session does not become available within this window the accept
+	// is treated as an empty poll and the consumer rotates. Defaults to
+	// 5s.
+	SessionAcceptTimeout time.Duration
 }
 
 // DefaultServiceBusConfig returns a config matching the Python defaults.
 func DefaultServiceBusConfig(connStr, queueName string) ServiceBusConfig {
 	return ServiceBusConfig{
-		ConnectionString: connStr,
-		QueueName:        queueName,
-		MaxWaitTime:      5 * time.Second,
+		ConnectionString:     connStr,
+		QueueName:            queueName,
+		MaxWaitTime:          5 * time.Second,
+		SessionAcceptTimeout: 5 * time.Second,
 	}
 }
 
@@ -102,6 +161,12 @@ type ServiceBus struct {
 	api       ServiceBusAPI
 
 	idemp map[string]map[string]map[string]StreamPos
+
+	// open[sessionID] -> the session receiver currently held for that
+	// tenant. Commit resolves the owning session by the record's Key
+	// (SessionID); the consume loop closes a session once it drains so
+	// the lock can rotate to whoever needs it next.
+	open map[string]serviceBusSession
 }
 
 // NewServiceBus constructs a Service Bus WAL backend.
@@ -109,9 +174,13 @@ func NewServiceBus(cfg ServiceBusConfig) *ServiceBus {
 	if cfg.MaxWaitTime <= 0 {
 		cfg.MaxWaitTime = 5 * time.Second
 	}
+	if cfg.SessionAcceptTimeout <= 0 {
+		cfg.SessionAcceptTimeout = 5 * time.Second
+	}
 	s := &ServiceBus{
 		config: cfg,
 		idemp:  make(map[string]map[string]map[string]StreamPos),
+		open:   make(map[string]serviceBusSession),
 	}
 	s.newClient = s.defaultNewClient
 	return s
@@ -127,25 +196,16 @@ func (s *ServiceBus) defaultNewClient(ctx context.Context) (ServiceBusAPI, error
 		_ = client.Close(ctx)
 		return nil, err
 	}
-	receiver, err := client.NewReceiverForQueue(s.config.QueueName, nil)
-	if err != nil {
-		_ = sender.Close(ctx)
-		_ = client.Close(ctx)
-		return nil, err
-	}
 	return &azServiceBusAdapter{
-		client:   client,
-		sender:   sender,
-		receiver: receiver,
-		// Pending received messages keyed by sequence number so
-		// Complete can resolve the SDK *ReceivedMessage handle.
-		pending: make(map[int64]*azservicebus.ReceivedMessage),
+		client:    client,
+		sender:    sender,
+		queueName: s.config.QueueName,
 	}, nil
 }
 
-// Connect builds the client (sender + receiver). Service Bus has no
-// cheap describe; connectivity surfaces on first Send/Receive (parity
-// with servicebus.py, which only created the client here).
+// Connect builds the client (sender). Service Bus has no cheap
+// describe; connectivity surfaces on first Send/AcceptNextSession
+// (parity with servicebus.py, which only created the client here).
 func (s *ServiceBus) Connect(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -164,10 +224,15 @@ func (s *ServiceBus) Connect(ctx context.Context) error {
 	return nil
 }
 
-// Close releases the client. Safe to call multiple times.
+// Close releases the client and any held session receivers. Safe to
+// call multiple times.
 func (s *ServiceBus) Close(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	for id, sess := range s.open {
+		_ = sess.Close(ctx)
+		delete(s.open, id)
+	}
 	if s.api != nil {
 		_ = s.api.Close(ctx)
 		s.api = nil
@@ -221,7 +286,18 @@ func (s *ServiceBus) Append(
 	return pos, nil
 }
 
-// PollBatch receives up to maxRecords, blocking up to timeout.
+// PollBatch services tenant sessions and returns up to maxRecords,
+// blocking up to timeout. It accepts the next available session,
+// receives what it can from that session in per-tenant FIFO order, then
+// rotates to the next session for fairness so no tenant starves. A
+// session from which records were delivered is kept open (tracked in
+// s.open) so Commit can ack on its link and so its still-locked
+// messages are not handed out twice within a poll cycle; a session that
+// yielded nothing is closed immediately so its lock rotates. Sessions
+// stay tracked across PollBatch calls until either every delivered
+// record is Committed (then the session is closed and its lock
+// released) or the lock is lost server-side (then those records
+// redeliver — at-least-once; the applier dedupes).
 func (s *ServiceBus) PollBatch(
 	ctx context.Context,
 	topic, groupID string,
@@ -239,37 +315,129 @@ func (s *ServiceBus) PollBatch(
 	api := s.api
 	s.mu.Unlock()
 
-	wait := timeout
-	if wait > s.config.MaxWaitTime {
-		wait = s.config.MaxWaitTime
-	}
-	msgs, err := api.Receive(ctx, maxRecords, wait)
-	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, err
+	deadline := time.Now().Add(timeout)
+	out := make([]Record, 0, maxRecords)
+	// Sessions we accepted this call but already drained, so the
+	// accept-next loop does not immediately re-pick them and spin.
+	visited := make(map[string]bool)
+
+	for len(out) < maxRecords {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
 		}
-		return nil, classifyServiceBusErr("servicebus receive", err)
-	}
-	out := make([]Record, 0, len(msgs))
-	for _, m := range msgs {
-		out = append(out, Record{
-			Key:   m.SessionID,
-			Value: m.Body,
-			Position: StreamPos{
-				Topic:       topic,
-				Partition:   0,
-				Offset:      m.SequenceNumber,
-				TimestampMs: m.EnqueuedMs,
-			},
-			Headers: bytesHeaders(m.Properties),
-		})
+
+		acceptWait := remaining
+		if acceptWait > s.config.SessionAcceptTimeout {
+			acceptWait = s.config.SessionAcceptTimeout
+		}
+		sess, err := api.AcceptNextSession(ctx, acceptWait)
+		if err != nil {
+			if errors.Is(err, errNoSession) {
+				// No session ready within the window. Return whatever we
+				// gathered; an empty slice + nil error is a normal "no
+				// records yet" signal per the Consumer contract.
+				break
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				if len(out) > 0 {
+					return out, nil
+				}
+				return nil, err
+			}
+			return nil, classifyServiceBusErr("servicebus accept session", err)
+		}
+		if sess == nil {
+			break
+		}
+
+		sid := sess.SessionID()
+		if visited[sid] {
+			// We already serviced this tenant this poll cycle. Releasing
+			// its lock lets the accept-next loop move on to other
+			// tenants (fair rotation) instead of spinning on this one.
+			s.closeSession(ctx, sess)
+			break
+		}
+		visited[sid] = true
+
+		rem := time.Until(deadline)
+		if rem <= 0 {
+			s.closeSession(ctx, sess)
+			break
+		}
+		recvWait := rem
+		if recvWait > s.config.MaxWaitTime {
+			recvWait = s.config.MaxWaitTime
+		}
+		msgs, rerr := sess.Receive(ctx, maxRecords-len(out), recvWait)
+		if rerr != nil {
+			if errors.Is(rerr, context.Canceled) || errors.Is(rerr, context.DeadlineExceeded) {
+				s.closeSession(ctx, sess)
+				if len(out) > 0 {
+					return out, nil
+				}
+				return nil, rerr
+			}
+			s.closeSession(ctx, sess)
+			return nil, classifyServiceBusErr("servicebus receive", rerr)
+		}
+		if len(msgs) == 0 {
+			// Empty session: release the lock so it rotates and another
+			// tenant (or this one later) can be accepted.
+			s.closeSession(ctx, sess)
+			continue
+		}
+		for _, m := range msgs {
+			out = append(out, Record{
+				Key:   m.SessionID,
+				Value: m.Body,
+				Position: StreamPos{
+					Topic:       topic,
+					Partition:   0,
+					Offset:      m.SequenceNumber,
+					TimestampMs: m.EnqueuedMs,
+				},
+				Headers: bytesHeaders(m.Properties),
+			})
+		}
+		// Keep this session open so Commit can ack on its link and so
+		// its in-flight (received, uncommitted) messages stay locked
+		// (not re-handed-out) until committed or the lock is lost.
+		s.trackSession(ctx, sess)
 	}
 	return out, nil
 }
 
-// Subscribe streams records by repeatedly receiving. Auto-completes
-// each delivered record, matching the InMemory/Kafka Subscribe
-// contract.
+// trackSession records a still-open session so Commit can resolve its
+// link by session id. If a previous receiver for the same session is
+// already tracked it is closed first (a fresh accept supersedes it).
+func (s *ServiceBus) trackSession(ctx context.Context, sess serviceBusSession) {
+	id := sess.SessionID()
+	s.mu.Lock()
+	prev, ok := s.open[id]
+	s.open[id] = sess
+	s.mu.Unlock()
+	if ok && prev != nil && prev != sess {
+		_ = prev.Close(ctx)
+	}
+}
+
+// closeSession closes a session receiver and drops it from the tracked
+// set if it was the tracked one for its session id.
+func (s *ServiceBus) closeSession(ctx context.Context, sess serviceBusSession) {
+	id := sess.SessionID()
+	s.mu.Lock()
+	if cur, ok := s.open[id]; ok && cur == sess {
+		delete(s.open, id)
+	}
+	s.mu.Unlock()
+	_ = sess.Close(ctx)
+}
+
+// Subscribe streams records by repeatedly polling sessions.
+// Auto-completes each delivered record, matching the InMemory/Kafka
+// Subscribe contract.
 func (s *ServiceBus) Subscribe(
 	ctx context.Context,
 	topic, groupID string,
@@ -310,18 +478,36 @@ func (s *ServiceBus) Subscribe(
 	return out, errCh, nil
 }
 
-// Commit completes (acks) the message by sequence number. Mirrors
-// servicebus.py commit -> complete_message.
+// Commit completes (acks) the message on the receiver that owns its
+// session. Mirrors servicebus.py commit -> complete_message. Service
+// Bus settlement is link-scoped: the message must be acked on the very
+// session receiver that delivered it, which is why we resolve the
+// session by record.Key (the SessionId / tenant) rather than holding a
+// single queue-wide receiver.
 func (s *ServiceBus) Commit(ctx context.Context, groupID string, record Record) error {
 	s.mu.Lock()
 	if !s.connected || s.api == nil {
 		s.mu.Unlock()
 		return fmt.Errorf("%w: not connected", ErrConnection)
 	}
-	api := s.api
+	sess, ok := s.open[record.Key]
 	s.mu.Unlock()
-	if err := api.Complete(ctx, record.Position.Offset); err != nil {
+	if !ok || sess == nil {
+		// The session lock was already released (drained + closed, or a
+		// rebalance). The message will be redelivered on a future accept
+		// of that session; the applier dedupes (at-least-once). This
+		// mirrors the "no pending message" no-op path in servicebus.py.
+		return nil
+	}
+	if err := sess.Complete(ctx, record.Position.Offset); err != nil {
 		return classifyServiceBusErr("servicebus complete", err)
+	}
+	// Once every in-flight message on this session is settled, release
+	// the session lock so the accept-next loop can re-take it (to drain
+	// any further messages for the same tenant) and so other tenants
+	// are not starved by a held-but-idle lock.
+	if sess.Pending() == 0 {
+		s.closeSession(ctx, sess)
 	}
 	return nil
 }
@@ -332,6 +518,18 @@ func classifyServiceBusErr(op string, err error) error {
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
+	}
+	// Azure surfaces actionable failures as *azservicebus.Error with a
+	// programmatic Code. Map those before falling back to string sniff.
+	var sbErr *azservicebus.Error
+	if errors.As(err, &sbErr) {
+		switch sbErr.Code {
+		case azservicebus.CodeTimeout:
+			return fmt.Errorf("%w: %s: %v", ErrTimeout, op, err)
+		case azservicebus.CodeConnectionLost, azservicebus.CodeUnauthorizedAccess,
+			azservicebus.CodeNotFound, azservicebus.CodeClosed:
+			return fmt.Errorf("%w: %s: %v", ErrConnection, op, err)
+		}
 	}
 	if isTimeout(err) {
 		return fmt.Errorf("%w: %s: %v", ErrTimeout, op, err)
@@ -344,17 +542,13 @@ func classifyServiceBusErr(op string, err error) error {
 	return fmt.Errorf("%w: %s: %v", ErrWal, op, err)
 }
 
-// azServiceBusAdapter adapts the SDK client/sender/receiver to
-// ServiceBusAPI. It keeps a sequence-number -> *ReceivedMessage map so
-// Complete can resolve the SDK handle (the WAL Commit contract only
-// gives us the StreamPos offset).
+// azServiceBusAdapter adapts the SDK client/sender to ServiceBusAPI.
+// The consume side hands back azServiceBusSession values, one per
+// accepted Service Bus session, so settlement is always link-correct.
 type azServiceBusAdapter struct {
-	client   *azservicebus.Client
-	sender   *azservicebus.Sender
-	receiver *azservicebus.Receiver
-
-	mu      sync.Mutex
-	pending map[int64]*azservicebus.ReceivedMessage
+	client    *azservicebus.Client
+	sender    *azservicebus.Sender
+	queueName string
 }
 
 func (a *azServiceBusAdapter) Send(ctx context.Context, sessionID string, body []byte, props map[string]string) error {
@@ -372,7 +566,59 @@ func (a *azServiceBusAdapter) Send(ctx context.Context, sessionID string, body [
 	return a.sender.SendMessage(ctx, msg, nil)
 }
 
-func (a *azServiceBusAdapter) Receive(ctx context.Context, maxMessages int, wait time.Duration) ([]serviceBusMessage, error) {
+func (a *azServiceBusAdapter) AcceptNextSession(ctx context.Context, wait time.Duration) (serviceBusSession, error) {
+	actx := ctx
+	if wait > 0 {
+		var cancel context.CancelFunc
+		actx, cancel = context.WithTimeout(ctx, wait)
+		defer cancel()
+	}
+	// AcceptNextSessionForQueue blocks until a session is available or
+	// the (bounded) context elapses. When no session is available it
+	// returns an *azservicebus.Error with Code == CodeTimeout — we map
+	// that to errNoSession so the consume loop treats it as an empty
+	// poll, not a failure.
+	r, err := a.client.AcceptNextSessionForQueue(actx, a.queueName, nil)
+	if err != nil {
+		var sbErr *azservicebus.Error
+		if errors.As(err, &sbErr) && sbErr.Code == azservicebus.CodeTimeout {
+			return nil, errNoSession
+		}
+		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			return nil, errNoSession
+		}
+		return nil, err
+	}
+	return &azServiceBusSession{receiver: r}, nil
+}
+
+func (a *azServiceBusAdapter) Close(ctx context.Context) error {
+	if a.sender != nil {
+		_ = a.sender.Close(ctx)
+	}
+	if a.client != nil {
+		return a.client.Close(ctx)
+	}
+	return nil
+}
+
+// azServiceBusSession wraps one SDK *SessionReceiver. It keeps a
+// sequence-number -> *ReceivedMessage map so Complete can resolve the
+// SDK handle (the WAL Commit contract only gives us the StreamPos
+// offset). All settlement happens on this session's link, which is the
+// only correctness-safe place to ack a session message.
+type azServiceBusSession struct {
+	receiver *azservicebus.SessionReceiver
+
+	mu      sync.Mutex
+	pending map[int64]*azservicebus.ReceivedMessage
+}
+
+func (a *azServiceBusSession) SessionID() string {
+	return a.receiver.SessionID()
+}
+
+func (a *azServiceBusSession) Receive(ctx context.Context, maxMessages int, wait time.Duration) ([]serviceBusMessage, error) {
 	rctx := ctx
 	if wait > 0 {
 		var cancel context.CancelFunc
@@ -382,8 +628,12 @@ func (a *azServiceBusAdapter) Receive(ctx context.Context, maxMessages int, wait
 	msgs, err := a.receiver.ReceiveMessages(rctx, maxMessages, nil)
 	if err != nil {
 		// A receive that times out with no messages is a normal empty
-		// poll, not an error.
+		// poll (session drained for now), not an error.
 		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			return nil, nil
+		}
+		var sbErr *azservicebus.Error
+		if errors.As(err, &sbErr) && sbErr.Code == azservicebus.CodeTimeout {
 			return nil, nil
 		}
 		return nil, err
@@ -409,6 +659,9 @@ func (a *azServiceBusAdapter) Receive(ctx context.Context, maxMessages int, wait
 			sess = *m.SessionID
 		}
 		a.mu.Lock()
+		if a.pending == nil {
+			a.pending = make(map[int64]*azservicebus.ReceivedMessage)
+		}
 		a.pending[seq] = m
 		a.mu.Unlock()
 		out = append(out, serviceBusMessage{
@@ -422,7 +675,7 @@ func (a *azServiceBusAdapter) Receive(ctx context.Context, maxMessages int, wait
 	return out, nil
 }
 
-func (a *azServiceBusAdapter) Complete(ctx context.Context, sequenceNumber int64) error {
+func (a *azServiceBusSession) Complete(ctx context.Context, sequenceNumber int64) error {
 	a.mu.Lock()
 	msg, ok := a.pending[sequenceNumber]
 	if ok {
@@ -437,15 +690,15 @@ func (a *azServiceBusAdapter) Complete(ctx context.Context, sequenceNumber int64
 	return a.receiver.CompleteMessage(ctx, msg, nil)
 }
 
-func (a *azServiceBusAdapter) Close(ctx context.Context) error {
+func (a *azServiceBusSession) Pending() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.pending)
+}
+
+func (a *azServiceBusSession) Close(ctx context.Context) error {
 	if a.receiver != nil {
-		_ = a.receiver.Close(ctx)
-	}
-	if a.sender != nil {
-		_ = a.sender.Close(ctx)
-	}
-	if a.client != nil {
-		return a.client.Close(ctx)
+		return a.receiver.Close(ctx)
 	}
 	return nil
 }

--- a/server/go/internal/wal/servicebus_test.go
+++ b/server/go/internal/wal/servicebus_test.go
@@ -6,21 +6,37 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"testing"
 	"time"
 )
 
-// fakeServiceBus implements ServiceBusAPI in memory. Messages with the
-// same session id are delivered in send order (per-tenant order).
-// Received-but-uncompleted messages are hidden until releaseInflight()
-// (models the message lock).
+// fakeServiceBus models a *session-enabled* Service Bus queue. It is
+// deliberately session-shaped to match a real session-required queue:
+//
+//   - There is NO queue-wide receive. The only way to read is to accept
+//     a session (AcceptNextSession), which returns a receiver scoped to
+//     exactly one session id. This makes the #543 regression — a plain
+//     non-session `Client.NewReceiverForQueue` receiver — impossible to
+//     express: ServiceBusAPI has no such method and the fake has no
+//     queue-wide read path. Reverting servicebus.go to a non-session
+//     receiver fails to compile against this seam.
+//   - Per-session FIFO: a session receiver yields that session's
+//     messages strictly in send order, lowest sequence first.
+//   - Session lock: at most one open receiver per session id at a time
+//     (AcceptNextSession skips a session that is already locked). An
+//     uncompleted message stays invisible until its session receiver is
+//     Closed (lock released) and the session is re-accepted — modelling
+//     at-least-once redelivery.
 type fakeServiceBus struct {
-	mu      sync.Mutex
-	msgs    []*fakeSBMsg
-	seq     int64
-	sendErr error
-	recvErr error
+	mu        sync.Mutex
+	msgs      []*fakeSBMsg
+	seq       int64
+	locked    map[string]bool // session id -> currently held by a receiver
+	sendErr   error
+	acceptErr error
+	recvErr   error
 }
 
 type fakeSBMsg struct {
@@ -29,18 +45,12 @@ type fakeSBMsg struct {
 	session   string
 	seqNum    int64
 	completed bool
-	inflight  bool
+	delivered bool // handed to a live session receiver, not yet released
 	enqMs     int64
 }
 
-func (f *fakeServiceBus) releaseInflight() {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	for _, m := range f.msgs {
-		if !m.completed {
-			m.inflight = false
-		}
-	}
+func newFakeServiceBus() *fakeServiceBus {
+	return &fakeServiceBus{locked: make(map[string]bool)}
 }
 
 func (f *fakeServiceBus) Send(ctx context.Context, sessionID string, body []byte, props map[string]string) error {
@@ -64,21 +74,105 @@ func (f *fakeServiceBus) Send(ctx context.Context, sessionID string, body []byte
 	return nil
 }
 
-func (f *fakeServiceBus) Receive(ctx context.Context, maxMessages int, wait time.Duration) ([]serviceBusMessage, error) {
+// AcceptNextSession returns a receiver for the next session that has
+// uncompleted, undelivered work and is not already locked. No such
+// session -> errNoSession (empty poll).
+func (f *fakeServiceBus) AcceptNextSession(ctx context.Context, wait time.Duration) (serviceBusSession, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.acceptErr != nil {
+		return nil, f.acceptErr
+	}
+	// Deterministic fairness: pick the session with the earliest
+	// pending sequence number that isn't locked.
+	type cand struct {
+		session string
+		minSeq  int64
+	}
+	best := map[string]int64{}
+	for _, m := range f.msgs {
+		if m.completed || m.delivered {
+			continue
+		}
+		if f.locked[m.session] {
+			continue
+		}
+		if cur, ok := best[m.session]; !ok || m.seqNum < cur {
+			best[m.session] = m.seqNum
+		}
+	}
+	if len(best) == 0 {
+		return nil, errNoSession
+	}
+	cands := make([]cand, 0, len(best))
+	for s, mn := range best {
+		cands = append(cands, cand{session: s, minSeq: mn})
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].minSeq < cands[j].minSeq })
+	sid := cands[0].session
+	f.locked[sid] = true
+	return &fakeServiceBusSession{parent: f, session: sid}, nil
+}
+
+func (f *fakeServiceBus) Close(ctx context.Context) error { return nil }
+
+// expireLocks models Service Bus releasing every session lock and
+// re-queueing delivered-but-uncompleted messages (lock expiry). After
+// this, an uncommitted message is eligible for redelivery on the next
+// AcceptNextSession — the at-least-once guarantee. This is the explicit
+// seam the redelivery tests use (the consumer keeps a session locked
+// until commit, so redelivery requires a real lock expiry).
+func (f *fakeServiceBus) expireLocks() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, m := range f.msgs {
+		if !m.completed {
+			m.delivered = false
+		}
+	}
+	f.locked = make(map[string]bool)
+}
+
+// fakeServiceBusSession is a per-session receiver. It only ever sees
+// messages whose session id matches; there is no path to read another
+// session's messages from here.
+type fakeServiceBusSession struct {
+	parent  *fakeServiceBus
+	session string
+	closed  bool
+}
+
+func (s *fakeServiceBusSession) SessionID() string { return s.session }
+
+func (s *fakeServiceBusSession) Receive(ctx context.Context, maxMessages int, wait time.Duration) ([]serviceBusMessage, error) {
+	f := s.parent
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if s.closed {
+		return nil, errors.New("servicebus: receive on closed session")
+	}
 	if f.recvErr != nil {
 		return nil, f.recvErr
 	}
-	out := []serviceBusMessage{}
+	// FIFO within the session: sort this session's eligible messages by
+	// sequence number and hand them out in order.
+	eligible := make([]*fakeSBMsg, 0)
 	for _, m := range f.msgs {
-		if m.completed || m.inflight {
+		if m.session != s.session {
 			continue
 		}
+		if m.completed || m.delivered {
+			continue
+		}
+		eligible = append(eligible, m)
+	}
+	sort.Slice(eligible, func(i, j int) bool { return eligible[i].seqNum < eligible[j].seqNum })
+	out := []serviceBusMessage{}
+	for _, m := range eligible {
 		if len(out) >= maxMessages {
 			break
 		}
-		m.inflight = true
+		m.delivered = true
 		out = append(out, serviceBusMessage{
 			Body:           append([]byte(nil), m.body...),
 			Properties:     m.props,
@@ -90,23 +184,60 @@ func (f *fakeServiceBus) Receive(ctx context.Context, maxMessages int, wait time
 	return out, nil
 }
 
-func (f *fakeServiceBus) Complete(ctx context.Context, sequenceNumber int64) error {
+// Pending counts this session's messages that were delivered through a
+// (still-open) receiver but not yet completed.
+func (s *fakeServiceBusSession) Pending() int {
+	f := s.parent
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, m := range f.msgs {
+		if m.session == s.session && m.delivered && !m.completed {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *fakeServiceBusSession) Complete(ctx context.Context, sequenceNumber int64) error {
+	f := s.parent
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, m := range f.msgs {
-		if m.seqNum == sequenceNumber {
+		// Settlement is link-scoped: a session receiver can only
+		// complete its own session's messages (mirrors Azure).
+		if m.session == s.session && m.seqNum == sequenceNumber {
 			m.completed = true
 		}
 	}
 	return nil
 }
 
-func (f *fakeServiceBus) Close(ctx context.Context) error { return nil }
+// Close releases the session lock. Any messages this receiver delivered
+// but that were not completed become visible again on a future accept
+// (lock expiry / at-least-once redelivery).
+func (s *fakeServiceBusSession) Close(ctx context.Context) error {
+	f := s.parent
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	for _, m := range f.msgs {
+		if m.session == s.session && !m.completed {
+			m.delivered = false
+		}
+	}
+	delete(f.locked, s.session)
+	return nil
+}
 
 func newTestServiceBus(t *testing.T, fake *fakeServiceBus) *ServiceBus {
 	t.Helper()
 	s := NewServiceBus(DefaultServiceBusConfig("Endpoint=sb://fake/;SharedAccessKeyName=x;SharedAccessKey=y", "entdb-wal"))
-	s.config.MaxWaitTime = 100 * time.Millisecond
+	s.config.MaxWaitTime = 50 * time.Millisecond
+	s.config.SessionAcceptTimeout = 50 * time.Millisecond
 	s.newClient = func(ctx context.Context) (ServiceBusAPI, error) { return fake, nil }
 	if err := s.Connect(context.Background()); err != nil {
 		t.Fatalf("Connect: %v", err)
@@ -129,8 +260,29 @@ func TestServiceBusAppendNotConnected(t *testing.T) {
 	}
 }
 
+func TestServiceBusPollBatchNotConnected(t *testing.T) {
+	s := NewServiceBus(DefaultServiceBusConfig("c", "q"))
+	if _, err := s.PollBatch(context.Background(), "q", "g", 10, 50*time.Millisecond); !errors.Is(err, ErrConnection) {
+		t.Fatalf("err = %v, want ErrConnection", err)
+	}
+}
+
+func TestServiceBusCommitNotConnected(t *testing.T) {
+	s := NewServiceBus(DefaultServiceBusConfig("c", "q"))
+	if err := s.Commit(context.Background(), "g", Record{Key: "t"}); !errors.Is(err, ErrConnection) {
+		t.Fatalf("err = %v, want ErrConnection", err)
+	}
+}
+
+func TestServiceBusSubscribeNotConnected(t *testing.T) {
+	s := NewServiceBus(DefaultServiceBusConfig("c", "q"))
+	if _, _, err := s.Subscribe(context.Background(), "q", "g"); !errors.Is(err, ErrConnection) {
+		t.Fatalf("err = %v, want ErrConnection", err)
+	}
+}
+
 func TestServiceBusAppendPollCommitRoundTrip(t *testing.T) {
-	fake := &fakeServiceBus{}
+	fake := newFakeServiceBus()
 	s := newTestServiceBus(t, fake)
 	ctx := context.Background()
 
@@ -154,28 +306,28 @@ func TestServiceBusAppendPollCommitRoundTrip(t *testing.T) {
 		t.Fatalf("header x-h = %q", got[0].Headers["x-h"])
 	}
 
-	none, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 100*time.Millisecond)
-	if err != nil {
-		t.Fatalf("PollBatch #2: %v", err)
-	}
-	if len(none) != 0 {
-		t.Fatalf("locked msg should be hidden, got %d", len(none))
-	}
 	if err := s.Commit(ctx, "g1", got[0]); err != nil {
 		t.Fatalf("Commit: %v", err)
 	}
-	fake.releaseInflight()
+	// Even after a server-side lock expiry the committed message must
+	// not come back.
+	fake.expireLocks()
 	empty, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 100*time.Millisecond)
 	if err != nil {
-		t.Fatalf("PollBatch #3: %v", err)
+		t.Fatalf("PollBatch #2: %v", err)
 	}
 	if len(empty) != 0 {
 		t.Fatalf("completed msg redelivered: got %d", len(empty))
 	}
 }
 
+// TestServiceBusRedeliveryWithoutCommit: a delivered-but-uncommitted
+// message must be redelivered after the session lock is released
+// (at-least-once; applier dedupes). Extends the original idea to the
+// session model: redelivery happens because the session receiver is
+// Closed without Complete and the session is then re-accepted.
 func TestServiceBusRedeliveryWithoutCommit(t *testing.T) {
-	fake := &fakeServiceBus{}
+	fake := newFakeServiceBus()
 	s := newTestServiceBus(t, fake)
 	ctx := context.Background()
 
@@ -186,19 +338,43 @@ func TestServiceBusRedeliveryWithoutCommit(t *testing.T) {
 	if err != nil || len(got) != 1 {
 		t.Fatalf("PollBatch #1: %v len=%d", err, len(got))
 	}
-	// No commit -> lock expires -> redelivered.
-	fake.releaseInflight()
-	again, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 150*time.Millisecond)
+	// No commit. While the session lock is held the message stays
+	// in-flight and is NOT re-handed-out (exactly-once-ish within the
+	// lock).
+	none, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 100*time.Millisecond)
 	if err != nil {
 		t.Fatalf("PollBatch #2: %v", err)
 	}
+	if len(none) != 0 {
+		t.Fatalf("in-flight (uncommitted, lock held) msg re-handed-out: %+v", none)
+	}
+	// Lock expires server-side without a commit -> the message must be
+	// redelivered (at-least-once; applier dedupes).
+	fake.expireLocks()
+	again, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 150*time.Millisecond)
+	if err != nil {
+		t.Fatalf("PollBatch #3: %v", err)
+	}
 	if len(again) != 1 || string(again[0].Value) != "v0" {
-		t.Fatalf("uncommitted msg not redelivered: %+v", again)
+		t.Fatalf("uncommitted msg not redelivered after lock expiry: %+v", again)
+	}
+	// Commit it now; even across a further lock expiry it must not
+	// come back.
+	if err := s.Commit(ctx, "g1", again[0]); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	fake.expireLocks()
+	final, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("PollBatch #4: %v", err)
+	}
+	if len(final) != 0 {
+		t.Fatalf("committed msg still redelivered: got %d", len(final))
 	}
 }
 
 func TestServiceBusIdempotentRetry(t *testing.T) {
-	fake := &fakeServiceBus{}
+	fake := newFakeServiceBus()
 	s := newTestServiceBus(t, fake)
 	ctx := context.Background()
 
@@ -219,8 +395,10 @@ func TestServiceBusIdempotentRetry(t *testing.T) {
 	}
 }
 
+// TestServiceBusPerTenantOrder: one tenant's records come back strictly
+// in send order (per-session FIFO == per-tenant ordering).
 func TestServiceBusPerTenantOrder(t *testing.T) {
-	fake := &fakeServiceBus{}
+	fake := newFakeServiceBus()
 	s := newTestServiceBus(t, fake)
 	ctx := context.Background()
 
@@ -243,14 +421,163 @@ func TestServiceBusPerTenantOrder(t *testing.T) {
 	}
 }
 
-func TestServiceBusReceiveErrorClassified(t *testing.T) {
-	fake := &fakeServiceBus{}
+// TestServiceBusMultiSessionOrdering: with several tenants interleaved
+// on the queue, EACH tenant's records must arrive in that tenant's send
+// order. Cross-tenant order is not promised (Service Bus doesn't), but
+// per-session FIFO is the per-tenant ordering guarantee the WAL needs.
+func TestServiceBusMultiSessionOrdering(t *testing.T) {
+	fake := newFakeServiceBus()
 	s := newTestServiceBus(t, fake)
+	ctx := context.Background()
+
+	tenants := []string{"tenant_a", "tenant_b", "tenant_c"}
+	const perTenant = 6
+	// Interleave appends across tenants so a non-FIFO consumer would
+	// scramble them.
+	for i := 0; i < perTenant; i++ {
+		for _, tn := range tenants {
+			if _, err := s.Append(ctx, "entdb-wal", tn, []byte(fmt.Sprintf("%s-%d", tn, i)), nil); err != nil {
+				t.Fatalf("Append: %v", err)
+			}
+		}
+	}
+
+	seen := map[string][]string{}
+	deadline := time.Now().Add(3 * time.Second)
+	total := len(tenants) * perTenant
+	for count := 0; count < total && time.Now().Before(deadline); {
+		recs, err := s.PollBatch(ctx, "entdb-wal", "g1", 4, 150*time.Millisecond)
+		if err != nil {
+			t.Fatalf("PollBatch: %v", err)
+		}
+		for _, r := range recs {
+			seen[r.Key] = append(seen[r.Key], string(r.Value))
+			if err := s.Commit(ctx, "g1", r); err != nil {
+				t.Fatalf("Commit: %v", err)
+			}
+			count++
+		}
+	}
+
+	for _, tn := range tenants {
+		vals := seen[tn]
+		if len(vals) != perTenant {
+			t.Fatalf("tenant %s: got %d records, want %d (%v)", tn, len(vals), perTenant, vals)
+		}
+		for i, v := range vals {
+			if want := fmt.Sprintf("%s-%d", tn, i); v != want {
+				t.Fatalf("tenant %s record %d = %q, want %q (per-session FIFO broken)", tn, i, v, want)
+			}
+		}
+	}
+}
+
+// TestServiceBusCommitStopsRedelivery: after Commit, the message must
+// not be redelivered even across many subsequent polls.
+func TestServiceBusCommitStopsRedelivery(t *testing.T) {
+	fake := newFakeServiceBus()
+	s := newTestServiceBus(t, fake)
+	ctx := context.Background()
+
+	if _, err := s.Append(ctx, "entdb-wal", "tenant_a", []byte("once"), nil); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	got, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 150*time.Millisecond)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("PollBatch: %v len=%d", err, len(got))
+	}
+	if err := s.Commit(ctx, "g1", got[0]); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		more, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 80*time.Millisecond)
+		if err != nil {
+			t.Fatalf("PollBatch #%d: %v", i, err)
+		}
+		if len(more) != 0 {
+			t.Fatalf("committed msg redelivered on poll #%d: %+v", i, more)
+		}
+	}
+}
+
+func TestServiceBusReceiveErrorClassified(t *testing.T) {
+	fake := newFakeServiceBus()
+	s := newTestServiceBus(t, fake)
+	if _, err := s.Append(context.Background(), "entdb-wal", "tenant_a", []byte("v"), nil); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
 	fake.mu.Lock()
 	fake.recvErr = errors.New("amqp: connection closed")
 	fake.mu.Unlock()
 	_, err := s.PollBatch(context.Background(), "entdb-wal", "g1", 5, 100*time.Millisecond)
 	if !errors.Is(err, ErrConnection) {
 		t.Fatalf("err = %v, want ErrConnection", err)
+	}
+}
+
+func TestServiceBusAcceptSessionErrorClassified(t *testing.T) {
+	fake := newFakeServiceBus()
+	s := newTestServiceBus(t, fake)
+	if _, err := s.Append(context.Background(), "entdb-wal", "tenant_a", []byte("v"), nil); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	fake.mu.Lock()
+	fake.acceptErr = errors.New("amqp: unauthorized")
+	fake.mu.Unlock()
+	_, err := s.PollBatch(context.Background(), "entdb-wal", "g1", 5, 100*time.Millisecond)
+	if !errors.Is(err, ErrConnection) {
+		t.Fatalf("err = %v, want ErrConnection", err)
+	}
+}
+
+// TestServiceBusReceiverIsSessionBased is the explicit #543 regression
+// guard. It asserts, structurally, that the ONLY consume entry point is
+// session-scoped:
+//
+//  1. ServiceBusAPI exposes AcceptNextSession (a *session* receiver) and
+//     NOT a queue-wide Receive. Reverting servicebus.go to the non-
+//     session `Client.NewReceiverForQueue` path would require a
+//     queue-wide Receive on this interface, which does not exist, so the
+//     regression cannot compile.
+//  2. Every record delivered carries the tenant SessionID as its Key,
+//     and Complete only settles messages on the owning session — proving
+//     settlement is link/session-scoped, not queue-wide.
+func TestServiceBusReceiverIsSessionBased(t *testing.T) {
+	fake := newFakeServiceBus()
+	s := newTestServiceBus(t, fake)
+	ctx := context.Background()
+
+	// The consume seam is a session, not a queue receiver. This is a
+	// compile-enforced assertion: AcceptNextSession returns something
+	// that satisfies serviceBusSession (a per-session receiver). A
+	// non-session queue receiver could not satisfy this seam.
+	var _ func(context.Context, time.Duration) (serviceBusSession, error) = fake.AcceptNextSession
+
+	if _, err := s.Append(ctx, "entdb-wal", "tenant_x", []byte("data"), nil); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	sess, err := fake.AcceptNextSession(ctx, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("AcceptNextSession: %v", err)
+	}
+	if sess.SessionID() != "tenant_x" {
+		t.Fatalf("session id = %q, want tenant_x (receiver is not session-scoped)", sess.SessionID())
+	}
+	msgs, err := sess.Receive(ctx, 10, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("session Receive: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].SessionID != "tenant_x" {
+		t.Fatalf("session receiver returned %d msgs %+v, want 1 for tenant_x", len(msgs), msgs)
+	}
+	_ = sess.Close(ctx)
+
+	// End-to-end: the record's Key is the session id (tenant).
+	got, err := s.PollBatch(ctx, "entdb-wal", "g1", 10, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("PollBatch: %v", err)
+	}
+	if len(got) != 1 || got[0].Key != "tenant_x" {
+		t.Fatalf("record key = %q (want tenant_x); session id must surface as the WAL key", got[0].Key)
 	}
 }


### PR DESCRIPTION
## Problem

The Azure Service Bus WAL backend (shipped v1.15.0 via #539) is broken for production. `defaultNewClient` created a **non-session** receiver via `Client.NewReceiverForQueue`. The producer stamps every message with `SessionId = tenant key` (per-tenant ordering depends on it). Against a real session-enabled queue a plain receiver fails at runtime (`entity requires sessions`) and, even otherwise, cannot preserve per-session FIFO. The unit fake had no session model, so this shipped undetected.

## Root cause

`server/go/internal/wal/servicebus.go:130` on `origin/main` — `defaultNewClient` calls `client.NewReceiverForQueue(...)` (a `*azservicebus.Receiver`, non-session). The header (lines 10–16) documents `SessionId -> tenant`, and the producer sets `msg.SessionID` (Send adapter), so the consume side had to be session-scoped but wasn't.

## Fix

Reshaped the `ServiceBusAPI` seam to be **session-scoped**: the only consume entry point is `AcceptNextSession`, returning a `serviceBusSession` (a per-session receiver) backed by `Client.AcceptNextSessionForQueue`. There is no queue-wide `Receive`.

- **Per-session FIFO == per-tenant order.** Cross-session order is not promised (Service Bus doesn't; the WAL contract only requires per-key order).
- **Fair rotation.** The accept-next loop services each tenant in turn and releases an idle/empty session lock so no tenant starves; a `visited` set within a poll cycle prevents spinning on one tenant. Once a session's in-flight set is fully settled, `Commit` releases its lock so the queue stays fully drainable.
- **At-least-once.** A received-but-uncommitted message stays locked until `Commit`; on lock loss it redelivers and the applier dedupes.
- **Commit == Complete** on the owning session's link (Service Bus settlement is link-scoped — resolved by `record.Key` / SessionId).
- Connected/Close lifecycle and `ErrConnection`-before-`Connect` behaviour unchanged. Error classification now also maps `*azservicebus.Error` codes (Timeout/ConnectionLost/Unauthorized/NotFound/Closed) before the string-sniff fallback.
- No new deps (`azservicebus` was already direct); `go mod tidy` reports zero churn. Other 4 cloud backends and memory/kafka untouched.

Relevant: `server/go/internal/wal/servicebus.go` (`ServiceBusAPI`/`serviceBusSession` interfaces, `defaultNewClient`, `PollBatch`, `Commit`, `azServiceBusAdapter`/`azServiceBusSession`).

## How the new fake prevents the regression

The fake now **models sessions**: no queue-wide read path, per-session FIFO, session locks, and an explicit lock-expiry seam for redelivery. Crucially the regression is **compile-enforced**: a non-session `*azservicebus.Receiver` cannot satisfy `serviceBusSession` (missing `Complete`/`SessionID`/`Pending`), so reverting `defaultNewClient` to `NewReceiverForQueue` does not build. `TestServiceBusReceiverIsSessionBased` additionally asserts the seam is session-scoped and that the SessionId surfaces as the WAL record key.

## Testing

New / changed tests in `servicebus_test.go`:
- `TestServiceBusMultiSessionOrdering` — interleaved multi-tenant load; each tenant's records arrive in that tenant's send order.
- `TestServiceBusRedeliveryWithoutCommit` — in-flight (locked) msg not re-handed-out; lock expiry → redeliver; then commit → no redeliver across a further expiry.
- `TestServiceBusCommitStopsRedelivery` — committed msg never redelivered across repeated polls.
- `TestServiceBusReceiverIsSessionBased` — explicit #543 regression guard (session-scoped seam + SessionId == record key).
- `TestServiceBusAcceptSessionErrorClassified` — accept-session error → `ErrConnection`.
- `TestServiceBusPollBatchNotConnected` / `...CommitNotConnected` / `...SubscribeNotConnected` — `ErrConnection` before `Connect` on every consumer entry point.
- Existing round-trip / idempotent-retry / per-tenant-order / receive-error tests retained, adapted to the session model.

Full local CI green: `go vet ./...` + `go test ./...` + `go test -race ./internal/wal/` (server/go), `go vet`/`go test ./...` (Go SDK), `pytest tests/python/integration/` (103 passed), `ruff check`/`format --check` (clean), `bash tests/python/e2e/run-e2e.sh` (22 passed, 1 skipped).

## Deferred (kept out of scope per #543 / no gold-plating)

- `cloud.google.com/go/pubsub/v2` indirect-dep cleanup: `go mod tidy` reports no churn — it is a legitimately-required transitive dep; removing it would need code changes outside this correctness fix.

The other two doc sub-items (in-memory-checkpoint restart re-replay window; non-unique `StreamPos` within a ms for pubsub/servicebus/eventhubs) are **included** as low-risk additions to ADR-005 "Failure modes".

Closes #543