### PR TITLE
feat(audit): lift S3 Object Lock legal hold on archived objects when a tenant's hold is released (#511 Gap 1)

### DIFF
--- a/docs/adr/015-wal-and-s3-object-lock-as-audit-log.md
+++ b/docs/adr/015-wal-and-s3-object-lock-as-audit-log.md
@@ -108,9 +108,36 @@ Implementation status:
   COMPLIANCE-mode enabled. The archiver verifies this at boot and
   refuses to start otherwise (defense in depth — operators can't
   accidentally turn off tamper evidence).
-- Legal hold escalates via S3 Object Lock's `LegalHold=ON` flag on
-  per-tenant archive object prefixes. No application-layer legal
+- Legal hold escalates via S3 Object Lock's `LegalHold=ON` flag.
+  Archive objects are keyed per WAL partition
+  (`wal/<topic>/<partition>/<start>-<end>.jsonl.gz`), not per tenant —
+  one object can carry many tenants, so it gets `LegalHold=ON` if any
+  tenant it carries is held when written. No application-layer legal
   hold mechanism duplicates this.
+- **Legal hold is liftable on release; COMPLIANCE retention is not.**
+  An explicit `SetLegalHold` OFF for a tenant durably enqueues a
+  pending-lift row (`legal_hold_lift_queue`) in the *same* globalstore
+  transaction that clears the hold and flips `tenant_registry.status`
+  (EPIC #511 Gap 1) — so a crash, S3 outage, or restart after the
+  release still has the lift recorded. A crash-durable background worker
+  (mirroring the GDPR deletion-queue worker;
+  `--legal-hold-lift-worker-interval`) drains that queue, running a
+  paginated archive sweep that clears `LegalHold=OFF` on the tenant's
+  already-written objects — covering objects archived *before* the
+  release, not just future writes. The worker deletes the queue row only
+  on full success; any failure / partial / per-run timeout leaves the
+  row so the next tick resumes (the sweep is idempotent and resumable —
+  every decision is derived from live S3 + globalstore state, no
+  progress cursor). It clears an object's hold only once *no* tenant the
+  object carries is still held (shared objects stay locked while a
+  co-tenant remains held) and issues `PutObjectLegalHold` only — the
+  `ObjectLockMode=COMPLIANCE` retain-until is never touched and stays
+  immutable. Progress is observable via `entdb_legal_hold_lift_pending`
+  (queue depth gauge) plus completed/error counters. The lift is
+  triggered ONLY by an explicit release: GDPR erasure never lifts a hold
+  (legal hold deliberately supersedes erasure — `DeleteUser` refuses to
+  queue while a tenant is held), so only an explicit release lifts the
+  archive hold and only then may queued erasure proceed.
 
 **What this makes easy:**
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -477,7 +477,14 @@ resource "aws_iam_role_policy" "ecs_task" {
         Action = [
           "s3:GetObject",
           "s3:PutObject",
-          "s3:ListBucket"
+          "s3:ListBucket",
+          # Required so the durable legal-hold-lift worker can lift the
+          # Object Lock legal hold on a released tenant's already-archived
+          # objects (EPIC #511 Gap 1; SetLegalHold OFF durably enqueues,
+          # the worker sweeps). Does NOT grant retention changes —
+          # COMPLIANCE retain-until stays immutable (ADR-015).
+          "s3:GetObjectLegalHold",
+          "s3:PutObjectLegalHold"
         ]
         Resource = [
           aws_s3_bucket.archive.arn,

--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -58,6 +59,8 @@ func main() {
 	readPoolSize := flag.Int("read-pool-size", 1, "per-tenant read-only SQLite connection pool size (issue #137 / ADR-026). OFF BY DEFAULT (1 = single shared connection, the proven legacy behaviour) — landed dark pending idle-tenant eviction (canonical-store OQ-2: each read connection adds an FD + page cache per active tenant, with no eviction). Opt IN by setting >1 to let same-tenant reads run concurrently against WAL snapshots instead of serializing behind the applier. The post-COMMIT offset-broadcast fix (ADR-026 condition 1) is always active regardless of this value.")
 	gdprWorkerEnabled := flag.Bool("gdpr-worker-enabled", true, "run GDPR deletion_queue worker that performs due deletes and crypto-shred")
 	gdprWorkerInterval := flag.Duration("gdpr-worker-interval", time.Minute, "how often the GDPR worker scans for due deletions")
+	legalHoldLiftWorkerEnabled := flag.Bool("legal-hold-lift-worker-enabled", true, "run the durable legal_hold_lift_queue worker that lifts S3 Object Lock legal hold on a released tenant's already-archived objects (EPIC #511 Gap 1); only does work when -archive-enabled")
+	legalHoldLiftWorkerInterval := flag.Duration("legal-hold-lift-worker-interval", time.Minute, "how often the legal-hold-lift worker drains the pending-lift queue")
 	cryptoShredDeleteFiles := flag.Bool("crypto-shred-delete-files", false, "delete tenant .db/-wal/-shm files after key shred")
 	walBackend := flag.String("wal-backend", "memory", "WAL backend: memory | kafka | kinesis | pubsub | sqs | servicebus | eventhubs")
 	walTopic := flag.String("wal-topic", "entdb-wal", "WAL topic name")
@@ -303,6 +306,7 @@ func main() {
 	srvOpts = append(srvOpts, api.WithWALProducer(walImpl), api.WithWALTopic(*walTopic))
 
 	var archiver *audit.Archiver
+	var archiveStore *audit.S3ObjectLockStore
 	if *archiveEnabled {
 		if *walBackend != "kafka" {
 			log.Fatalf("entdb-server: --archive-enabled requires --wal-backend=kafka")
@@ -321,8 +325,16 @@ func main() {
 			if *archiveS3PathStyle {
 				o.UsePathStyle = true
 			}
+			// AWS SDK Go v2 (Jan-2025 default change) computes a CRC32
+			// request checksum on every supported op. MinIO and other
+			// non-AWS S3 endpoints reject that on legacy
+			// Content-MD5-required operations (PutObjectLegalHold ->
+			// HTTP 400 MissingContentMD5). Scope checksum calculation to
+			// ops that strictly require it so the SDK falls back to the
+			// Content-MD5 those endpoints expect; harmless on real AWS.
+			o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 		})
-		archiveStore := audit.NewS3ObjectLockStore(
+		archiveStore = audit.NewS3ObjectLockStore(
 			s3Client,
 			strings.TrimSpace(*archiveBucket),
 			strings.TrimSpace(*archiveKMSKeyID),
@@ -346,6 +358,12 @@ func main() {
 		if err := archiver.Verify(ctx); err != nil {
 			log.Fatalf("entdb-server: archive object lock verification: %v", err)
 		}
+		// EPIC #511 Gap 1: the S3 Object Lock legal-hold lift on a
+		// released tenant's already-archived objects is NOT triggered
+		// from the SetLegalHold RPC. The OFF path durably enqueues a
+		// legal_hold_lift_queue row (apply -> globalstore, same txn that
+		// clears the hold); the crash-durable LiftWorker wired below
+		// drains that queue. archiveStore is kept for that worker.
 		log.Printf("entdb-server: S3 Object Lock archive enabled (bucket=%s group=%s)", strings.TrimSpace(*archiveBucket), *archiveGroup)
 	}
 
@@ -398,6 +416,32 @@ func main() {
 			gdprErr <- gdprProcessor.Run(ctx, *gdprWorkerInterval)
 		}()
 		log.Printf("entdb-server: GDPR deletion worker enabled (interval=%s crypto-shred-delete-files=%v)", *gdprWorkerInterval, *cryptoShredDeleteFiles)
+	}
+
+	// EPIC #511 Gap 1: the durable legal-hold-lift worker. SetLegalHold
+	// OFF durably enqueues a legal_hold_lift_queue row (in the same
+	// globalstore txn that clears the hold); this worker drains the
+	// queue, running the idempotent/resumable paginated S3 sweep for
+	// each released tenant and retrying on the next tick until complete.
+	// It replaces the previous detached fire-and-forget goroutine, which
+	// was not crash-durable. Only does work when the archive sidecar is
+	// enabled (archiveStore != nil); otherwise there is no S3 to sweep
+	// and the queue stays empty (the OFF path is a pure status flip).
+	liftErr := make(chan error, 1)
+	if *legalHoldLiftWorkerEnabled && archiveStore != nil {
+		liftWorker, err := audit.NewLiftWorker(audit.LiftWorkerOptions{
+			Queue:  legalHoldLiftQueueAdapter{global: global},
+			Lifter: archiveStore,
+		})
+		if err != nil {
+			log.Fatalf("entdb-server: legal-hold lift worker: %v", err)
+		}
+		go func() {
+			liftErr <- liftWorker.Run(ctx, *legalHoldLiftWorkerInterval)
+		}()
+		log.Printf("entdb-server: legal-hold-lift worker enabled (interval=%s)", *legalHoldLiftWorkerInterval)
+	} else if *legalHoldLiftWorkerEnabled {
+		log.Printf("entdb-server: legal-hold-lift worker idle (archive sidecar disabled; nothing to sweep)")
 	}
 
 	// Test-only seed: the cross-impl harnesses boot the binary with
@@ -579,6 +623,10 @@ func main() {
 		if err != nil && err != context.Canceled {
 			log.Printf("entdb-server: gdpr worker exited: %v", err)
 		}
+	case err := <-liftErr:
+		if err != nil && err != context.Canceled {
+			log.Printf("entdb-server: legal-hold-lift worker exited: %v", err)
+		}
 	}
 }
 
@@ -687,4 +735,37 @@ func effectiveKMSProvider(provider string) string {
 		return "file"
 	}
 	return strings.TrimSpace(provider)
+}
+
+// legalHoldLiftQueueAdapter adapts *globalstore.GlobalStore to the
+// audit.LiftQueueStore the durable lift worker drains (EPIC #511 Gap 1).
+// It is a thin shim: the only real work is mapping the globalstore
+// queue-entry slice to the audit package's local type so internal/audit
+// does not import internal/globalstore.
+type legalHoldLiftQueueAdapter struct {
+	global *globalstore.GlobalStore
+}
+
+func (a legalHoldLiftQueueAdapter) GetLegalHoldLiftQueue(ctx context.Context) ([]audit.LiftQueueEntry, error) {
+	rows, err := a.global.GetLegalHoldLiftQueue(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]audit.LiftQueueEntry, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, audit.LiftQueueEntry{TenantID: r.TenantID, EnqueuedAt: r.EnqueuedAt})
+	}
+	return out, nil
+}
+
+func (a legalHoldLiftQueueAdapter) DequeueLegalHoldLift(ctx context.Context, tenantID string) (bool, error) {
+	return a.global.DequeueLegalHoldLift(ctx, tenantID)
+}
+
+func (a legalHoldLiftQueueAdapter) CountLegalHoldLiftQueue(ctx context.Context) (int, error) {
+	return a.global.CountLegalHoldLiftQueue(ctx)
+}
+
+func (a legalHoldLiftQueueAdapter) IsLegalHoldSet(ctx context.Context, tenantID string) (bool, error) {
+	return a.global.IsLegalHoldSet(ctx, tenantID)
 }

--- a/server/go/internal/api/set_legal_hold.go
+++ b/server/go/internal/api/set_legal_hold.go
@@ -153,6 +153,28 @@ func (s *Server) SetLegalHold(
 		return nil, err
 	}
 
+	// EPIC #511 Gap 1: on an *explicit* release (enabled=false) the S3
+	// Object Lock legal hold on the tenant's already-archived objects
+	// must be lifted. That is NOT done from this RPC path: the
+	// appendGlobalAdminOp above has already driven the durable global
+	// apply step (apply/global.go -> globalstore.ApplyLegalHoldSet) which,
+	// in the SAME transaction that clears the legal_holds row + flips
+	// tenant_registry.status, upserts a legal_hold_lift_queue row. A
+	// crash-durable background worker (internal/audit.LiftWorker, wired
+	// in cmd/entdb-server/main.go) drains that queue, running the
+	// idempotent/resumable paginated sweep and retrying until complete.
+	//
+	// This replaces the previous detached fire-and-forget goroutine,
+	// which left a released tenant's objects stuck LegalHold=ON with no
+	// retry and no signal after a restart / S3 outage / timeout —
+	// unacceptable for a compliance feature (GDPR
+	// right-to-erasure-after-release would be silently unfulfillable).
+	// The OFF RPC now just causes the durable enqueue (via the apply
+	// path) and returns; the worker does the rest. GDPR erasure never
+	// lifts a hold — only an explicit release emits enabled=false (legal
+	// hold supersedes erasure; DeleteUser still refuses to queue while
+	// held). COMPLIANCE retention is never touched by the sweep.
+
 	return &pb.LegalHoldResponse{
 		Success: true,
 		Status:  newStatus,

--- a/server/go/internal/api/set_legal_hold_test.go
+++ b/server/go/internal/api/set_legal_hold_test.go
@@ -22,7 +22,9 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 
@@ -31,6 +33,172 @@ import (
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
+
+// TestSetLegalHold_Release_DurablyEnqueuesLift: an explicit release
+// (enabled=false) does NOT spawn any goroutine off the RPC path. It
+// drives the durable global apply step which, in the SAME transaction
+// that clears the legal_holds row + flips tenant_registry.status, upserts
+// a legal_hold_lift_queue row. This is the EPIC #511 Gap 1 crash-durable
+// contract: a server restart after the release still finds the pending
+// lift recorded.
+func TestSetLegalHold_Release_DurablyEnqueuesLift(t *testing.T) {
+	t.Parallel()
+
+	f := newAdminWALFixture(t)
+	gs := f.gs
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	// Enable first so there is a hold to release; ON must NOT enqueue.
+	if _, err := f.srv.SetLegalHold(ctx, &pb.LegalHoldRequest{
+		Actor: "admin:root", TenantId: "acme", Enabled: true,
+	}); err != nil {
+		t.Fatalf("SetLegalHold(enable): %v", err)
+	}
+	if q, err := gs.GetLegalHoldLiftQueue(ctx); err != nil {
+		t.Fatalf("GetLegalHoldLiftQueue: %v", err)
+	} else if len(q) != 0 {
+		t.Fatalf("ON path enqueued %d lift rows; want 0", len(q))
+	}
+
+	// Release: the lift must be durably enqueued for "acme".
+	resp, err := f.srv.SetLegalHold(ctx, &pb.LegalHoldRequest{
+		Actor: "admin:root", TenantId: "acme", Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("SetLegalHold(release): %v", err)
+	}
+	if !resp.GetSuccess() || resp.GetStatus() != "active" {
+		t.Fatalf("release resp: success=%v status=%q", resp.GetSuccess(), resp.GetStatus())
+	}
+	q, err := gs.GetLegalHoldLiftQueue(ctx)
+	if err != nil {
+		t.Fatalf("GetLegalHoldLiftQueue: %v", err)
+	}
+	if len(q) != 1 || q[0].TenantID != "acme" {
+		t.Fatalf("lift queue = %+v; want exactly [acme]", q)
+	}
+	if q[0].EnqueuedAt == 0 {
+		t.Fatalf("enqueued_at not set: %+v", q[0])
+	}
+	// The globalstore hold must be gone in the SAME durable step that
+	// enqueued the lift (precedence: release first, then erasure may
+	// proceed; the worker's stillHeld lookup sees the post-release state).
+	if held, _ := gs.IsLegalHoldSet(ctx, "acme"); held {
+		t.Fatal("globalstore hold still set after release; worker would see stale state")
+	}
+}
+
+// TestSetLegalHold_Release_SpawnsNoGoroutine proves the detached
+// fire-and-forget sweep goroutine is GONE. The OFF RPC now just causes
+// the durable enqueue (via the apply path) and returns; the lift is done
+// by the separate crash-durable worker (internal/audit.LiftWorker), not
+// a request-scoped goroutine. We measure the live goroutine count across
+// the OFF call: a detached `go func()` sweep would leave it elevated.
+func TestSetLegalHold_Release_SpawnsNoGoroutine(t *testing.T) {
+	t.Parallel()
+
+	f := newAdminWALFixture(t)
+	gs := f.gs
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	// Settle any transient goroutines, then snapshot the baseline.
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	if _, err := f.srv.SetLegalHold(ctx, &pb.LegalHoldRequest{
+		Actor: "admin:root", TenantId: "acme", Enabled: false,
+	}); err != nil {
+		t.Fatalf("SetLegalHold(release): %v", err)
+	}
+
+	// A detached sweep goroutine would still be alive here. Allow brief
+	// settle for the synchronous applier-driven enqueue to finish.
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	after := runtime.NumGoroutine()
+	// Allow tiny scheduler noise but not a leaked long-lived sweep.
+	if after > before+1 {
+		t.Fatalf("goroutine count grew %d -> %d across the OFF RPC; "+
+			"the detached lift goroutine must be gone (lift is now the durable worker)",
+			before, after)
+	}
+
+	// And the lift is instead recorded durably.
+	q, err := gs.GetLegalHoldLiftQueue(ctx)
+	if err != nil {
+		t.Fatalf("GetLegalHoldLiftQueue: %v", err)
+	}
+	if len(q) != 1 || q[0].TenantID != "acme" {
+		t.Fatalf("lift queue = %+v; want exactly [acme] (durable, not a goroutine)", q)
+	}
+}
+
+// TestSetLegalHold_Enable_DoesNotEnqueueLift: the ON path must never
+// enqueue a lift — legal hold is being ADDED, not lifted.
+func TestSetLegalHold_Enable_DoesNotEnqueueLift(t *testing.T) {
+	t.Parallel()
+
+	f := newAdminWALFixture(t)
+	ctx := context.Background()
+	if _, err := f.gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if _, err := f.srv.SetLegalHold(ctx, &pb.LegalHoldRequest{
+		Actor: "admin:root", TenantId: "acme", Enabled: true,
+	}); err != nil {
+		t.Fatalf("SetLegalHold(enable): %v", err)
+	}
+	q, err := f.gs.GetLegalHoldLiftQueue(ctx)
+	if err != nil {
+		t.Fatalf("GetLegalHoldLiftQueue: %v", err)
+	}
+	if len(q) != 0 {
+		t.Fatalf("ON path enqueued %d lift rows; want 0", len(q))
+	}
+}
+
+// TestSetLegalHold_Release_ReEnqueueKeepsEarliestAge: re-releasing an
+// already-queued tenant (idempotent re-issue) must not reset
+// enqueued_at — the age drives operator alerting on a stuck lift.
+func TestSetLegalHold_Release_ReEnqueueKeepsEarliestAge(t *testing.T) {
+	t.Parallel()
+
+	f := newAdminWALFixture(t)
+	gs := f.gs
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	rel := func() {
+		if _, err := f.srv.SetLegalHold(ctx, &pb.LegalHoldRequest{
+			Actor: "admin:root", TenantId: "acme", Enabled: false,
+		}); err != nil {
+			t.Fatalf("SetLegalHold(release): %v", err)
+		}
+	}
+	rel()
+	q1, err := gs.GetLegalHoldLiftQueue(ctx)
+	if err != nil || len(q1) != 1 {
+		t.Fatalf("first release queue=%+v err=%v", q1, err)
+	}
+	first := q1[0].EnqueuedAt
+	rel()
+	q2, err := gs.GetLegalHoldLiftQueue(ctx)
+	if err != nil || len(q2) != 1 {
+		t.Fatalf("second release queue=%+v err=%v", q2, err)
+	}
+	if q2[0].EnqueuedAt != first {
+		t.Fatalf("re-release reset enqueued_at: was %d now %d (want unchanged)",
+			first, q2[0].EnqueuedAt)
+	}
+}
 
 // TestSetLegalHold_AdminEnable_HappyPath: admin actor sets the hold; the
 // response carries success=true + status="legal_hold" and the

--- a/server/go/internal/audit/archiver_test.go
+++ b/server/go/internal/audit/archiver_test.go
@@ -287,6 +287,12 @@ func (f *fakeObjectLockStore) PutLockedObject(_ context.Context, obj ArchiveObje
 	return nil
 }
 
+func (f *fakeObjectLockStore) LiftLegalHoldForReleasedTenant(
+	context.Context, string, TenantHeldFunc,
+) (LiftSummary, error) {
+	return LiftSummary{}, nil
+}
+
 func gunzipLines(t *testing.T, body []byte) []string {
 	t.Helper()
 	gz, err := gzip.NewReader(bytes.NewReader(body))

--- a/server/go/internal/audit/legalhold_lift.go
+++ b/server/go/internal/audit/legalhold_lift.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Legal-hold lift on already-archived S3 objects (EPIC #511 Gap 1).
+//
+// When a tenant is placed under legal hold the archiver escalates every
+// *subsequent* archive write to ObjectLockLegalHoldStatus=ON
+// (archiver.go:buildObject -> s3_lock.go:PutLockedObject). Releasing the
+// hold (SetLegalHold OFF) previously had no effect on objects already
+// written to S3 — they stayed legal-hold-locked forever, requiring
+// manual S3 surgery and blocking the GDPR-erasure-after-release story.
+//
+// This file closes that gap. On an explicit release the api layer
+// triggers LiftLegalHoldForReleasedTenant as a background sweep (the RPC
+// does not block on it). GDPR erasure NEVER triggers a lift: legal hold
+// deliberately supersedes erasure, so only an explicit release lifts the
+// hold and only THEN may queued erasure proceed (the DeleteUser
+// precondition gate in internal/api/delete_user.go is unchanged).
+//
+// Object-key reality (important): archive objects are keyed
+// "wal/<topic>/<partition>/<start>-<end>.jsonl.gz" — per WAL partition,
+// NOT per tenant. A single archive object can carry records for many
+// tenants and gets legal-hold=ON if ANY of those tenants was held when
+// it was written. There is therefore no per-tenant key prefix to scan;
+// the sweep walks the whole archive prefix ("wal/") and, for each object
+// whose legal hold is ON, decodes the object body to recover its
+// authoritative tenant set (the bounded entdb-tenant-sample metadata may
+// truncate and is not relied on) and clears the hold only once NONE of
+// the tenants the object carries is still under legal hold. That rule is
+// what makes the sweep:
+//
+//   - idempotent          : an already-OFF / never-held object is skipped;
+//   - partial-completion-safe : a re-run finishes an interrupted sweep
+//     (each object is decided independently from current S3 + globalstore
+//     state, no progress cursor to corrupt);
+//   - safe for shared objects : another tenant still on hold keeps the
+//     object's hold ON;
+//   - a no-op for a tenant with no archived objects.
+//
+// COMPLIANCE-mode retention is NEVER touched — only PutObjectLegalHold is
+// issued, which flips the legal-hold flag and leaves
+// ObjectLockMode=COMPLIANCE + ObjectLockRetainUntilDate intact (ADR-015:
+// retention is immutable; legal hold is liftable on release).
+
+package audit
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// withContentMD5 registers the smithy Content-MD5 build-step middleware
+// for a single S3 call. PutObjectLegalHold is a legacy
+// Content-MD5-required operation; MinIO and other non-AWS S3 endpoints
+// reject it with HTTP 400 MissingContentMD5 unless the header is
+// present. AWS SDK Go v2's post-Jan-2025 default computes a CRC32
+// trailer instead, so we add the legacy MD5 explicitly. Harmless on
+// real AWS S3 (it accepts a correct Content-MD5).
+func withContentMD5(o *s3.Options) {
+	o.APIOptions = append(o.APIOptions, smithyhttp.AddContentChecksumMiddleware)
+}
+
+// archivePrefix is the single root prefix every archive object is
+// written under (see archiver.buildObject key format). The lift sweep
+// paginates this prefix; there is no narrower per-tenant prefix because
+// the key is per WAL partition.
+const archivePrefix = "wal/"
+
+// TenantHeldFunc reports whether tenantID is *still* under legal hold.
+// The sweep consults it per tenant referenced by a held object so a
+// shared object keeps its hold while any co-tenant remains held. Backed
+// by globalstore.IsLegalHoldSet in production.
+type TenantHeldFunc func(ctx context.Context, tenantID string) (bool, error)
+
+// LiftSummary reports one LiftLegalHoldForReleasedTenant pass. It is
+// safe to log: counts only, no object bodies.
+type LiftSummary struct {
+	// Scanned is the number of archive objects enumerated.
+	Scanned int
+	// HeldScanned is the number of objects observed with legal hold ON.
+	HeldScanned int
+	// Lifted is the number of objects whose legal hold this pass cleared.
+	Lifted int
+	// SkippedStillHeld is the number of held objects left ON because
+	// some tenant they carry is still under legal hold.
+	SkippedStillHeld int
+}
+
+// LiftLegalHoldForReleasedTenant clears the S3 Object Lock legal hold on
+// archive objects that no longer carry any still-held tenant, after
+// tenantID's hold has been released. See the file header for the design
+// (trigger, idempotency, retention untouched, shared-object safety).
+//
+// The sweep is resumable: it derives every decision from live S3 +
+// stillHeld state, so a crashed / re-invoked run simply finishes the
+// remaining objects. An object whose body cannot be decoded is treated
+// conservatively (left ON) so a corrupt object never silently drops a
+// hold; that surfaces as an error to the caller for visibility.
+func (s *S3ObjectLockStore) LiftLegalHoldForReleasedTenant(
+	ctx context.Context,
+	tenantID string,
+	stillHeld TenantHeldFunc,
+) (LiftSummary, error) {
+	var summary LiftSummary
+	if s == nil || s.client == nil {
+		return summary, errors.New("audit: s3 client is required")
+	}
+	if s.bucket == "" {
+		return summary, errors.New("audit: s3 bucket is required")
+	}
+	if tenantID == "" {
+		return summary, errors.New("audit: released tenant id is required")
+	}
+	if stillHeld == nil {
+		return summary, errors.New("audit: still-held lookup is required")
+	}
+
+	var continuationToken *string
+	for {
+		if err := ctx.Err(); err != nil {
+			return summary, err
+		}
+		page, err := s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(s.bucket),
+			Prefix:            aws.String(archivePrefix),
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return summary, fmt.Errorf("audit: list archive objects: %w", err)
+		}
+		for _, obj := range page.Contents {
+			key := aws.ToString(obj.Key)
+			if key == "" {
+				continue
+			}
+			summary.Scanned++
+			if err := s.liftOneObject(ctx, key, tenantID, stillHeld, &summary); err != nil {
+				return summary, err
+			}
+		}
+		if page.IsTruncated == nil || !*page.IsTruncated || aws.ToString(page.NextContinuationToken) == "" {
+			break
+		}
+		continuationToken = page.NextContinuationToken
+	}
+	return summary, nil
+}
+
+// liftOneObject applies the lift rule to a single archive object. It is
+// a no-op when the object's legal hold is already OFF (idempotency) and
+// leaves the hold ON when any tenant the object carries is still held
+// (shared-object safety). Only PutObjectLegalHold(OFF) is ever issued —
+// COMPLIANCE retention is never touched.
+func (s *S3ObjectLockStore) liftOneObject(
+	ctx context.Context,
+	key, releasedTenant string,
+	stillHeld TenantHeldFunc,
+	summary *LiftSummary,
+) error {
+	lhOut, err := s.client.GetObjectLegalHold(ctx, &s3.GetObjectLegalHoldInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("audit: get legal hold %q: %w", key, err)
+	}
+	if lhOut == nil || lhOut.LegalHold == nil ||
+		lhOut.LegalHold.Status != types.ObjectLockLegalHoldStatusOn {
+		// Already OFF / never held — nothing to do (idempotent).
+		return nil
+	}
+	summary.HeldScanned++
+
+	tenants, err := s.objectTenants(ctx, key)
+	if err != nil {
+		return fmt.Errorf("audit: decode held object %q: %w", key, err)
+	}
+	// Conservative: if the released tenant is not even in this object,
+	// some *other* held tenant is keeping it ON — leave it.
+	carriesReleased := false
+	for _, t := range tenants {
+		if t == releasedTenant {
+			carriesReleased = true
+			break
+		}
+	}
+	if !carriesReleased {
+		summary.SkippedStillHeld++
+		return nil
+	}
+	for _, t := range tenants {
+		held, herr := stillHeld(ctx, t)
+		if herr != nil {
+			return fmt.Errorf("audit: still-held lookup tenant %q: %w", t, herr)
+		}
+		if held {
+			// A co-tenant is still under hold; the object stays ON.
+			summary.SkippedStillHeld++
+			return nil
+		}
+	}
+
+	if _, err := s.client.PutObjectLegalHold(ctx, &s3.PutObjectLegalHoldInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		LegalHold: &types.ObjectLockLegalHold{
+			Status: types.ObjectLockLegalHoldStatusOff,
+		},
+	}, withContentMD5); err != nil {
+		return fmt.Errorf("audit: clear legal hold %q: %w", key, err)
+	}
+	summary.Lifted++
+	return nil
+}
+
+// objectTenants downloads an archive object and returns the
+// authoritative set of tenant ids it carries by decoding the gzip-JSONL
+// body with the same line shape the archiver writes (archiver.go). The
+// bounded entdb-tenant-sample metadata is deliberately not used here —
+// it can truncate and is not authoritative.
+func (s *S3ObjectLockStore) objectTenants(ctx context.Context, key string) ([]string, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get object %q: %w", key, err)
+	}
+	defer func() {
+		if out != nil && out.Body != nil {
+			_ = out.Body.Close()
+		}
+	}()
+
+	gz, err := gzip.NewReader(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gunzip %q: %w", key, err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	seen := map[string]struct{}{}
+	scanner := bufio.NewScanner(gz)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		raw := bytes.TrimSpace(scanner.Bytes())
+		if len(raw) == 0 {
+			continue
+		}
+		var line archiveLine
+		if err := json.Unmarshal(raw, &line); err != nil {
+			return nil, fmt.Errorf("decode archive line in %q: %w", key, err)
+		}
+		value := line.Value
+		if len(value) == 0 && line.ValueBase64 != "" {
+			// base64-encoded non-JSON value: the WAL Event is JSON, so a
+			// base64 line is never an Event we can read a tenant from.
+			// Fall back to the record key, which the archiver sets to
+			// the tenant id for tenant-scoped writes.
+			if line.Key != "" {
+				seen[line.Key] = struct{}{}
+			}
+			continue
+		}
+		if ev, derr := wal.DecodeEvent(value); derr == nil && ev.TenantID != "" {
+			seen[ev.TenantID] = struct{}{}
+			continue
+		}
+		if line.Key != "" {
+			seen[line.Key] = struct{}{}
+		}
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("scan archive body %q: %w", key, err)
+	}
+	return sortedKeys(seen), nil
+}

--- a/server/go/internal/audit/legalhold_lift_test.go
+++ b/server/go/internal/audit/legalhold_lift_test.go
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package audit
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// liftObject is one object in the in-memory S3 fake. RetainUntil +
+// LockMode model the immutable COMPLIANCE retention; the test asserts
+// they are NEVER mutated by a legal-hold lift.
+type liftObject struct {
+	body        []byte
+	legalHoldOn bool
+	lockMode    types.ObjectLockMode
+	retainUntil time.Time
+}
+
+// liftFakeS3 is an in-memory S3 supporting the four lift calls plus the
+// archive write path. It records every PutObjectLegalHold so a test can
+// prove COMPLIANCE retention was never touched (only the legal-hold
+// flag flips).
+type liftFakeS3 struct {
+	objects map[string]*liftObject
+
+	listCalls       int
+	getLHCalls      int
+	putLHCalls      int
+	pageSize        int // 0 => single page
+	listErr         error
+	putLHErr        error
+	putLHKeyMutated []string // keys we issued a legal-hold PUT for
+}
+
+func newLiftFakeS3() *liftFakeS3 {
+	return &liftFakeS3{objects: map[string]*liftObject{}}
+}
+
+func (f *liftFakeS3) seed(key string, body []byte, legalHoldOn bool) {
+	f.objects[key] = &liftObject{
+		body:        body,
+		legalHoldOn: legalHoldOn,
+		lockMode:    types.ObjectLockModeCompliance,
+		retainUntil: time.Date(2033, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+}
+
+func (f *liftFakeS3) GetObjectLockConfiguration(context.Context, *s3.GetObjectLockConfigurationInput, ...func(*s3.Options)) (*s3.GetObjectLockConfigurationOutput, error) {
+	return &s3.GetObjectLockConfigurationOutput{ObjectLockConfiguration: &types.ObjectLockConfiguration{
+		ObjectLockEnabled: types.ObjectLockEnabledEnabled,
+		Rule: &types.ObjectLockRule{DefaultRetention: &types.DefaultRetention{
+			Mode: types.ObjectLockRetentionModeCompliance, Days: aws.Int32(1),
+		}},
+	}}, nil
+}
+
+func (f *liftFakeS3) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	body, _ := io.ReadAll(in.Body)
+	f.objects[aws.ToString(in.Key)] = &liftObject{
+		body:        body,
+		legalHoldOn: in.ObjectLockLegalHoldStatus == types.ObjectLockLegalHoldStatusOn,
+		lockMode:    in.ObjectLockMode,
+		retainUntil: aws.ToTime(in.ObjectLockRetainUntilDate),
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (f *liftFakeS3) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	f.listCalls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	keys := make([]string, 0, len(f.objects))
+	for k := range f.objects {
+		if strings.HasPrefix(k, aws.ToString(in.Prefix)) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	start := 0
+	if in.ContinuationToken != nil {
+		for i, k := range keys {
+			if k == aws.ToString(in.ContinuationToken) {
+				start = i
+				break
+			}
+		}
+	}
+	end := len(keys)
+	truncated := false
+	if f.pageSize > 0 && start+f.pageSize < len(keys) {
+		end = start + f.pageSize
+		truncated = true
+	}
+
+	out := &s3.ListObjectsV2Output{}
+	for _, k := range keys[start:end] {
+		out.Contents = append(out.Contents, types.Object{Key: aws.String(k)})
+	}
+	if truncated {
+		out.IsTruncated = aws.Bool(true)
+		out.NextContinuationToken = aws.String(keys[end])
+	}
+	return out, nil
+}
+
+func (f *liftFakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	o, ok := f.objects[aws.ToString(in.Key)]
+	if !ok {
+		return nil, errors.New("NoSuchKey")
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(o.body))}, nil
+}
+
+func (f *liftFakeS3) GetObjectLegalHold(_ context.Context, in *s3.GetObjectLegalHoldInput, _ ...func(*s3.Options)) (*s3.GetObjectLegalHoldOutput, error) {
+	f.getLHCalls++
+	o, ok := f.objects[aws.ToString(in.Key)]
+	if !ok {
+		return nil, errors.New("NoSuchKey")
+	}
+	status := types.ObjectLockLegalHoldStatusOff
+	if o.legalHoldOn {
+		status = types.ObjectLockLegalHoldStatusOn
+	}
+	return &s3.GetObjectLegalHoldOutput{LegalHold: &types.ObjectLockLegalHold{Status: status}}, nil
+}
+
+func (f *liftFakeS3) PutObjectLegalHold(_ context.Context, in *s3.PutObjectLegalHoldInput, _ ...func(*s3.Options)) (*s3.PutObjectLegalHoldOutput, error) {
+	f.putLHCalls++
+	if f.putLHErr != nil {
+		return nil, f.putLHErr
+	}
+	o, ok := f.objects[aws.ToString(in.Key)]
+	if !ok {
+		return nil, errors.New("NoSuchKey")
+	}
+	// The lift MUST only flip the legal-hold flag. COMPLIANCE retention
+	// stays exactly as written — assert it here and never let the fake
+	// mutate it.
+	o.legalHoldOn = in.LegalHold.Status == types.ObjectLockLegalHoldStatusOn
+	f.putLHKeyMutated = append(f.putLHKeyMutated, aws.ToString(in.Key))
+	return &s3.PutObjectLegalHoldOutput{}, nil
+}
+
+// gzJSONL builds a gzip-JSONL archive body carrying one WAL Event per
+// tenant id — the exact shape archiver.buildObject writes.
+func gzJSONL(t *testing.T, tenantIDs ...string) []byte {
+	t.Helper()
+	var raw bytes.Buffer
+	for i, tid := range tenantIDs {
+		ev := wal.Event{
+			TenantID:       tid,
+			Actor:          "actor",
+			IdempotencyKey: tid + "-idem",
+			TsMs:           int64(1000 + i),
+			Ops:            []map[string]any{{"op": "noop"}},
+		}
+		val, err := ev.Encode()
+		if err != nil {
+			t.Fatalf("encode event: %v", err)
+		}
+		line := archiveLine{
+			Topic:     "entdb-wal",
+			Partition: 0,
+			Offset:    int64(i),
+			Key:       tid,
+			Value:     val,
+		}
+		enc, err := json.Marshal(line)
+		if err != nil {
+			t.Fatalf("marshal line: %v", err)
+		}
+		raw.Write(enc)
+		raw.WriteByte('\n')
+	}
+	var gzbuf bytes.Buffer
+	gw := gzip.NewWriter(&gzbuf)
+	if _, err := gw.Write(raw.Bytes()); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return gzbuf.Bytes()
+}
+
+// assertRetentionIntact fails if any object's COMPLIANCE lock mode or
+// retain-until changed — the core ADR-015 invariant the lift must honour.
+func assertRetentionIntact(t *testing.T, f *liftFakeS3) {
+	t.Helper()
+	for k, o := range f.objects {
+		if o.lockMode != types.ObjectLockModeCompliance {
+			t.Fatalf("object %q lock mode = %q, want COMPLIANCE (retention must be immutable)", k, o.lockMode)
+		}
+		if o.retainUntil.IsZero() {
+			t.Fatalf("object %q retain-until was cleared (retention must be immutable)", k)
+		}
+	}
+}
+
+func heldNone(context.Context, string) (bool, error) { return false, nil }
+
+func TestLiftReleasesAllArchivedObjectsForTenant(t *testing.T) {
+	ctx := context.Background()
+	f := newLiftFakeS3()
+	f.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "tenant-a"), true)
+	f.seed("wal/entdb-wal/0/2-3.jsonl.gz", gzJSONL(t, "tenant-a"), true)
+	f.seed("wal/entdb-wal/1/0-0.jsonl.gz", gzJSONL(t, "tenant-a"), true)
+
+	store := NewS3ObjectLockStore(f, "audit-bucket", "")
+	sum, err := store.LiftLegalHoldForReleasedTenant(ctx, "tenant-a", heldNone)
+	if err != nil {
+		t.Fatalf("lift: %v", err)
+	}
+	if sum.Scanned != 3 || sum.HeldScanned != 3 || sum.Lifted != 3 || sum.SkippedStillHeld != 0 {
+		t.Fatalf("summary = %+v, want all 3 lifted", sum)
+	}
+	for k, o := range f.objects {
+		if o.legalHoldOn {
+			t.Fatalf("object %q still has legal hold ON after release", k)
+		}
+	}
+	assertRetentionIntact(t, f)
+}
+
+func TestLiftIsIdempotentOnReRun(t *testing.T) {
+	ctx := context.Background()
+	f := newLiftFakeS3()
+	f.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "tenant-a"), true)
+	f.seed("wal/entdb-wal/0/2-3.jsonl.gz", gzJSONL(t, "tenant-a"), true)
+
+	store := NewS3ObjectLockStore(f, "audit-bucket", "")
+	if _, err := store.LiftLegalHoldForReleasedTenant(ctx, "tenant-a", heldNone); err != nil {
+		t.Fatalf("first lift: %v", err)
+	}
+	putsAfterFirst := f.putLHCalls
+	if putsAfterFirst != 2 {
+		t.Fatalf("first run issued %d legal-hold PUTs, want 2", putsAfterFirst)
+	}
+
+	// Re-run: every object is already OFF, so the sweep is a pure no-op
+	// for the mutating call (partial-completion-safe / idempotent).
+	sum, err := store.LiftLegalHoldForReleasedTenant(ctx, "tenant-a", heldNone)
+	if err != nil {
+		t.Fatalf("re-run lift: %v", err)
+	}
+	if sum.Lifted != 0 || sum.HeldScanned != 0 {
+		t.Fatalf("re-run summary = %+v, want zero lifted/held", sum)
+	}
+	if f.putLHCalls != putsAfterFirst {
+		t.Fatalf("re-run issued extra legal-hold PUTs: %d -> %d", putsAfterFirst, f.putLHCalls)
+	}
+	assertRetentionIntact(t, f)
+}
+
+func TestLiftIsNoOpWhenNothingHeld(t *testing.T) {
+	ctx := context.Background()
+	f := newLiftFakeS3()
+	// Objects exist but were never legal-hold-locked.
+	f.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "tenant-a"), false)
+	f.seed("wal/entdb-wal/0/2-3.jsonl.gz", gzJSONL(t, "tenant-b"), false)
+
+	store := NewS3ObjectLockStore(f, "audit-bucket", "")
+	sum, err := store.LiftLegalHoldForReleasedTenant(ctx, "tenant-a", heldNone)
+	if err != nil {
+		t.Fatalf("lift: %v", err)
+	}
+	if sum.HeldScanned != 0 || sum.Lifted != 0 {
+		t.Fatalf("summary = %+v, want no-op", sum)
+	}
+	if f.putLHCalls != 0 {
+		t.Fatalf("no-op sweep issued %d legal-hold PUTs, want 0", f.putLHCalls)
+	}
+
+	// And a tenant with zero archived objects: also a clean no-op.
+	empty := NewS3ObjectLockStore(newLiftFakeS3(), "audit-bucket", "")
+	if sum2, err := empty.LiftLegalHoldForReleasedTenant(ctx, "ghost", heldNone); err != nil || sum2.Scanned != 0 {
+		t.Fatalf("empty-bucket lift: sum=%+v err=%v", sum2, err)
+	}
+	assertRetentionIntact(t, f)
+}
+
+func TestLiftKeepsHoldWhenCoTenantStillHeld(t *testing.T) {
+	ctx := context.Background()
+	f := newLiftFakeS3()
+	// Shared object: tenant-a (released) + tenant-b (still held).
+	f.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "tenant-a", "tenant-b"), true)
+	// tenant-a-only object: must be released.
+	f.seed("wal/entdb-wal/0/2-3.jsonl.gz", gzJSONL(t, "tenant-a"), true)
+
+	stillHeld := func(_ context.Context, tid string) (bool, error) {
+		return tid == "tenant-b", nil
+	}
+	store := NewS3ObjectLockStore(f, "audit-bucket", "")
+	sum, err := store.LiftLegalHoldForReleasedTenant(ctx, "tenant-a", stillHeld)
+	if err != nil {
+		t.Fatalf("lift: %v", err)
+	}
+	if sum.Lifted != 1 || sum.SkippedStillHeld != 1 {
+		t.Fatalf("summary = %+v, want 1 lifted + 1 skipped", sum)
+	}
+	if !f.objects["wal/entdb-wal/0/0-1.jsonl.gz"].legalHoldOn {
+		t.Fatal("shared object lost its hold while tenant-b is still held")
+	}
+	if f.objects["wal/entdb-wal/0/2-3.jsonl.gz"].legalHoldOn {
+		t.Fatal("tenant-a-only object should have been released")
+	}
+	assertRetentionIntact(t, f)
+}
+
+func TestLiftDoesNotTouchOtherTenantsObjects(t *testing.T) {
+	ctx := context.Background()
+	f := newLiftFakeS3()
+	// tenant-b is held and is NOT being released; its object must be
+	// left strictly untouched (no legal-hold PUT against its key).
+	f.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "tenant-a"), true)
+	f.seed("wal/entdb-wal/0/2-3.jsonl.gz", gzJSONL(t, "tenant-b"), true)
+
+	stillHeld := func(_ context.Context, tid string) (bool, error) {
+		return tid == "tenant-b", nil
+	}
+	store := NewS3ObjectLockStore(f, "audit-bucket", "")
+	if _, err := store.LiftLegalHoldForReleasedTenant(ctx, "tenant-a", stillHeld); err != nil {
+		t.Fatalf("lift: %v", err)
+	}
+	if !f.objects["wal/entdb-wal/0/2-3.jsonl.gz"].legalHoldOn {
+		t.Fatal("tenant-b's object lost its hold (other tenant unaffected invariant)")
+	}
+	for _, k := range f.putLHKeyMutated {
+		if k == "wal/entdb-wal/0/2-3.jsonl.gz" {
+			t.Fatalf("lift issued a legal-hold PUT against another tenant's object %q", k)
+		}
+	}
+	assertRetentionIntact(t, f)
+}
+
+func TestLiftPaginatesAcrossPages(t *testing.T) {
+	ctx := context.Background()
+	f := newLiftFakeS3()
+	f.pageSize = 2
+	keys := []string{
+		"wal/entdb-wal/0/0-0.jsonl.gz",
+		"wal/entdb-wal/0/1-1.jsonl.gz",
+		"wal/entdb-wal/0/2-2.jsonl.gz",
+		"wal/entdb-wal/0/3-3.jsonl.gz",
+		"wal/entdb-wal/0/4-4.jsonl.gz",
+	}
+	for _, k := range keys {
+		f.seed(k, gzJSONL(t, "tenant-a"), true)
+	}
+
+	store := NewS3ObjectLockStore(f, "audit-bucket", "")
+	sum, err := store.LiftLegalHoldForReleasedTenant(ctx, "tenant-a", heldNone)
+	if err != nil {
+		t.Fatalf("lift: %v", err)
+	}
+	if sum.Scanned != 5 || sum.Lifted != 5 {
+		t.Fatalf("summary = %+v, want 5 scanned/lifted across pages", sum)
+	}
+	if f.listCalls < 3 {
+		t.Fatalf("listCalls = %d, want >= 3 (pagination not exercised)", f.listCalls)
+	}
+	assertRetentionIntact(t, f)
+}
+
+func TestLiftPropagatesListError(t *testing.T) {
+	ctx := context.Background()
+	f := newLiftFakeS3()
+	f.listErr = errors.New("s3 throttled")
+	store := NewS3ObjectLockStore(f, "audit-bucket", "")
+	if _, err := store.LiftLegalHoldForReleasedTenant(ctx, "tenant-a", heldNone); err == nil {
+		t.Fatal("expected list error to propagate")
+	}
+}

--- a/server/go/internal/audit/legalhold_lift_worker.go
+++ b/server/go/internal/audit/legalhold_lift_worker.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Durable legal-hold-lift worker (EPIC #511 Gap 1, ADR-015).
+//
+// Why this exists: SetLegalHold OFF used to launch the archive sweep as
+// a detached fire-and-forget goroutine off the RPC path. That was NOT
+// crash-durable — a server restart / S3 outage / >timeout left a
+// released tenant's objects stuck LegalHold=ON with no retry and no
+// signal, which silently breaks GDPR right-to-erasure-after-release. For
+// a compliance feature that is unacceptable.
+//
+// The trigger is now durable: ApplyLegalHoldSet (the WAL-driven global
+// apply step that clears the legal_holds row + flips
+// tenant_registry.status) ALSO upserts a legal_hold_lift_queue row in
+// the SAME transaction. This worker — mirroring the GDPR
+// deletion_queue worker (internal/gdpr/processor.go) — drains that queue
+// on an interval, running the existing idempotent/resumable paginated
+// sweep for each queued tenant. On full success the row is deleted; on
+// ANY failure / partial / per-run timeout the row is left for the next
+// tick (retry/resume). The per-run timeout is therefore safe: the row
+// persists and the next tick continues exactly where state left off
+// (every sweep decision is derived from live S3 + globalstore state, so
+// there is no progress cursor to corrupt).
+//
+// Correctness of the sweep itself is unchanged (per-partition
+// shared-object safety, COMPLIANCE retention never touched, GDPR
+// precedence, MinIO Content-MD5) — only the trigger + execution model
+// changed (detached goroutine -> durable queue + retrying worker).
+
+package audit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+)
+
+// LiftQueueStore is the slice of globalstore the lift worker needs. Kept
+// as an interface so the worker is unit-testable with an in-memory fake
+// and so this package does not hard-depend on globalstore.
+type LiftQueueStore interface {
+	// GetLegalHoldLiftQueue returns every pending-lift entry, oldest first.
+	GetLegalHoldLiftQueue(ctx context.Context) ([]LiftQueueEntry, error)
+	// DequeueLegalHoldLift removes a tenant's pending-lift row after a
+	// fully-successful sweep.
+	DequeueLegalHoldLift(ctx context.Context, tenantID string) (bool, error)
+	// CountLegalHoldLiftQueue returns the current queue depth (the
+	// entdb_legal_hold_lift_pending gauge source).
+	CountLegalHoldLiftQueue(ctx context.Context) (int, error)
+	// IsLegalHoldSet backs the per-object co-tenant guard: a shared
+	// archive object keeps its hold while ANY tenant it carries is still
+	// under legal hold.
+	IsLegalHoldSet(ctx context.Context, tenantID string) (bool, error)
+}
+
+// LiftQueueEntry is one queued tenant whose archive legal hold must be
+// lifted. Mirrors globalstore.LegalHoldLiftQueueEntry without the
+// package dependency.
+type LiftQueueEntry struct {
+	TenantID   string
+	EnqueuedAt int64
+}
+
+// LegalHoldLifter is the sweep seam (implemented by *S3ObjectLockStore).
+// Kept as an interface so the worker is unit-testable with a fake S3.
+type LegalHoldLifter interface {
+	LiftLegalHoldForReleasedTenant(ctx context.Context, tenantID string, stillHeld TenantHeldFunc) (LiftSummary, error)
+}
+
+// LiftWorkerOptions configures a LiftWorker.
+type LiftWorkerOptions struct {
+	// Queue is the durable globalstore-backed pending-lift queue.
+	Queue LiftQueueStore
+	// Lifter runs the paginated S3 sweep for a released tenant.
+	Lifter LegalHoldLifter
+	// RunTimeout bounds a single tenant's sweep. Zero => 30m. A
+	// timed-out sweep simply leaves the queue row for the next tick (the
+	// sweep is resumable), so the bound never corrupts state.
+	RunTimeout time.Duration
+}
+
+// liftRunTimeoutDefault bounds one tenant's sweep per tick. The sweep is
+// idempotent/resumable and the queue row survives a timeout, so the next
+// tick resumes — the bound only stops a single stuck S3 endpoint from
+// blocking the whole queue forever.
+const liftRunTimeoutDefault = 30 * time.Minute
+
+// LiftWorker drains the durable legal_hold_lift_queue: for each queued
+// tenant it runs the resumable archive sweep, deletes the row only on
+// full success, and publishes the pending/completed/error metrics.
+type LiftWorker struct {
+	queue      LiftQueueStore
+	lifter     LegalHoldLifter
+	runTimeout time.Duration
+}
+
+// NewLiftWorker constructs a LiftWorker. Queue + Lifter are required.
+func NewLiftWorker(opts LiftWorkerOptions) (*LiftWorker, error) {
+	if opts.Queue == nil {
+		return nil, errors.New("audit: lift worker requires a queue store")
+	}
+	if opts.Lifter == nil {
+		return nil, errors.New("audit: lift worker requires a lifter")
+	}
+	rt := opts.RunTimeout
+	if rt <= 0 {
+		rt = liftRunTimeoutDefault
+	}
+	return &LiftWorker{queue: opts.Queue, lifter: opts.Lifter, runTimeout: rt}, nil
+}
+
+// Run drains the queue immediately and then every interval until ctx is
+// cancelled. Mirrors gdpr.Processor.Run. A RunOnce error is logged and
+// the loop continues (a transient S3 outage must not kill the worker —
+// the rows persist and the next tick retries); only ctx cancellation
+// stops the loop.
+func (w *LiftWorker) Run(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		return errors.New("audit: lift worker interval must be positive")
+	}
+	for {
+		if _, err := w.RunOnce(ctx); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			slog.ErrorContext(ctx, "audit: legal-hold lift worker tick failed (queue retained; retrying next tick)",
+				"error", err)
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// LiftWorkerSummary reports one RunOnce pass.
+type LiftWorkerSummary struct {
+	// TenantsScanned is the number of queued tenants this tick attempted.
+	TenantsScanned int
+	// TenantsCompleted is the number whose sweep fully succeeded and was
+	// dequeued.
+	TenantsCompleted int
+	// TenantsRetained is the number left in the queue (failure / partial
+	// / timeout) for the next tick.
+	TenantsRetained int
+}
+
+// RunOnce processes every queued tenant once. A per-tenant failure does
+// NOT abort the pass — every queued tenant gets a chance and any failing
+// row is simply retained for the next tick. The pending gauge is
+// refreshed at entry and exit so a scrape between ticks is accurate.
+func (w *LiftWorker) RunOnce(ctx context.Context) (*LiftWorkerSummary, error) {
+	w.publishPending(ctx)
+	entries, err := w.queue.GetLegalHoldLiftQueue(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("audit: read legal-hold lift queue: %w", err)
+	}
+	summary := &LiftWorkerSummary{}
+	stillHeld := func(c context.Context, tid string) (bool, error) {
+		return w.queue.IsLegalHoldSet(c, tid)
+	}
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return summary, err
+		}
+		summary.TenantsScanned++
+		if w.processOne(ctx, e.TenantID, stillHeld) {
+			summary.TenantsCompleted++
+		} else {
+			summary.TenantsRetained++
+		}
+	}
+	w.publishPending(ctx)
+	return summary, nil
+}
+
+// processOne runs the sweep for one tenant and dequeues it only on full
+// success. Returns true iff the row was dequeued. Any failure (sweep
+// error, per-run timeout, dequeue error) leaves the row for the next
+// tick and bumps the error metric.
+func (w *LiftWorker) processOne(parent context.Context, tenantID string, stillHeld TenantHeldFunc) bool {
+	ctx, cancel := context.WithTimeout(parent, w.runTimeout)
+	defer cancel()
+
+	sum, err := w.lifter.LiftLegalHoldForReleasedTenant(ctx, tenantID, stillHeld)
+	if err != nil {
+		metrics.IncLegalHoldLiftErrors()
+		slog.ErrorContext(ctx, "audit: legal-hold lift sweep failed (queue row retained for retry)",
+			"tenant_id", tenantID, "error", err,
+			"scanned", sum.Scanned, "lifted", sum.Lifted)
+		return false
+	}
+	ok, derr := w.queue.DequeueLegalHoldLift(parent, tenantID)
+	if derr != nil {
+		// The sweep succeeded but the row could not be removed; leave it
+		// — a re-run of the (idempotent) sweep next tick is harmless and
+		// the row will be cleared then.
+		metrics.IncLegalHoldLiftErrors()
+		slog.ErrorContext(ctx, "audit: legal-hold lift dequeue failed (will retry; sweep is idempotent)",
+			"tenant_id", tenantID, "error", derr)
+		return false
+	}
+	metrics.IncLegalHoldLiftCompleted()
+	slog.InfoContext(ctx, "audit: legal-hold lift sweep complete",
+		"tenant_id", tenantID, "dequeued", ok,
+		"scanned", sum.Scanned, "held_scanned", sum.HeldScanned,
+		"lifted", sum.Lifted, "skipped_still_held", sum.SkippedStillHeld)
+	return true
+}
+
+// publishPending refreshes the entdb_legal_hold_lift_pending gauge from
+// the durable queue depth. A count error is logged but never aborts the
+// tick — the gauge is observability, not correctness.
+func (w *LiftWorker) publishPending(ctx context.Context) {
+	n, err := w.queue.CountLegalHoldLiftQueue(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "audit: count legal-hold lift queue for metric failed",
+			"error", err)
+		return
+	}
+	metrics.SetLegalHoldLiftPending(n)
+}

--- a/server/go/internal/audit/legalhold_lift_worker_test.go
+++ b/server/go/internal/audit/legalhold_lift_worker_test.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Durability + retry + metrics tests for the legal-hold-lift worker
+// (EPIC #511 Gap 1, ADR-015). These prove the rework's core promise:
+// the lift survives a server restart (it runs purely from the persisted
+// queue, NOT a request-scoped goroutine) and a transient S3 error is
+// retried on the next tick. The shared-object / idempotent / retention
+// correctness lives in legalhold_lift_test.go and is unchanged.
+
+package audit
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+)
+
+// fakeLiftQueue is an in-memory stand-in for the durable
+// globalstore-backed queue. The worker reads/dequeues/counts purely
+// through this — a fresh instance with a pre-populated queue models a
+// server that crashed AFTER the release was committed and restarted with
+// no in-memory state.
+type fakeLiftQueue struct {
+	pending  map[string]int64 // tenant_id -> enqueued_at
+	held     map[string]bool  // tenant_id -> still under legal hold
+	getErr   error            // injected GetLegalHoldLiftQueue error
+	getCalls int
+}
+
+func newFakeLiftQueue() *fakeLiftQueue {
+	return &fakeLiftQueue{pending: map[string]int64{}, held: map[string]bool{}}
+}
+
+func (q *fakeLiftQueue) GetLegalHoldLiftQueue(context.Context) ([]LiftQueueEntry, error) {
+	q.getCalls++
+	if q.getErr != nil {
+		return nil, q.getErr
+	}
+	out := make([]LiftQueueEntry, 0, len(q.pending))
+	for tid, at := range q.pending {
+		out = append(out, LiftQueueEntry{TenantID: tid, EnqueuedAt: at})
+	}
+	return out, nil
+}
+
+func (q *fakeLiftQueue) DequeueLegalHoldLift(_ context.Context, tenantID string) (bool, error) {
+	_, ok := q.pending[tenantID]
+	delete(q.pending, tenantID)
+	return ok, nil
+}
+
+func (q *fakeLiftQueue) CountLegalHoldLiftQueue(context.Context) (int, error) {
+	return len(q.pending), nil
+}
+
+func (q *fakeLiftQueue) IsLegalHoldSet(_ context.Context, tenantID string) (bool, error) {
+	return q.held[tenantID], nil
+}
+
+// liftMetric reads one legal-hold-lift collector value by metric name.
+func liftMetric(t *testing.T, name string) float64 {
+	t.Helper()
+	for _, c := range metrics.LegalHoldLiftCollectors() {
+		ch := make(chan *prometheus.Desc, 1)
+		c.Describe(ch)
+		close(ch)
+		matched := false
+		for d := range ch {
+			if d != nil && strings.Contains(d.String(), name) {
+				matched = true
+			}
+		}
+		if matched {
+			return testutil.ToFloat64(c)
+		}
+	}
+	t.Fatalf("metric %q not found in LegalHoldLiftCollectors", name)
+	return 0
+}
+
+// TestLiftWorker_DurableRestart proves the lift survives a server
+// restart. The queue is pre-populated (modelling a release that was
+// committed durably) and the worker is constructed FRESH with zero
+// in-memory state — no request-scoped goroutine, no detached sweep. The
+// worker completes the lift purely from the persisted queue + live S3.
+// The SetLegalHold OFF path no longer spawns a goroutine at all (asserted
+// structurally below by TestLiftWorker_NoGoroutineInOFFPath).
+func TestLiftWorker_DurableRestart(t *testing.T) {
+	ctx := context.Background()
+
+	// Live S3 still carries the held object from before the "crash".
+	s3 := newLiftFakeS3()
+	s3.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "acme"), true)
+	s3.seed("wal/entdb-wal/0/2-3.jsonl.gz", gzJSONL(t, "acme"), true)
+	store := NewS3ObjectLockStore(s3, "audit-bucket", "")
+
+	// Durable queue as it would be AFTER the release committed but
+	// BEFORE any sweep ran (server then crashed/restarted).
+	q := newFakeLiftQueue()
+	q.pending["acme"] = 1700000000
+
+	// Fresh worker — the ONLY state it has is the persisted queue.
+	w, err := NewLiftWorker(LiftWorkerOptions{Queue: q, Lifter: store})
+	if err != nil {
+		t.Fatalf("NewLiftWorker: %v", err)
+	}
+
+	sum, err := w.RunOnce(ctx)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if sum.TenantsScanned != 1 || sum.TenantsCompleted != 1 || sum.TenantsRetained != 0 {
+		t.Fatalf("summary = %+v; want 1 scanned/1 completed/0 retained", sum)
+	}
+	// Every previously-held object's hold is now OFF, purely from the
+	// persisted queue + live S3 (no in-process trigger).
+	for k, o := range s3.objects {
+		if o.legalHoldOn {
+			t.Fatalf("object %q still ON after durable-restart lift", k)
+		}
+	}
+	assertRetentionIntact(t, s3)
+	// Row removed only after the full success.
+	if _, ok := q.pending["acme"]; ok {
+		t.Fatal("queue row not removed after successful lift")
+	}
+}
+
+// TestLiftWorker_RetryAfterTransientS3Error proves retry/resume: a
+// transient S3 List error on the first tick leaves the queue row in
+// place (no dequeue, error metric bumped); the next tick succeeds and
+// removes the row. This is the durability guarantee the old detached
+// goroutine lacked.
+func TestLiftWorker_RetryAfterTransientS3Error(t *testing.T) {
+	ctx := context.Background()
+
+	s3 := newLiftFakeS3()
+	s3.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "acme"), true)
+	store := NewS3ObjectLockStore(s3, "audit-bucket", "")
+
+	q := newFakeLiftQueue()
+	q.pending["acme"] = 1700000000
+
+	w, err := NewLiftWorker(LiftWorkerOptions{Queue: q, Lifter: store})
+	if err != nil {
+		t.Fatalf("NewLiftWorker: %v", err)
+	}
+
+	errsBefore := liftMetric(t, "entdb_legal_hold_lift_errors_total")
+
+	// Tick 1: transient List failure.
+	s3.listErr = errors.New("s3: throttled (transient)")
+	sum1, err := w.RunOnce(ctx)
+	if err != nil {
+		t.Fatalf("RunOnce tick1: %v", err)
+	}
+	if sum1.TenantsCompleted != 0 || sum1.TenantsRetained != 1 {
+		t.Fatalf("tick1 summary = %+v; want 0 completed/1 retained", sum1)
+	}
+	if _, ok := q.pending["acme"]; !ok {
+		t.Fatal("queue row removed despite a failed sweep — retry would be impossible")
+	}
+	if s3.objects["wal/entdb-wal/0/0-1.jsonl.gz"].legalHoldOn != true {
+		t.Fatal("object hold cleared despite a failed list — must stay ON for retry")
+	}
+	if got := liftMetric(t, "entdb_legal_hold_lift_errors_total"); got != errsBefore+1 {
+		t.Fatalf("errors_total = %v; want %v after one failed tick", got, errsBefore+1)
+	}
+
+	// Tick 2: S3 recovers, the SAME persisted row drives a successful sweep.
+	s3.listErr = nil
+	sum2, err := w.RunOnce(ctx)
+	if err != nil {
+		t.Fatalf("RunOnce tick2: %v", err)
+	}
+	if sum2.TenantsCompleted != 1 || sum2.TenantsRetained != 0 {
+		t.Fatalf("tick2 summary = %+v; want 1 completed/0 retained", sum2)
+	}
+	if _, ok := q.pending["acme"]; ok {
+		t.Fatal("queue row not removed after the retry succeeded")
+	}
+	if s3.objects["wal/entdb-wal/0/0-1.jsonl.gz"].legalHoldOn {
+		t.Fatal("object hold still ON after the successful retry tick")
+	}
+	assertRetentionIntact(t, s3)
+}
+
+// TestLiftWorker_Metrics proves the pending gauge tracks the durable
+// queue depth and the completed counter advances per fully-swept tenant.
+func TestLiftWorker_Metrics(t *testing.T) {
+	ctx := context.Background()
+
+	s3 := newLiftFakeS3()
+	s3.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "t1"), true)
+	s3.seed("wal/entdb-wal/0/2-3.jsonl.gz", gzJSONL(t, "t2"), true)
+	store := NewS3ObjectLockStore(s3, "audit-bucket", "")
+
+	q := newFakeLiftQueue()
+	q.pending["t1"] = 1700000001
+	q.pending["t2"] = 1700000002
+
+	w, err := NewLiftWorker(LiftWorkerOptions{Queue: q, Lifter: store})
+	if err != nil {
+		t.Fatalf("NewLiftWorker: %v", err)
+	}
+
+	completedBefore := liftMetric(t, "entdb_legal_hold_lift_completed_total")
+
+	if _, err := w.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if got := liftMetric(t, "entdb_legal_hold_lift_pending"); got != 0 {
+		t.Fatalf("pending gauge = %v; want 0 after both tenants swept", got)
+	}
+	if got := liftMetric(t, "entdb_legal_hold_lift_completed_total"); got != completedBefore+2 {
+		t.Fatalf("completed_total = %v; want %v (+2)", got, completedBefore+2)
+	}
+}
+
+// TestLiftWorker_SharedObjectCoTenantStillHeld proves the worker
+// preserves the existing shared-object safety: a co-tenant still under
+// legal hold (via the queue-backed IsLegalHoldSet) keeps the shared
+// object ON; the released tenant's row is still removed (its own sweep
+// completed without error — nothing more it can do until the co-tenant
+// is released too).
+func TestLiftWorker_SharedObjectCoTenantStillHeld(t *testing.T) {
+	ctx := context.Background()
+
+	s3 := newLiftFakeS3()
+	// One archive object carries BOTH tenants (per-partition key).
+	s3.seed("wal/entdb-wal/0/0-1.jsonl.gz", gzJSONL(t, "released", "cotenant"), true)
+	store := NewS3ObjectLockStore(s3, "audit-bucket", "")
+
+	q := newFakeLiftQueue()
+	q.pending["released"] = 1700000000
+	q.held["cotenant"] = true // still under hold
+
+	w, err := NewLiftWorker(LiftWorkerOptions{Queue: q, Lifter: store})
+	if err != nil {
+		t.Fatalf("NewLiftWorker: %v", err)
+	}
+	if _, err := w.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if !s3.objects["wal/entdb-wal/0/0-1.jsonl.gz"].legalHoldOn {
+		t.Fatal("shared object lifted while a co-tenant is still held")
+	}
+	assertRetentionIntact(t, s3)
+}
+
+// TestLiftWorker_GetQueueErrorIsTickError proves a queue-read failure
+// surfaces from RunOnce (so Run logs + retries next tick) and does NOT
+// silently drop pending lifts.
+func TestLiftWorker_GetQueueErrorIsTickError(t *testing.T) {
+	ctx := context.Background()
+	s3 := newLiftFakeS3()
+	store := NewS3ObjectLockStore(s3, "audit-bucket", "")
+	q := newFakeLiftQueue()
+	q.getErr = errors.New("globalstore: db locked")
+
+	w, err := NewLiftWorker(LiftWorkerOptions{Queue: q, Lifter: store})
+	if err != nil {
+		t.Fatalf("NewLiftWorker: %v", err)
+	}
+	if _, err := w.RunOnce(ctx); err == nil {
+		t.Fatal("RunOnce returned nil on a queue-read failure; want error")
+	}
+}
+
+// TestLiftWorker_Run_StopsOnContextCancel proves Run honours ctx
+// cancellation (graceful shutdown) and a transient RunOnce error does
+// not kill the loop.
+func TestLiftWorker_Run_StopsOnContextCancel(t *testing.T) {
+	s3 := newLiftFakeS3()
+	store := NewS3ObjectLockStore(s3, "audit-bucket", "")
+	q := newFakeLiftQueue()
+
+	w, err := NewLiftWorker(LiftWorkerOptions{Queue: q, Lifter: store})
+	if err != nil {
+		t.Fatalf("NewLiftWorker: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx, 10*time.Millisecond) }()
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	select {
+	case rerr := <-done:
+		if !errors.Is(rerr, context.Canceled) {
+			t.Fatalf("Run returned %v; want context.Canceled", rerr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not stop within 2s of ctx cancel")
+	}
+}
+
+// TestNewLiftWorker_RequiresDeps pins the constructor guards.
+func TestNewLiftWorker_RequiresDeps(t *testing.T) {
+	s3 := newLiftFakeS3()
+	store := NewS3ObjectLockStore(s3, "b", "")
+	if _, err := NewLiftWorker(LiftWorkerOptions{Lifter: store}); err == nil {
+		t.Fatal("NewLiftWorker without Queue: want error")
+	}
+	if _, err := NewLiftWorker(LiftWorkerOptions{Queue: newFakeLiftQueue()}); err == nil {
+		t.Fatal("NewLiftWorker without Lifter: want error")
+	}
+}

--- a/server/go/internal/audit/s3_lock.go
+++ b/server/go/internal/audit/s3_lock.go
@@ -35,15 +35,30 @@ type ArchiveObject struct {
 // ObjectLockStore writes archive objects and verifies that the
 // destination supports Object Lock in COMPLIANCE mode before archival
 // starts.
+//
+// LiftLegalHoldForReleasedTenant sweeps the archive prefix and clears
+// the S3 Object Lock legal hold on objects that no longer carry any
+// still-held tenant once tenantID's hold has been released. It never
+// touches COMPLIANCE-mode retention (immutable by design — ADR-015) and
+// is idempotent / partial-completion-safe (see legalhold_lift.go).
 type ObjectLockStore interface {
 	VerifyObjectLock(ctx context.Context) error
 	PutLockedObject(ctx context.Context, obj ArchiveObject) error
+	LiftLegalHoldForReleasedTenant(ctx context.Context, tenantID string, stillHeld TenantHeldFunc) (LiftSummary, error)
 }
 
 // S3API is the small subset of the AWS S3 client needed by this package.
+// The legal-hold-lift sweep adds list/get/get-legal-hold/put-legal-hold
+// on top of the archive write path; PutObjectLegalHold is the only
+// mutating call and it touches the legal-hold flag only — never the
+// COMPLIANCE retention, which stays immutable (ADR-015).
 type S3API interface {
 	GetObjectLockConfiguration(ctx context.Context, params *s3.GetObjectLockConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetObjectLockConfigurationOutput, error)
 	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	GetObjectLegalHold(ctx context.Context, params *s3.GetObjectLegalHoldInput, optFns ...func(*s3.Options)) (*s3.GetObjectLegalHoldOutput, error)
+	PutObjectLegalHold(ctx context.Context, params *s3.PutObjectLegalHoldInput, optFns ...func(*s3.Options)) (*s3.PutObjectLegalHoldOutput, error)
 }
 
 // S3ObjectLockStore stores WAL archive objects in a single S3 bucket.

--- a/server/go/internal/audit/s3_lock_test.go
+++ b/server/go/internal/audit/s3_lock_test.go
@@ -120,3 +120,22 @@ func (f *fakeS3Client) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...
 	}
 	return &s3.PutObjectOutput{}, nil
 }
+
+// The plain fakeS3Client only exercises the archive-write path; the
+// legal-hold-lift sweep is covered by liftFakeS3 in
+// legalhold_lift_test.go. These stubs just satisfy the S3API interface.
+func (f *fakeS3Client) ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	return &s3.ListObjectsV2Output{}, nil
+}
+
+func (f *fakeS3Client) GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeS3Client) GetObjectLegalHold(context.Context, *s3.GetObjectLegalHoldInput, ...func(*s3.Options)) (*s3.GetObjectLegalHoldOutput, error) {
+	return &s3.GetObjectLegalHoldOutput{}, nil
+}
+
+func (f *fakeS3Client) PutObjectLegalHold(context.Context, *s3.PutObjectLegalHoldInput, ...func(*s3.Options)) (*s3.PutObjectLegalHoldOutput, error) {
+	return &s3.PutObjectLegalHoldOutput{}, nil
+}

--- a/server/go/internal/globalstore/apply.go
+++ b/server/go/internal/globalstore/apply.go
@@ -302,6 +302,19 @@ func (g *GlobalStore) ApplyLegalHoldSet(ctx context.Context, in LegalHoldApply) 
 		); err != nil {
 			return fmt.Errorf("globalstore: apply legal_hold_set clear: %w", err)
 		}
+		// EPIC #511 Gap 1: on an *explicit* release, durably enqueue the
+		// S3 Object Lock legal-hold lift for this tenant's
+		// already-archived objects IN THIS SAME TRANSACTION. Committing
+		// the pending-lift row atomically with the hold release is what
+		// makes the lift crash-durable: a server restart / S3 outage
+		// after the release still finds the pending row and a background
+		// worker resumes the (idempotent, paginated) sweep on its next
+		// tick. GDPR erasure never reaches here — only SetLegalHold OFF
+		// emits a legal_hold_set op with enabled=false (legal hold
+		// supersedes erasure; ADR-015).
+		if err := enqueueLegalHoldLiftTx(ctx, tx, in.TenantID, in.CreatedAt); err != nil {
+			return err
+		}
 	}
 	if _, err := tx.ExecContext(ctx,
 		`UPDATE tenant_registry SET status = ? WHERE tenant_id = ?`,

--- a/server/go/internal/globalstore/legalhold.go
+++ b/server/go/internal/globalstore/legalhold.go
@@ -101,3 +101,89 @@ func (g *GlobalStore) IsLegalHoldSet(ctx context.Context, tenantID string) (bool
 	}
 	return true, nil
 }
+
+// LegalHoldLiftQueueEntry is one pending-lift row: a tenant whose hold
+// was explicitly released and whose already-archived S3 objects still
+// need their Object Lock legal hold cleared.
+type LegalHoldLiftQueueEntry struct {
+	TenantID   string
+	EnqueuedAt int64
+}
+
+// enqueueLegalHoldLiftTx upserts a pending-lift row INSIDE the caller's
+// transaction. It is called from ApplyLegalHoldSet on the durable
+// release path so the pending lift is committed atomically with clearing
+// the legal_holds row + flipping tenant_registry.status — a crash AFTER
+// the release still has the lift recorded. ON CONFLICT keeps the
+// earliest enqueued_at so a re-release does not reset the age. EPIC #511
+// Gap 1.
+func enqueueLegalHoldLiftTx(ctx context.Context, tx *sql.Tx, tenantID string, enqueuedAt int64) error {
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO legal_hold_lift_queue (tenant_id, enqueued_at)
+		 VALUES (?, ?)
+		 ON CONFLICT(tenant_id) DO NOTHING`,
+		tenantID, enqueuedAt,
+	); err != nil {
+		return fmt.Errorf("globalstore: enqueue legal-hold lift %q: %w", tenantID, err)
+	}
+	return nil
+}
+
+// GetLegalHoldLiftQueue returns every pending-lift entry, oldest first.
+// The background lift worker drains this on its tick. Reading purely
+// from the durable table is what makes the lift survive a server
+// restart (no in-memory trigger state).
+func (g *GlobalStore) GetLegalHoldLiftQueue(ctx context.Context) ([]*LegalHoldLiftQueueEntry, error) {
+	rows, err := g.db.QueryContext(ctx,
+		`SELECT tenant_id, enqueued_at
+		 FROM legal_hold_lift_queue
+		 ORDER BY enqueued_at, tenant_id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("globalstore: list legal-hold lift queue: %w", err)
+	}
+	defer rows.Close()
+	out := []*LegalHoldLiftQueueEntry{}
+	for rows.Next() {
+		var e LegalHoldLiftQueueEntry
+		if err := rows.Scan(&e.TenantID, &e.EnqueuedAt); err != nil {
+			return nil, fmt.Errorf("globalstore: scan legal-hold lift row: %w", err)
+		}
+		out = append(out, &e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("globalstore: iterate legal-hold lift rows: %w", err)
+	}
+	return out, nil
+}
+
+// DequeueLegalHoldLift removes a tenant's pending-lift row. The worker
+// calls this only after the sweep for that tenant has fully completed;
+// any failure / partial run leaves the row so the next tick retries.
+// Returns true iff a row existed.
+func (g *GlobalStore) DequeueLegalHoldLift(ctx context.Context, tenantID string) (bool, error) {
+	res, err := g.db.ExecContext(ctx,
+		`DELETE FROM legal_hold_lift_queue WHERE tenant_id = ?`,
+		tenantID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("globalstore: dequeue legal-hold lift %q: %w", tenantID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("globalstore: rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
+// CountLegalHoldLiftQueue returns the number of pending-lift rows. Used
+// to publish the entdb_legal_hold_lift_pending gauge.
+func (g *GlobalStore) CountLegalHoldLiftQueue(ctx context.Context) (int, error) {
+	var n int
+	if err := g.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM legal_hold_lift_queue`,
+	).Scan(&n); err != nil {
+		return 0, fmt.Errorf("globalstore: count legal-hold lift queue: %w", err)
+	}
+	return n, nil
+}

--- a/server/go/internal/globalstore/legalhold_lift_queue_test.go
+++ b/server/go/internal/globalstore/legalhold_lift_queue_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for the durable legal_hold_lift_queue (EPIC #511 Gap 1,
+// ADR-015). The critical assertion is that ApplyLegalHoldSet enqueues
+// the pending lift IN THE SAME transaction that clears the hold + flips
+// tenant_registry.status — so a crash after an explicit release still
+// has the lift durably recorded. ON never enqueues; the queue CRUD
+// round-trips; re-release keeps the earliest enqueued_at.
+
+package globalstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+)
+
+func TestApplyLegalHoldSet_ReleaseEnqueuesLiftAtomically(t *testing.T) {
+	clock := int64(1700000000)
+	gs := newStore(t, func() int64 { return clock })
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	// ON: hold set, registry flips to legal_hold, queue stays EMPTY.
+	if err := gs.ApplyLegalHoldSet(ctx, globalstore.LegalHoldApply{
+		TenantID: "acme", HeldBy: "admin:root", Reason: "x",
+		CreatedAt: clock, Enabled: true,
+	}); err != nil {
+		t.Fatalf("ApplyLegalHoldSet(on): %v", err)
+	}
+	if held, _ := gs.IsLegalHoldSet(ctx, "acme"); !held {
+		t.Fatal("hold not set after enable")
+	}
+	if q, err := gs.GetLegalHoldLiftQueue(ctx); err != nil || len(q) != 0 {
+		t.Fatalf("queue after ON = %+v err=%v; want empty", q, err)
+	}
+
+	// OFF (explicit release): hold cleared, registry back to active,
+	// AND a pending-lift row exists — all from the one apply step.
+	clock = 1700000050
+	if err := gs.ApplyLegalHoldSet(ctx, globalstore.LegalHoldApply{
+		TenantID: "acme", HeldBy: "admin:root", Reason: "",
+		CreatedAt: clock, Enabled: false,
+	}); err != nil {
+		t.Fatalf("ApplyLegalHoldSet(off): %v", err)
+	}
+	if held, _ := gs.IsLegalHoldSet(ctx, "acme"); held {
+		t.Fatal("hold still set after release")
+	}
+	tnt, _ := gs.GetTenant(ctx, "acme")
+	if tnt == nil || tnt.Status != "active" {
+		t.Fatalf("registry status = %v; want active", tnt)
+	}
+	q, err := gs.GetLegalHoldLiftQueue(ctx)
+	if err != nil {
+		t.Fatalf("GetLegalHoldLiftQueue: %v", err)
+	}
+	if len(q) != 1 || q[0].TenantID != "acme" || q[0].EnqueuedAt != clock {
+		t.Fatalf("lift queue = %+v; want [{acme %d}]", q, clock)
+	}
+}
+
+func TestLegalHoldLiftQueue_CRUDRoundTrip(t *testing.T) {
+	gs := newStore(t, nil)
+	ctx := context.Background()
+
+	if n, err := gs.CountLegalHoldLiftQueue(ctx); err != nil || n != 0 {
+		t.Fatalf("empty count = %d err=%v; want 0", n, err)
+	}
+	if ok, err := gs.DequeueLegalHoldLift(ctx, "ghost"); err != nil || ok {
+		t.Fatalf("dequeue missing = %v err=%v; want false/nil", ok, err)
+	}
+
+	// Enqueue via the only real path: an explicit release
+	// (ApplyLegalHoldSet enabled=false) of a registered tenant.
+	for _, tt := range []struct {
+		tid string
+		at  int64
+	}{{"t-b", 200}, {"t-a", 100}, {"t-c", 300}} {
+		if _, err := gs.CreateTenant(ctx, tt.tid, tt.tid, "us-east-1"); err != nil {
+			t.Fatalf("CreateTenant %s: %v", tt.tid, err)
+		}
+		if err := gs.ApplyLegalHoldSet(ctx, globalstore.LegalHoldApply{
+			TenantID: tt.tid, HeldBy: "admin:root", CreatedAt: tt.at, Enabled: false,
+		}); err != nil {
+			t.Fatalf("enqueue %s: %v", tt.tid, err)
+		}
+	}
+	q, err := gs.GetLegalHoldLiftQueue(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// Oldest-first ordering (enqueued_at, then tenant_id).
+	if len(q) != 3 || q[0].TenantID != "t-a" || q[1].TenantID != "t-b" || q[2].TenantID != "t-c" {
+		t.Fatalf("ordering = %+v; want t-a,t-b,t-c by enqueued_at", q)
+	}
+	if n, _ := gs.CountLegalHoldLiftQueue(ctx); n != 3 {
+		t.Fatalf("count = %d; want 3", n)
+	}
+	if ok, err := gs.DequeueLegalHoldLift(ctx, "t-b"); err != nil || !ok {
+		t.Fatalf("dequeue t-b = %v err=%v; want true", ok, err)
+	}
+	if n, _ := gs.CountLegalHoldLiftQueue(ctx); n != 2 {
+		t.Fatalf("count after dequeue = %d; want 2", n)
+	}
+}
+
+func TestApplyLegalHoldSet_ReReleaseKeepsEarliestEnqueuedAt(t *testing.T) {
+	clock := int64(1700000000)
+	gs := newStore(t, func() int64 { return clock })
+	ctx := context.Background()
+	if _, err := gs.CreateTenant(ctx, "acme", "Acme", "us-east-1"); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	off := func(at int64) {
+		if err := gs.ApplyLegalHoldSet(ctx, globalstore.LegalHoldApply{
+			TenantID: "acme", HeldBy: "admin:root", CreatedAt: at, Enabled: false,
+		}); err != nil {
+			t.Fatalf("ApplyLegalHoldSet(off @%d): %v", at, err)
+		}
+	}
+	off(1700000010)
+	off(1700000099) // re-release later — must NOT bump enqueued_at
+	q, err := gs.GetLegalHoldLiftQueue(ctx)
+	if err != nil || len(q) != 1 {
+		t.Fatalf("queue = %+v err=%v; want one row", q, err)
+	}
+	if q[0].EnqueuedAt != 1700000010 {
+		t.Fatalf("enqueued_at = %d; want earliest 1700000010 (re-release must not reset age)",
+			q[0].EnqueuedAt)
+	}
+}

--- a/server/go/internal/globalstore/schema.go
+++ b/server/go/internal/globalstore/schema.go
@@ -72,6 +72,20 @@ CREATE TABLE IF NOT EXISTS legal_holds (
     PRIMARY KEY (tenant_id, held_by)
 );
 
+-- legal_hold_lift_queue records a tenant whose legal hold was explicitly
+-- released (SetLegalHold OFF) and whose already-archived S3 objects must
+-- have their Object Lock legal hold lifted. The row is enqueued in the
+-- SAME globalstore transaction that clears the legal_holds row + flips
+-- tenant_registry.status (ApplyLegalHoldSet), so a crash AFTER release
+-- still has the pending lift durably recorded. A background worker drains
+-- it by running the paginated S3 sweep and deletes the row only on full
+-- success; any failure leaves the row for the next tick (retry/resume).
+-- EPIC #511 Gap 1, ADR-015.
+CREATE TABLE IF NOT EXISTS legal_hold_lift_queue (
+    tenant_id   TEXT PRIMARY KEY,
+    enqueued_at INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS tenant_quotas (
     tenant_id                  TEXT PRIMARY KEY,
     max_writes_per_month       INTEGER NOT NULL DEFAULT 0,

--- a/server/go/internal/metrics/legalhold.go
+++ b/server/go/internal/metrics/legalhold.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Legal-hold-lift metrics expose the health of the durable S3 Object
+// Lock legal-hold lift queue + worker (EPIC #511 Gap 1, ADR-015).
+//
+// Before this, an explicit SetLegalHold OFF launched a detached
+// fire-and-forget goroutine: a crash / S3 outage / timeout left a
+// released tenant's objects stuck LegalHold=ON with NO signal, which
+// silently broke GDPR right-to-erasure-after-release. The pending gauge
+// is now the operator alerting signal: it climbs when a release was
+// recorded but the sweep has not yet completed, and drains to 0 once the
+// worker has lifted every object.
+//
+// Metric names and label sets are deliberately stable so dashboards and
+// alert rules survive across releases:
+//
+//	entdb_legal_hold_lift_pending             Gauge
+//	entdb_legal_hold_lift_completed_total     Counter
+//	entdb_legal_hold_lift_errors_total        Counter
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	legalHoldLiftPending = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "entdb_legal_hold_lift_pending",
+			Help: "Tenants whose legal hold was released but whose archived S3 objects' Object Lock legal hold has not yet been fully lifted (durable legal_hold_lift_queue depth)",
+		},
+	)
+
+	legalHoldLiftCompleted = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "entdb_legal_hold_lift_completed_total",
+			Help: "Total tenants whose archive legal-hold lift sweep fully completed and was removed from the durable queue",
+		},
+	)
+
+	legalHoldLiftErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "entdb_legal_hold_lift_errors_total",
+			Help: "Total legal-hold lift sweep failures (queue/list/get/put). The queue row is retained and retried on the next worker tick",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(legalHoldLiftPending, legalHoldLiftCompleted, legalHoldLiftErrors)
+}
+
+// SetLegalHoldLiftPending publishes the current durable lift-queue depth
+// (tenants released but not yet fully swept). Called by the lift worker
+// at the start and end of every tick.
+func SetLegalHoldLiftPending(n int) {
+	legalHoldLiftPending.Set(float64(n))
+}
+
+// IncLegalHoldLiftCompleted records that one tenant's lift sweep fully
+// completed and its durable queue row was removed.
+func IncLegalHoldLiftCompleted() {
+	legalHoldLiftCompleted.Inc()
+}
+
+// IncLegalHoldLiftErrors records one lift sweep failure. The queue row is
+// left in place so the next worker tick retries (resumable sweep).
+func IncLegalHoldLiftErrors() {
+	legalHoldLiftErrors.Inc()
+}
+
+// LegalHoldLiftCollectors returns the lift collectors so tests can
+// register them against a fresh prometheus.Registry without touching the
+// default one.
+func LegalHoldLiftCollectors() []prometheus.Collector {
+	return []prometheus.Collector{legalHoldLiftPending, legalHoldLiftCompleted, legalHoldLiftErrors}
+}

--- a/tests/python/e2e/docker-compose.archive.yml
+++ b/tests/python/e2e/docker-compose.archive.yml
@@ -112,6 +112,12 @@ services:
       - "-archive-poll-timeout=1s"
       - "-archive-retry-backoff=2s"
       - "-archive-s3-path-style=true"
+      # EPIC #511 Gap 1: the durable legal-hold-lift worker is on by
+      # default; tighten its interval so the release -> sweep round-trip
+      # completes well within the test's 90s poll window. The lift is NOT
+      # a request-scoped goroutine — it is this crash-durable worker
+      # draining the legal_hold_lift_queue.
+      - "-legal-hold-lift-worker-interval=2s"
     depends_on:
       redpanda:
         condition: service_healthy

--- a/tests/python/e2e/test_archive_object_lock.py
+++ b/tests/python/e2e/test_archive_object_lock.py
@@ -16,9 +16,15 @@ What this asserts (success criteria 1, 2, 5 from issue #511):
 4. The ``entdb_archive_lag_events`` Prometheus gauge is exported and
    drains back to 0 once the archiver has caught up — the operator
    alert signal named in ADR-015's failure-modes section.
-
-Legal-hold-on-existing-objects (criterion 4) and ops docs remain open
-checklist items on #511 and are deliberately not covered here.
+5. Legal-hold lift (EPIC #511 Gap 1): with the tenant under legal hold
+   the archiver writes objects with ``LegalHold=ON``; an explicit
+   ``SetLegalHold`` OFF durably enqueues a lift and the crash-durable
+   background worker (NOT a request-scoped goroutine) then lifts the
+   hold on those already-written objects while the
+   ``ObjectLockMode=COMPLIANCE`` retention stays exactly as written
+   (immutable — ADR-015). The ``entdb_legal_hold_lift_pending`` gauge is
+   exported and drains to 0 once the worker has finished — the operator
+   signal the old detached goroutine never provided.
 """
 
 from __future__ import annotations
@@ -160,9 +166,154 @@ async def test_wal_archives_to_s3_object_lock_compliance(s3, scope) -> None:
     )
     assert drained, f"archive lag did not drain to 0; last sample: {lag_lines!r}"
 
-    # Sanity: the writes counter advanced past our batch.
-    writes = _scrape_metric_lines("entdb_archive_writes_total")
+    # Sanity: the writes counter advances past our batch. Poll rather
+    # than one-shot — the final archive batch may still be mid-flush
+    # when the lag gauge first reads 0 for the other partitions.
+    writes: list[str] = []
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        writes = _scrape_metric_lines("entdb_archive_writes_total")
+        if writes and float(writes[0].rsplit(" ", 1)[1]) >= 12.0:
+            break
+        time.sleep(2)
     assert writes, "entdb_archive_writes_total not exported"
     assert float(writes[0].rsplit(" ", 1)[1]) >= 12.0, (
         f"entdb_archive_writes_total={writes[0]!r}, want >= 12"
+    )
+
+
+def _legal_hold_status(s3, key: str) -> str | None:
+    """Return the object's S3 Object Lock legal-hold status, or None
+    when no legal-hold configuration is present (never held)."""
+    try:
+        resp = s3.get_object_legal_hold(Bucket=S3_BUCKET, Key=key)
+    except Exception:  # noqa: BLE001 — boto raises when no legal hold set
+        return None
+    return resp.get("LegalHold", {}).get("Status")
+
+
+async def test_legal_hold_lift_on_release(s3, db_client) -> None:
+    """EPIC #511 Gap 1: set hold ON -> archive -> release -> the durable
+    background worker lifts the hold while COMPLIANCE retention is
+    untouched. The release does NOT run the sweep on the RPC goroutine —
+    it durably enqueues legal_hold_lift_queue and the crash-durable
+    LiftWorker drains it; the entdb_legal_hold_lift_pending gauge drains
+    to 0 once done.
+
+    Uses a dedicated, registry-backed tenant (created via CreateTenant so
+    it flows WAL -> applier -> globalstore, which SetLegalHold's tenant
+    gate requires) and writes through admin:root, the tenant creator.
+    """
+    tenant = f"lh-lift-{int(time.time())}"
+    created = await db_client.create_tenant(tenant, name="Legal-Hold Lift E2E", actor="admin:root")
+    assert created.get("success"), f"create_tenant failed: {created!r}"
+    lh_scope = db_client.tenant(tenant).actor("admin:root")
+
+    # 1. Put the dedicated tenant under legal hold. The archiver consults
+    #    globalstore.IsLegalHoldSet per batch, so writes AFTER this land
+    #    in S3 with ObjectLockLegalHoldStatus=ON.
+    res = await db_client.set_legal_hold(tenant, enabled=True, actor="admin:root")
+    assert res.get("success"), f"set_legal_hold ON failed: {res!r}"
+
+    # 2. Write a fresh batch so the archiver flushes held objects.
+    for i in range(12):
+        plan = lh_scope.plan()
+        plan.create(
+            pb.User(
+                email=f"hold-{i}-{time.time_ns()}@example.com",
+                name=f"Hold User {i}",
+            )
+        )
+        result = await plan.commit(wait_applied=True)
+        assert result.success, f"held commit {i} failed: {result.error}"
+
+    # 3. Wait until an archived object carrying THIS tenant has legal
+    #    hold ON. The key is per WAL partition, so filter by decoding the
+    #    body and matching our tenant id.
+    held_key: str | None = None
+    retain_before: object = None
+    deadline = time.time() + 90
+    while time.time() < deadline and not held_key:
+        for obj in _list_archive_objects(s3):
+            k = obj["Key"]
+            if _legal_hold_status(s3, k) != "ON":
+                continue
+            body = s3.get_object(Bucket=S3_BUCKET, Key=k)["Body"].read()
+            with gzip.GzipFile(fileobj=io.BytesIO(body)) as gz:
+                blob = gz.read().decode()
+            if tenant not in blob:
+                continue
+            held_key = k
+            head = s3.head_object(Bucket=S3_BUCKET, Key=k)
+            retain_before = head.get("ObjectLockRetainUntilDate")
+            assert head.get("ObjectLockMode") == "COMPLIANCE", (
+                f"held object {k!r} not COMPLIANCE: {head.get('ObjectLockMode')!r}"
+            )
+            assert retain_before is not None, f"held object {k!r} has no retain-until"
+            break
+        if not held_key:
+            time.sleep(2)
+    assert held_key, (
+        "no archived object for the held tenant reached LegalHold=ON within "
+        "90s — archiver did not escalate writes for the held tenant"
+    )
+
+    # 4. Explicit release. This does NOT run the sweep on the RPC path:
+    #    it durably enqueues a legal_hold_lift_queue row (same globalstore
+    #    txn that clears the hold) and returns once the hold is cleared.
+    #    The crash-durable LiftWorker drains the queue on its interval.
+    res = await db_client.set_legal_hold(tenant, enabled=False, actor="admin:root")
+    assert res.get("success"), f"set_legal_hold OFF failed: {res!r}"
+    assert res.get("status") == "active", f"unexpected release status: {res!r}"
+
+    # 4b. The durable pending-lift gauge must be exported (operator signal
+    #     the old detached goroutine never provided). It may already be 0
+    #     if the fast-interval worker swept before this scrape; we only
+    #     require the metric to EXIST here and drain to 0 below.
+    pending_lines = _scrape_metric_lines("entdb_legal_hold_lift_pending")
+    assert pending_lines, (
+        "entdb_legal_hold_lift_pending not exported on /metrics — the "
+        "durable-lift observability signal is missing"
+    )
+
+    # 5. The background worker (NOT a request goroutine) must flip the
+    #    previously-held object's legal hold OFF, and its COMPLIANCE
+    #    retention must be byte-for-byte unchanged (ADR-015: legal hold is
+    #    liftable on release; retention is immutable).
+    deadline = time.time() + 90
+    lifted = False
+    while time.time() < deadline:
+        status = _legal_hold_status(s3, held_key)
+        if status in (None, "OFF"):
+            lifted = True
+            break
+        time.sleep(2)
+    assert lifted, (
+        f"legal hold on {held_key!r} did not lift to OFF within 90s — the "
+        "durable LiftWorker did not drain the queue"
+    )
+
+    head_after = s3.head_object(Bucket=S3_BUCKET, Key=held_key)
+    assert head_after.get("ObjectLockMode") == "COMPLIANCE", (
+        f"retention mode changed on lift: {head_after.get('ObjectLockMode')!r}"
+    )
+    assert head_after.get("ObjectLockRetainUntilDate") == retain_before, (
+        "Object Lock retain-until changed during legal-hold lift — "
+        f"before={retain_before!r} after={head_after.get('ObjectLockRetainUntilDate')!r}; "
+        "COMPLIANCE retention MUST be immutable (ADR-015)"
+    )
+
+    # 6. Once the worker has finished, the pending gauge drains to 0 —
+    #    proving the durable queue emptied (the "no signal" gap closed).
+    deadline = time.time() + 60
+    drained = False
+    while time.time() < deadline:
+        lines = _scrape_metric_lines("entdb_legal_hold_lift_pending")
+        if lines and all(float(ln.rsplit(" ", 1)[1]) == 0.0 for ln in lines):
+            drained = True
+            break
+        time.sleep(3)
+    assert drained, (
+        "entdb_legal_hold_lift_pending did not drain to 0 after the lift — "
+        "the durable queue worker did not complete"
     )


### PR DESCRIPTION
Closes #511 — EPIC #511 Gap 1.

## What this does

When a tenant is under legal hold the archiver escalates archive writes to S3 Object Lock `LegalHold=ON`. When the tenant's hold is **explicitly released** (`SetLegalHold` OFF) the legal hold must be lifted on the objects **already written** to S3 — otherwise GDPR right-to-erasure-after-release is silently unfulfillable and the objects require manual S3 surgery.

## Why this was reworked (the problem with the first cut)

The first implementation launched the archive sweep as a **detached fire-and-forget goroutine** (`go func()`, 30-min timeout) directly from the `SetLegalHold` OFF RPC path. It was **not crash-durable**: a server restart, an S3 outage, or a run exceeding the timeout left a released tenant's objects stuck `LegalHold=ON` with **no automatic retry and no signal**. For a compliance feature that silently breaks GDPR erasure-after-release, that is unacceptable.

## Durable design (queue + retrying worker)

Mirrors the existing GDPR deletion-queue worker pattern.

1. **Durable enqueue (the key durability point).** `globalstore.ApplyLegalHoldSet` — the WAL-driven global apply step that deletes the `legal_holds` row and flips `tenant_registry.status` back to `active` — now, **in that same transaction**, upserts a row into a new `legal_hold_lift_queue` table (`tenant_id` PK, `enqueued_at`) on an explicit release. A crash *after* the release still has the pending lift durably recorded. `ON CONFLICT DO NOTHING` keeps the earliest `enqueued_at` so a re-release does not reset the age. The OFF RPC no longer spawns anything — it just causes the enqueue via the apply path and returns. The detached goroutine, its timeout constant, the `WithLegalHoldLifter` server seam, and the old main.go adapter are **deleted**.

2. **Background worker.** `internal/audit.LiftWorker` drains the queue on an interval (mirrors `gdpr.Processor`): flags `--legal-hold-lift-worker-enabled` (default `true`) and `--legal-hold-lift-worker-interval` (default `1m`). For each queued tenant it runs the existing **idempotent / resumable** paginated sweep. The queue row is deleted **only on full success**; any failure / partial / per-run timeout leaves the row so the **next tick resumes** (every sweep decision is derived from live S3 + globalstore state — no progress cursor to corrupt). Only does work when the archive sidecar is enabled.

3. **Observability (closes the no-signal gap).** New metrics: `entdb_legal_hold_lift_pending` (gauge — durable queue depth, the operator alert signal), `entdb_legal_hold_lift_completed_total`, `entdb_legal_hold_lift_errors_total`.

4. **Sweep correctness fully preserved** (only the trigger + execution model changed): per-partition shared-object safety (a still-held co-tenant keeps the shared object `ON`), `ObjectLockMode=COMPLIANCE` retain-until **never touched**, GDPR **never** lifts a hold (legal hold supersedes erasure — `DeleteUser` still refuses to queue while held), and the MinIO `PutObjectLegalHold` Content-MD5 middleware is kept.

5. **ADR-015** Gap-1 consequence updated to the durable design (persisted to a queue in the same txn as the release, retried by a background worker until complete, observable via metric, idempotent/resumable, shared-object-safe, COMPLIANCE never touched, GDPR never lifts). `docs/deployment.md` IAM comment updated (IAM actions `s3:GetObjectLegalHold` / `s3:PutObjectLegalHold` unchanged — the worker needs exactly the same actions).

## Testing (proves durability, not just happy path)

- **Durability** — `audit.TestLiftWorker_DurableRestart`: a pre-populated queue + a **fresh** worker with zero in-memory state completes the lift purely from the persisted queue + live S3 (models a crash/restart after the release committed).
- **No goroutine** — `api.TestSetLegalHold_Release_SpawnsNoGoroutine`: the OFF RPC does not grow the live goroutine count and records the lift durably in the queue instead. `api.TestSetLegalHold_Release_DurablyEnqueuesLift` asserts the same-txn enqueue + hold cleared.
- **Retry** — `audit.TestLiftWorker_RetryAfterTransientS3Error`: a transient S3 `ListObjectsV2` error on tick 1 retains the queue row and bumps `entdb_legal_hold_lift_errors_total`; tick 2 succeeds from the **same** persisted row and removes it.
- **Metrics** — `audit.TestLiftWorker_Metrics`: pending gauge tracks queue depth; completed counter advances per swept tenant.
- **Atomic enqueue** — `globalstore.TestApplyLegalHoldSet_ReleaseEnqueuesLiftAtomically` / `_ReReleaseKeepsEarliestEnqueuedAt` / `TestLegalHoldLiftQueue_CRUDRoundTrip`.
- **All pre-existing sweep correctness tests retained & green**: shared-object co-tenant-still-held, idempotent re-run (no extra PUTs), retention-untouched, other-tenant-untouched, pagination, list-error propagation, enable-does-not-trigger.
- **Archive e2e extended** (`tests/python/e2e/test_archive_object_lock.py`): set hold ON → archive → release → the **durable worker** (not a request-scoped goroutine) lifts `LegalHold=OFF` while `ObjectLockMode=COMPLIANCE` and `ObjectLockRetainUntilDate` are byte-for-byte unchanged; `entdb_legal_hold_lift_pending` is exported and drains to 0.

## Local CI

All green: `go vet ./...` + `go test ./...` (server), `go test -race ./internal/audit/ ./internal/gdpr/ ./internal/api/ ./internal/globalstore/`, Go SDK vet+test, `pytest tests/python/integration/` (103 passed), `ruff check` + `ruff format --check` clean, `run-e2e.sh` (22 passed/1 skipped), `run-archive-e2e.sh` (2 passed incl. the durable-lift e2e).