### PR TITLE
docs: regenerate sdk-go reference after #521

### DIFF
--- a/docs/generated/sdk-go.md
+++ b/docs/generated/sdk-go.md
@@ -320,7 +320,7 @@ func (a *Admin) CreateTenant(ctx context.Context, actor, tenantID, name string, 
     Pass WithRegion to pin the tenant to a specific geographic region (e.g.
     “WithRegion("eu-west-1")“); when omitted the server defaults the
     tenant to its own served region. The pinned region is reflected on
-    [TenantDetail.Region].
+    TenantDetail.Region.
 
 func (a *Admin) CreateUser(ctx context.Context, actor, userID, email, name string) (*UserInfo, error)
     CreateUser registers a new user in the global registry. “email“ is unique


### PR DESCRIPTION
Regenerates docs/generated/sdk-go.md against current main. #521's committed snapshot predated other merged SDK changes, leaving the file stale and the #40 docs-coverage guard red. One-file, generator-output only.