### PR TITLE
chore(go): drop conceptual Python references and port-era annotations

### DIFF
--- a/server/go/cmd/entdb-schema/check.go
+++ b/server/go/cmd/entdb-schema/check.go
@@ -1,8 +1,8 @@
 // `check` subcommand — verify the current schema is compatible with a
 // baseline snapshot. Exits 0 on compatible, 1 on breaking, 2 on error.
 //
-// Mirrors the deleted Python tool's UX. The classification rules live
-// in schema.Check; this subcommand is purely flag parsing + formatting.
+// The classification rules live in schema.Check; this subcommand is
+// purely flag parsing + formatting.
 
 package main
 

--- a/server/go/cmd/entdb-schema/decode.go
+++ b/server/go/cmd/entdb-schema/decode.go
@@ -6,7 +6,7 @@
 //   2. Bare body: {"node_types": [...], "edge_types": [...]}
 //      — what `(*Registry).MarshalJSON` emits directly.
 //
-// The Python-era `.schema-snapshot.json` files use shape (1). The
+// Snapshot files written by `entdb-schema snapshot` use shape (1). The
 // server's `GetSchema` RPC returns shape (2). Both must round-trip
 // through this decoder for the migration story in §6 of the issue to
 // hold.

--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -662,8 +662,7 @@ func schemaRegistryForProfile(profile string) (*schema.Registry, error) {
 }
 
 // splitBrokers parses a comma-separated broker list and returns
-// non-empty entries. Mirrors the way Python passes brokers as a single
-// string via KAFKA_BROKERS.
+// non-empty entries.
 func splitBrokers(s string) []string {
 	out := []string{}
 	for _, b := range strings.Split(s, ",") {

--- a/server/go/internal/acl/actor.go
+++ b/server/go/internal/acl/actor.go
@@ -36,7 +36,6 @@ const (
 )
 
 // String returns the canonical prefix without the trailing colon.
-// Mirrors the prefix strings used by the Python Principal type.
 func (k ActorKind) String() string {
 	switch k {
 	case ActorKindUser:

--- a/server/go/internal/acl/capability.go
+++ b/server/go/internal/acl/capability.go
@@ -23,8 +23,7 @@ const (
 	CoreCapAdmin CoreCapability = 5
 )
 
-// String returns the wire-stable name for a CoreCapability. Mirrors
-// the Python enum value names.
+// String returns the wire-stable name for a CoreCapability.
 func (c CoreCapability) String() string {
 	switch c {
 	case CoreCapUnspecified:

--- a/server/go/internal/acl/enforcer.go
+++ b/server/go/internal/acl/enforcer.go
@@ -8,9 +8,7 @@ import (
 )
 
 // Enforcer is the top-level ACL facade. One Enforcer per server; it
-// owns the Registry, Resolver, Checker and Filter. Mirrors the role
-// of AclManager + CapabilityRegistry + canonical_store ACL helpers in
-// the Python server.
+// owns the Registry, Resolver, Checker and Filter.
 //
 // Handlers in server/go/internal/api do not call Resolver / Checker /
 // Filter directly — they go through Enforcer so the (registry,

--- a/server/go/internal/acl/filter.go
+++ b/server/go/internal/acl/filter.go
@@ -6,7 +6,7 @@ import (
 	"context"
 )
 
-// VisibilityReader is the bulk read-path predicate. Mirrors the SQL
+// VisibilityReader is the bulk read-path predicate. Implements the SQL
 // JOIN against node_visibility post-filter pattern documented in
 // docs/go-port/shared/acl.md "Post-read filtering / SQL JOIN".
 //
@@ -29,8 +29,8 @@ type VisibilityReader interface {
 //
 // The Filter does NOT enforce typed-capability requirements beyond
 // READ; richer per-row checks (capability_mappings on field reads)
-// belong on the Checker single-node path. The Python server uses the
-// same split: SQL JOIN for read filtering, _check_capability for
+// belong on the Checker single-node path. The design uses a split:
+// SQL JOIN for read filtering, single-node capability check for
 // per-row authorization.
 type Filter struct {
 	resolver *Resolver

--- a/server/go/internal/acl/permission.go
+++ b/server/go/internal/acl/permission.go
@@ -23,23 +23,23 @@ const (
 	// "deny" in node_access.permission. The zero value is DENY, NOT
 	// "unspecified", matching the behaviour of an unset grant.
 	PermDeny Permission = iota
-	// PermRead — implies READ. Python "read".
+	// PermRead — implies READ. Stored as "read".
 	PermRead
-	// PermComment — implies READ, COMMENT. Python "comment".
+	// PermComment — implies READ, COMMENT. Stored as "comment".
 	PermComment
-	// PermWrite — implies READ, COMMENT, WRITE. Python "write".
+	// PermWrite — implies READ, COMMENT, WRITE. Stored as "write".
 	PermWrite
-	// PermShare — implies READ, COMMENT, WRITE, SHARE. Python "share".
+	// PermShare — implies READ, COMMENT, WRITE, SHARE. Stored as "share".
 	PermShare
 	// PermDelete — implies READ, COMMENT, WRITE, DELETE (NOT SHARE).
-	// Python "delete".
+	// Stored as "delete".
 	PermDelete
-	// PermAdmin — implies every positive permission. Python "admin".
+	// PermAdmin — implies every positive permission. Stored as "admin".
 	PermAdmin
 )
 
 // String returns the canonical lowercase form stored in
-// node_access.permission. Mirrors Permission.value in the Python enum.
+// node_access.permission.
 func (p Permission) String() string {
 	switch p {
 	case PermDeny:

--- a/server/go/internal/api/add_group_member.go
+++ b/server/go/internal/api/add_group_member.go
@@ -6,20 +6,14 @@
 //
 // # WAL-first restoration
 //
-// The Python handler writes group_users DIRECTLY via canonical_store
-// (bypassing the WAL, in violation of CLAUDE.md §1). The Go port
-// restores the WAL-first invariant: this handler appends an
+// This handler restores the WAL-first invariant: it appends an
 // `add_group_member` op to the per-tenant WAL and lets the Applier
-// (server/go/internal/apply/ops_add_group_member.go, op-type wired in
-// W1.10) materialize the row. A rebuild-from-empty-WAL therefore
-// reconstructs membership; the Python path silently loses it.
+// (server/go/internal/apply/ops_add_group_member.go) materialize the
+// row. A rebuild-from-empty-WAL therefore reconstructs membership.
 //
 // # Trusted-actor substitution
 //
-// The Python handler does NOT call `_trusted_actor` and never reads
-// `request.context.actor` for authorization — any authenticated caller
-// can mutate any group in any tenant they can reach. Pinned as a
-// privilege-escalation gap in commit fece3fb. The Go port closes it:
+// Privilege-escalation gap closed in commit fece3fb:
 //
 //  1. `auth.Authoritative(ctx, claimed)` is the single source of truth
 //     for caller identity. The wire-claimed `request.context.actor` is
@@ -33,7 +27,7 @@
 //
 //   - The op uses `INSERT OR REPLACE INTO group_users` (apply path), so
 //     a re-add with the same (group_id, member_actor_id) overwrites
-//     role + joined_at. Matches Python parity.
+//     role + joined_at.
 //   - The WAL Append carries an idempotency key derived from
 //     (tenant_id, group_id, member_actor_id, role) so a network retry
 //     of the same logical request returns the original StreamPos
@@ -47,8 +41,8 @@
 //	INVALID_ARGUMENT tenant_id / group_id / member_actor_id empty.
 //	PERMISSION_DENIED trusted actor is neither admin/system nor
 //	                    owner/admin member of tenant_id.
-//	OK + success=false WAL append failed (matches Python in-band
-//	                    error shape: gRPC OK, response.Error set).
+//	OK + success=false WAL append failed (in-band error shape:
+//	                    gRPC OK, response.Error set).
 //	OK + success=true WAL append accepted; apply happens
 //	                    asynchronously (caller fences via
 //	                    WaitForOffset on subsequent reads).
@@ -77,7 +71,7 @@ const addGroupMemberWALTopic = "entdb-wal"
 
 // AddGroupMember adds (or re-adds, idempotently) a member to a group.
 // See package-level doc for the WAL-first restoration and trusted-actor
-// substitution that diverge from the Python source.
+// substitution.
 func (s *Server) AddGroupMember(
 	ctx context.Context,
 	req *pb.GroupMemberRequest,
@@ -175,9 +169,9 @@ func (s *Server) AddGroupMember(
 		wal.HeaderIdempotencyKey: []byte(idempKey),
 	}
 	if _, err := s.producer.Append(ctx, addGroupMemberWALTopic, tenantID, value, headers); err != nil {
-		// Parity with Python: in-band error, gRPC OK. The spec calls
-		// this out explicitly (docs/go-port/rpcs/AddGroupMember.md
-		// "Error contract" status-code parity quirk).
+		// In-band error, gRPC OK. The spec calls this out explicitly
+		// (docs/go-port/rpcs/AddGroupMember.md "Error contract"
+		// status-code parity quirk).
 		statusLabel = "error"
 		return &pb.GroupMemberResponse{Success: false, Error: err.Error()}, nil
 	}

--- a/server/go/internal/api/add_group_member_test.go
+++ b/server/go/internal/api/add_group_member_test.go
@@ -1,22 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Tests for AddGroupMember. The Go handler diverges from the Python
-// source on two CLAUDE.md-flagged invariants — see
+// Tests for AddGroupMember. Two CLAUDE.md-flagged invariants — see
 // add_group_member.go's package-level doc:
 //
-//  1. WAL-first restoration. The Python handler writes group_users
-//     directly via canonical_store, bypassing the WAL. The Go handler
-//     appends an `add_group_member` op to the per-tenant WAL and lets
-//     the Applier materialize the row. Tests assert on what landed on
-//     the WAL — they do NOT poke at SQLite, because the apply path is
-//     covered separately in apply/ops_add_group_member.go's tests.
+//  1. WAL-first restoration. The handler appends an `add_group_member`
+//     op to the per-tenant WAL and lets the Applier materialize the
+//     row. Tests assert on what landed on the WAL — they do NOT poke at
+//     SQLite, because the apply path is covered separately in
+//     apply/ops_add_group_member.go's tests.
 //
-//  2. Trusted-actor substitution. The Python handler honours the
-//     wire-claimed actor; the Go handler ignores it and resolves
-//     identity via auth.Authoritative. The non-admin denial test below
-//     pins the privilege-escalation regression (commit fece3fb): a
-//     bob-authenticated session that claims admin:root in the request
-//     body is rejected as user:bob.
+//  2. Trusted-actor substitution. The handler ignores the wire-claimed
+//     actor and resolves identity via auth.Authoritative. The non-admin
+//     denial test below pins the privilege-escalation regression
+//     (commit fece3fb): a bob-authenticated session that claims
+//     admin:root in the request body is rejected as user:bob.
 //
 // Coverage:
 //

--- a/server/go/internal/api/add_tenant_member.go
+++ b/server/go/internal/api/add_tenant_member.go
@@ -28,7 +28,7 @@
 //
 //   - Append/wait for a global `member_added` WAL op.
 //   - NO mailbox / notification fanout. The added member is silent —
-//     discovery is via GetUserTenants. Matches Python parity.
+//     discovery is via GetUserTenants.
 //   - NO FK validation on tenant_id / user_id. Both can refer to rows
 //     that were never created — preserved for parity (see the spec's
 //     "Open questions / risks" section; harden in a separate ticket).

--- a/server/go/internal/api/archive_tenant.go
+++ b/server/go/internal/api/archive_tenant.go
@@ -5,18 +5,15 @@
 //
 // Wire contract: proto/entdb/v1/entdb.proto:120 (rpc), :890-898 (messages).
 //
-// Behavioural parity with Python is preserved deliberately, including the
-// known gap below. The handler:
+// The handler:
 //
 //   - Returns UNIMPLEMENTED when global_store is not wired.
 //   - Returns INVALID_ARGUMENT for empty actor / tenant_id.
 //   - Resolves the trusted actor via auth.Authoritative (CLAUDE.md
 //     trusted-actor invariant — see docs/go-port/shared/auth-interceptor.md).
-//   - narrowing: only system: / admin: actors may archive. The
-//     Python handler additionally lets the tenant "owner" archive after a
-//     member-role lookup; the Go port restricts this to admin-only for now.
-//     The owner branch will land alongside the WAL-first restoration (see
-//     "Known gaps" below).
+//   - narrowing: only system: / admin: actors may archive. The owner
+//     branch will land alongside the WAL-first restoration (see "Known
+//     gaps" below).
 //   - Appends a global `tenant_archived` WAL op and waits for the applier
 //     to set tenant_registry.status = "archived". Re-archiving an already-
 //     archived tenant is idempotent and returns success=true.
@@ -26,10 +23,9 @@
 // Known gaps:
 //
 //  1. No archiver / cold-storage handoff, no member or API-key revocation.
-//     Mirrors Python's no-op-after-flag behaviour.
 //  2. Legal-hold collision: `archived` and `legal_hold` share one status
 //     column. Spec "Open questions" item 1 flags this. We do not gate on
-//     current status here — Python doesn't either.
+//     current status here.
 
 package api
 
@@ -84,12 +80,11 @@ func (s *Server) ArchiveTenant(
 	// rebind to the interceptor-bound identity before any authz decision.
 	// In no-auth deployments / unit tests with no Identity on ctx, the
 	// claimed actor is returned as-is (auth.Authoritative documented
-	// fallback) — matching the Python ContextVar fall-through.
+	// fallback).
 	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
 
-	//  narrowing: admin-only. The Python handler also allows the
-	// tenant owner via a member-role lookup; owner-allowed archive remains
-	// a separate authz follow-up.
+	//  narrowing: admin-only. Owner-allowed archive remains a separate
+	// authz follow-up.
 	if !trusted.IsAdmin() && !trusted.IsSystem() {
 		status = "error"
 		return nil, errs.Errorf(codes.PermissionDenied,

--- a/server/go/internal/api/cancel_user_deletion.go
+++ b/server/go/internal/api/cancel_user_deletion.go
@@ -14,11 +14,9 @@
 //     payload's `actor` is UNTRUSTED post-#168.
 //   - "Within grace window" is enforced by the pre-read of deletion_queue.
 //     If the GDPR worker has already swept the row to 'completed', this
-//     RPC is a silent no-op:
-//     success=false, error="" — IDENTICAL to the Python parity contract
-//     (see spec "Error contract" table). The Go port does NOT promote
-//     past-no-return to FAILED_PRECONDITION; that's a documented v2
-//     follow-up (separate proto + store + test change).
+//     RPC is a silent no-op: success=false, error="" (see spec "Error
+//     contract" table). Promoting past-no-return to FAILED_PRECONDITION
+//     is a documented v2 follow-up (separate proto + store + test change).
 //   - On successful cancel, append/wait for a global
 //     `user_deletion_canceled` WAL op. The applier removes the pending
 //     deletion_queue row and flips user_registry.status back to "active"
@@ -89,8 +87,8 @@ func (s *Server) CancelUserDeletion(ctx context.Context, req *pb.CancelUserDelet
 		return &pb.CancelUserDeletionResponse{Success: false, Error: err.Error()}, nil
 	}
 	if entry == nil || entry.Status != "pending" {
-		// In-band no-op: row never existed or already completed. Same
-		// metric label ("ok") as Python — no abort fires.
+		// In-band no-op: row never existed or already completed.
+		// No abort fires; metric label stays "ok".
 		return &pb.CancelUserDeletionResponse{Success: false}, nil
 	}
 

--- a/server/go/internal/api/cancel_user_deletion_test.go
+++ b/server/go/internal/api/cancel_user_deletion_test.go
@@ -1,7 +1,5 @@
-// Tests for the CancelUserDeletion RPC. The four Python contract pins
-// in docs/go-port/rpcs/CancelUserDeletion.md ("Contract tests pinning
-// behavior") collapse to three behaviours in the Go port — happy
-// within-grace cancel, past-no-return silent no-op, and the
+// Tests for the CancelUserDeletion RPC. Three behaviours are covered:
+// happy within-grace cancel, past-no-return silent no-op, and the
 // trusted-actor escalation guard. Each test below covers one arm.
 //
 // The auth helper withTrustedUser is defined in update_user_test.go

--- a/server/go/internal/api/change_member_role.go
+++ b/server/go/internal/api/change_member_role.go
@@ -4,24 +4,18 @@
 //
 // Port spec: docs/go-port/rpcs/ChangeMemberRole.md.
 //
-// Behaviour parity vs. the Python handler is preserved on the wire shape
-// (request/response, error code asymmetry between auth-failure and
-// missing-row), but two PLAN.md §6 drifts are folded in here:
+// Two PLAN.md §6 improvements are folded in here:
 //
 //  1. WAL-first global mutation. The handler appends a global
 //     `member_role_changed` op and waits for the applier to update the
 //     tenant_members row; it does not write globalstore directly.
 //
-//  2. Last-owner demotion protection. The Python handler (spec §"Open
-//     questions" item 2) lets the sole owner demote themselves and
-//     brick the tenant. The Go port adds an explicit check: if the
+//  2. Last-owner demotion protection. An explicit check: if the
 //     target user is the only "owner" row in tenant_members and
-//     new_role != "owner", reject with FAILED_PRECONDITION. This is
-//     the §6 drift the spec asked us to add on the Go side.
+//     new_role != "owner", reject with FAILED_PRECONDITION.
 //
 //  3. Region pin gap (spec §"Open questions" item 5). Not fixed here —
-//     parity preserved; the Go handler does NOT call s.checkTenant.
-//     Filed as a follow-up.
+//     the handler does NOT call s.checkTenant. Filed as a follow-up.
 
 package api
 
@@ -51,8 +45,7 @@ const grpcMethodChangeMemberRole = "ChangeMemberRole"
 //
 // Last-owner protection: if the target user is the sole "owner" of the
 // tenant and the new role is not "owner", the call is rejected with
-// codes.FailedPrecondition. This is a Go-side improvement over the
-// Python handler's silent self-brick.
+// codes.FailedPrecondition.
 func (s *Server) ChangeMemberRole(
 	ctx context.Context,
 	req *pb.ChangeMemberRoleRequest,
@@ -142,7 +135,7 @@ func (s *Server) ChangeMemberRole(
 	}
 
 	if !targetFound {
-		// Soft failure (matches Python: gRPC OK, response.success=false).
+		// Soft failure: gRPC OK, response.success=false.
 		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "ok", time.Since(start))
 		return &pb.ChangeMemberRoleResponse{Success: false, Error: "Member not found"}, nil
 	}

--- a/server/go/internal/api/change_member_role_test.go
+++ b/server/go/internal/api/change_member_role_test.go
@@ -1,7 +1,6 @@
 // Tests for ChangeMemberRole. Behavioural pins are documented in
-// docs/go-port/rpcs/ChangeMemberRole.md. The Go-side drift this file
-// enforces is the last-owner demotion protection (PLAN.md §6) — the
-// Python handler does NOT have this and the Go port adds it.
+// docs/go-port/rpcs/ChangeMemberRole.md. The last-owner demotion
+// protection (PLAN.md §6) is an improvement added in the Go port.
 
 package api_test
 
@@ -85,8 +84,7 @@ func TestChangeMemberRole_AdminPromotesMember(t *testing.T) {
 }
 
 // TestChangeMemberRole_AdminDemotesAdmin pins the demote path and
-// confirms admin role grants the privilege (not just owner — Go
-// widens the Python "owner-only" rule).
+// confirms admin role grants the privilege (not just owner).
 func TestChangeMemberRole_AdminDemotesAdmin(t *testing.T) {
 	t.Parallel()
 
@@ -127,8 +125,7 @@ func TestChangeMemberRole_AdminDemotesAdmin(t *testing.T) {
 
 // TestChangeMemberRole_NonAdminDenied pins the negative path: a plain
 // member (carol) attempting to mutate roles is rejected with
-// PERMISSION_DENIED. Mirrors the Python pin
-// `test_change_role_by_member_denied`.
+// PERMISSION_DENIED.
 func TestChangeMemberRole_NonAdminDenied(t *testing.T) {
 	t.Parallel()
 

--- a/server/go/internal/api/create_tenant.go
+++ b/server/go/internal/api/create_tenant.go
@@ -38,11 +38,9 @@ import (
 //   - Wire actor (req.Actor) is UNTRUSTED. The trusted principal is
 //     resolved via auth.Authoritative(ctx, claimed) — privilege-escalation
 //     remediation per commit fece3fb.
-//   - Admin-only: decision deviating from current Python (which
-//     has no admin gate today). Any caller whose trusted actor is not
-//     admin: or system: gets PERMISSION_DENIED. This closes the multi-
-//     tenant abuse vector flagged in the spec ("Admin gate" open
-//     question).
+//   - Admin-only: any caller whose trusted actor is not admin: or system:
+//     gets PERMISSION_DENIED. This closes the multi-tenant abuse vector
+//     flagged in the spec ("Admin gate" open question).
 func (s *Server) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) (*pb.CreateTenantResponse, error) {
 	start := time.Now()
 	resultStatus := "ok"

--- a/server/go/internal/api/create_tenant_test.go
+++ b/server/go/internal/api/create_tenant_test.go
@@ -95,8 +95,8 @@ func TestCreateTenant_AdminHappyPath(t *testing.T) {
 	if len(members) != 1 {
 		t.Fatalf("members: got %d, want 1 (%+v)", len(members), members)
 	}
-	// The admin's bare ID (without the "admin:" prefix) is what's stored
-	// as the user_id, mirroring _actor_user_id in the Python source.
+	// The admin's bare ID (without the "admin:" prefix) is stored as
+	// the user_id.
 	if members[0].UserID != "root" {
 		t.Fatalf("owner user_id: got %q, want %q", members[0].UserID, "root")
 	}
@@ -157,10 +157,8 @@ func TestCreateTenant_NonAdminPermissionDenied(t *testing.T) {
 }
 
 // TestCreateTenant_DuplicateAlreadyExists: a second CreateTenant with the
-// same tenant_id surfaces as ALREADY_EXISTS. ( deviates from
-// Python's success=false channel for typed-error ergonomics; spec note
-// in CreateTenant.md "Error contract" allows the deviation in the Go
-// port.)
+// same tenant_id surfaces as ALREADY_EXISTS (spec note in
+// CreateTenant.md "Error contract").
 func TestCreateTenant_DuplicateAlreadyExists(t *testing.T) {
 	t.Parallel()
 	f := newAdminWALFixture(t, api.WithRegion("us-east-1"))

--- a/server/go/internal/api/create_user_test.go
+++ b/server/go/internal/api/create_user_test.go
@@ -8,10 +8,8 @@
 //   - Empty required field aborts with INVALID_ARGUMENT.
 //
 // The Go port deliberately upgrades the duplicate-key path to
-// codes.AlreadyExists (the Python handler returns OK+success=false). The
-// spec calls this out as an acceptable parity break — the Python contract
-// test only inspects success=false, which is no longer reachable, but the
-// upgraded code is a strict superset of information.
+// codes.AlreadyExists. The spec calls this out as an acceptable
+// deviation — the upgraded code is a strict superset of information.
 
 package api_test
 

--- a/server/go/internal/api/delegate_access.go
+++ b/server/go/internal/api/delegate_access.go
@@ -8,17 +8,10 @@
 //
 // # Closes the silent-drop bug
 //
-// The Python handler appended an `admin_delegate_access` event to the WAL
-// but the applier had NO dispatch branch for it — events were silently
-// dropped on replay. The Python handler also direct-wrote via
-// canonical_store, bypassing the WAL (CLAUDE.md invariant #1 violation).
-//
-// W1.10 closed the applier-side gap on Go (apply/ops_delegate_access.go).
 // This handler closes the gRPC-side gap by emitting a per-node
 // `delegate_access` op for every node owned by `from_user`, so the
-// applier can materialise each grant. With W1.10 + W2.DelegateAccess in
-// place, an admin's bulk delegation survives a WAL replay — which is
-// the contract Python silently breaks.
+// applier (apply/ops_delegate_access.go) can materialise each grant.
+// An admin's bulk delegation now survives a WAL replay.
 //
 // # Behavioural pins
 //
@@ -33,7 +26,7 @@
 //     are persisted but filtered at read time by the visibility joins.
 //   - WAL-first (CLAUDE.md invariant #1): we emit one
 //     `delegate_access` op per node owned by from_user inside a single
-//     TransactionEvent. The applier (W1.10) materialises each into a
+//     TransactionEvent. The applier materialises each into a
 //     node_access row keyed (node_id, actor_id) with granted_by =
 //     trusted-actor.
 //   - `delegated` echo: the count of nodes the owner held at handler-call
@@ -214,7 +207,7 @@ func (s *Server) DelegateAccess(
 
 // listNodesByOwner returns every node_id whose owner_actor matches
 // fromUser inside tenantID. The silent-drop bug meant this SELECT was
-// not run on replay; W1.10 closed that gap.
+// not run on replay; the applier fix closed that gap.
 //
 // We open the tenant DB lazily so a fresh tenant with no nodes still
 // returns an empty slice rather than a "tenant not open" error.

--- a/server/go/internal/api/delegate_access_test.go
+++ b/server/go/internal/api/delegate_access_test.go
@@ -6,13 +6,9 @@
 // docs/go-port/rpcs/DelegateAccess.md "Implementation outline":
 //
 //  1. Admin delegates -> grant materialises after the applier picks up
-//     the WAL event. THIS is the test that proves the
-//     silent-drop bug is fixed: the Python applier had no
-//     admin_delegate_access dispatch branch, so the WAL event was
-//     appended-and-ignored. With the Go applier (W1.10) + this handler
-//     (W2) wired through an in-memory WAL + canonical store, the grant
-//     becomes a row in node_access on replay -- which is the contract
-//     Python silently breaks today.
+//     the WAL event. THIS is the test that proves the silent-drop bug
+//     is fixed: the applier's delegate_access dispatch branch
+//     materialises the grant into a node_access row on replay.
 //
 //  2. Non-admin caller -> PERMISSION_DENIED. Closes the wire-payload
 //     trust gap (privilege-escalation regression pinned by commit
@@ -162,7 +158,7 @@ func (f *delegateFixture) appendCreateNode(t *testing.T, tenantID, nodeID, owner
 }
 
 // waitForIdempKey polls until idemKey appears in applied_events for
-// tenantID, or the deadline fires. Mirrors the apply package's helper.
+// tenantID, or the deadline fires.
 func (f *delegateFixture) waitForIdempKey(t *testing.T, tenantID, idemKey string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -215,12 +211,10 @@ func (f *delegateFixture) waitForGrant(t *testing.T, tenantID, nodeID, actorID s
 //
 // Setup: alice (owner) owns two nodes in acme. carol (admin) calls
 // DelegateAccess(from=alice, to=bob, permission=read). The handler
-// emits two delegate_access ops on the WAL; the applier (W1.10
-// dispatch branch) materialises both into node_access rows.
+// emits two delegate_access ops on the WAL; the applier materialises
+// both into node_access rows.
 //
-// Pinned by docs/go-port/rpcs/DelegateAccess.md §"Open questions" item 1:
-// the Python applier silently drops admin_delegate_access events; the
-// Go applier MUST close that gap.
+// Pinned by docs/go-port/rpcs/DelegateAccess.md §"Open questions" item 1.
 func TestDelegateAccess_AdminDelegatesGrantMaterialisesAfterApply(t *testing.T) {
 	t.Parallel()
 	f := newDelegateFixture(t)
@@ -263,8 +257,7 @@ func TestDelegateAccess_AdminDelegatesGrantMaterialisesAfterApply(t *testing.T) 
 	}
 
 	// THIS is the bug-closed assertion: the applier must materialise
-	// the grant for both nodes. If the applier silently dropped the
-	// event (the Python bug), waitForGrant times out.
+	// the grant for both nodes.
 	for _, nodeID := range []string{"doc1", "doc2"} {
 		perm, exp := f.waitForGrant(t, tenantID, nodeID, "user:bob")
 		if perm != "read" {

--- a/server/go/internal/api/delete_user.go
+++ b/server/go/internal/api/delete_user.go
@@ -34,15 +34,14 @@
 //     and flip user_registry.status to "pending_deletion" in one
 //     globalstore transaction.
 //
-// Legal-hold gate (NEW behavior, behind a flag):
+// Legal-hold gate (behind a flag):
 //
-// The Python handler does not check legal hold at queue time. Per spec
-// "Side effects" / "Open questions" §4 the Go port adds an explicit
-// FAILED_PRECONDITION gate: before queueing, walk
-// globalstore.GetUserTenants and reject if any tenant has a legal_holds
-// row (globalstore.IsLegalHoldSet). The check is gated on
-// Server.WithLegalHoldOnDelete(true) so day-zero parity tests pass with
-// the gate disabled; production deployments MUST flip this on once a
+// Per spec "Side effects" / "Open questions" §4, before queueing the
+// handler walks globalstore.GetUserTenants and rejects with
+// FAILED_PRECONDITION if any tenant has a legal_holds row
+// (globalstore.IsLegalHoldSet). The check is gated on
+// Server.WithLegalHoldOnDelete(true) so bring-up tests pass with the
+// gate disabled; production deployments MUST flip this on once a
 // contract test has pinned the new behavior.
 //
 // DeleteUser is a global WAL mutation. The actual erasure events emitted
@@ -114,9 +113,8 @@ func (s *Server) DeleteUser(ctx context.Context, req *pb.DeleteUserRequest) (*pb
 			"DeleteUser requires the user themselves or an admin actor")
 	}
 
-	// Existence check. The Python handler returns OK + success=false on
-	// a missing user — keep that asymmetric contract for SDK parity. Do
-	// NOT promote to NOT_FOUND.
+	// Existence check. A missing user is reported in-band: success=false,
+	// error="User not found". Do NOT promote to NOT_FOUND.
 	user, err := s.global.GetUser(ctx, userID)
 	if err != nil {
 		outcome = "error"
@@ -137,10 +135,9 @@ func (s *Server) DeleteUser(ctx context.Context, req *pb.DeleteUserRequest) (*pb
 		}, nil
 	}
 
-	// Optional legal-hold gate (Go-port addition). Walk the user's
-	// tenants and reject with FAILED_PRECONDITION if any is held. The
-	// gate is off by default to keep day-zero parity with Python; flip
-	// via api.WithLegalHoldOnDelete(true).
+	// Optional legal-hold gate. Walk the user's tenants and reject with
+	// FAILED_PRECONDITION if any is held. The gate is off by default;
+	// flip via api.WithLegalHoldOnDelete(true).
 	if s.legalHoldOnDelete {
 		members, mErr := s.global.GetUserTenants(ctx, userID)
 		if mErr != nil {

--- a/server/go/internal/api/delete_user_test.go
+++ b/server/go/internal/api/delete_user_test.go
@@ -14,11 +14,10 @@
 //   4. Already-pending → idempotent: re-queueing returns the EXISTING
 //      requested_at / execute_at (does NOT push the timestamps forward).
 //
-// Plus the standard config / required-arg gates carried over from the
-// Python contract: Unimplemented when globalstore is not wired,
-// InvalidArgument for empty actor / user_id, PermissionDenied when a
-// non-admin tries to delete another user, and OK + success=false +
-// error="User not found" for an unknown user.
+// Plus the standard config / required-arg gates: Unimplemented when
+// globalstore is not wired, InvalidArgument for empty actor / user_id,
+// PermissionDenied when a non-admin tries to delete another user, and
+// OK + success=false + error="User not found" for an unknown user.
 
 package api_test
 
@@ -128,8 +127,7 @@ func TestDeleteUser_Admin_HappyPath(t *testing.T) {
 
 // TestDeleteUser_LegalHold_Blocks: when WithLegalHoldOnDelete(true), a
 // user belonging to a tenant with a legal_holds row gets
-// FAILED_PRECONDITION. NEW Go-port behaviour (Python has no such gate
-// at queue time); see DeleteUser.md "Side effects" §4.
+// FAILED_PRECONDITION. See DeleteUser.md "Side effects" §4.
 func TestDeleteUser_LegalHold_Blocks(t *testing.T) {
 	t.Parallel()
 	f := newAdminWALFixture(t)

--- a/server/go/internal/api/execute_atomic.go
+++ b/server/go/internal/api/execute_atomic.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// W2 — ExecuteAtomic RPC (Python -> Go server port, EPIC #407).
+// ExecuteAtomic RPC.
 //
 // Spec: docs/go-port/rpcs/ExecuteAtomic.md. This is the central write
 // path for the entire system: every mutation enters via this handler,
@@ -15,8 +15,7 @@
 //	     for create_node.data / update_node.patch are translated to
 //	     id-keyed maps via payload.StructToPayload before WAL append.
 //
-// Key behaviours (pinned by the Python contract tests, see spec §
-// "Contract tests"):
+// Key behaviours (pinned by contract tests, see spec § "Contract tests"):
 //
 //   - The wire-claimed actor (req.context.actor) is UNTRUSTED. The
 //     handler resolves the trusted identity via auth.Authoritative and
@@ -145,8 +144,7 @@ func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest
 	}
 
 	// Tenant-membership + role + status check. Best-effort: skipped when
-	// no globalstore is wired (single-node bring-up / no-auth tests),
-	// matching the Python `if self.global_store is not None` guard.
+	// no globalstore is wired (single-node bring-up / no-auth tests).
 	hasDelete := false
 	for _, op := range ops {
 		switch op["op"].(string) {
@@ -163,22 +161,21 @@ func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest
 	// op order, and resolve in-transaction "$alias" references on edge
 	// from/to so the WAL event only ever carries concrete node ids.
 	//
-	// Why resolve at ingress (deviation from Python, which resolves at
-	// apply time): the WAL is the audit-of-record; a bare UUID is a
-	// stable, unambiguous identity, whereas "$alias" is meaningful only
-	// in the context of one in-flight transaction. Resolving here keeps
-	// the applier dispatch table free of map-shape branching for the
-	// alias_ref payload and prevents alias bugs from poisoning the
-	// consumer loop (the original symptom: "poison event: create_edge
-	// missing from/to" halted the applier for every subsequent RPC).
+	// Why resolve at ingress: the WAL is the audit-of-record; a bare
+	// UUID is a stable, unambiguous identity, whereas "$alias" is
+	// meaningful only in the context of one in-flight transaction.
+	// Resolving here keeps the applier dispatch table free of map-shape
+	// branching for the alias_ref payload and prevents alias bugs from
+	// poisoning the consumer loop (the original symptom: "poison event:
+	// create_edge missing from/to" halted the applier for every
+	// subsequent RPC).
 	//
 	// Ordering: we walk ops in declared order. Each create_node with an
 	// "as" field publishes its (server-filled) id into the alias map;
 	// subsequent edge ops referencing that alias resolve against the
 	// map. A reference to an alias that has not been previously defined
-	// in the SAME transaction is an INVALID_ARGUMENT — matches the
-	// Python applier's lookup miss (which would surface as a poison
-	// event today). Aliases never span transactions.
+	// in the SAME transaction is an INVALID_ARGUMENT. Aliases never
+	// span transactions.
 	createdNodeIDs := make([]string, 0)
 	aliasMap := make(map[string]string)
 	for _, op := range ops {
@@ -641,7 +638,7 @@ func (s *Server) translatePrecondition(typeID int32, pre *pb.UpdateNodePrecondit
 
 // translatePayload runs name->id translation for a create_node.data /
 // update_node.patch struct. The schema-less / unknown-type-id path is a
-// digit-key passthrough (matches Python's lazy schema fallthrough).
+// digit-key passthrough.
 //
 // The result is stored under the op's "data"/"patch" key as
 // map[string]any with stringified field-id keys — that's the shape the
@@ -665,7 +662,7 @@ func (s *Server) translatePayload(typeID int32, st *structpb.Struct) (map[string
 }
 
 // convertACL maps the wire AclEntry slice to the internal list-of-dicts
-// the applier expects. Mirrors _acl_proto_to_list in the Python handler.
+// the applier expects.
 func convertACL(in []*pb.AclEntry) []any {
 	if len(in) == 0 {
 		return nil
@@ -711,8 +708,8 @@ func resolveEdgeRef(raw any, aliasMap map[string]string) (string, error) {
 			return "", fmt.Errorf("missing node reference")
 		}
 		if strings.HasPrefix(v, "$") {
-			// Bare "$alias" string is the Python on-the-wire
-			// short-form some SDKs emit when bypassing NodeRef.
+			// Bare "$alias" string is a short-form some SDKs emit
+			// when bypassing NodeRef.
 			// Treat it identically to {"ref":"$alias"}.
 			return resolveAlias(v, aliasMap)
 		}
@@ -840,9 +837,8 @@ func (s *Server) checkTenantWriteAccess(ctx context.Context, tenantID string, ac
 	}
 
 	if !actor.IsUser() {
-		// Group / unknown actor kinds aren't valid callers — the Python
-		// gate rejects these at the auth layer; here we treat them as
-		// non-members for defensive parity.
+		// Group / unknown actor kinds aren't valid callers — treat them as
+		// non-members.
 		return errs.Errorf(codes.PermissionDenied,
 			"actor %q is not a member of tenant %q", actor.String(), tenantID)
 	}

--- a/server/go/internal/api/execute_atomic_test.go
+++ b/server/go/internal/api/execute_atomic_test.go
@@ -1,6 +1,6 @@
-// Tests for the ExecuteAtomic RPC (W2 — EPIC #407).
+// Tests for the ExecuteAtomic RPC.
 //
-// Coverage targets the Python contract pins listed in
+// Coverage targets the contract pins listed in
 // docs/go-port/rpcs/ExecuteAtomic.md "Contract tests pinning behavior":
 //
 //   - Empty op list -> INVALID_ARGUMENT.
@@ -461,8 +461,7 @@ func TestExecuteAtomic_PayloadIsFieldIDKeyed(t *testing.T) {
 }
 
 // TestExecuteAtomic_UnknownFieldNameDropped: an unknown name on the
-// wire is silently dropped (matches Python ingress permissiveness). The
-// WAL event keeps the known field only.
+// wire is silently dropped. The WAL event keeps the known field only.
 func TestExecuteAtomic_UnknownFieldNameDropped(t *testing.T) {
 	t.Parallel()
 	f := newXAFixture(t)
@@ -807,15 +806,15 @@ func tenantShardingDeny() *tenant.Sharding {
 }
 
 // =============================================================================
-// W7 — $alias resolution at gRPC ingress.
+// $alias resolution at gRPC ingress.
 //
-// The Python SDK emits {"alias_ref": "$charlie"} for edge endpoints
-// declared with as_="charlie" on a sibling create_node. Before the W7
-// fix the Go server forwarded that ref untouched to the WAL, the
-// applier read op["from"] as an empty string (it's a map, not a
-// string), and halted with "poison event: create_edge missing from/to"
-// — which then took every subsequent RPC down with UNAVAILABLE because
-// the applier's consumer loop was dead.
+// Edge endpoints declared with as_="charlie" on a sibling create_node
+// arrive as {"alias_ref": "$charlie"}. Before the fix the Go server
+// forwarded that ref untouched to the WAL, the applier read op["from"]
+// as an empty string (it's a map, not a string), and halted with
+// "poison event: create_edge missing from/to" — which then took every
+// subsequent RPC down with UNAVAILABLE because the applier's consumer
+// loop was dead.
 //
 // These tests pin the new behavior: aliases are resolved against a
 // per-transaction map at the handler, the WAL only ever sees bare
@@ -1024,8 +1023,7 @@ func TestExecuteAtomic_AliasResolution_UnresolvedAliasRejected(t *testing.T) {
 // TestExecuteAtomic_AliasResolution_ForwardReferenceRejected pins that
 // aliases are resolved in op order: an edge that references an alias
 // defined LATER in the same transaction must fail, not silently
-// half-work. (Python parity: the applier's alias map is populated
-// linearly too.)
+// half-work. The alias map is populated linearly.
 func TestExecuteAtomic_AliasResolution_ForwardReferenceRejected(t *testing.T) {
 	t.Parallel()
 	f := newXAFixture(t)
@@ -1190,8 +1188,8 @@ func TestExecuteAtomic_AliasResolution_DeleteEdgeAlias(t *testing.T) {
 }
 
 // TestExecuteAtomic_AliasResolution_DottedFormSupported pins the
-// Python-parity dotted-alias form: "$alice.id" resolves the same as
-// "$alice". The dotted form is supported for legacy reasons.
+// dotted-alias form: "$alice.id" resolves the same as "$alice".
+// The dotted form is supported for legacy reasons.
 func TestExecuteAtomic_AliasResolution_DottedFormSupported(t *testing.T) {
 	t.Parallel()
 	f := newXAFixture(t)

--- a/server/go/internal/api/export_user_data.go
+++ b/server/go/internal/api/export_user_data.go
@@ -23,24 +23,20 @@
 //     "updated_at","owner_actor","data_policy"}]}]}.
 //   - `payload` stays field-id-keyed (CLAUDE.md invariant #6) — the
 //     handler does not translate to field names.
-//   - Read-only RPC: no WAL append, no SQLite writes. Python's open
-//     question #3 (audit-record the export itself via WAL) is left as
-//     a follow-up — preserving current behavior keeps parity tight.
+//   - Read-only RPC: no WAL append, no SQLite writes. Audit-recording
+//     the export itself via WAL is left as a follow-up (open question
+//     #3 in the spec).
 //   - Streaming export is deferred to Phase 2 (open question #1 in the
 //     spec): the bundle is built in-memory and returned inline as
-//     `export_json`. A 10M-node user will OOM the server today; the
-//     port matches that pathology rather than silently changing the
-//     wire shape.
-//   - Go-port delta vs Python: aborts use real status.Errorf returns
-//     rather than the Python try/except envelope. The
-//     `success=false, error=…` in-band branch only fires for genuine
-//     internal errors (json.Marshal of the bundle), matching the spec's
-//     "real aborts" note.
+//     `export_json`. A 10M-node user will OOM the server today.
+//   - Aborts use real status.Errorf returns. The `success=false,
+//     error=…` in-band branch only fires for genuine internal errors
+//     (json.Marshal of the bundle), matching the spec's "real aborts"
+//     note.
 //
 // Metrics: emits entdb_grpc_requests_total{method="ExportUserData",
 // status="ok"|"error"} via the shared chokepoint, on every code path
-// (including aborts) — matches the Python handler which always records
-// before re-raising.
+// (including aborts).
 
 package api
 

--- a/server/go/internal/api/export_user_data_test.go
+++ b/server/go/internal/api/export_user_data_test.go
@@ -1,4 +1,4 @@
-// Tests for the ExportUserData RPC (W2 — EPIC #407, GDPR Article 20).
+// Tests for the ExportUserData RPC (GDPR Article 20).
 //
 // Spec: docs/go-port/rpcs/ExportUserData.md.
 //
@@ -140,7 +140,7 @@ func TestExportUserData_Admin_HappyPath(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
 
 	// admin:root is the trusted caller; the wire `actor` is also set to
-	// admin:root for parity with how Python's contract test invokes it.
+	// admin:root for parity with the contract test.
 	resp, err := srv.ExportUserData(withTrustedUser(ctx, "admin:root"), &pb.ExportUserDataRequest{
 		Actor:  "admin:root",
 		UserId: "alice",

--- a/server/go/internal/api/freeze_gate.go
+++ b/server/go/internal/api/freeze_gate.go
@@ -30,8 +30,7 @@ import (
 // mutatingMethods is the allow-list of gRPC full method names that
 // trigger the freeze gate. Reads (Get*, List*, Search*, Query*,
 // Health, GetSchema, GetReceiptStatus, WaitForOffset, ExportUserData)
-// are intentionally absent — `_check_tenant_access(require_write=False)`
-// returns the role even for frozen users.
+// are intentionally absent — read access is permitted even for frozen users.
 //
 // Self-targeted admin RPCs (FreezeUser unfreeze, CancelUserDeletion,
 // DeleteUser) are also absent because they MUST remain callable
@@ -111,10 +110,8 @@ func (s *Server) checkFreezeGate(ctx context.Context, fullMethod string) error {
 		return errs.Internal(ctx, "freeze-gate: lookup user", err)
 	}
 	if user == nil {
-		// Unknown user — fail closed (Python does the same: an
-		// unknown user has no membership, so `_check_tenant_access`
-		// aborts PERMISSION_DENIED). The exact message differs from
-		// Python; keep it precise.
+		// Unknown user — fail closed. An unknown user has no
+		// membership; deny.
 		return status.Errorf(codes.PermissionDenied, "freeze-gate: user %q not found", trusted.ID())
 	}
 	if isFrozenStatus(user.Status) {

--- a/server/go/internal/api/freeze_user_test.go
+++ b/server/go/internal/api/freeze_user_test.go
@@ -192,8 +192,8 @@ func TestFreezeUser_Unfreeze_Idempotent(t *testing.T) {
 }
 
 // TestFreezeUser_Self_HappyPath: alice can freeze herself (the "self"
-// arm of _is_self_or_admin). Spec flags this as debatable for GDPR
-// Article 18 but matches Python today.
+// arm of the self-or-admin gate). Spec flags this as debatable for
+// GDPR Article 18.
 func TestFreezeUser_Self_HappyPath(t *testing.T) {
 	t.Parallel()
 	f := newAdminWALFixture(t)

--- a/server/go/internal/api/get_connected_nodes.go
+++ b/server/go/internal/api/get_connected_nodes.go
@@ -50,12 +50,11 @@ const getConnectedNodesMethod = "GetConnectedNodes"
 
 // MaxConnectedDepth caps BFS traversal depth. The wire proto exposes no
 // depth field today; the effective depth=1 contract joins one level only.
-// Raising it is a behaviour change — track via EPIC #407 before flipping.
+// Raising it is a behaviour change — consider carefully before flipping.
 const MaxConnectedDepth = 1
 
-// MaxConnectedResultLimit caps the per-call result size. The Python
-// handler has no upper bound (open question 1 in the spec); the Go port
-// clamps at 1000 to match the convention used elsewhere in the server.
+// MaxConnectedResultLimit caps the per-call result size at 1000, matching
+// the convention used elsewhere in the server (open question 1 in the spec).
 // Limits ≤ 0 coerce to defaultConnectedLimit.
 const MaxConnectedResultLimit = 1000
 
@@ -73,7 +72,6 @@ func (s *Server) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNode
 
 	tenantID := req.GetContext().GetTenantId()
 	if err := s.checkTenant(ctx, tenantID); err != nil {
-		// Tighter than Python (which collapses every error to nodes=[]).
 		// Spec "Error contract" recommends propagating PERMISSION_DENIED
 		// from the tenant gate; we follow that recommendation.
 		resultStatus = "error"
@@ -97,26 +95,25 @@ func (s *Server) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNode
 		offset = 0
 	}
 
-	// Empty source short-circuits to []. Matches Python's "vacuous query"
-	// semantics (an empty node_id never matches any edge row).
+	// Empty source short-circuits to [] — an empty node_id never matches
+	// any edge row.
 	if req.GetNodeId() == "" {
 		return &pb.GetConnectedNodesResponse{Nodes: []*pb.Node{}, HasMore: false}, nil
 	}
 
-	// Without a store, we cannot resolve any traversal. Match the
-	// Python swallow: empty response, status="error".
+	// Without a store, we cannot resolve any traversal: return empty
+	// response, status="error".
 	if s.store == nil {
 		resultStatus = "error"
 		return &pb.GetConnectedNodesResponse{Nodes: []*pb.Node{}, HasMore: false}, nil
 	}
 
 	// Build a per-call ACL filter. The Resolver is created with a nil
-	// GroupMembershipReader because the W2 CanonicalStore does not yet
-	// expose GroupsContaining (group expansion lands in W1.10 alongside
-	// the store-side ResolveActorGroups port). Trivial expansion —
-	// returning [actor] — is the correct fallback for the unit cases
-	// pinned today; once group expansion ships, swap in a reader-backed
-	// Resolver via a Server option without rewriting this handler.
+	// GroupMembershipReader because the CanonicalStore does not yet
+	// expose GroupsContaining. Trivial expansion — returning [actor] —
+	// is the correct fallback; once group expansion ships, swap in a
+	// reader-backed Resolver via a Server option without rewriting this
+	// handler.
 	resolver := acl.NewResolver(nil)
 	filter := acl.NewFilter(resolver, storeVisibilityAdapter{s: s.store})
 
@@ -136,9 +133,8 @@ func (s *Server) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNode
 	edgeTypeID := req.GetEdgeTypeId()
 	collected, err := s.bfsConnected(ctx, tenantID, req.GetNodeId(), edgeTypeID, aclActor, filter, limit, offset)
 	if err != nil {
-		// Python `except Exception` -> nodes=[]. We mirror; the metric
-		// is recorded as "error" so the swallow doesn't inflate the
-		// success counter.
+		// Collapse internal errors to nodes=[]; the metric is recorded
+		// as "error" so the swallow doesn't inflate the success counter.
 		resultStatus = "error"
 		return &pb.GetConnectedNodesResponse{Nodes: []*pb.Node{}, HasMore: false}, nil
 	}
@@ -147,9 +143,8 @@ func (s *Server) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNode
 	for _, n := range collected {
 		pn, perr := s.storeNodeToProto("", n)
 		if perr != nil {
-			// A single bad row collapses the whole response to empty —
-			// matches Python's broad except. Recording as error so the
-			// metric reflects the swallow.
+			// A single bad row collapses the whole response to empty.
+			// Recording as error so the metric reflects the swallow.
 			resultStatus = "error"
 			return &pb.GetConnectedNodesResponse{Nodes: []*pb.Node{}, HasMore: false}, nil
 		}
@@ -179,9 +174,9 @@ func (s *Server) bfsConnected(
 	limit, offset int32,
 ) ([]*store.Node, error) {
 	// Visited starts with the source so we never yield the source itself
-	// (Python's SQL JOIN matches `e.from_node_id = node_id` and the
-	// returned rows are the `to_node_id` side — the source never appears
-	// in the result).
+	// (the SQL JOIN matches `e.from_node_id = node_id`; the returned
+	// rows are the `to_node_id` side — the source never appears in the
+	// result).
 	visited := map[string]struct{}{sourceID: {}}
 	frontier := []string{sourceID}
 

--- a/server/go/internal/api/get_connected_nodes_test.go
+++ b/server/go/internal/api/get_connected_nodes_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Tests for the GetConnectedNodes RPC (W2 — EPIC #407).
+// Tests for the GetConnectedNodes RPC.
 //
 // Behaviour pinned here:
 //   - Single-hop traversal returns every connected outbound node, ordered
@@ -111,7 +111,7 @@ func TestGetConnectedNodes_SingleHop(t *testing.T) {
 
 // TestGetConnectedNodes_DepthLimitHonored: a 2-hop graph
 // (src -> a -> grandchild) yields only `a`, not `grandchild`, because
-// the BFS depth cap is 1 (the Python single-JOIN contract).
+// the BFS depth cap is 1.
 func TestGetConnectedNodes_DepthLimitHonored(t *testing.T) {
 	t.Parallel()
 	srv, cs, ctx := connectedTestServer(t)
@@ -244,7 +244,7 @@ func TestGetConnectedNodes_SourceNotAccessibleReturnsEmpty(t *testing.T) {
 
 // TestGetConnectedNodes_UnknownTenantPropagatesError: the tenant gate
 // returns NOT_FOUND for an unknown tenant; the handler must propagate it
-// (spec: "deliberate behavior tightening" vs. Python's swallow).
+// (spec: "deliberate behavior tightening").
 func TestGetConnectedNodes_UnknownTenantPropagatesError(t *testing.T) {
 	t.Parallel()
 	srv, _, ctx := connectedTestServer(t)

--- a/server/go/internal/api/get_edges_from.go
+++ b/server/go/internal/api/get_edges_from.go
@@ -85,7 +85,7 @@ func (s *Server) GetEdgesFrom(ctx context.Context, req *pb.GetEdgesRequest) (*pb
 	}
 
 	// Pass limit=0 to the store so it returns the full result set; we
-	// slice + compute has_more here for parity with Python.
+	// slice + compute has_more here.
 	edges, err := s.store.GetEdgesFrom(ctx, tenantID, req.GetNodeId(), edgeTypeFilter, 0)
 	if err != nil {
 		// Swallow store errors — return empty response with codes.OK.

--- a/server/go/internal/api/get_edges_from_test.go
+++ b/server/go/internal/api/get_edges_from_test.go
@@ -1,7 +1,6 @@
-// Tests for GetEdgesFrom RPC (EPIC #407).
+// Tests for GetEdgesFrom RPC.
 //
-// Contract pins (mirrored from docs/go-port/rpcs/GetEdgesFrom.md and
-// the Python contract suite):
+// Contract pins (from docs/go-port/rpcs/GetEdgesFrom.md):
 //
 //   - Empty seed: test_grpc_contract.py:241-247 — call succeeds,
 //                     edges == [].
@@ -10,7 +9,7 @@
 //                     ACL filter on destinations — preserved parity gap;
 //                     see GetEdgesFrom.md §"Auth").
 //   - Missing source: unknown from_node_id returns empty edges, no
-//                     error (no special-case path in Python).
+//                     error (no NOT_FOUND special-case).
 //   - Type filter: edge_type_id != 0 narrows the result set;
 //                     edge_type_id == 0 returns every type.
 //   - Internal error: store fault (tenant DB never opened) collapses
@@ -174,8 +173,7 @@ func TestGetEdgesFrom_MultipleEdgesAllReturned(t *testing.T) {
 }
 
 // TestGetEdgesFrom_MissingSourceReturnsEmpty: an unknown from_node_id
-// returns an empty edge list with no error — Python does not special-
-// case missing nodes here (no NOT_FOUND).
+// returns an empty edge list with no error (no NOT_FOUND).
 func TestGetEdgesFrom_MissingSourceReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	srv, cs := newEdgesServer(t, "tenant-miss")

--- a/server/go/internal/api/get_edges_to.go
+++ b/server/go/internal/api/get_edges_to.go
@@ -2,7 +2,7 @@
 // Spec: docs/go-port/rpcs/GetEdgesTo.md.
 //
 // Wire contract: proto/entdb/v1/entdb.proto:67 (rpc), :476-491 (request /
-// response), :493-507 (Edge). Reference Python handler:
+// response), :493-507 (Edge).
 //
 // Symmetric inverse of GetEdgesFrom: returns edges whose `to_node_id`
 // matches the requested node, scoped to a single tenant. Cross-tenant
@@ -11,7 +11,7 @@
 // in another tenant cannot leak through the
 // `WHERE tenant_id = ? AND to_node_id = ?` filter.
 //
-// Semantics (preserved from the Python handler):
+// Semantics:
 //
 //   - Read-only. No WAL append, no SQLite mutation, no global_store write.
 //   - Tenant gate runs first via s.checkTenant; UNAVAILABLE /

--- a/server/go/internal/api/get_mailbox.go
+++ b/server/go/internal/api/get_mailbox.go
@@ -3,7 +3,7 @@
 // `notifications` table. The RPC is retained for proto compatibility
 // and contract pinning (see docs/go-port/rpcs/GetMailbox.md).
 //
-// Behavior parity with the Python stub:
+// Behavior:
 //
 //  1. Run the tenant gate (CheckTenant): sharding + region. Errors
 //     from the gate (UNAVAILABLE with redirect trailer,

--- a/server/go/internal/api/get_mailbox_test.go
+++ b/server/go/internal/api/get_mailbox_test.go
@@ -1,6 +1,6 @@
 // Tests for the deprecated GetMailbox stub.
 //
-// The Python contract test at
+// The contract test at
 // tests/python/integration/test_grpc_contract.py:274-280 pins the
 // happy-path shape (`items == [] and unread_count == 0`). The Go
 // unit tests below pin the same shape plus the tenant-gate
@@ -23,8 +23,8 @@ import (
 
 // TestGetMailbox_HappyPath: with a registered tenant, the stub
 // returns an empty, well-formed response — `items == []`,
-// `unread_count == 0`, `has_more == false`. Mirrors the Python
-// contract pin at test_grpc_contract.py:274-280.
+// `unread_count == 0`, `has_more == false`. Mirrors the contract
+// pin at test_grpc_contract.py:274-280.
 func TestGetMailbox_HappyPath(t *testing.T) {
 	t.Parallel()
 	gs := newGlobalStore(t)

--- a/server/go/internal/api/get_node.go
+++ b/server/go/internal/api/get_node.go
@@ -2,9 +2,9 @@
 // Spec: docs/go-port/rpcs/GetNode.md.
 //
 // Wire contract: proto/entdb/v1/entdb.proto:55 (rpc), :394-407
-// (request/response), :454-472 (Node). Reference Python handler:
+// (request/response), :454-472 (Node).
 //
-// Semantics (preserved from the Python handler):
+// Semantics:
 //
 //   - Read-only single-node lookup keyed on (tenant_id, node_id). Per
 //     the spec, type_id on the request is ACCEPTED but NOT used to
@@ -41,11 +41,9 @@
 //     position before reading. Default 30s when wait_timeout_ms == 0.
 //     Wait failures are silent.
 //
-//   - Unlike Python, we do NOT swallow uncaught exceptions into
-//     found=false. The Python handler's outer try/except is a
-//     defensive artifact unreachable in real grpc.aio runtime (where
-//     context.abort is terminal). In Go, gRPC errors are returned as
-//     real status codes. See spec "Quirk to preserve".
+//   - Uncaught exceptions are NOT swallowed into found=false. In Go,
+//     gRPC errors are returned as real status codes. See spec "Quirk
+//     to preserve".
 //
 // No WAL append, no SQLite write.
 
@@ -119,7 +117,7 @@ func (s *Server) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNo
 
 	// 4. Cross-tenant read membership check. PERMISSION_DENIED here
 	//    fires BEFORE the row lookup, so non-members cannot probe for
-	//    node existence (spec "Error contract" / Python `:1024-1025`).
+	//    node existence (spec "Error contract").
 	role, err := s.checkCrossTenantRead(ctx, tenantID, actor)
 	if err != nil {
 		resultStatus = "error"
@@ -139,7 +137,7 @@ func (s *Server) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNo
 	}
 
 	// 6. The actual read. Missing -> Found=false with status OK. Per
-	//    spec, type_id is NOT used as a filter (Python parity).
+	//    spec, type_id is NOT used as a filter.
 	n, err := s.store.GetNode(ctx, tenantID, nodeID)
 	if err != nil {
 		if errors.Is(err, store.ErrNodeNotFound) {
@@ -153,8 +151,7 @@ func (s *Server) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNo
 	//    confirmed the actor has SOME access in the tenant; now we
 	//    confirm the specific node grants them read. This fires AFTER
 	//    the row lookup, so it returns PERMISSION_DENIED, not the
-	//    found=false signal a non-member would see — matching Python
-	//    `:1041-1045`.
+	//    found=false signal a non-member would see.
 	if role == roleCrossTenant {
 		ok, err := s.hasNodeAccess(ctx, tenantID, nodeID, actor.String())
 		if err != nil {
@@ -242,9 +239,7 @@ func nodeToProto(reg *schema.Registry, n *store.Node) (*pb.Node, error) {
 		id, perr := strconv.ParseUint(k, 10, 32)
 		if perr != nil {
 			// Non-digit key on disk is unexpected; skip silently
-			// rather than corrupting the wire response. Matches
-			// Python's id_to_name_keys passthrough where an
-			// unparseable key falls into the decimal-string bucket.
+			// rather than corrupting the wire response.
 			continue
 		}
 		idKeyed[uint32(id)] = v

--- a/server/go/internal/api/get_node_by_key.go
+++ b/server/go/internal/api/get_node_by_key.go
@@ -2,9 +2,9 @@
 // Spec: docs/go-port/rpcs/GetNodeByKey.md.
 //
 // Wire contract: proto/entdb/v1/entdb.proto:144 (rpc), :1087-1120
-// (request/response). Reference Python:
+// (request/response).
 //
-// Semantics (preserved from the Python handler):
+// Semantics:
 //
 //   - Read-only. No WAL append, no global_store touch.
 //   - tenant_id / actor are TOP-LEVEL on this RPC (no
@@ -37,8 +37,8 @@
 //     collation. Caller (SDK) owns normalisation.
 //
 // Catch-all internal errors degrade to `found=false` with metric
-// label "error" (Python parity, :1125-1128). Exception: tenant-gate
-// errors (UNAVAILABLE / FAILED_PRECONDITION / NOT_FOUND) propagate
+// label "error". Exception: tenant-gate errors
+// (UNAVAILABLE / FAILED_PRECONDITION / NOT_FOUND) propagate
 // unchanged so SDKs can react to the redirect trailer.
 
 package api
@@ -91,21 +91,19 @@ func (s *Server) GetNodeByKey(ctx context.Context, req *pb.GetNodeByKeyRequest) 
 	}
 
 	// 3. Optional read-after-write wait. Best-effort: timeouts are
-	//    swallowed to match Python's `_wait_for_offset` semantics
-	//    (logs + falls through). int64 → store API takes int64 too.
-	//    Spec "after_offset type drift": Python stringifies; Go keeps
-	//    it native because the store's WaitForOffset signature is
-	//    `int64`. The wire format is unchanged — this is a server-
-	//    internal type alignment.
+	//    swallowed (logs + falls through). int64 → store API takes int64
+	//    too. Spec "after_offset type drift": the server keeps the native
+	//    int64 because the store's WaitForOffset signature requires it.
+	//    The wire format is unchanged — this is a server-internal type
+	//    alignment.
 	if req.GetAfterOffset() != 0 {
 		waitCtx, cancel := context.WithTimeout(ctx, waitForOffsetTimeout)
 		_ = s.store.WaitForOffset(waitCtx, req.GetTenantId(), req.GetAfterOffset())
 		cancel()
 	}
 
-	// 4. Unwrap the typed Value to a native scalar. Python uses
-	//    json_format.MessageToDict; the structpb Go API exposes
-	//    AsInterface which returns the same shape (string/float64/
+	// 4. Unwrap the typed Value to a native scalar. structpb.AsInterface
+	//    returns the same shape as a JSON decode (string/float64/
 	//    bool/nil/[]any/map[string]any).
 	rawValue := unwrapStructpbValue(req.GetValue())
 
@@ -118,13 +116,13 @@ func (s *Server) GetNodeByKey(ctx context.Context, req *pb.GetNodeByKeyRequest) 
 		rawValue,
 	)
 	if err != nil {
-		// Catch-all parity (:1125-1128). Don't propagate Internal —
+		// Catch-all: degrade to found=false. Don't propagate Internal —
 		// SDK clients branch on resp.Found.
 		resultStatus = "error"
 		return &pb.GetNodeByKeyResponse{Found: false}, nil
 	}
 	if node == nil {
-		// In-band miss. status=ok (Python parity at :1105).
+		// In-band miss. status=ok.
 		return &pb.GetNodeByKeyResponse{Found: false}, nil
 	}
 
@@ -146,9 +144,8 @@ func (s *Server) GetNodeByKey(ctx context.Context, req *pb.GetNodeByKeyRequest) 
 	// 8. Translate to the wire shape. payload_json is field-id-keyed
 	//    on disk (CLAUDE.md invariant #6); GetNodeByKey does not do
 	//    name translation here — the SDK consumer pairs the response
-	//    with its registered proto schema. Emitting it as a Struct
-	//    with string-int keys preserves the shape Python emits via
-	//    `_dict_to_struct`.
+	//    with its registered proto schema. Keys are emitted as
+	//    stringified field_ids.
 	resp := &pb.GetNodeByKeyResponse{
 		Found: true,
 		Node: &pb.Node{
@@ -167,9 +164,7 @@ func (s *Server) GetNodeByKey(ctx context.Context, req *pb.GetNodeByKeyRequest) 
 
 // unwrapStructpbValue returns the native Go scalar carried by a
 // google.protobuf.Value. nil / NullValue → nil; the SQLite binder
-// treats nil as SQL NULL, which matches Python's json_format
-// MessageToDict when the field was unset (returns {} → unwrapped to
-// None at the call site).
+// treats nil as SQL NULL (equivalent to the field being unset).
 func unwrapStructpbValue(v *structpb.Value) any {
 	if v == nil {
 		return nil
@@ -185,7 +180,7 @@ func unwrapStructpbValue(v *structpb.Value) any {
 //
 // This is intentionally a thin same-tenant gate: cross-tenant reads
 // require the cross-tenant grant lookup that lives behind GetNode
-// proper. For W2 the deny-only contract pins the
+// proper. The deny-only contract pins the
 // "ACL_DENIED → PERMISSION_DENIED" branch the spec calls out.
 func checkNodeACL(ownerActor, aclJSON, actor string) error {
 	if actor == "" {

--- a/server/go/internal/api/get_node_by_key_test.go
+++ b/server/go/internal/api/get_node_by_key_test.go
@@ -1,4 +1,4 @@
-// Tests for the GetNodeByKey RPC (W2 — EPIC #407).
+// Tests for the GetNodeByKey RPC.
 //
 // Spec: docs/go-port/rpcs/GetNodeByKey.md. The four cases pinned here
 // match the contract bullets the spec calls out:
@@ -248,7 +248,7 @@ func TestGetNodeByCompositeKey_StoreLevel(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed a Task node with a (owner_id=alice, title="finish go port")
-	// composite tuple. Field ids 2 and 1 (Python sample).
+	// composite tuple. Field ids 2 and 1.
 	seedNodeByKey(t, cs, gnbkTenant, "task-1", "user:alice",
 		map[string]any{
 			"1": "finish go port",

--- a/server/go/internal/api/get_node_test.go
+++ b/server/go/internal/api/get_node_test.go
@@ -1,4 +1,4 @@
-// Tests for the GetNode RPC (W2 — EPIC #407).
+// Tests for the GetNode RPC.
 //
 // Spec: docs/go-port/rpcs/GetNode.md. Four behaviours pinned here:
 //
@@ -162,9 +162,9 @@ func TestGetNode_MissingNode(t *testing.T) {
 // TestGetNode_NoPermission pins the cross-tenant gate: a non-member
 // caller (no membership row, no node_access row) sees
 // PERMISSION_DENIED, regardless of whether the node exists. The
-// global_store is wired so the membership check actually runs (Python
-// `_check_cross_tenant_read` short-circuits to "local" only when no
-// global_store is configured — spec "Open questions / risks" item 5).
+// global_store is wired so the membership check actually runs
+// (short-circuits to "local" only when no global_store is configured —
+// spec "Open questions / risks" item 5).
 //
 // We seed the tenant + a node owned by alice, then query as bob who
 // has no membership and no grants. PERMISSION_DENIED fires before the
@@ -208,8 +208,8 @@ func TestGetNode_NoPermission(t *testing.T) {
 }
 
 // TestGetNode_PayloadIsIDKeyedOnWire is the explicit invariant-#6
-// pin: the on-disk payload is keyed by field_id (Python parity, see
-// CLAUDE.md), AND the wire payload egress also stays id-keyed (the
+// pin: the on-disk payload is keyed by field_id (CLAUDE.md invariant
+// #6), AND the wire payload egress also stays id-keyed (the
 // SDK does the id->name translation client-side). This is the
 // "zero-translation egress" rule from
 // docs/go-port/shared/payload-translation.md.

--- a/server/go/internal/api/get_nodes.go
+++ b/server/go/internal/api/get_nodes.go
@@ -2,9 +2,9 @@
 // Spec: docs/go-port/rpcs/GetNodes.md.
 //
 // Wire contract: proto/entdb/v1/entdb.proto:58 (rpc), :409-422 (request/
-// response). Reference Python handler:
+// response).
 //
-// Semantics (preserved from the Python handler):
+// Semantics:
 //
 //   - Tenant gate first via Server.checkTenant (NOT_FOUND /
 //     UNAVAILABLE / FAILED_PRECONDITION on miss).
@@ -34,13 +34,13 @@
 //     verbatim: this masks data-loss bugs but is the documented
 //     contract.
 //
-// Hardening delta vs Python (flagged in PR body for #407 owner):
+// Hardening:
 //
-//   - Batch-size cap: Python has no upper bound; a 100k-id payload
-//     happily melts the SQLite pool and blows past gRPC's 4 MiB
-//     default response size. The Go port aborts
-//     RESOURCE_EXHAUSTED at len(node_ids) > maxBatchNodeIDs (1000)
-//     BEFORE doing any I/O. Spec "Notes on performance & limits".
+//   - Batch-size cap: the server aborts RESOURCE_EXHAUSTED at
+//     len(node_ids) > maxBatchNodeIDs (1000) BEFORE doing any I/O,
+//     preventing large payloads from melting the SQLite pool or
+//     exceeding the gRPC 4 MiB default response size. Spec "Notes on
+//     performance & limits".
 //
 // No WAL append, no SQLite write, no audit row. Pure read.
 
@@ -65,14 +65,12 @@ const (
 
 	// maxBatchNodeIDs is the server-side guardrail for a single
 	// GetNodes request. Above this we reject before doing any I/O
-	// with codes.RESOURCE_EXHAUSTED. Python has no such cap; this is
-	// a Go-port hardening delta for issue #407.
+	// with codes.RESOURCE_EXHAUSTED.
 	maxBatchNodeIDs = 1000
 
 	// getNodesFanout is the bounded concurrency for per-id store
 	// lookups. Caps in-flight SQLite reads at a small constant so a
-	// 1000-id batch doesn't starve the pool. Behaviour-preserving
-	// with respect to Python (which is serial); only a perf knob.
+	// 1000-id batch doesn't starve the pool. Only a perf knob.
 	getNodesFanout = 32
 
 	// getNodesAfterOffsetDefault is the 30s default fence timeout.
@@ -101,8 +99,7 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetContext().GetActor()))
 
 	// Batch-size cap. Reject BEFORE any I/O so a hostile / buggy
-	// caller cannot cause work to start. Python parity gap; flagged
-	// in PR body.
+	// caller cannot cause work to start.
 	if len(req.GetNodeIds()) > maxBatchNodeIDs {
 		resultStatus = "error"
 		return nil, errs.Errorf(codes.ResourceExhausted,
@@ -110,8 +107,7 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 			len(req.GetNodeIds()), maxBatchNodeIDs)
 	}
 
-	// Empty node_ids -> empty response. Python returns the same shape
-	// (the for-loop simply doesn't run).
+	// Empty node_ids -> empty response.
 	if len(req.GetNodeIds()) == 0 {
 		return &pb.GetNodesResponse{
 			Nodes:      []*pb.Node{},
@@ -129,10 +125,9 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 		return nil, err
 	}
 
-	// after_offset fence. Python wraps the call with a swallowing
-	// try/except so a timeout is observed as "all missing". We
-	// preserve that for v1 (spec "Open Questions" #1): a fence
-	// failure is intentionally NOT a hard error here.
+	// after_offset fence. A timeout is observed as "all missing" for
+	// v1 (spec "Open Questions" #1): a fence failure is intentionally
+	// NOT a hard error here.
 	if req.GetAfterOffset() != "" && s.store != nil {
 		timeout := getNodesAfterOffsetDefault
 		if ms := req.GetWaitTimeoutMs(); ms > 0 {
@@ -152,9 +147,8 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 	}
 
 	if s.store == nil {
-		// No per-tenant store wired -- preserve Python's bare-except
-		// behaviour: everything missing, status OK, metric=error so
-		// the swallow doesn't inflate the ok counter.
+		// No per-tenant store wired — everything missing, status OK,
+		// metric=error so the swallow doesn't inflate the ok counter.
 		resultStatus = "error"
 		return &pb.GetNodesResponse{
 			Nodes:      []*pb.Node{},
@@ -179,8 +173,7 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 				<-sem
 				wg.Done()
 				if r := recover(); r != nil {
-					// Per-id panic -- treat as "missing", consistent
-					// with Python's outer bare-except.
+					// Per-id panic -- treat as "missing".
 					fatalMu.Lock()
 					hadFatal = true
 					fatalMu.Unlock()
@@ -203,9 +196,8 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 	wg.Wait()
 
 	if hadFatal {
-		// At least one panic during the fan-out. Python's bare-except
-		// returns "all missing"; the safest parity move when we can't
-		// trust partial state is to do the same and flag the metric
+		// At least one panic during the fan-out. When partial state
+		// cannot be trusted, return "all missing" and flag the metric
 		// as error.
 		resultStatus = "error"
 		return &pb.GetNodesResponse{
@@ -224,8 +216,7 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 		pn, perr := s.storeNodeToProto("", results[i])
 		if perr != nil {
 			// Conversion failure on a single row -- fold into
-			// missing_ids rather than failing the whole batch
-			// (matches Python's "swallow and degrade" stance).
+			// missing_ids rather than failing the whole batch.
 			missing = append(missing, id)
 			continue
 		}

--- a/server/go/internal/api/get_nodes_test.go
+++ b/server/go/internal/api/get_nodes_test.go
@@ -1,9 +1,9 @@
-// Tests for the GetNodes RPC (W2 — EPIC #407).
+// Tests for the GetNodes RPC.
 //
 // Spec: docs/go-port/rpcs/GetNodes.md. Coverage targets the contract
 // pins enumerated there:
 //
-//   - Empty node_ids -> nodes=[] missing_ids=[] OK (Python parity).
+//   - Empty node_ids -> nodes=[] missing_ids=[] OK.
 //   - Single id round-trip: existing id surfaces as a Node; unknown id
 //     surfaces in missing_ids.
 //   - Multi-id round-trip: multiple existing ids preserve request order
@@ -12,7 +12,7 @@
 //     into missing_ids; the cross-tenant denied case must NOT be
 //     distinguishable from not-found (spec "Auth").
 //   - Oversize batch (> maxBatchNodeIDs) -> RESOURCE_EXHAUSTED before
-//     any I/O. Hardening delta vs Python (no Python equivalent).
+//     any I/O. Go-server hardening; no equivalent in the old server.
 //   - Unknown tenant -> NOT_FOUND from the tenant gate
 //     (CheckTenant / globalstore.GetTenant).
 
@@ -166,7 +166,7 @@ func TestGetNodes_SingleMiss(t *testing.T) {
 //   - Order: nodes in request order, gaps closed (denied/missing
 //     are absent, not nil-padded).
 //   - Duplicates: requesting the same id twice yields the node twice
-//     (Python iterates verbatim — spec "Batch semantics" #5).
+//     (spec "Batch semantics" #5).
 func TestGetNodes_MultiPreservesOrderAndDuplicates(t *testing.T) {
 	t.Parallel()
 	const tenantID = "acme"
@@ -266,10 +266,10 @@ func TestGetNodes_MissingAndDeniedMergedIntoMissingIds(t *testing.T) {
 	}
 }
 
-// TestGetNodes_OversizeBatchRejected pins the Go-port hardening
-// delta: above maxBatchNodeIDs (1000) the handler aborts
-// RESOURCE_EXHAUSTED before any tenant / store I/O. Python has no
-// such cap; the cap is documented in the spec "Open Questions" #4.
+// TestGetNodes_OversizeBatchRejected pins the server hardening:
+// above maxBatchNodeIDs (1000) the handler aborts
+// RESOURCE_EXHAUSTED before any tenant / store I/O. The cap is
+// documented in the spec "Open Questions" #4.
 func TestGetNodes_OversizeBatchRejected(t *testing.T) {
 	t.Parallel()
 	const tenantID = "acme"

--- a/server/go/internal/api/get_receipt_status.go
+++ b/server/go/internal/api/get_receipt_status.go
@@ -1,4 +1,4 @@
-// W2.03 — GetReceiptStatus RPC (Python -> Go server port, EPIC #407).
+// GetReceiptStatus RPC.
 //
 // Spec: docs/go-port/rpcs/GetReceiptStatus.md. The handler is a pure
 // read of the per-tenant applied_events table indexed by

--- a/server/go/internal/api/get_receipt_status_test.go
+++ b/server/go/internal/api/get_receipt_status_test.go
@@ -1,6 +1,6 @@
-// Tests for the GetReceiptStatus RPC (W2.03 — EPIC #407).
+// Tests for the GetReceiptStatus RPC.
 //
-// Pinning these three cases mirrors the Python contract tests at
+// Pinning these three cases covers the contract tests at
 // tests/python/integration/test_grpc_contract.py:313-326 (APPLIED for
 // a recorded key, PENDING for an unknown key) and the spec error
 // contract at docs/go-port/rpcs/GetReceiptStatus.md (any store fault
@@ -71,8 +71,8 @@ func TestGetReceiptStatus_AppliedKeyReturnsApplied(t *testing.T) {
 }
 
 // Case 2: receipt for a key never recorded returns PENDING + empty
-// error. Pinned by spec "Error contract" row 5 and the Python contract
-// test's "never-issued" assertion (test_grpc_contract.py:325-326).
+// error. Pinned by spec "Error contract" row 5 and the contract test's
+// "never-issued" assertion (test_grpc_contract.py:325-326).
 func TestGetReceiptStatus_UnknownKeyReturnsPending(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -99,8 +99,8 @@ func TestGetReceiptStatus_UnknownKeyReturnsPending(t *testing.T) {
 // Case 3: a store-internal error (here: the tenant DB has never been
 // opened, so the read-side pool lookup returns ErrTenantNotOpen) must
 // surface as status=UNKNOWN + error=<msg> with NO gRPC error. This is
-// the Python `except Exception` -> UNKNOWN collapse documented in the
-// spec "Error contract" row 4.
+// the exception-to-UNKNOWN collapse documented in the spec "Error
+// contract" row 4.
 func TestGetReceiptStatus_StoreErrorReturnsUnknownNotGRPC(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -118,11 +118,11 @@ func TestGetReceiptStatus_StoreErrorReturnsUnknownNotGRPC(t *testing.T) {
 		t.Fatalf("status: got %v, want UNKNOWN", resp.GetStatus())
 	}
 	if resp.GetError() == "" {
-		t.Fatalf("error: got empty, want non-empty (Python populates `error` on UNKNOWN)")
+		t.Fatalf("error: got empty, want non-empty")
 	}
 	// Sanity-check that the error message refers to the underlying
-	// fault rather than being a generic placeholder. We don't pin the
-	// exact string — the Python contract is just "non-empty".
+	// fault rather than being a generic placeholder. The contract only
+	// requires "non-empty".
 	if !strings.Contains(resp.GetError(), tenantID) && !strings.Contains(resp.GetError(), "tenant") {
 		t.Logf("error message: %q (no tenant context; allowed but worth noting)", resp.GetError())
 	}

--- a/server/go/internal/api/get_schema.go
+++ b/server/go/internal/api/get_schema.go
@@ -2,31 +2,29 @@
 // Spec: docs/go-port/rpcs/GetSchema.md.
 //
 // Wire contract: proto/entdb/v1/entdb.proto:79 (rpc), :590-596 (request),
-// :598-607 (response). Reference Python:
+// :598-607 (response).
 //
-// Semantics (preserved byte-for-byte from the Python handler):
+// Semantics:
 //
 //   - Read-only. No WAL append, no global_store touch.
 //   - No Permission check; auth interceptor handles credentials.
-//   - Swallow all errors as OK. The Python handler catches every
-//     exception path and returns &GetSchemaResponse{Fingerprint: ""}
+//   - Swallow all errors as OK: returns &GetSchemaResponse{Fingerprint: ""}
 //     with grpc.OK. The sole contract pin
 //     (tests/python/integration/test_grpc_contract.py:208) only
 //     asserts `fingerprint != "" || HasField("schema")`, so the
 //     empty-but-OK response is the documented degraded path.
 //   - Optional req.TenantId drives a data-driven fallback when the
 //     registry is empty: we synthesise placeholder type entries from
-//     distinct type_ids observed in that tenant's SQLite. stub:
-//     the canonicalstore Go port doesn't expose GetDistinctTypeIDs
-//     yet, so the fallback is a no-op here and surfaces as the same
-//     empty-Struct response Python returns when its SQLite query
-//     errors (`:1665-1666`). This matches the contract pin and is
-//     flagged in the EPIC for the canonicalstore follow-up.
+//     distinct type_ids observed in that tenant's SQLite. The
+//     canonicalstore doesn't expose GetDistinctTypeIDs yet, so the
+//     fallback is a no-op here and surfaces as an empty-Struct response.
+//     This matches the contract pin and is flagged for the canonicalstore
+//     follow-up.
 //
-// Known latent bug (preserved for parity, NOT fixed here): the Python
-// handler reads req.TenantId without cross-checking the caller's
-// authenticated tenant binding, leaking distinct type_ids across
-// tenants. See spec "Open questions / risks" — flagged as follow-up.
+// Known latent bug (not fixed here): req.TenantId is read without
+// cross-checking the caller's authenticated tenant binding, leaking
+// distinct type_ids across tenants. See spec "Open questions / risks"
+// — flagged as follow-up.
 
 package api
 
@@ -58,9 +56,9 @@ func (s *Server) GetSchema(_ context.Context, req *pb.GetSchemaRequest) (resp *p
 
 	defer func() {
 		if r := recover(); r != nil {
-			// Match Python's outer except (`:1686-1689`): degrade to
-			// empty fingerprint with OK status. resp/err are named
-			// returns so the deferred closure can overwrite them.
+			// Degrade to empty fingerprint with OK status. resp/err
+			// are named returns so the deferred closure can overwrite
+			// them.
 			status = "error"
 			resp = &pb.GetSchemaResponse{Fingerprint: ""}
 			err = nil
@@ -69,9 +67,8 @@ func (s *Server) GetSchema(_ context.Context, req *pb.GetSchemaRequest) (resp *p
 	}()
 
 	// Snapshot fingerprint up front so a marshal failure later still
-	// returns it (matches Python's `self.schema_registry.fingerprint
-	// or ""` at `:1684` — fingerprint is computed at freeze, not at
-	// serialise time).
+	// returns it. Fingerprint is computed at freeze, not at
+	// serialise time.
 	var fingerprint string
 	if s.registry != nil {
 		fingerprint = s.registry.Fingerprint()
@@ -80,25 +77,22 @@ func (s *Server) GetSchema(_ context.Context, req *pb.GetSchemaRequest) (resp *p
 	schemaMap, ierr := s.snapshotSchemaMap()
 	if ierr != nil {
 		// Marshal of an in-memory registry should never fail (it's
-		// strongly typed Go), but if it does, Python's outer except
-		// kicks in. Return empty fingerprint to match `:1684`'s `or ""`
-		// fallback when registry is unfrozen.
+		// strongly typed Go), but if it does, degrade to empty
+		// fingerprint with OK status.
 		status = "error"
 		return &pb.GetSchemaResponse{Fingerprint: ""}, nil
 	}
 
 	// Data-driven fallback when the registry is empty and the caller
-	// provided a tenant_id (`:1645-1664`). The Go canonicalstore port
-	// does not yet expose GetDistinctTypeIDs; until it does, this path
-	// degrades to the same empty-Struct result Python returns when its
-	// SQLite query errors at `:1665-1666` — well within the contract
-	// pin (fingerprint or schema field present; an empty Struct still
-	// counts as "schema field present"). Flagged in the EPIC for the
-	// canonicalstore follow-up.
+	// provided a tenant_id. The canonicalstore does not yet expose
+	// GetDistinctTypeIDs; until it does, this path degrades to an
+	// empty-Struct result — well within the contract pin (fingerprint
+	// or schema field present; an empty Struct still counts as "schema
+	// field present"). Flagged for the canonicalstore follow-up.
 	_ = mapHasTypes(schemaMap)
 	_ = req.GetTenantId()
 
-	// type_id filter (`:1668-1679`). Applied after the fallback so the
+	// type_id filter. Applied after the fallback so the
 	// node_types/edge_types maps reflect either registry contents or
 	// the fallback synthesis (today: just registry contents).
 	if req.GetTypeId() != 0 {
@@ -109,7 +103,7 @@ func (s *Server) GetSchema(_ context.Context, req *pb.GetSchemaRequest) (resp *p
 	if ierr != nil {
 		// Numeric values are emitted as float64 via the JSON round-trip
 		// in snapshotSchemaMap, so this should not fire in practice.
-		// If it does, degrade per Python's outer except (`:1686-1689`).
+		// If it does, degrade to empty fingerprint with OK status.
 		status = "error"
 		return &pb.GetSchemaResponse{Fingerprint: ""}, nil
 	}
@@ -120,16 +114,14 @@ func (s *Server) GetSchema(_ context.Context, req *pb.GetSchemaRequest) (resp *p
 	}, nil
 }
 
-// snapshotSchemaMap lowers the registry into the Python `to_dict()`
-// shape: {"node_types": [...], "edge_types": [...]}. We piggyback on
+// snapshotSchemaMap lowers the registry into the wire shape:
+// {"node_types": [...], "edge_types": [...]}. It piggybacks on
 // schema.Registry.MarshalJSON (which already sorts by id and normalises
-// nil slices to []) and unmarshal back into a map[string]any so
-// structpb.NewStruct can consume it. JSON-round-trip is the same
-// canonical form the fingerprint canonicaliser uses, so the wire bytes
-// stay aligned with Python's `_dict_to_struct` (`:154-159`).
+// nil slices to []) and unmarshals back into a map[string]any so
+// structpb.NewStruct can consume it. The JSON round-trip is the same
+// canonical form the fingerprint canonicaliser uses.
 //
-// Returns an empty map for a nil registry — matches Python returning
-// empty `node_types: []` / `edge_types: []` for an empty SchemaRegistry.
+// Returns an empty map for a nil registry.
 func (s *Server) snapshotSchemaMap() (map[string]any, error) {
 	if s.registry == nil {
 		return map[string]any{
@@ -157,8 +149,8 @@ func (s *Server) snapshotSchemaMap() (map[string]any, error) {
 }
 
 // mapHasTypes reports whether the snapshot contains any node or edge
-// type entries. Mirrors the truthy check at `:1644` that decides
-// whether to fall back to the per-tenant SQLite distinct-type read.
+// type entries. Used to decide whether to fall back to the per-tenant
+// SQLite distinct-type read.
 func mapHasTypes(m map[string]any) bool {
 	if nt, ok := m["node_types"].([]any); ok && len(nt) > 0 {
 		return true
@@ -169,7 +161,7 @@ func mapHasTypes(m map[string]any) bool {
 	return false
 }
 
-// filterByTypeID applies the optional req.type_id filter (`:1668-1679`).
+// filterByTypeID applies the optional req.type_id filter.
 // Keeps node entries with matching type_id and edge entries that touch
 // it via from_type_id or to_type_id.
 //

--- a/server/go/internal/api/get_schema_test.go
+++ b/server/go/internal/api/get_schema_test.go
@@ -1,8 +1,7 @@
 // Tests for the GetSchema RPC. Spec: docs/go-port/rpcs/GetSchema.md.
 //
-// The sole contract pin from the Python test suite
-// (tests/python/integration/test_grpc_contract.py:208) requires either
-// fingerprint != "" or HasField("schema"). The cases below cover both
+// The sole contract pin from tests/python/integration/test_grpc_contract.py:208
+// requires either fingerprint != "" or HasField("schema"). The cases below cover both
 // the empty-registry path (Struct populated, fingerprint empty) and the
 // frozen-registry path (Struct populated AND fingerprint set), plus the
 // optional type_id filter and the degraded swallow-errors path.
@@ -20,8 +19,8 @@ import (
 
 // TestGetSchema_NoRegistry covers Server constructed without
 // WithSchemaRegistry — should return OK with an empty Struct and empty
-// fingerprint, matching Python's behaviour when SchemaRegistry is empty
-// and tenant_id is also empty.
+// fingerprint (same as when the registry is empty and tenant_id is
+// also empty).
 func TestGetSchema_NoRegistry(t *testing.T) {
 	t.Parallel()
 	srv := New()
@@ -184,17 +183,17 @@ func TestGetSchema_PopulatedRegistry(t *testing.T) {
 	}
 
 	// Fingerprint is constant across filtered/unfiltered responses
-	// (the Python handler computes it from the unfiltered registry).
+	// (computed from the unfiltered registry).
 	if resp2.GetFingerprint() != fp || resp3.GetFingerprint() != fp {
 		t.Errorf("fingerprint changed under filter: %q / %q / %q",
 			resp.GetFingerprint(), resp2.GetFingerprint(), resp3.GetFingerprint())
 	}
 }
 
-// TestGetSchema_ContractPin asserts the sole behavioural pin from the
-// Python contract test (test_grpc_contract.py:208): the response
-// satisfies `fingerprint != "" || HasField("schema")` for both the
-// happy path and the degraded empty-registry path.
+// TestGetSchema_ContractPin asserts the sole behavioural pin from
+// test_grpc_contract.py:208: the response satisfies
+// `fingerprint != "" || HasField("schema")` for both the happy path
+// and the degraded empty-registry path.
 func TestGetSchema_ContractPin(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/server/go/internal/api/get_tenant.go
+++ b/server/go/internal/api/get_tenant.go
@@ -2,33 +2,30 @@
 // Spec: docs/go-port/rpcs/GetTenant.md.
 //
 // Wire contract: proto/entdb/v1/entdb.proto:119 (rpc), :880-883
-// (request), :885-888 (response), :853-863 (TenantDetail). Reference
+// (request), :885-888 (response), :853-863 (TenantDetail).
 //
-// Semantics (preserved byte-for-byte from the Python handler):
+// Semantics:
 //
 //   - Read-only on globalstore.tenant_registry. No WAL append, no
 //     per-tenant SQLite touch (CLAUDE.md invariants #1 / #4 satisfied
 //     trivially — the registry is the cross-tenant exception).
 //   - NO membership / admin gate. Any authenticated caller can read any
 //     tenant's metadata. This cross-tenant metadata leak is preserved
-//     for parity and is REQUIRED, not a bug we're free to fix here.
-//     Flagged as a follow-up in the spec "Open questions / risks"
-//     section.
+//     and is REQUIRED, not a bug we're free to fix here. Flagged as a
+//     follow-up in the spec "Open questions / risks" section.
 //   - Authoritative actor is still resolved via auth.Authoritative so
 //     the privilege-escalation fix (commit fece3fb) holds: a malicious
 //     caller cannot claim `actor: "system:admin"` and expect the
 //     handler to honour the body claim. The actor is then NOT consulted
-//     for any authorization decision — this matches Python's posture.
+//     for any authorization decision.
 //   - Argument validation (`actor == ""` / `tenant_id == ""`) returns
 //     `INVALID_ARGUMENT` cleanly via status.Error, BEFORE the recover
 //     block. The contract test at test_grpc_contract.py:472-476
 //     accepts either form. See spec "Error contract".
 //   - All other unexpected errors / panics degrade to
-//     `&GetTenantResponse{Found: false}, nil` with metric label
-//     "error". Mirrors Python's catch-all at :2392-2395.
+//     `&GetTenantResponse{Found: false}, nil` with metric label "error".
 //   - `s.global == nil` returns `UNIMPLEMENTED` (defensive — no test
-//     pins this path but it guards against partial deployments;
-//     mirrors :2370-2374).
+//     pins this path but it guards against partial deployments).
 
 package api
 
@@ -78,16 +75,15 @@ func (s *Server) GetTenant(ctx context.Context, req *pb.GetTenantRequest) (resp 
 	}
 
 	// Resolve the trusted actor. The result is intentionally NOT used
-	// for any membership/admin check — Python posture is "any
-	// authenticated caller may read any tenant's row". We still call
-	// Authoritative so the call shape matches every other registry RPC
-	// (defence in depth: if a future hardening pass adds a gate here,
-	// it gets the trusted identity, not the wire claim).
+	// for any membership/admin check — any authenticated caller may
+	// read any tenant's row. We still call Authoritative so the call
+	// shape matches every other registry RPC (defence in depth: if a
+	// future hardening pass adds a gate here, it gets the trusted
+	// identity, not the wire claim).
 	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
 
 	// Defer recover AFTER input validation so a panic in the lookup
-	// degrades to `found=false` (Python parity, :2392-2395) without
-	// swallowing INVALID_ARGUMENT.
+	// degrades to `found=false` without swallowing INVALID_ARGUMENT.
 	defer func() {
 		if r := recover(); r != nil {
 			status = "error"
@@ -99,18 +95,16 @@ func (s *Server) GetTenant(ctx context.Context, req *pb.GetTenantRequest) (resp 
 
 	tenant, lookupErr := s.global.GetTenant(ctx, req.GetTenantId())
 	if lookupErr != nil {
-		// Python's outer except catches every SQLite / runtime error
-		// and returns found=false with OK status. Do NOT propagate as
-		// codes.Internal — that would break the contract test at
-		// test_grpc_contract.py:466-471 which only accepts
-		// `r.found is False` on the negative path.
+		// Return found=false with OK status. Do NOT propagate as
+		// codes.Internal — the contract test at
+		// test_grpc_contract.py:466-471 only accepts `r.found is False`
+		// on the negative path.
 		status = "error"
 		return &pb.GetTenantResponse{Found: false}, nil
 	}
 	if tenant == nil {
-		// Genuine not-found. Python returns found=false with OK status
-		// (:2383-2385). Metric label stays "ok" — this is the success
-		// path for a well-formed lookup.
+		// Genuine not-found. Metric label stays "ok" — this is the
+		// success path for a well-formed lookup.
 		return &pb.GetTenantResponse{Found: false}, nil
 	}
 

--- a/server/go/internal/api/get_tenant_members.go
+++ b/server/go/internal/api/get_tenant_members.go
@@ -2,27 +2,25 @@
 // Spec: docs/go-port/rpcs/GetTenantMembers.md.
 //
 // Wire contract: proto/entdb/v1/entdb.proto:125 (rpc), :921-928
-// (request/response), :902-907 (TenantMemberInfo). Reference Python:
+// (request/response), :902-907 (TenantMemberInfo).
 //
-// Semantics (preserved byte-for-byte from the Python handler):
+// Semantics:
 //
 //   - Read-only. One SELECT against globalstore.tenant_members; no WAL
 //     append, no per-tenant SQLite touch (CLAUDE.md invariant #4 —
 //     globalstore is the legitimate cross-tenant path).
 //   - No `_check_tenant` gate, no `_check_cross_tenant_read`, no
 //     capability lookup; no membership gate beyond non-empty argument
-//     validation. Preserved for parity — flagged for follow-up in the
-//     EPIC's open-questions section.
+//     validation. Flagged for follow-up in the spec's open-questions
+//     section.
 //   - Trusted-actor rebinding via auth.Authoritative is applied at the
-//     top, even though the Python source reads `request.actor` directly
-//     today. This closes the privilege-escalation gap addressed by
-//     commit fece3fb (issue #168) for free, and the rebinding has no
-//     observable effect on the response because there is no member-only
-//     gate.
-//   - INVALID_ARGUMENT messages and ordering match Python verbatim:
-//     actor-check fires before tenant-check, with the exact strings
-//     `"actor is required"` and `"tenant_id is required"`. SDK callers
-//     that string-match these errors stay green.
+//     top. This closes the privilege-escalation gap addressed by commit
+//     fece3fb (issue #168) for free, and the rebinding has no observable
+//     effect on the response because there is no member-only gate.
+//   - INVALID_ARGUMENT messages and ordering: actor-check fires before
+//     tenant-check, with the exact strings `"actor is required"` and
+//     `"tenant_id is required"`. SDK callers that string-match these
+//     errors stay green.
 //   - Unknown tenant -> empty list + OK (the SELECT returns 0 rows).
 //   - Internal globalstore failures are silently swallowed: the handler
 //     returns an empty members slice with grpc.OK. This is hostile to

--- a/server/go/internal/api/get_tenant_members_test.go
+++ b/server/go/internal/api/get_tenant_members_test.go
@@ -9,11 +9,8 @@
 //  1. Empty members list for a tenant with no members.
 //  2. Single-member round-trip (fields populated, joined_at preserved).
 //  3. Multi-member round-trip (rows ordered by joined_at ascending).
-//  4. Unknown tenant -> empty list (no NOT_FOUND, parity with Python).
+//  4. Unknown tenant -> empty list (no NOT_FOUND — no tenant gate runs).
 //  5. Empty tenant_id -> INVALID_ARGUMENT.
-//
-// The Python handler also rejects empty actor with INVALID_ARGUMENT;
-// covered alongside (5) for ordering parity.
 
 package api_test
 
@@ -29,8 +26,7 @@ import (
 )
 
 // TestGetTenantMembers_EmptyTenant: a tenant that exists but has no
-// members returns members=[] with OK. The slice is non-nil (matches
-// Python's `members=[]` default for a repeated field).
+// members returns members=[] with OK. The slice is non-nil.
 func TestGetTenantMembers_EmptyTenant(t *testing.T) {
 	t.Parallel()
 
@@ -152,9 +148,9 @@ func TestGetTenantMembers_MultipleMembers(t *testing.T) {
 }
 
 // TestGetTenantMembers_UnknownTenant: an unknown tenant_id returns an
-// empty list with OK (parity with Python — no NOT_FOUND because the
-// handler never calls _check_tenant). This is a behavioural pin: a
-// future tightening that adds a tenant gate would break this contract.
+// empty list with OK — no NOT_FOUND because the handler never calls
+// _check_tenant. This is a behavioural pin: a future tightening that
+// adds a tenant gate would break this contract.
 func TestGetTenantMembers_UnknownTenant(t *testing.T) {
 	t.Parallel()
 

--- a/server/go/internal/api/get_tenant_quota.go
+++ b/server/go/internal/api/get_tenant_quota.go
@@ -2,7 +2,7 @@
 // Spec: docs/go-port/rpcs/GetTenantQuota.md.
 //
 // Wire contract: proto/entdb/v1/entdb.proto:142 (rpc), :1063-1068 (request),
-// :1070-1085 (response). Reference Python:
+// :1070-1085 (response).
 //
 // Semantics:
 //
@@ -132,10 +132,8 @@ func (s *Server) GetTenantQuota(
 
 // nextCalendarMonthStartMs returns the Unix-millisecond timestamp of the
 // start of the UTC calendar month immediately following the one
-// containing t. Kept local to this file to avoid adding new exported
-// helpers / fields per the W2 task constraints; the equivalent for the
-// start-of-current-month lives in the globalstore package as
-// calendarMonthStartMs.
+// containing t. The equivalent for the start-of-current-month lives in
+// the globalstore package as calendarMonthStartMs.
 func nextCalendarMonthStartMs(t time.Time) int64 {
 	t = t.UTC()
 	year, month := t.Year(), t.Month()

--- a/server/go/internal/api/get_tenant_quota_test.go
+++ b/server/go/internal/api/get_tenant_quota_test.go
@@ -4,7 +4,7 @@
 //     usage.
 //  2. Admin-role happy path — a tenant user with role=admin succeeds.
 //  3. Plain member → PERMISSION_DENIED. The handler is admin/owner-only;
-//     tenant role=member is NOT enough (matches Python contract test
+//     tenant role=member is NOT enough (contract pin:
 //     test_grpc_contract.py:483-486).
 //  4. Non-member → PERMISSION_DENIED, even with claimed actor on the
 //     wire (privilege-escalation pin).

--- a/server/go/internal/api/get_tenant_test.go
+++ b/server/go/internal/api/get_tenant_test.go
@@ -104,8 +104,7 @@ func TestGetTenant_UnknownTenantInBandFalse(t *testing.T) {
 
 // TestGetTenant_EmptyTenantIDInvalidArgument pins
 // test_grpc_contract.py:472-476: an empty tenant_id yields
-// INVALID_ARGUMENT. The Go port returns this cleanly via status.Error
-// (Python's argument-validation-vs-catch-all wart is fixed here; spec
+// INVALID_ARGUMENT returned cleanly via status.Error (spec
 // "Error contract").
 func TestGetTenant_EmptyTenantIDInvalidArgument(t *testing.T) {
 	t.Parallel()

--- a/server/go/internal/api/get_user.go
+++ b/server/go/internal/api/get_user.go
@@ -4,7 +4,7 @@
 // Wire contract: proto/entdb/v1/entdb.proto:113 (rpc), :816-824
 // (request/response), :793-800 (UserInfo).
 //
-// Semantics (preserved from the Python handler):
+// Semantics:
 //
 //   - Authenticated, but unrestricted. Any authenticated actor may
 //     read any user's profile. NO self/admin gate — the handler
@@ -83,8 +83,7 @@ func (s *Server) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.GetUs
 	// trusted-actor pattern documented in CLAUDE.md / commit fece3fb.
 	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
 
-	// Read globalstore.user_registry. (nil, nil) on miss mirrors
-	// Python's `dict | None` contract.
+	// Read globalstore.user_registry. (nil, nil) on miss.
 	user, err := s.global.GetUser(ctx, req.GetUserId())
 	if err != nil {
 		// Internal errors are swallowed into found=false with codes.OK

--- a/server/go/internal/api/get_user_tenants.go
+++ b/server/go/internal/api/get_user_tenants.go
@@ -1,4 +1,4 @@
-// W2 — GetUserTenants RPC (Python -> Go server port, EPIC #407).
+// GetUserTenants RPC.
 //
 // Spec: docs/go-port/rpcs/GetUserTenants.md.
 //
@@ -10,25 +10,23 @@
 //     "Tenant registry not configured".
 //   - The trusted-actor invariant is honoured: the wire-claimed actor
 //     is run through auth.Authoritative so the interceptor's identity
-//     wins over any payload-claimed identity. Per the Python parity
-//     contract today, the resolved actor is NOT used for an authz
-//     decision (any authenticated caller may read any user's
-//     memberships). The privilege-boundary gap is documented in the
-//     spec and tracked as a follow-up; do NOT plug it here without
-//     coordinated proto/contract-test changes (see spec "Auth"
-//     section).
+//     wins over any payload-claimed identity. The resolved actor is NOT
+//     used for an authz decision (any authenticated caller may read any
+//     user's memberships). The privilege-boundary gap is documented in
+//     the spec and tracked as a follow-up; do NOT plug it here without
+//     coordinated proto/contract-test changes (see spec "Auth" section).
 //   - Memberships are returned in joined_at ASC order, sourced from
 //     globalstore.GetUserTenants. Empty list when the user has no
 //     memberships.
-//   - Catch-all parity: any error from globalstore (or a panic inside
-//     the handler body after validation) collapses to OK with
+//   - Catch-all: any error from globalstore (or a panic inside the
+//     handler body after validation) collapses to OK with
 //     memberships=[]. We MUST NOT propagate codes.Internal — the
 //     contract test relies on the empty-OK degradation.
 //
 // Metrics: emits entdb_grpc_requests_total{method="GetUserTenants",
-// status="ok"|"error"} via the shared metrics chokepoint. Matching
-// Python, the validation and UNIMPLEMENTED short-circuits do NOT emit
-// metrics — only the post-validation success-or-degraded path does.
+// status="ok"|"error"} via the shared metrics chokepoint. The
+// validation and UNIMPLEMENTED short-circuits do NOT emit metrics —
+// only the post-validation success-or-degraded path does.
 
 package api
 
@@ -80,15 +78,15 @@ func (s *Server) GetUserTenants(
 	}()
 
 	// Trusted-actor resolution. The result is intentionally not used
-	// for an authz decision (Python parity); the call exists so the
-	// interceptor's identity always wins over any payload-claimed
-	// actor (defence in depth — see the spec's "privilege-boundary
-	// gap" note and the comment block above).
+	// for an authz decision; the call exists so the interceptor's
+	// identity always wins over any payload-claimed actor (defence in
+	// depth — see the spec's "privilege-boundary gap" note and the
+	// comment block above).
 	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
 
 	rows, qerr := s.global.GetUserTenants(ctx, req.GetUserId())
 	if qerr != nil {
-		// Python silently swallows and returns memberships=[] OK.
+		// Silently swallows and returns memberships=[] OK.
 		outcome = "error"
 		return &pb.GetUserTenantsResponse{
 			Memberships: []*pb.TenantMemberInfo{},

--- a/server/go/internal/api/get_user_test.go
+++ b/server/go/internal/api/get_user_test.go
@@ -1,4 +1,4 @@
-// Tests for the GetUser RPC (W2 — EPIC #407).
+// Tests for the GetUser RPC.
 //
 // Spec: docs/go-port/rpcs/GetUser.md. Three branches pinned here, one
 // per contract test referenced by the spec:

--- a/server/go/internal/api/health.go
+++ b/server/go/internal/api/health.go
@@ -65,12 +65,12 @@ func (s *Server) Health(ctx context.Context, _ *pb.HealthRequest) (*pb.HealthRes
 		components["wal"] = probeWAL(s.producer)
 	}
 
-	// Storage probe. Python never actually opens an SQLite cursor and
-	// returns "healthy" unconditionally; we preserve that contract but
-	// still report "unknown" when no store handle is wired so a
-	// misconfigured server doesn't silently report healthy. The nil
-	// check is on the concrete *store.CanonicalStore pointer to avoid
-	// the typed-nil-in-interface trap.
+	// Storage probe. The contract is "healthy" when a store handle is
+	// wired (no live SQLite cursor check is performed); still report
+	// "unknown" when no store handle is wired so a misconfigured server
+	// doesn't silently report healthy. The nil check is on the concrete
+	// *store.CanonicalStore pointer to avoid the typed-nil-in-interface
+	// trap.
 	if s.store == nil {
 		components["storage"] = "unknown"
 	} else {
@@ -97,7 +97,6 @@ func (s *Server) Health(ctx context.Context, _ *pb.HealthRequest) (*pb.HealthRes
 // in the Health handler so this helper can stay simple).
 // Contract:
 //   - producer w/o IsConnected() (e.g. in-memory) -> "healthy"
-//     (matches Python hasattr() fall-through)
 //   - IsConnected() panics -> "unknown"
 //   - IsConnected() == true -> "healthy"
 //   - IsConnected() == false -> "unhealthy"

--- a/server/go/internal/api/health_test.go
+++ b/server/go/internal/api/health_test.go
@@ -123,8 +123,7 @@ func TestHealth_NoDepsWired(t *testing.T) {
 
 // TestHealth_WALProducerWithoutIsConnected pins the in-memory-backend
 // branch: a Producer that doesn't implement the optional IsConnected
-// probe is treated as healthy. Mirrors Python's
-// `hasattr(self.wal, "is_connected")` shim returning False.
+// probe is treated as healthy.
 func TestHealth_WALProducerWithoutIsConnected(t *testing.T) {
 	t.Parallel()
 

--- a/server/go/internal/api/helpers.go
+++ b/server/go/internal/api/helpers.go
@@ -85,7 +85,7 @@ func (s *Server) lookupMemberRole(ctx context.Context, tenantID, userID string) 
 }
 
 // readRole captures the outcome of the cross-tenant read-membership
-// check. Mirrors the Python `_check_cross_tenant_read` sentinels.
+// check.
 //
 // Consolidated from per-handler duplicates (get_node.go's readRole and
 // get_nodes.go's crossTenantRole — same semantics, different names).
@@ -182,8 +182,8 @@ func edgeToProto(e *store.Edge) *pb.Edge {
 
 // edgePropsToStruct parses a stored props_json column into a typed
 // Struct. Empty / invalid input lowers to an empty Struct, never nil:
-// the Python wire shape always emits the field so SDK consumers can
-// rely on `edge.props.fields` being addressable without a nil check.
+// the wire shape always emits the field so SDK consumers can rely on
+// `edge.props.fields` being addressable without a nil check.
 func edgePropsToStruct(propsJSON string) *structpb.Struct {
 	if propsJSON == "" {
 		s, _ := structpb.NewStruct(map[string]any{})
@@ -312,9 +312,8 @@ func parsePayloadFieldID(s string) (uint32, bool) {
 // authActorToACLActor bridges the auth.Actor (caller identity admitted
 // by the interceptor) and the acl.Actor (ACL grant subject). user /
 // system translate directly; admin maps to system because admins
-// bypass ACL on the read path (matches Python's "admin can read
-// everything" handler-level convention — expressing admin as system:
-// here picks up the same bypass in acl.Filter.FilterReadable).
+// bypass ACL on the read path — expressing admin as system: here picks
+// up the same bypass in acl.Filter.FilterReadable.
 //
 // Consolidated from query_nodes.go and get_connected_nodes.go. Picks
 // the defensive form: IsZero short-circuits, admin -> system to
@@ -339,9 +338,8 @@ func authActorToACLActor(a auth.Actor) acl.Actor {
 
 // storeVisibilityAdapter satisfies acl.VisibilityReader by forwarding
 // to CanonicalStore.GetVisibleNodeIDs. The store method is named
-// GetVisibleNodeIDs (renamed from the Python _get_visible_nodes); the
-// acl interface uses the unprefixed name. Both signatures are
-// otherwise identical.
+// GetVisibleNodeIDs; the acl interface uses the unprefixed name. Both
+// signatures are otherwise identical.
 type storeVisibilityAdapter struct {
 	s *store.CanonicalStore
 }

--- a/server/go/internal/api/list_mailbox_users.go
+++ b/server/go/internal/api/list_mailbox_users.go
@@ -9,8 +9,7 @@
 //     tenant returns ListMailboxUsersResponse{user_ids: []}.
 //   - The handler MUST NOT touch the WAL, canonical SQLite, schema, ACL,
 //     audit, quota, or crypto — it is read-only and identity-independent.
-//   - An unknown tenant MUST surface NOT_FOUND via tenant.CheckTenant
-//     (mirrors the Python _check_tenant gate).
+//   - An unknown tenant MUST surface NOT_FOUND via tenant.CheckTenant.
 
 package api
 
@@ -21,9 +20,9 @@ import (
 )
 
 // ListMailboxUsers implements entdb.v1.EntDBService/ListMailboxUsers as
-// a deprecated stub: tenant gate, then an empty response. Resurrecting
-// a real implementation is intentionally out of scope for EPIC #407 —
-// see the open-questions section of the port spec.
+// a deprecated stub: tenant gate, then an empty response. See the
+// open-questions section of the port spec for resurrecting a real
+// implementation.
 func (s *Server) ListMailboxUsers(
 	ctx context.Context,
 	req *pb.ListMailboxUsersRequest,
@@ -31,8 +30,7 @@ func (s *Server) ListMailboxUsers(
 	if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
 		return nil, err
 	}
-	// UserIds is explicitly a zero-length, non-nil slice to mirror the
-	// Python `ListMailboxUsersResponse(user_ids=[])` pinned by
+	// UserIds is explicitly a zero-length, non-nil slice pinned by
 	// test_grpc_contract.py:286.
 	return &pb.ListMailboxUsersResponse{UserIds: []string{}}, nil
 }

--- a/server/go/internal/api/list_mailbox_users_test.go
+++ b/server/go/internal/api/list_mailbox_users_test.go
@@ -21,8 +21,7 @@ import (
 
 // TestListMailboxUsers_EmptyForValidTenant pins the deprecated-stub
 // contract: a tenant that passes the gate returns an empty user_ids
-// list. The slice must be non-nil — matches Python's
-// `ListMailboxUsersResponse(user_ids=[])` repeated-field default.
+// list. The slice must be non-nil (non-nil repeated-field default).
 func TestListMailboxUsers_EmptyForValidTenant(t *testing.T) {
 	t.Parallel()
 

--- a/server/go/internal/api/list_shared_with_me.go
+++ b/server/go/internal/api/list_shared_with_me.go
@@ -44,20 +44,20 @@
 //     `nodes=[]` with status OK rather than surfacing the fault. This
 //     is hostile to debugging but load-bearing for parity; flagged for
 //     tightening in a separate issue.
-//   - Hardening delta vs Python: limit clamped to [0, 1000]; default
-//     when zero is 100 (matches Python). Negative limit/offset clamped
-//     to 0 instead of being passed through to SQLite (where negative
-//     LIMIT means "unlimited" — undefined behaviour).
+//   - Limit is clamped to [0, 1000]; default when zero is 100.
+//     Negative limit/offset are clamped to 0 rather than passed
+//     through to SQLite (where negative LIMIT means "unlimited" —
+//     undefined behaviour).
 //
 // Note on group resolution: this implementation does NOT yet expand
 // groups for the per-tenant query (group_users-backed
-// `acl.Resolver.Expand` is wired only in W1.10). The bare actor is
-// passed as a single-element actor list, which is parity with the
-// "user has no groups" steady state. Group-share inclusion is covered
-// by the cross-tenant path because ShareNode fans out group → members
-// at write time and writes one `shared_index` row per (member,
-// source_tenant, node). When the per-tenant group resolver lands, swap
-// in `acl.Resolver.ExpandIDs(ctx, tenant, actor)` here.
+// `acl.Resolver.Expand`). The bare actor is passed as a single-element
+// actor list, matching the "user has no groups" steady state. Group-
+// share inclusion is covered by the cross-tenant path because ShareNode
+// fans out group → members at write time and writes one `shared_index`
+// row per (member, source_tenant, node). When the per-tenant group
+// resolver lands, swap in `acl.Resolver.ExpandIDs(ctx, tenant, actor)`
+// here.
 //
 // NOT modified by this PR: server/go/internal/api/server.go (per task statement).
 
@@ -114,8 +114,7 @@ func (s *Server) ListSharedWithMe(
 		return emptyListSharedWithMeResponse(), nil
 	}
 
-	// Limit/offset clamping. Python passes raw values through to
-	// SQLite; the Go port hardens this — see file header.
+	// Limit/offset clamping — see file header for the rationale.
 	limit := req.GetLimit()
 	if limit <= 0 {
 		limit = listSharedWithMeDefaultLimit
@@ -161,8 +160,7 @@ func (s *Server) ListSharedWithMe(
 				if s.store == nil {
 					// No store wired — we can't fetch the full Node,
 					// so the cross-tenant path is unusable. Skip
-					// silently (matches the Python "no global_store"
-					// graceful degrade applied in reverse).
+					// silently.
 					continue
 				}
 				n, err := s.store.GetNode(ctx, e.SourceTenant, e.NodeID)
@@ -208,7 +206,7 @@ func (s *Server) ListSharedWithMe(
 }
 
 // emptyListSharedWithMeResponse is the canned empty response. Nodes is
-// a non-nil empty slice for symmetry with Python's `nodes=[]`.
+// a non-nil empty slice (non-nil repeated-field default).
 func emptyListSharedWithMeResponse() *pb.ListSharedWithMeResponse {
 	return &pb.ListSharedWithMeResponse{
 		Nodes:   []*pb.Node{},

--- a/server/go/internal/api/list_shared_with_me_test.go
+++ b/server/go/internal/api/list_shared_with_me_test.go
@@ -1,4 +1,4 @@
-// Tests for the ListSharedWithMe RPC (W2 — EPIC #407).
+// Tests for the ListSharedWithMe RPC.
 //
 // The behaviours pinned here mirror the contract in
 // docs/go-port/rpcs/ListSharedWithMe.md.

--- a/server/go/internal/api/list_tenants.go
+++ b/server/go/internal/api/list_tenants.go
@@ -34,12 +34,10 @@
 //     escape the swallow.
 //
 // Source-of-truth: the Go port reads its tenant inventory from
-// globalstore.ListTenants("active") (the registry table) rather than
-// the Python directory scan over `data_dir/tenant_*.db`. The two land
-// on the same set in production deployments because tenant creation
-// always inserts into the registry first; the empty-globalstore branch
-// from Python (test harness with no globalstore) is preserved by the
-// nil-globalstore short-circuit below.
+// globalstore.ListTenants("active") (the registry table). Tenant
+// creation always inserts into the registry first; the embedded-harness
+// branch (no globalstore) is preserved by the nil-globalstore short-
+// circuit below.
 
 package api
 
@@ -149,8 +147,8 @@ func (s *Server) ListTenants(
 		visible = []string{}
 	}
 
-	// Stable ascending order. Spec note: Python returns sorted glob
-	// order; explicit sort.Strings defends against future drift.
+	// Stable ascending order. Explicit sort.Strings defends against
+	// future drift.
 	sort.Strings(visible)
 
 	out := make([]*pb.TenantInfo, 0, len(visible))

--- a/server/go/internal/api/list_tenants_test.go
+++ b/server/go/internal/api/list_tenants_test.go
@@ -5,9 +5,8 @@
 //     (over-the-wire empty request without auth interceptor →
 //     PERMISSION_DENIED).
 //
-// The Go port maps these onto auth.WithIdentity(ctx, ...) instead of
-// the Python ContextVar, but the visibility classes and error contract
-// are identical.
+// The Go port maps these onto auth.WithIdentity(ctx, ...). The
+// visibility classes and error contract are identical.
 
 package api_test
 

--- a/server/go/internal/api/list_users.go
+++ b/server/go/internal/api/list_users.go
@@ -86,10 +86,9 @@ func (s *Server) ListUsers(
 
 	rows, err := s.global.ListUsers(ctx, statusFilter, limit, offset)
 	if err != nil {
-		// Mirror Python's outer `except Exception` swallow: log via the
-		// metrics label, return an empty list with codes.OK. Tracked as
-		// a parity wart for follow-up — this hides DB outages from
-		// callers and breaks pagination clients silently.
+		// Swallow: log via the metrics label, return an empty list with
+		// codes.OK. Tracked as a parity wart for follow-up — this hides
+		// DB outages from callers and breaks pagination clients silently.
 		statusLabel = "error"
 		return &pb.ListUsersResponse{Users: []*pb.UserInfo{}}, nil
 	}

--- a/server/go/internal/api/list_users_test.go
+++ b/server/go/internal/api/list_users_test.go
@@ -1,14 +1,14 @@
 // Behavioural tests for ListUsers. Spec is docs/go-port/rpcs/ListUsers.md.
 //
-// The four cases below cover the parity shape Python pins:
+// The four cases below cover the contract shape:
 //
 //  1. Empty registry -> users=[], OK.
 //  2. Multi-row round-trip -> proto fields preserved, ordered by
 //     created_at (the underlying globalstore.ListUsers contract).
 //  3. Default limit=100 + status="active" applied when the request
 //     omits them.
-//  4. Internal globalstore error -> codes.OK with users=[]. Python
-//     swallows; the Go port mirrors verbatim.
+//  4. Internal globalstore error -> codes.OK with users=[] (silent
+//     swallow for parity).
 //
 // Wart-tracking: cases 1 and 2 also exercise the "no admin scope"
 // behaviour by passing a plain user:<id> actor; today this is allowed.
@@ -30,7 +30,7 @@ import (
 
 // TestListUsers_EmptyRegistry: a fresh globalstore with no user_registry
 // rows returns ListUsersResponse{users: []} and codes.OK. The Users
-// slice MUST be non-nil to mirror the Python repeated-field default.
+// slice MUST be non-nil (non-nil repeated-field default).
 func TestListUsers_EmptyRegistry(t *testing.T) {
 	t.Parallel()
 
@@ -47,7 +47,7 @@ func TestListUsers_EmptyRegistry(t *testing.T) {
 		t.Fatalf("ListUsers: response is nil")
 	}
 	if resp.Users == nil {
-		t.Fatalf("ListUsers: Users is nil; want empty slice (parity pin)")
+		t.Fatalf("ListUsers: Users is nil; want empty slice")
 	}
 	if len(resp.Users) != 0 {
 		t.Fatalf("ListUsers: len(Users) = %d; want 0", len(resp.Users))
@@ -220,7 +220,7 @@ func userIDFromIndex(i int) string {
 }
 
 // TestListUsers_EmptyActorInvalidArgument pins the wire-validation
-// branch: actor=="" -> codes.InvalidArgument. Python pin:
+// branch: actor=="" -> codes.InvalidArgument. Contract pin:
 // tests/python/integration/test_grpc_contract.py:423-427.
 func TestListUsers_EmptyActorInvalidArgument(t *testing.T) {
 	t.Parallel()
@@ -282,7 +282,7 @@ func TestListUsers_InternalErrorSwallowed(t *testing.T) {
 		t.Fatalf("ListUsers: response is nil; want empty Users slice")
 	}
 	if resp.Users == nil {
-		t.Fatalf("ListUsers: Users is nil; want non-nil empty slice (parity pin)")
+		t.Fatalf("ListUsers: Users is nil; want non-nil empty slice")
 	}
 	if len(resp.Users) != 0 {
 		t.Fatalf("ListUsers: len(Users) = %d; want 0 on swallowed error", len(resp.Users))

--- a/server/go/internal/api/query_nodes.go
+++ b/server/go/internal/api/query_nodes.go
@@ -6,8 +6,7 @@
 // Wire contract: proto/entdb/v1/entdb.proto:61 (rpc), :424-452
 // (request/response), :675-690 (FieldFilter / FilterOp).
 //
-// Behavior parity with the Python handler, with one DELIBERATE behavior
-// fix flagged by the spec:
+// Behavior with one DELIBERATE behavior fix flagged by the spec:
 //
 //  1. Tenant gate runs first via s.checkTenant (sharding + region +
 //     globalstore existence). Same call shape as every other
@@ -20,15 +19,14 @@
 //     are supported as AND-ed predicates per issue #501. CONTAINS and IN
 //     remain reserved (the wire enum declares them but the server still
 //     surfaces them as INVALID_ARGUMENT pending the full MongoDB-operator
-//     allow-list in W1.10's queryfilter package).
+//     allow-list).
 //  5. ACL post-filter on cross-tenant reads via acl.Filter.FilterReadable.
-//     The Python handler iterates can_access; the equivalent Go path is
-//     the bulk VisibleNodeIDs JOIN already implemented in
+//     The bulk VisibleNodeIDs JOIN is implemented in
 //     store.GetVisibleNodeIDs and exposed through acl.Filter.
 //  6. Response: id-keyed payload Struct (PayloadToStruct) — pinned by
 //     the contract suite. has_more is the cheap (len == limit) heuristic
-//     preserved verbatim (the cross-tenant ACL post-filter makes it
-//     leakier but EPIC #407 explicitly defers a fix).
+//     (the cross-tenant ACL post-filter makes it leakier; a fix is
+//     deferred).
 //
 // BEHAVIOR CHANGE flagged in the spec ("Error contract" / "Open
 // questions" §5): the Go port MUST surface gRPC errors so unsupported
@@ -176,11 +174,11 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 // (LIKE-with-wildcards, parameterised IN-list) and the issue defers
 // them. Both surface as INVALID_ARGUMENT.
 //
-// Inlined operator shape: the Python SDK historically smuggled non-EQ
-// operators through “Op=EQ, Value=Struct{"$gt": v}“. We honour that
-// shape so the existing SDK call site keeps working — the inlined
-// operator overrides the wire “op“ field. Unknown inlined keys (e.g.
-// “$nin“, “$between“) still surface as INVALID_ARGUMENT.
+// Inlined operator shape: non-EQ operators may be smuggled through
+// “Op=EQ, Value=Struct{“$gt”: v}”. We honour that shape so the
+// existing SDK call site keeps working — the inlined operator overrides
+// the wire “op” field. Unknown inlined keys (e.g. “$nin”, “$between”)
+// still surface as INVALID_ARGUMENT.
 func (s *Server) fieldFiltersToStoreFilters(typeName string, filters []*pb.FieldFilter) ([]store.QueryFilter, error) {
 	if len(filters) == 0 {
 		return nil, nil
@@ -222,10 +220,9 @@ func (s *Server) fieldFiltersToStoreFilters(typeName string, filters []*pb.Field
 		}
 
 		// Inlined operator detection: a Struct value carrying
-		// ``$gt``/``$lt``/... keys. The Python SDK uses this shape to
-		// fan a single FieldFilter into a multi-op predicate (e.g.
-		// ``{"price": {"$gte": 100, "$lt": 200}}``). Emit one store
-		// filter per inlined entry.
+		// ``$gt``/``$lt``/... keys fans a single FieldFilter into a
+		// multi-op predicate (e.g. ``{"price": {"$gte": 100, "$lt":
+		// 200}}``). Emit one store filter per inlined entry.
 		if subs, ok := inlinedFilterOps(raw); ok {
 			for _, sub := range subs {
 				op, ok := storeFilterOpFromInlineKey(sub.key)
@@ -292,8 +289,8 @@ func storeFilterOpToToken(op store.QueryFilterOp) string {
 	}
 }
 
-// storeFilterOpFromInlineKey maps the MongoDB-style “$gt“ keys used
-// by the Python SDK when smuggling non-EQ operators through Op=EQ.
+// storeFilterOpFromInlineKey maps the MongoDB-style “$gt” inlined
+// operator keys to the store comparison-operator type.
 func storeFilterOpFromInlineKey(key string) (store.QueryFilterOp, bool) {
 	switch key {
 	case "$eq":
@@ -314,9 +311,9 @@ func storeFilterOpFromInlineKey(key string) (store.QueryFilterOp, bool) {
 
 // inlinedFilterOps reports whether the FieldFilter value carries the
 // inlined operator shape (a JSON object whose first key starts with
-// “$“) and, if so, returns the (op-key, value) pairs in iteration
-// order. The shape historically lets callers express “{"price":
-// {"$gt": 10, "$lt": 100}}“.
+// “$”) and, if so, returns the (op-key, value) pairs in iteration
+// order. Callers use this to express “{“price”: {“$gt”: 10, “$lt”:
+// 100}}”.
 type inlinedFilterOp struct {
 	key   string
 	value any

--- a/server/go/internal/api/query_nodes_test.go
+++ b/server/go/internal/api/query_nodes_test.go
@@ -1,4 +1,4 @@
-// Tests for the QueryNodes RPC (W2 — EPIC #407).
+// Tests for the QueryNodes RPC.
 //
 // Spec: docs/go-port/rpcs/QueryNodes.md.
 //
@@ -9,14 +9,14 @@
 //     pages.
 //  3. ACL post-filter excludes nodes the cross-tenant caller cannot
 //     read; nodes with a direct grant survive.
-//  4. Unsupported FilterOp (GTE) -> codes.InvalidArgument. This is the
-//     deliberate behaviour FIX over Python's silent exception swallow
-//     called out in the spec "Open questions" §5.
+//  4. Unsupported FilterOp (GTE) -> codes.InvalidArgument. The handler
+//     surfaces errors so unsupported filters reach the SDK (spec
+//     "Open questions" §5).
 //  5. Inlined-operator value (Op=EQ, Value={"$gte":, ...}) -> codes.
-//     InvalidArgument. Same parity-fix rationale as (4).
+//     InvalidArgument. Same rationale as (4).
 //  6. Sort by node_id ascending returns rows in lexical order.
 //
-// Tests live in `package api_test` per the W2 task brief.
+// Tests live in `package api_test`.
 
 package api_test
 
@@ -257,8 +257,8 @@ func TestQueryNodes_RangeOperatorsANDed(t *testing.T) {
 }
 
 // TestQueryNodes_UnsupportedOperator pins the still-rejected operators.
-// CONTAINS and IN remain INVALID_ARGUMENT pending the W1.10 queryfilter
-// package; issue #501 explicitly scoped them out.
+// CONTAINS and IN remain INVALID_ARGUMENT; issue #501 explicitly scoped
+// them out.
 func TestQueryNodes_UnsupportedOperator(t *testing.T) {
 	t.Parallel()
 	f := newQueryNodesFixture(t)
@@ -405,10 +405,8 @@ func TestQueryNodes_ACLPostFilter(t *testing.T) {
 }
 
 // TestQueryNodes_InlinedOperator pins the inlined-operator shape: a
-// Struct value carrying “$gte“ / “$lt“ / ...keys fans into one
-// store filter per inlined entry. This is the wire shape the Python
-// SDK has historically emitted; issue #501 wires the server to accept
-// it natively.
+// Struct value carrying “$gte” / “$lt” / ...keys fans into one store
+// filter per inlined entry (issue #501).
 func TestQueryNodes_InlinedOperator(t *testing.T) {
 	t.Parallel()
 	f := newQueryNodesFixture(t)

--- a/server/go/internal/api/remove_group_member.go
+++ b/server/go/internal/api/remove_group_member.go
@@ -6,25 +6,22 @@
 //
 // # Behavioural pins
 //
-//   - WAL-first restoration. The Go port routes the membership delete
-//     through wal.Append as a `remove_group_member` op (W1.10 applier
-//     handler at server/go/internal/apply/ops_remove_group_member.go),
-//     so a replay-from-empty-WAL reconstructs the same group_users
-//     state. The group-derived shared_index cleanup is represented as a
-//     paired WAL op and applied best-effort by the applier, not by the
+//   - WAL-first restoration. The membership delete routes through
+//     wal.Append as a `remove_group_member` op (applier handler at
+//     server/go/internal/apply/ops_remove_group_member.go), so a
+//     replay-from-empty-WAL reconstructs the same group_users state.
+//     The group-derived shared_index cleanup is represented as a paired
+//     WAL op and applied best-effort by the applier, not by the
 //     handler.
 //
-//   - Auth (Go HARDENS vs Python). The Go port gates the RPC behind
-//     admin/system trusted actors OR a tenant "owner"/"admin" membership
-//     row, matching AddTenantMember / ChangeMemberRole / RemoveTenantMember.
-//     There is no "group owner" concept in the schema today; v1 rule is
-//     tenant-admin.
+//   - Auth. The RPC is gated behind admin/system trusted actors OR a
+//     tenant "owner"/"admin" membership row, matching AddTenantMember /
+//     ChangeMemberRole / RemoveTenantMember. There is no "group owner"
+//     concept in the schema today; v1 rule is tenant-admin.
 //
 //   - Trusted-actor rebind. The wire `actor` is UNTRUSTED. Privilege
 //     decisions consult auth.Authoritative(ctx) only. The privilege-
-//     escalation regression pinned by commit fece3fb applies here too
-//     even though Python does not invoke `_trusted_actor` for this
-//     RPC.
+//     escalation regression pinned by commit fece3fb applies here too.
 //
 //   - Cascade scope. Per spec §"Side effects" item 6.2: only group-
 //     derived shared_index entries are cleaned up. Direct grants on
@@ -36,8 +33,8 @@
 //     undercounts (spec ordering invariant).
 //
 //   - Idempotency. Removing a non-existent (group, member) returns
-//     success=false, error="" with code OK (parity with Python and
-//     spec §"Error contract"). Repeats are safe — the op is a
+//     success=false, error="" with code OK (spec §"Error contract").
+//     Repeats are safe — the op is a
 //     DELETE with no rows-affected tracking on the apply path, the
 //     pre-read is a SELECT, and the shared_index cleanup op is
 //     delete-if-exists.
@@ -116,10 +113,10 @@ func (s *Server) RemoveGroupMember(
 	claimed := auth.ParseActor(req.GetContext().GetActor())
 	trusted := auth.Authoritative(ctx, claimed)
 
-	// Capability check — Go HARDENS vs Python (spec §"Open questions"
-	// item 6 latent privilege escalation). System / admin prefixed trusted
-	// actors bypass; otherwise the caller must be a tenant owner/admin,
-	// mirroring AddTenantMember / ChangeMemberRole / RemoveTenantMember.
+	// Capability check (spec §"Open questions" item 6). System / admin
+	// prefixed trusted actors bypass; otherwise the caller must be a
+	// tenant owner/admin, mirroring AddTenantMember / ChangeMemberRole /
+	// RemoveTenantMember.
 	if !(trusted.IsSystem() || trusted.IsAdmin()) {
 		if s.global == nil {
 			status = "error"
@@ -143,8 +140,7 @@ func (s *Server) RemoveGroupMember(
 	//   1. `found` — was the (group, member) pair a row in group_users?
 	//      The WAL DELETE is rows-affected-agnostic at the applier
 	//      layer (ops_remove_group_member.go just runs the DELETE);
-	//      the response.success flag mirrors Python's canonical_store
-	//      return value, so we read it here.
+	//      we read the membership state here to populate response.success.
 	//
 	//   2. `groupAccess` — node_access rows where actor_id == groupID
 	//      and actor_type == 'group'. Pre-read ordering is load-
@@ -173,7 +169,7 @@ func (s *Server) RemoveGroupMember(
 	}
 
 	// WAL append — restores CLAUDE.md §1. Op shape is the contract the
-	// W1.10 applier handler reads at apply/ops_remove_group_member.go.
+	// applier handler reads at apply/ops_remove_group_member.go.
 	idempKey, err := newIdempotencyKey()
 	if err != nil {
 		status = "error"

--- a/server/go/internal/api/remove_group_member_test.go
+++ b/server/go/internal/api/remove_group_member_test.go
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Tests for RemoveGroupMember (EPIC #407, — WAL-first restoration).
+// Tests for RemoveGroupMember (WAL-first).
 //
 // Behaviour pinned here:
 //
-//   1. Admin happy path — admin trusted actor removes an existing
-//      member; WAL records the `remove_group_member` op, the
-//      shared_index cascade clears the member's group-derived rows,
-//      and direct grants on individual nodes survive untouched.
-//   2. Non-admin → PERMISSION_DENIED (Go HARDENS vs Python; the
-//      Python handler skips the capability check entirely).
-//   3. Idempotent remove-not-member: a (group, member) pair that
-//      isn't a row returns success=false, error="" with code OK and
-//      still appends a WAL record (the applier's DELETE is a no-op).
-//   4. Direct grants preserved: a node_access row whose actor_id is
-//      the member (NOT the group) is left in place after the cascade.
+//  1. Admin happy path — admin trusted actor removes an existing
+//     member; WAL records the `remove_group_member` op, the
+//     shared_index cascade clears the member's group-derived rows,
+//     and direct grants on individual nodes survive untouched.
+//  2. Non-admin → PERMISSION_DENIED (the handler gates on admin/owner
+//     role; callers without it are rejected).
+//  3. Idempotent remove-not-member: a (group, member) pair that
+//     isn't a row returns success=false, error="" with code OK and
+//     still appends a WAL record (the applier's DELETE is a no-op).
+//  4. Direct grants preserved: a node_access row whose actor_id is
+//     the member (NOT the group) is left in place after the cascade.
 
 package api_test
 
@@ -306,9 +306,8 @@ func TestRemoveGroupMember_AdminHappyPath_WALAndCascade(t *testing.T) {
 }
 
 // TestRemoveGroupMember_NonAdminDenied: a regular tenant member (role
-// "member") is rejected with PERMISSION_DENIED. This is the Go-side
-// hardening of the Python parity gap (capability_registry has no entry
-// for RemoveGroupMember).
+// "member") is rejected with PERMISSION_DENIED. The handler gates on
+// admin/owner role; callers with only "member" are rejected.
 func TestRemoveGroupMember_NonAdminDenied(t *testing.T) {
 	t.Parallel()
 	f := newRGMFixture(t, "acme")
@@ -366,8 +365,7 @@ func TestRemoveGroupMember_NonAdminDenied(t *testing.T) {
 // TestRemoveGroupMember_IdempotentRemoveNotMember: removing a (group,
 // member) pair that does not exist returns success=false, error="" and
 // still appends a WAL record so a replay observes the (idempotent)
-// DELETE. Mirrors test_acl_v2.py:590-591 and the spec idempotency
-// contract (§"Open questions" item 2).
+// DELETE (spec idempotency contract §"Open questions" item 2).
 func TestRemoveGroupMember_IdempotentRemoveNotMember(t *testing.T) {
 	t.Parallel()
 	f := newRGMFixture(t, "acme")

--- a/server/go/internal/api/remove_tenant_member.go
+++ b/server/go/internal/api/remove_tenant_member.go
@@ -7,12 +7,11 @@
 //
 // # Behavioural pins
 //
-//   - Auth (Go HARDENS vs Python): the Python handler skips the
-//     admin/owner role check entirely (a latent privilege escalation —
-//     any authenticated caller can remove any member). The Go port
-//     closes that gap mirroring AddTenantMember/ChangeMemberRole:
-//     non-admin callers must be the tenant's "owner" or "admin" role,
-//     otherwise PERMISSION_DENIED.
+//   - Auth: the handler gates on admin/owner role, closing the latent
+//     privilege escalation gap (any authenticated caller removing any
+//     member). Non-admin callers must be the tenant's "owner" or
+//     "admin" role, otherwise PERMISSION_DENIED. Mirrors
+//     AddTenantMember/ChangeMemberRole.
 //
 //     The actor on the wire is UNTRUSTED. We rebind to the trusted
 //     actor returned by auth.Authoritative before any privilege check,
@@ -35,14 +34,14 @@
 //
 //   - Last-OWNER protection: removing the only "owner" returns
 //     success=false with error="Cannot remove the last owner of a
-//     tenant" (NOT a gRPC error code — this is a domain-level "no-op"
-//     per Python's contract). "admin" is NOT protected — only "owner".
+//     tenant" (NOT a gRPC error code — domain-level "no-op").
+//     "admin" is NOT protected — only "owner".
 //     Do NOT add an admin guard without an ADR (spec §"Last-admin
 //     nuance").
 //
 //   - Idempotent removal of a non-member: success=false,
 //     error="Member not found", gRPC code OK. Metric label = "ok"
-//     (Python's distribution: dashboards depend on it).
+//     (dashboards depend on it).
 
 package api
 
@@ -97,12 +96,10 @@ func (s *Server) RemoveTenantMember(
 	// auth interceptor (when enabled) installs a verified Identity on
 	// ctx; auth.Authoritative substitutes it for the wire claim. In
 	// no-auth dev/test mode (no interceptor) the claim flows through
-	// unchanged — same behaviour as Python's
-	// auth_interceptor.get_authoritative_actor.
+	// unchanged.
 	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
 
-	// Admin/owner gate — Go HARDENS vs Python (closes the privilege-
-	// escalation gap). Mirrors the pattern in AddTenantMember and
+	// Admin/owner gate. Mirrors the pattern in AddTenantMember and
 	// ChangeMemberRole.
 	if !isAdminOrSystemActor(trusted) {
 		role, err := s.getTenantMemberRole(ctx, req.GetTenantId(), trusted.ID())

--- a/server/go/internal/api/remove_tenant_member_test.go
+++ b/server/go/internal/api/remove_tenant_member_test.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Tests for RemoveTenantMember. The Go port closes
-// the auth-parity gap against Python — see RemoveTenantMember.md
+// Tests for RemoveTenantMember. See RemoveTenantMember.md
 // "Auth (admin only; trusted-actor)".
 
 package api_test
@@ -87,9 +86,8 @@ func TestRemoveTenantMember_AdminHappyPath(t *testing.T) {
 }
 
 // TestRemoveTenantMember_NonAdminDenied: a regular member trying to
-// remove another member is rejected with PERMISSION_DENIED. This is
-// the auth-parity-gap fix — Python lets this succeed (latent privilege
-// escalation; spec §"Auth").
+// remove another member is rejected with PERMISSION_DENIED (latent
+// privilege escalation closed; spec §"Auth").
 func TestRemoveTenantMember_NonAdminDenied(t *testing.T) {
 	t.Parallel()
 	gs := newGlobalStore(t)

--- a/server/go/internal/api/revoke_access.go
+++ b/server/go/internal/api/revoke_access.go
@@ -35,9 +35,8 @@
 //
 // # Error contract
 //
-// Mirrors the Python contract: errors come back as
-// RevokeAccessResponse{Found:false, Error:<string>} on the response,
-// NOT as a gRPC status error. Three observable paths:
+// Errors come back as RevokeAccessResponse{Found:false, Error:<string>}
+// on the response, NOT as a gRPC status error. Three observable paths:
 //
 //	PermissionDenied Found=false, Error="permission denied: ..."
 //	WAL/append failure Found=false, Error=<err>
@@ -61,9 +60,9 @@
 //
 // Emits entdb_grpc_requests_total{method="RevokeAccess",
 // status="ok"|"denied"|"error"} via the shared metrics chokepoint.
-// Labels follow the Python convention: "denied" specifically for
-// PermissionDenied, "error" for any other failure, "ok" for the happy
-// path including idempotent revoke-not-granted.
+// Labels: "denied" specifically for PermissionDenied, "error" for any
+// other failure, "ok" for the happy path including idempotent
+// revoke-not-granted.
 
 package api
 

--- a/server/go/internal/api/revoke_access_test.go
+++ b/server/go/internal/api/revoke_access_test.go
@@ -1,5 +1,5 @@
-// Tests for RevokeAccess. Behavioural parity with the Python handler
-// is pinned by the cross-language contract suite at
+// Tests for RevokeAccess. Behavioural parity is pinned by the
+// cross-language contract suite at
 // tests/python/integration/test_grpc_contract.py:351-361. This file covers
 // the three branches the spec calls out:
 //

--- a/server/go/internal/api/revoke_all_user_access.go
+++ b/server/go/internal/api/revoke_all_user_access.go
@@ -7,13 +7,11 @@
 //
 // # Behavioural pins
 //
-//   - WAL-FIRST RESTORATION (Go HARDENS vs Python). The Go port appends
-//     a single `admin_revoke_access` op into the WAL; the broadened
-//     applier (server/go/internal/apply/ops_admin_revoke_access.go)
+//   - WAL-FIRST. A single `admin_revoke_access` op is appended to the
+//     WAL; the applier (server/go/internal/apply/ops_admin_revoke_access.go)
 //     deletes from node_access AND group_users AND node_visibility for
 //     the user. PLAN.md §6.4 item 2. Pinned by
-//     docs/go-port/rpcs/RevokeAllUserAccess.md "WAL invariant gap (Go
-//     port MUST fix)".
+//     docs/go-port/rpcs/RevokeAllUserAccess.md "WAL invariant gap".
 //
 //   - Trusted-actor authz. The wire `actor` field is UNTRUSTED. We
 //     rebind to the auth.Authoritative identity from ctx before any
@@ -30,19 +28,16 @@
 //     before the auth gate. Pinned by
 //     tests/python/integration/test_grpc_contract.py:584-596.
 //
-//   - Tally semantics. Python returns rowcounts from the synchronous
-//     SQLite delete. The Go path is WAL-first, so we read the current
-//     row counts BEFORE appending the WAL event, wait for the applier,
-//     and return those pre-append counts as the tallies. Re-running is
-//     idempotent (the applier's per-event dedupe via applied_events)
-//     and the second call will see zero rows pre-append, matching
-//     Python's "no-op on retry" tally.
+//   - Tally semantics. The handler reads current row counts BEFORE
+//     appending the WAL event, waits for the applier, and returns those
+//     pre-append counts as the tallies. Re-running is idempotent (the
+//     applier's per-event dedupe via applied_events) and the second call
+//     will see zero rows pre-append (no-op on retry).
 //
 //   - Cross-tenant cleanup (shared_index). The same tenant WAL event
 //     carries an `access_revoked` op, applied by the applier after the
 //     tenant-scoped revoke op. The returned revoked_shared count is
-//     read before append, matching Python's synchronous-rowcount
-//     semantics.
+//     read before append.
 //
 //   - Idempotency key. Synthesized from (tenant_id, user_id,
 //     trusted_actor) so retries within the same admin's session
@@ -71,10 +66,10 @@ import (
 const revokeAllUserAccessMethod = "RevokeAllUserAccess"
 
 // revokeAllUserAccessTopic is the WAL topic the handler appends to.
-// Mirrors the cmd/entdb-server/main.go default flag value
-// ("entdb-wal"). Hard-coded here because the Server type has no topic
-// option; centralizing this constant keeps the api package
-// self-contained until the cross-RPC topic wiring lands.
+// Matches the cmd/entdb-server/main.go default flag value ("entdb-wal").
+// Hard-coded here because the Server type has no topic option;
+// centralizing this constant keeps the api package self-contained until
+// the cross-RPC topic wiring lands.
 const revokeAllUserAccessTopic = "entdb-wal"
 
 // revokeAllUserAccessSharedLimit caps the cross-tenant shared_index
@@ -143,10 +138,9 @@ func (s *Server) RevokeAllUserAccess(
 	}
 
 	// Pre-append tallies. Reading from the per-tenant SQLite gives the
-	// "rows that will be deleted by the applier" count, matching
-	// Python's synchronous-rowcount semantics. Idempotent retries
-	// (which the applier dedupes) will see zero rows here on the
-	// second call — same shape as Python's repeat-call no-op.
+	// "rows that will be deleted by the applier" count. Idempotent
+	// retries (which the applier dedupes) will see zero rows here on
+	// the second call.
 	revokedGrants, revokedGroups, err := s.countAccessRowsForUser(
 		ctx, req.GetTenantId(), req.GetUserId(),
 	)
@@ -156,10 +150,10 @@ func (s *Server) RevokeAllUserAccess(
 	}
 	revokedShared := s.countSharedIndexRows(ctx, req.GetUserId(), req.GetTenantId())
 
-	// WAL append: a single `admin_revoke_access` op. The applier's
-	// W1.10-broadened branch (apply/ops_admin_revoke_access.go) deletes
-	// node_access + group_users + node_visibility in one BEGIN
-	// IMMEDIATE txn — atomic on the tenant SQLite side.
+	// WAL append: a single `admin_revoke_access` op. The applier
+	// (apply/ops_admin_revoke_access.go) deletes node_access +
+	// group_users + node_visibility in one BEGIN IMMEDIATE txn —
+	// atomic on the tenant SQLite side.
 	idempKey := fmt.Sprintf("revoke-all:%s:%s:%s",
 		req.GetTenantId(), req.GetUserId(), trusted.String())
 	ev := apply.Event{
@@ -208,8 +202,7 @@ func (s *Server) RevokeAllUserAccess(
 
 // countAccessRowsForUser reads node_access and group_users counts for
 // userID from the per-tenant SQLite. Returns (grants, groups). A
-// missing tenant DB is treated as "no rows" (matches Python's empty-
-// store semantics — no rows to revoke).
+// missing tenant DB is treated as "no rows" — nothing to revoke.
 func (s *Server) countAccessRowsForUser(
 	ctx context.Context, tenantID, userID string,
 ) (int64, int64, error) {

--- a/server/go/internal/api/search_mailbox.go
+++ b/server/go/internal/api/search_mailbox.go
@@ -4,7 +4,7 @@
 // land in the per-tenant `notifications` table and a future FTS5-backed
 // implementation will land behind this same RPC.
 //
-// Spec: docs/go-port/rpcs/SearchMailbox.md (EPIC #407).
+// Spec: docs/go-port/rpcs/SearchMailbox.md.
 //
 // Error contract today (pinned by tests/python/integration/test_grpc_
 // contract.py:267-273):

--- a/server/go/internal/api/search_nodes.go
+++ b/server/go/internal/api/search_nodes.go
@@ -18,11 +18,11 @@
 //     coarse RPC-level check.
 //   - ACL post-filter is applied ONLY when the actor is classified
 //     "cross_tenant" (i.e. not a tenant member, not a system identity).
-//     In-tenant members see the unfiltered FTS result set — same as
-//     Python QueryNodes. Tightening this requires its own decision doc.
-//   - Order of operations matches Python exactly: tenant -> validate
-//     query -> searchable lookup -> SQL -> ACL trim -> proto convert.
-//     Swapping any two breaks at least one contract test.
+//     In-tenant members see the unfiltered FTS result set. Tightening
+//     this requires its own decision doc.
+//   - Order of operations: tenant -> validate query -> searchable
+//     lookup -> SQL -> ACL trim -> proto convert. Swapping any two
+//     breaks at least one contract test.
 //
 // Error contract:
 //
@@ -108,8 +108,7 @@ func (s *Server) SearchNodes(
 	//    etc.) is swallowed and reported as an empty result with codes.OK.
 	//    See spec lines 63-66.
 	if s.store == nil {
-		// No store wired — same contract as the Python "no canonical
-		// store" path: empty result, codes.OK.
+		// No store wired — empty result, codes.OK.
 		return &pb.SearchNodesResponse{Nodes: []*pb.Node{}}, nil
 	}
 
@@ -125,15 +124,14 @@ func (s *Server) SearchNodes(
 	rows, ferr := s.store.SearchNodes(ctx, tenantID, typeID, q, searchableFIDs, limit, offset)
 	if ferr != nil {
 		// Swallow + empty + log "error" outcome. Operators see the
-		// elevated metric label; clients see codes.OK. Matches Python
-		// blanket except.
+		// elevated metric label; clients see codes.OK.
 		outcome = "error"
 		return &pb.SearchNodesResponse{Nodes: []*pb.Node{}}, nil
 	}
 
 	// 5. ACL post-filter — only when the actor is classified
 	//    "cross_tenant". In-tenant members and system actors see the
-	//    unfiltered set (parity with QueryNodes; see spec line 42).
+	//    unfiltered set (see spec line 42).
 	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
 	if s.isCrossTenantReader(ctx, tenantID, trusted) {
 		rows = filterNodesByActor(rows, trusted)
@@ -169,9 +167,8 @@ func (s *Server) isCrossTenantReader(ctx context.Context, tenantID string, trust
 	}
 	if trusted.IsZero() {
 		// No identity at all — treat as cross-tenant so the ACL filter
-		// drops everything not explicitly shared. Matches the spirit of
-		// the Python PD branch which becomes an empty response via the
-		// outer swallow.
+		// drops everything not explicitly shared, producing an empty
+		// response via the outer swallow.
 		return true
 	}
 	member, err := s.global.IsMember(ctx, tenantID, trusted.ID())
@@ -191,12 +188,10 @@ func (s *Server) isCrossTenantReader(ctx context.Context, tenantID string, trust
 //   - any ACL entry on the row grants the trusted actor (matching the
 //     legacy `principal` field or the newer `grantee`).
 //
-// This is the minimal can_access shape in scope for W2 — the full
-// group-expansion + capability-typed grant evaluation lives in
-// internal/acl and will be wired in a later wave (see spec
-// "Open questions / risks: ACL trim cost"). For parity, an actor with
-// no matching grants sees zero rows — the Python PD-via-swallow path
-// produces the same empty-set outcome.
+// This is the minimal can_access shape; the full group-expansion +
+// capability-typed grant evaluation lives in internal/acl and will be
+// wired in a later change (see spec "Open questions / risks: ACL trim
+// cost"). An actor with no matching grants sees zero rows.
 func filterNodesByActor(rows []*store.Node, trusted auth.Actor) []*store.Node {
 	if len(rows) == 0 {
 		return rows

--- a/server/go/internal/api/search_nodes_test.go
+++ b/server/go/internal/api/search_nodes_test.go
@@ -1,4 +1,4 @@
-// Tests for the SearchNodes RPC (W2 — EPIC #407).
+// Tests for the SearchNodes RPC.
 //
 // Spec: docs/go-port/rpcs/SearchNodes.md. Five branches pinned here, in
 // the order the spec walks them:
@@ -325,8 +325,8 @@ func TestSearchNodes_QueryTooLong(t *testing.T) {
 
 // TestSearchNodes_MalformedFTSQueryReturnsEmpty: any error after the
 // validation gates is swallowed and the handler returns codes.OK with
-// an empty node list. We pin this for parity; flipping to INTERNAL is
-// a future contract-test update.
+// an empty node list. Flipping to INTERNAL is a future contract-test
+// update.
 func TestSearchNodes_MalformedFTSQueryReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	srv, cs, tenantID := newSearchTestServer(t)

--- a/server/go/internal/api/server.go
+++ b/server/go/internal/api/server.go
@@ -37,11 +37,10 @@ type Server struct {
 	region   string
 	registry *schema.Registry
 
-	// legalHoldOnDelete gates the Go-port addition of a legal-hold
-	// precondition check at GDPR queue time (DeleteUser). Off by
-	// default to keep day-zero parity with the Python handler, which
-	// has no such gate. See docs/go-port/rpcs/DeleteUser.md "Side
-	// effects" / "Open questions" §4.
+	// legalHoldOnDelete gates the legal-hold precondition check at GDPR
+	// queue time (DeleteUser). Off by default; see
+	// docs/go-port/rpcs/DeleteUser.md "Side effects" / "Open
+	// questions" §4.
 	legalHoldOnDelete bool
 
 	// aclEnforcer is the optional ACL Enforcer wired by main.go (or
@@ -110,11 +109,10 @@ func WithEnforcer(e *acl.Enforcer) Option {
 	return func(srv *Server) { srv.aclEnforcer = e }
 }
 
-// WithLegalHoldOnDelete enables the Go-port-only legal-hold gate at
-// DeleteUser queue time. When true, the handler walks the user's
-// tenants and rejects with codes.FailedPrecondition if any tenant has
-// a legal_holds row. Off by default for byte-for-byte parity with the
-// Python handler at HEAD. See docs/go-port/rpcs/DeleteUser.md.
+// WithLegalHoldOnDelete enables the legal-hold gate at DeleteUser queue
+// time. When true, the handler walks the user's tenants and rejects
+// with codes.FailedPrecondition if any tenant has a legal_holds row.
+// Off by default. See docs/go-port/rpcs/DeleteUser.md.
 func WithLegalHoldOnDelete(enabled bool) Option {
 	return func(srv *Server) { srv.legalHoldOnDelete = enabled }
 }

--- a/server/go/internal/api/set_legal_hold.go
+++ b/server/go/internal/api/set_legal_hold.go
@@ -5,16 +5,12 @@
 //
 // Wire contract: proto/entdb/v1/entdb.proto:132 (rpc), :982-992 (messages).
 //
-// Behavioural parity with Python is preserved on the wire shape. Three
-// PLAN.md §6 drifts are folded in here:
+// Three PLAN.md §6 drifts are folded in here:
 //
 //  1. WAL-first restoration (CLAUDE.md invariant #1, spec "Open questions"
-//     item 1). The Python handler writes the status flip directly to
-//     globalstore SQLite — a WAL replay against a blank globalstore
-//     loses the hold. The Go port closes that gap by appending a
-//     `legal_hold_set` op to the global WAL scope. The applier
-//     materialises the op against globalstore.legal_holds and flips
-//     tenant_registry.status before the handler returns.
+//     item 1). A `legal_hold_set` op is appended to the global WAL scope.
+//     The applier materialises the op against globalstore.legal_holds and
+//     flips tenant_registry.status before the handler returns.
 //
 //  2. Compliance-officer trusted-actor gate (spec §"Auth"). Today only
 //     admin: / system: actors may set or clear a hold. The "compliance
@@ -101,11 +97,8 @@ func (s *Server) SetLegalHold(
 
 	// Tenant gate: sharding ownership + registry existence + region pin.
 	// CheckTenant returns NOT_FOUND when the tenant is missing from
-	// tenant_registry. This is a Go-port tightening over the Python
-	// handler (which returns OK + success=false + error="Tenant not
-	// found"); the Python asymmetry is hostile to SDK callers and
-	// every other mutating RPC has converged on the
-	// status-code form.
+	// tenant_registry. Every mutating RPC converges on the status-code
+	// form.
 	if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
 		resultStatus = "error"
 		return nil, err
@@ -115,14 +108,13 @@ func (s *Server) SetLegalHold(
 	// interceptor-bound identity before any authz decision. In
 	// no-auth deployments / unit tests with no Identity on ctx, the
 	// claimed actor is returned as-is (auth.Authoritative documented
-	// fallback) — matching the Python ContextVar fall-through.
+	// fallback).
 	claimed := auth.ParseActor(req.GetActor())
 	trusted := auth.Authoritative(ctx, claimed)
 
 	// Compliance-officer gate. Today admin: / system: stand in for
 	// the not-yet-wired "compliance officer" role (spec "Open questions"
-	// item 5). The owner branch in the Python handler is deferred to
-	// match other RPCs (e.g. ArchiveTenant) — admin-only.
+	// item 5) — admin-only, matching ArchiveTenant.
 	if !(trusted.IsAdmin() || trusted.IsSystem()) {
 		resultStatus = "error"
 		return nil, errs.Errorf(codes.PermissionDenied,

--- a/server/go/internal/api/set_legal_hold_test.go
+++ b/server/go/internal/api/set_legal_hold_test.go
@@ -8,9 +8,9 @@
 //
 //  deviations (intentional, documented in set_legal_hold.go header):
 //
-//   - Unknown tenant -> NOT_FOUND (Python: OK + success=false). All
-//     mutating RPCs converge on the status-code form.
-//   - Owner role bypass deferred — admin-only. Mirrors ArchiveTenant.
+//   - Unknown tenant -> NOT_FOUND (all mutating RPCs converge on the
+//     status-code form).
+//   - Owner role bypass deferred — admin-only, matching ArchiveTenant.
 
 package api_test
 
@@ -415,10 +415,7 @@ func TestSetLegalHold_GlobalStoreNotConfigured(t *testing.T) {
 }
 
 // TestSetLegalHold_UnknownTenantNotFound: an admin call against a tenant
-// not in the registry returns NOT_FOUND (via checkTenant). This is the
-//
-//	deviation from Python's OK + success=false response — see
-//
+// not in the registry returns NOT_FOUND (via checkTenant). See
 // set_legal_hold.go header note.
 func TestSetLegalHold_UnknownTenantNotFound(t *testing.T) {
 	t.Parallel()
@@ -440,7 +437,7 @@ func TestSetLegalHold_UnknownTenantNotFound(t *testing.T) {
 // TestSetLegalHold_AppendsWALEvent_WhenProducerWired: when the WAL
 // producer is wired, the handler appends a `set_legal_hold` op to the
 // configured topic. This is the WAL-first restoration the Go port
-// adds on top of Python parity (CLAUDE.md invariant #1).
+// adds on top of the WAL-first invariant (CLAUDE.md invariant #1).
 //
 // The applier (apply/ops_set_legal_hold.go) consumes the op and writes
 // a globalstore.legal_holds row; that side of the contract is covered

--- a/server/go/internal/api/share_node.go
+++ b/server/go/internal/api/share_node.go
@@ -2,19 +2,15 @@
 
 // ShareNode RPC.
 // Spec: docs/go-port/rpcs/ShareNode.md.
-// Applier branch (W1.10): server/go/internal/apply/ops_share_node.go.
+// Applier branch: server/go/internal/apply/ops_share_node.go.
 //
 // # WAL-first restoration (PLAN.md §6)
 //
-// The Python ShareNode handler bypassed the WAL (CLAUDE.md invariant
-// #1), writing directly to the canonical store, which means a
-// materialized-view rebuild from the WAL silently dropped every share
-// grant. The Go port restores the invariant: handler appends a
-// `share_node` op to the WAL, the applier (already wired in W1.10 —
-// ops_share_node.go) consumes it and writes node_access. There is no
+// The handler appends a `share_node` op to the WAL; the applier
+// (ops_share_node.go) consumes it and writes node_access. There is no
 // direct CanonicalStore.ShareNode call from this handler.
 //
-// # Auth model — trusted-actor + acl.Checker (Phase 4A.2)
+// # Auth model — trusted-actor + acl.Checker
 //
 //  1. checkTenant: sharding ownership + region pinning. Errors from
 //     the gate (UNAVAILABLE w/ redirect, FAILED_PRECONDITION on region
@@ -30,7 +26,7 @@
 //     "owner OR explicit-ADMIN-grant OR system/admin" semantic.
 //     Non-owner / unknown node → soft-fail (OK + success=false).
 //
-// # Error contract (matches Python soft-fail shape)
+// # Error contract
 //
 // ShareNodeResponse is { success bool, error string } — NOT a
 // google.rpc.Status. The handler returns success=false on
@@ -51,8 +47,8 @@
 // On success: a single record is appended to the WAL. The applier
 // then writes one row to node_access (and, for cross-tenant grants,
 // one row to GlobalStore.shared_index via SharedAdded result). NO
-// mailbox fanout — Python doesn't either (spec §"Side effects",
-// open question 2). NO direct SQLite write from this handler.
+// mailbox fanout (spec §"Side effects", open question 2). NO direct
+// SQLite write from this handler.
 //
 // Idempotency: until the proto carries an idempotency_key, retries
 // generate distinct WAL records that collapse at the applier via
@@ -153,8 +149,7 @@ func (s *Server) ShareNode(
 	//    NOT_FOUND on the underlying GetNode (surfaced by the Checker
 	//    via NodeMetaReader) lowers to soft-fail success=false — a
 	//    missing node is indistinguishable from "no grant" to the
-	//    caller, matching the Python PermissionError-via-missing-node
-	//    behaviour at spec §Wire-contract.NodeId.
+	//    caller (spec §Wire-contract.NodeId).
 	aclActor := authActorToACLActor(trusted)
 	if err := s.aclCheck(ctx, acl.CheckRequest{
 		TenantID:      tenantID,
@@ -184,8 +179,7 @@ func (s *Server) ShareNode(
 		return &pb.ShareNodeResponse{Success: false, Error: err.Error()}, nil
 	}
 
-	// 5. Build the WAL op envelope. Mirror the Python applier's
-	//    op shape (apply/ops_share_node.go:18-31). Field defaults:
+	// 5. Build the WAL op envelope. Field defaults:
 	//    actor_type → "user", permission → "read" (spec §Wire-contract).
 	actorType := req.GetActorType()
 	if actorType == "" {
@@ -296,9 +290,8 @@ func crossTenantHint(actorID, sourceTenant string) (userID, src string) {
 // (the applier collapses via INSERT OR REPLACE) but distinct user-
 // driven re-shares still land. Mirrors spec §Side-effects: "Re-issuing
 // the same ShareNode produces an INSERT OR REPLACE that updates
-// granted_at." When the proto gains an idempotency_key field
-// (#407 follow-up), prefer the caller-supplied value over this
-// derived form.
+// granted_at." When the proto gains an idempotency_key field, prefer
+// the caller-supplied value over this derived form.
 func newShareNodeIdempotencyKey(tenantID, granter, nodeID, recipient string) string {
 	return strings.Join([]string{
 		"share_node",

--- a/server/go/internal/api/share_node_test.go
+++ b/server/go/internal/api/share_node_test.go
@@ -407,8 +407,8 @@ func TestShareNode_NoProducerUnimplemented(t *testing.T) {
 // shareNodeFixtureWithStore is shareNodeFixture but also returns the
 // underlying *store.CanonicalStore so tests can seed node_access rows
 // directly (the path normally taken by the applier). Used by the
-// Phase 4A.2 grant-based ADMIN tests where we want bob to have a
-// pre-existing ADMIN row before the gRPC call.
+// grant-based ADMIN tests where we want bob to have a pre-existing
+// ADMIN row before the gRPC call.
 func shareNodeFixtureWithStore(t *testing.T) (*api.Server, *store.CanonicalStore, *wal.InMemory, context.Context) {
 	t.Helper()
 	ctx := context.Background()
@@ -452,11 +452,10 @@ func shareNodeFixtureWithStore(t *testing.T) (*api.Server, *store.CanonicalStore
 
 // TestShareNode_NonOwnerWithAdminGrant: a user that is NOT the node
 // owner but holds an explicit ADMIN grant on the node can re-share.
-// Phase 4A.2 expansion: before this change the handler enforced an
-// owner-only branch that rejected this case. The acl.Checker handles
-// owner short-circuit + grant-based ADMIN; wiring it in restores the
-// "ADMIN means I can delegate" semantic that every adjacent system
-// uses (see .claude/triage/sharenode-owner-share-analysis.md §3 #3).
+// The acl.Checker handles owner short-circuit + grant-based ADMIN;
+// wiring it in restores the "ADMIN means I can delegate" semantic that
+// every adjacent system uses (see
+// .claude/triage/sharenode-owner-share-analysis.md §3 #3).
 func TestShareNode_NonOwnerWithAdminGrant(t *testing.T) {
 	t.Parallel()
 
@@ -507,9 +506,8 @@ func TestShareNode_NonOwnerWithAdminGrant(t *testing.T) {
 }
 
 // TestShareNode_NonOwnerWithReadGrant: a user with ONLY a READ grant
-// on the node cannot re-share. Phase 4A.2: pin the lower bound of the
-// acl.Checker grant-walk — READ does not satisfy CORE_CAP_ADMIN, so
-// the soft-fail "permission denied" path fires and NO WAL record is
+// on the node cannot re-share. READ does not satisfy CORE_CAP_ADMIN,
+// so the soft-fail "permission denied" path fires and NO WAL record is
 // written.
 func TestShareNode_NonOwnerWithReadGrant(t *testing.T) {
 	t.Parallel()
@@ -548,9 +546,8 @@ func TestShareNode_NonOwnerWithReadGrant(t *testing.T) {
 }
 
 // TestShareNode_EmptyNodeOrActorSoftFail: empty node_id or actor_id
-// surface as soft-fail success=false rather than INVALID_ARGUMENT —
-// matches Python's "no shape validation" behaviour (spec §Error-
-// contract: "Python doesn't validate node_id/actor_id shape today").
+// surface as soft-fail success=false rather than INVALID_ARGUMENT
+// (spec §Error-contract: no shape validation on node_id/actor_id).
 func TestShareNode_EmptyNodeOrActorSoftFail(t *testing.T) {
 	t.Parallel()
 

--- a/server/go/internal/api/transfer_ownership.go
+++ b/server/go/internal/api/transfer_ownership.go
@@ -6,19 +6,13 @@
 //
 // # WAL-first restoration (CLAUDE.md §1)
 //
-// The Python handler bypasses the WAL and writes nodes.owner_actor
-// directly via canonical_store._sync_transfer_ownership — a long-
-// standing violation of "every mutation goes through the WAL"
-// (CLAUDE.md invariant #1, called out in PLAN.md §6.1).
-//
-// The Go port restores the invariant: the handler appends a
-// `transfer_ownership` op to the per-tenant WAL via the shared
-// wal.Producer, then synchronously materialises the change in the
-// per-tenant SQLite via store.TransferOwnership. The applier already
-// dispatches the same op on replay (see internal/apply/ops_transfer_ownership.go),
-// so a future rebuild from the WAL will reproduce the transfer
-// exactly. Idempotency-key based de-dupe in the applier keeps the
-// in-flight + replay paths from double-applying.
+// The handler appends a `transfer_ownership` op to the per-tenant WAL
+// via the shared wal.Producer, then synchronously materialises the
+// change in the per-tenant SQLite via store.TransferOwnership. The
+// applier dispatches the same op on replay (see
+// internal/apply/ops_transfer_ownership.go), so a WAL rebuild
+// reproduces the transfer exactly. Idempotency-key based de-dupe in
+// the applier keeps the in-flight + replay paths from double-applying.
 //
 // # Auth model — trusted-actor, current-owner-only
 //
@@ -34,8 +28,7 @@
 //  4. Owner-only authorization: the trusted actor MUST equal the
 //     node's current owner_actor. Non-owner callers — even those who
 //     hold an ADMIN ACL grant on the node — are rejected with
-//     PERMISSION_DENIED. This is a Go-side hardening over the Python
-//     handler, which performs no authorization beyond _check_tenant.
+//     PERMISSION_DENIED.
 //
 // # Side effects
 //
@@ -59,16 +52,9 @@
 //	PERMISSION_DENIED trusted actor is not the current owner.
 //	OK + found=true transfer applied.
 //
-// Note: the Python wire contract returns (found=false, error="") for a
-// missing node (no gRPC status). The Go port hardens this to NOT_FOUND
-// because:
-//   - It is consistent with the rest of the surface (every
-//     "row missing" path uses codes.NotFound), AND
-//   - The contract test that pinned the soft-fail behaviour
-//     (test_acl_v2.py:534-536) is being retired alongside the Python
-//     server in EPIC #407. Existing Python tests targeting
-//     TransferOwnership are pinned via the parity harness, not via this
-//     wire shape.
+// Note: this handler returns NOT_FOUND for a missing node (no gRPC
+// status soft-fail), consistent with every other "row missing" path on
+// the surface which uses codes.NotFound.
 //
 // Metrics: emits entdb_grpc_requests_total{method="TransferOwnership",
 // status="ok"|"error"} via the shared chokepoint.
@@ -93,10 +79,9 @@ import (
 
 const grpcMethodTransferOwnership = "TransferOwnership"
 
-// transferOwnershipTopic is the WAL topic the handler appends to. Mirrors
-// the per-tenant Kafka topic naming in the Python wal/kafka.py module —
-// each tenant key partitions onto its own slot so total order is
-// preserved per-tenant. The applier consumes from the same topic name.
+// transferOwnershipTopic is the WAL topic the handler appends to. Each
+// tenant key partitions onto its own slot so total order is preserved
+// per-tenant. The applier consumes from the same topic name.
 const transferOwnershipTopic = "entdb-wal"
 
 // TransferOwnership reassigns nodes.owner_actor and refreshes node_visibility.
@@ -111,8 +96,7 @@ func (s *Server) TransferOwnership(
 		metrics.RecordGRPCRequest(grpcMethodTransferOwnership, statusLabel, time.Since(start))
 	}()
 
-	// 1. Validation. Mirror the Python required-arg checks plus the
-	//    Go-side hardening called out in spec §"Wire contract".
+	// 1. Validation. Required-arg checks per spec §"Wire contract".
 	if req.GetContext() == nil || req.GetContext().GetTenantId() == "" {
 		statusLabel = "error"
 		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
@@ -167,10 +151,10 @@ func (s *Server) TransferOwnership(
 	// 5. Current-owner-only authorization. The trusted actor's full
 	//    "kind:id" form must match the stored owner_actor verbatim.
 	//    system: callers are NOT bypassed here — TransferOwnership is a
-	//    user-initiated handoff, not an admin override (the Python
-	//    bulk-reassign handler `TransferUserContent` covers the admin
-	//    path). Group ownership is technically representable on disk
-	//    but a group cannot be a caller, so it cannot pass this gate.
+	//    user-initiated handoff, not an admin override (TransferUserContent
+	//    covers the admin path). Group ownership is technically
+	//    representable on disk but a group cannot be a caller, so it
+	//    cannot pass this gate.
 	if trusted.IsZero() || trusted.String() != current.OwnerActor {
 		statusLabel = "error"
 		return nil, errs.Errorf(codes.PermissionDenied,
@@ -229,8 +213,8 @@ func (s *Server) TransferOwnership(
 }
 
 // isValidActorString reports whether s is a kind:id-prefixed actor string
-// the spec accepts for `new_owner`. Mirrors auth.ParseActor's prefix
-// table (user:/group:/system:/admin:) and rejects KindUnknown so a bare
+// the spec accepts for `new_owner`. Uses auth.ParseActor's prefix table
+// (user:/group:/system:/admin:) and rejects KindUnknown so a bare
 // "alice" or a tenant-qualified "tenant_a:user:alice" is refused with
 // INVALID_ARGUMENT.
 //

--- a/server/go/internal/api/transfer_ownership_test.go
+++ b/server/go/internal/api/transfer_ownership_test.go
@@ -9,10 +9,8 @@
 //     state; response.found = true.
 //   - Non-owner caller is rejected with codes.PermissionDenied — even
 //     when the caller is "system:" or holds an ACL grant on the node.
-//     This is a Go-side hardening over the Python handler (which only
-//     calls _check_tenant). See package-level doc on transfer_ownership.go.
-//   - Missing node returns codes.NotFound (Go hardens vs. Python's
-//     "found=false, error=''" soft fail).
+//     See package-level doc on transfer_ownership.go.
+//   - Missing node returns codes.NotFound.
 //   - Recipient sees the node post-apply: store.GetNode reports the new
 //     owner; node_visibility row exists for the recipient.
 //
@@ -179,7 +177,6 @@ func TestTransferOwnership_RecipientSeesNode(t *testing.T) {
 // TestTransferOwnership_NonOwner_PermissionDenied: a caller who is not
 // the current owner gets PermissionDenied — regardless of whether they
 // are a tenant member, hold an ACL grant, or are even a system: actor.
-// This is the Go-side hardening over the Python handler's no-auth path.
 func TestTransferOwnership_NonOwner_PermissionDenied(t *testing.T) {
 	t.Parallel()
 	f := newXferFixture(t)
@@ -237,8 +234,7 @@ func TestTransferOwnership_PrivilegeEscalation_IgnoresClaimedActor(t *testing.T)
 }
 
 // TestTransferOwnership_MissingNode_NotFound: the node_id does not
-// exist in the tenant → codes.NotFound. Hardens the Python "found=false,
-// error=”" soft-fail per spec §"Error contract".
+// exist in the tenant → codes.NotFound, per spec §”Error contract”.
 func TestTransferOwnership_MissingNode_NotFound(t *testing.T) {
 	t.Parallel()
 	f := newXferFixture(t)
@@ -315,8 +311,7 @@ func TestTransferOwnership_InvalidArgument_EmptyFields(t *testing.T) {
 }
 
 // TestTransferOwnership_InvalidActorString: a tenant-qualified or bare
-// principal in new_owner is rejected with InvalidArgument (the Python
-// handler accepted any string).
+// principal in new_owner is rejected with InvalidArgument.
 func TestTransferOwnership_InvalidActorString(t *testing.T) {
 	t.Parallel()
 	f := newXferFixture(t)

--- a/server/go/internal/api/transfer_user_content.go
+++ b/server/go/internal/api/transfer_user_content.go
@@ -76,13 +76,11 @@ const (
 	// owner_actor inside one SQLite write transaction; without a chunk
 	// cap a 10M-owned-node tenant would hold the per-tenant write lock
 	// for the duration of the UPDATE, blocking other writers.
-	//
-	// The Python handler emits exactly ONE event regardless of size —
-	// see spec "Open questions" §2 for the documented risk. Chunking is
-	// the Go-side mitigation. Chunk size is conservative; the Applier
-	// op handler accepts both the un-chunked form (no node_ids field —
-	// rewrite all rows for `from_user`) and the chunked form (explicit
-	// node_ids list) so behaviour is identical for small batches.
+	// See spec "Open questions" §2 for the documented risk. Chunk size
+	// is conservative; the Applier op handler accepts both the
+	// un-chunked form (no node_ids field — rewrite all rows for
+	// `from_user`) and the chunked form (explicit node_ids list) so
+	// behaviour is identical for small batches.
 	transferUserContentChunkSize = 1000
 
 	// transferUserContentTopic is the WAL topic used for tenant-scoped
@@ -156,8 +154,8 @@ func (s *Server) TransferUserContent(
 		}
 	}
 
-	// Tenant WAL append. Source of truth for the ownership rename. The
-	// op shape mirrors apply/ops_admin_transfer_content.go (W1.10).
+	// Tenant WAL append. Source of truth for the ownership rename.
+	// Op shape: apply/ops_admin_transfer_content.go.
 	//
 	// Chunking: when the producer is wired AND a canonical store is
 	// available we enumerate owned node_ids first and split into
@@ -195,8 +193,8 @@ func (s *Server) TransferUserContent(
 			"to_user":   req.GetToUser(),
 		}
 		if len(chunk) > 0 {
-			// Convert []string -> []any so JSON marshalling preserves
-			// the ordering Python's json.dumps emits.
+			// Convert []string -> []any so JSON marshalling produces
+			// a stable array encoding.
 			ids := make([]any, 0, len(chunk))
 			for _, id := range chunk {
 				ids = append(ids, id)
@@ -256,8 +254,7 @@ func (s *Server) TransferUserContent(
 // `tenantID` and returns them split into chunks of size
 // transferUserContentChunkSize. When the canonical store is unwired
 // (or returns no rows / errors) it returns a single empty chunk so the
-// caller still emits exactly one un-chunked event (parity with the
-// Python single-event shape).
+// caller still emits exactly one un-chunked event.
 func (s *Server) transferUserContentChunks(
 	ctx context.Context, tenantID, fromUser string,
 ) [][]string {
@@ -280,10 +277,9 @@ func (s *Server) transferUserContentChunks(
 }
 
 // randHex16 returns a 32-char lowercase hex string. Used as the random
-// suffix on the idempotency key. The Python handler uses uuid4 hex
-// (32 chars) — same alphabet, same length. Falls back to a
-// nanosecond-timestamp on rand failure (defensive — crypto/rand on
-// Linux has not failed in production memory).
+// suffix on the idempotency key (32 chars, lowercase hex). Falls back
+// to a nanosecond-timestamp on rand failure (defensive — crypto/rand
+// on Linux has not failed in production memory).
 func randHex16() string {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/server/go/internal/api/update_user.go
+++ b/server/go/internal/api/update_user.go
@@ -88,8 +88,7 @@ func (s *Server) UpdateUser(ctx context.Context, req *pb.UpdateUserRequest) (*pb
 	}
 
 	if req.GetEmail() == "" && req.GetName() == "" && req.GetStatus() == "" {
-		// In-band failure (no abort). Python returns "ok" metric here;
-		// we do the same.
+		// In-band failure (no abort); "ok" metric label.
 		return &pb.UpdateUserResponse{Success: false, Error: "No fields to update"}, nil
 	}
 
@@ -99,8 +98,7 @@ func (s *Server) UpdateUser(ctx context.Context, req *pb.UpdateUserRequest) (*pb
 		return &pb.UpdateUserResponse{Success: false, Error: err.Error()}, nil
 	}
 	if user == nil {
-		// In-band not-found. Same metric label ("ok") as Python — no
-		// abort fires.
+		// In-band not-found; "ok" metric label, no abort.
 		return &pb.UpdateUserResponse{Success: false, Error: "User not found"}, nil
 	}
 

--- a/server/go/internal/api/update_user_test.go
+++ b/server/go/internal/api/update_user_test.go
@@ -1,8 +1,7 @@
-// Tests for the UpdateUser RPC. The seven Python contract pins enumerated
-// in docs/go-port/rpcs/UpdateUser.md ("Contract tests pinning behavior")
-// reduce to five behaviours in the Go port — happy self-update, happy
-// admin-other, non-admin-other denied, no-fields in-band failure, and
-// not-found in-band failure. Each test below covers one of those arms.
+// Tests for the UpdateUser RPC. Five behaviours are pinned here:
+// happy self-update, happy admin-other, non-admin-other denied,
+// no-fields in-band failure, and not-found in-band failure.
+// Each test below covers one of those arms.
 
 package api_test
 

--- a/server/go/internal/api/wait_for_offset.go
+++ b/server/go/internal/api/wait_for_offset.go
@@ -18,16 +18,14 @@ import (
 // least the requested WAL stream position into the per-tenant SQLite
 // view, or the per-RPC deadline elapses, or the context is cancelled.
 //
-// Spec: docs/go-port/rpcs/WaitForOffset.md. The Go
-// port uses the store-level sync.Cond watcher implemented in W1.8
-// (store/offset.go) so the handler parks on a single select and does not
-// burn a goroutine on a busy-loop.
+// Spec: docs/go-port/rpcs/WaitForOffset.md. Uses the store-level
+// sync.Cond watcher (store/offset.go) so the handler parks on a
+// single select and does not burn a goroutine on a busy-loop.
 //
 // Differences from the original handler:
 //   - The original swallowed all internal errors and returned OK + reached=false.
-//     The Go port honours ctx cancellation as a real gRPC status
-//     (DEADLINE_EXCEEDED) — this matches grpc-go idiom and is the
-//     contract pinned by the W2 task spec.
+//     This handler honours ctx cancellation as a real gRPC status
+//     (DEADLINE_EXCEEDED) — consistent with grpc-go idiom.
 //   - Topic/partition prefix in stream_position is ignored: split on last `:`,
 //     parse trailing int; non-numeric → 0.
 func (s *Server) WaitForOffset(ctx context.Context, req *pb.WaitForOffsetRequest) (*pb.WaitForOffsetResponse, error) {
@@ -103,9 +101,8 @@ func (s *Server) currentAppliedPosition(ctx context.Context, tenantID, requested
 	topic, partition := parseStreamTopicPartition(requested)
 	off, err := s.store.GetAppliedOffset(ctx, tenantID, topic, partition)
 	if err != nil || off == 0 {
-		// 0 here means either no row, or applier genuinely at offset 0.
-		// Python collapses the latter to "" via `or ""` truthiness; we
-		// mirror that to keep contract tests deterministic.
+		// 0 means either no row, or applier genuinely at offset 0;
+		// collapse to "" to keep contract tests deterministic.
 		return ""
 	}
 	if topic == "" {

--- a/server/go/internal/apply/acladapter.go
+++ b/server/go/internal/apply/acladapter.go
@@ -18,8 +18,7 @@ import (
 // CrossTenantGrantReader, VisibilityReader, GroupMembershipReader),
 // backed by store.CanonicalStore + globalstore.GlobalStore.
 //
-// W1.9 (acl) deferred this adapter to W1.10 (apply) on the theory that
-// the applier owns the read-after-write consistency story — the same
+// The applier owns the read-after-write consistency story — the same
 // adapter is used by the gRPC read RPCs.
 //
 // All methods are safe for concurrent goroutine use to the extent the
@@ -100,13 +99,11 @@ func (r *StoreReaders) GrantsForNode(ctx context.Context, tenantID, nodeID strin
 		// acl.PermDeny is the zero value of Permission, which makes
 		// IsDeny() flag any grant whose permission column is empty /
 		// unparseable as an explicit DENY — wrong for typed-cap-only
-		// rows (the Go ShareNode handler accepts an empty permission
-		// when CoreCaps is set). Default to PermRead for non-deny
-		// rows so the deny-pass in acl.Checker doesn't fire on a
-		// well-formed typed-cap grant. Mirrors the Python
-		// AclManager.check_permission contract where an unset
-		// permission column never means "deny" — only the literal
-		// "deny" string does.
+		// rows (the ShareNode handler accepts an empty permission when
+		// CoreCaps is set). Default to PermRead for non-deny rows so
+		// the deny-pass in acl.Checker doesn't fire on a well-formed
+		// typed-cap grant. An unset permission column never means
+		// "deny" — only the literal "deny" string does.
 		if perm, ok := acl.ParsePermission(permStr); ok {
 			g.Permission = perm
 		} else {
@@ -150,8 +147,7 @@ func (r *StoreReaders) CrossTenantGrant(ctx context.Context, sourceTenant, nodeI
 		return acl.PermDeny, false, nil
 	}
 	// foreignActor is "kind:id"; the shared_index keys on the bare
-	// user_id (no kind prefix). Mirror the Python lookup behaviour by
-	// stripping the "user:" prefix when present.
+	// user_id (no kind prefix). Strip the "user:" prefix when present.
 	userID := foreignActor
 	if len(userID) > 5 && userID[:5] == "user:" {
 		userID = userID[5:]

--- a/server/go/internal/apply/applier.go
+++ b/server/go/internal/apply/applier.go
@@ -29,7 +29,7 @@ type Options struct {
 	GroupID  string
 
 	// BatchSize is the max records PollBatch returns per iteration.
-	// Defaults to 32 (matches the Python applier batch_size default).
+	// Defaults to 32.
 	BatchSize int
 
 	// PollTimeout is how long PollBatch blocks waiting for records.
@@ -45,10 +45,9 @@ type Options struct {
 	FanoutHook func(ctx context.Context, ev *Event, res *Result)
 
 	// HaltOnPoison toggles halt-on-error behaviour. Defaults to true
-	// (production parity with Python halt_on_error=True). Tests that
-	// want to explore skip-and-continue paths can flip it; the contract
-	// pinned by docs/go-port/shared/applier.md is that production must
-	// halt.
+	// (production must halt). Tests that want to explore
+	// skip-and-continue paths can flip it; the contract is pinned by
+	// docs/go-port/shared/applier.md.
 	HaltOnPoison *bool
 
 	// MaxApplyConcurrency caps how many distinct tenants' records the
@@ -318,8 +317,7 @@ func (a *Applier) finalizeBatch(ctx context.Context, records []Record, results [
 				// be re-delivered after restart.
 				return res.Err
 			}
-			// skip-and-continue: still commit the offset (mirrors
-			// Python halt_on_error=False) and move on.
+			// skip-and-continue: still commit the offset and move on.
 		}
 		// ADR-027 invariant 3 (load-bearing): the WAL/consumer-group
 		// offset commit and the persisted per-tenant offset advance

--- a/server/go/internal/apply/applier_test.go
+++ b/server/go/internal/apply/applier_test.go
@@ -359,9 +359,8 @@ func TestApplier_GlobalExactReplayRemainsApplied(t *testing.T) {
 }
 
 // TestApplier_DelegateAccessFix is the contract-pinning regression for
-// PLAN.md §6.4 item 1 — the Python applier silently drops
-// admin_delegate_access events. The Go applier MUST materialise the
-// node_access grant on replay.
+// PLAN.md §6.4 item 1 — admin_delegate_access events MUST be
+// materialised as node_access grants on replay.
 func TestApplier_DelegateAccessFix(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
@@ -402,8 +401,7 @@ func TestApplier_DelegateAccessFix(t *testing.T) {
 		"doc1",
 	).Scan(&actor, &perm)
 	if err != nil {
-		t.Fatalf("delegate-access did not materialise a node_access row: %v "+
-			"(this is the Python bug — the Go applier MUST close it)", err)
+		t.Fatalf("delegate-access did not materialise a node_access row: %v", err)
 	}
 	if actor != "user:bob" || perm != "read" {
 		t.Fatalf("delegate-access wrong row: actor=%q perm=%q (want user:bob/read)", actor, perm)
@@ -723,8 +721,8 @@ func TestApplier_GroupMembership(t *testing.T) {
 }
 
 // TestApplier_AdminRevokeAccessBroadens confirms PLAN.md §6.4 item 2:
-// admin_revoke_access deletes node_access AND group_users (Python only
-// deletes node_visibility).
+// admin_revoke_access deletes node_access AND group_users AND
+// node_visibility.
 func TestApplier_AdminRevokeAccessBroadens(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
@@ -770,7 +768,7 @@ func TestApplier_AdminRevokeAccessBroadens(t *testing.T) {
 		var n int
 		_ = db.QueryRowContext(context.Background(), q.sql, q.args...).Scan(&n)
 		if n != 0 {
-			t.Errorf("admin_revoke_access did not clean up %s (n=%d) — Python parity bug not closed", q.name, n)
+			t.Errorf("admin_revoke_access did not clean up %s (n=%d)", q.name, n)
 		}
 	}
 }

--- a/server/go/internal/apply/errors.go
+++ b/server/go/internal/apply/errors.go
@@ -10,13 +10,12 @@ import (
 )
 
 // Sentinel errors returned by the applier. Each wraps an internal/errs
-// sentinel so the gRPC layer maps them to the Python server's status
-// codes (see docs/go-port/shared/error-mapping.md).
+// sentinel so the gRPC layer maps them to the appropriate status codes
+// (see docs/go-port/shared/error-mapping.md).
 var (
 	// ErrPoisonEvent signals an event the applier refuses to apply
 	// because it is structurally malformed (missing required fields,
-	// unknown op-type, etc.). Halts the consumer; mirrors the Python
-	// halt_on_error=True behaviour.
+	// unknown op-type, etc.). Halts the consumer.
 	ErrPoisonEvent = fmt.Errorf("%w: poison event", errs.ErrInvalidArgument)
 
 	// ErrUnknownOpType signals an op-type the applier does not know
@@ -49,7 +48,7 @@ var (
 // the values are already in the same shape the structpb encoder
 // expects on the egress side. JSON-canonical comparison (see
 // preconditionMatches in ops_update_node.go) keeps numeric and string
-// equality consistent with the Python applier's behaviour.
+// equality consistent across JSON round-trips.
 type PreconditionFailure struct {
 	OpIndex  int
 	Field    string

--- a/server/go/internal/apply/event.go
+++ b/server/go/internal/apply/event.go
@@ -9,7 +9,7 @@
 //
 // docs/go-port/PLAN.md §6):
 //
-//   - DelegateAccess applier dispatch (was silently dropped in Python).
+//   - DelegateAccess applier dispatch (previously absent from the applier).
 //   - WAL-first restoration for share_node, revoke_access, delegate_access,
 //     transfer_ownership, add_group_member, remove_group_member,
 //     set_legal_hold.
@@ -36,16 +36,13 @@ import "github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 type Event = wal.Event
 
 // OpType enumerates the op-type strings carried inside Event.Ops[i]["op"].
-// Mirrors the Python applier's `op_type` if/elif ladder
-//
-//	plus the new
-//
-// op types added by the Go port to close the WAL-first drift gap
+// The base set corresponds to the applier's original dispatch table;
+// additional op types were added to close WAL-first drift gaps
 // (docs/go-port/PLAN.md §6).
 type OpType string
 
 const (
-	// Steady-state ops the Python applier already implements.
+	// Steady-state ops.
 	OpCreateNode OpType = "create_node"
 	OpUpdateNode OpType = "update_node"
 	OpDeleteNode OpType = "delete_node"
@@ -60,13 +57,11 @@ const (
 	// issue-#501 range operators reused via store.QueryFilter.
 	OpDeleteWhere OpType = "delete_where"
 
-	// admin ops the Python applier already implements (broadened in Go).
+	// Admin ops (broadened in the WAL-first restoration).
 	OpAdminTransferContent OpType = "admin_transfer_content"
 	OpAdminRevokeAccess    OpType = "admin_revoke_access"
 
-	// WAL-first restorations from PLAN.md §6.1. The Python handlers
-	// write SQLite directly today; the Go port appends a WAL event and
-	// the dispatch branches below apply it on replay.
+	// WAL-first restorations from PLAN.md §6.1.
 	OpShareNode          OpType = "share_node"
 	OpRevokeAccess       OpType = "revoke_access"
 	OpDelegateAccess     OpType = "delegate_access"

--- a/server/go/internal/apply/ops_add_group_member.go
+++ b/server/go/internal/apply/ops_add_group_member.go
@@ -8,8 +8,7 @@ import (
 )
 
 // applyAddGroupMember dispatches an "add_group_member" op. Restores
-// the WAL-first invariant flagged in PLAN.md §6.1 — the Python
-// AddGroupMember handler writes group_users directly today.
+// the WAL-first invariant flagged in PLAN.md §6.1.
 //
 // op shape:
 //

--- a/server/go/internal/apply/ops_admin_revoke_access.go
+++ b/server/go/internal/apply/ops_admin_revoke_access.go
@@ -9,10 +9,8 @@ import (
 
 // applyAdminRevokeAccess dispatches an "admin_revoke_access" op.
 //
-// PLAN.md §6.4 item 2: the Python applier only deletes from
-// node_visibility, leaving node_access and group_users intact. The
-// Go applier broadens this to revoke every grant + group membership
-// AND every visibility row for the user, matching the behaviour the
+// PLAN.md §6.4 item 2: revokes every grant + group membership AND
+// every visibility row for the user, matching the behaviour the
 // RevokeAllUserAccess handler intends to deliver.
 //
 // op shape:

--- a/server/go/internal/apply/ops_create_node.go
+++ b/server/go/internal/apply/ops_create_node.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 )
 
-// applyCreateNode dispatches a "create_node" op. Mirrors
+// applyCreateNode dispatches a "create_node" op.
 //
-// The op shape (field-id-keyed payload, per CLAUDE.md invariant #6):
+// Op shape (field-id-keyed payload, per CLAUDE.md invariant #6):
 //
 //	{
 //	  "op": "create_node",
@@ -23,9 +23,7 @@ import (
 //
 // owner_actor comes from the surrounding event.actor. Per the spec, the
 // applier never generates node ids — caller-supplied ids are required
-// (the Python applier accepts a missing id and asks canonical_store to
-// generate one; the Go port rejects it so determinism doesn't depend on
-// the UUID source).
+// so determinism doesn't depend on the UUID source.
 func (a *Applier) applyCreateNode(ctx context.Context, tx *BatchTxn, ev *Event, op map[string]any, aliases nodeAliasMap, res *Result) error {
 	nodeID := stringField(op, "id")
 	if nodeID == "" {

--- a/server/go/internal/apply/ops_delegate_access.go
+++ b/server/go/internal/apply/ops_delegate_access.go
@@ -11,17 +11,15 @@ import (
 
 // applyDelegateAccess dispatches a "delegate_access" op.
 //
-// CRITICAL FIX (PLAN.md §6.4 item 1): the Python applier has no
-// dispatch branch for admin_delegate_access events; the WAL event is
-// silently dropped on replay. The Python tests only pass because the
-// handler also writes node_access directly. The Go applier closes that
-// gap by materialising the grant in the same row shape that
+// CRITICAL FIX (PLAN.md §6.4 item 1): delegate_access events were
+// previously silently dropped on replay. This applier branch closes
+// that gap by materialising the grant in the same row shape that
 // share_node uses.
 //
 // Semantically delegate_access is identical to share_node — the
 // "delegating actor must already hold the cap" check happens at the
-// gRPC handler / acl checker layer (W1.9), not here. Storing the grant
-// is the applier's only job.
+// gRPC handler / acl checker layer, not here. Storing the grant is
+// the applier's only job.
 //
 // op shape: same as share_node, but the granted_by field is recorded
 // as event.actor (the delegator).

--- a/server/go/internal/apply/ops_revoke_access.go
+++ b/server/go/internal/apply/ops_revoke_access.go
@@ -8,8 +8,7 @@ import (
 )
 
 // applyRevokeAccess dispatches a "revoke_access" op. Restores the WAL-
-// first invariant flagged in PLAN.md §6.1 — the Python RevokeAccess
-// handler deletes node_access directly today.
+// first invariant flagged in PLAN.md §6.1.
 //
 // op shape:
 //

--- a/server/go/internal/apply/ops_set_legal_hold.go
+++ b/server/go/internal/apply/ops_set_legal_hold.go
@@ -29,8 +29,7 @@ import (
 //	}
 func (a *Applier) applySetLegalHold(ctx context.Context, ev *Event, op map[string]any) error {
 	if a.global == nil {
-		// Global store not wired; skip silently. This is the same
-		// trade-off the Python server makes — if globalstore isn't
+		// Global store not wired; skip silently. When globalstore isn't
 		// available, set_legal_hold is a no-op.
 		return nil
 	}

--- a/server/go/internal/apply/ops_share_node.go
+++ b/server/go/internal/apply/ops_share_node.go
@@ -10,9 +10,8 @@ import (
 )
 
 // applyShareNode dispatches a "share_node" op. Restores the WAL-first
-// invariant flagged in PLAN.md §6.1 — the Python ShareNode handler
-// writes node_access directly today, bypassing the WAL. This applier
-// branch makes the grant survive a full WAL rebuild.
+// invariant flagged in PLAN.md §6.1 — this applier branch makes the
+// grant survive a full WAL rebuild.
 //
 // op shape:
 //

--- a/server/go/internal/apply/ops_tenant_membership.go
+++ b/server/go/internal/apply/ops_tenant_membership.go
@@ -10,11 +10,10 @@ import (
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 )
 
-// Tenant-membership ops. The Python server writes these directly to
-// globalstore today (carve-out from CLAUDE.md invariant #1 documented
-// in docs/go-port/shared/global-store.md). The Go applier optionally
-// drives globalstore through the WAL too, so a stand-alone WAL replay
-// can rebuild membership audit history.
+// Tenant-membership ops. The applier optionally drives globalstore
+// through the WAL so a stand-alone WAL replay can rebuild membership
+// audit history (carve-out from CLAUDE.md invariant #1 documented in
+// docs/go-port/shared/global-store.md).
 //
 // All three branches are no-ops when a.global is nil (globalstore not
 // wired in this configuration).

--- a/server/go/internal/apply/ops_transfer_ownership.go
+++ b/server/go/internal/apply/ops_transfer_ownership.go
@@ -11,9 +11,7 @@ import (
 )
 
 // applyTransferOwnership dispatches a "transfer_ownership" op.
-// Restores the WAL-first invariant flagged in PLAN.md §6.1 — the
-// Python TransferOwnership handler updates nodes.owner_actor directly
-// today.
+// Restores the WAL-first invariant flagged in PLAN.md §6.1.
 //
 // Refreshes node_visibility for the new owner so the visibility index
 // stays consistent (PLAN.md §6.4 item 3 calls out the
@@ -37,8 +35,7 @@ func (a *Applier) applyTransferOwnership(ctx context.Context, tx *BatchTxn, ev *
 		ev.TenantID, nodeID,
 	).Scan(&aclJSON)
 	if errors.Is(err, sql.ErrNoRows) {
-		// Missing target: no-op (matches the Python soft-no-target
-		// pattern; halts only on infra errors).
+		// Missing target: no-op; halt only on infra errors.
 		return nil
 	}
 	if err != nil {

--- a/server/go/internal/apply/result.go
+++ b/server/go/internal/apply/result.go
@@ -4,12 +4,12 @@ package apply
 
 import "github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 
-// Status mirrors the receipt status the Python applier returns from
-// ExecuteAtomic (see docs/go-port/shared/applier.md "Receipt
-// construction"). APPLIED means the event committed; SKIPPED means the
-// idempotency-key probe inside the txn matched a prior row;
-// FAILED is the catch-all error path; FAILED_PRECONDITION is the
-// CAS-miss path that aborts the batch but advances the WAL offset.
+// Status is the receipt status returned from ExecuteAtomic (see
+// docs/go-port/shared/applier.md "Receipt construction"). APPLIED
+// means the event committed; SKIPPED means the idempotency-key probe
+// inside the txn matched a prior row; FAILED is the catch-all error
+// path; FAILED_PRECONDITION is the CAS-miss path that aborts the
+// batch but advances the WAL offset.
 type Status uint8
 
 const (
@@ -26,8 +26,7 @@ const (
 )
 
 // String returns the wire form ("APPLIED" / "SKIPPED" / "FAILED" /
-// "FAILED_PRECONDITION"). Mirrors the Python ApplyResult.status enum
-// values with the CAS extension.
+// "FAILED_PRECONDITION").
 func (s Status) String() string {
 	switch s {
 	case StatusApplied:
@@ -43,8 +42,7 @@ func (s Status) String() string {
 	}
 }
 
-// Result is the outcome of applying one event. Mirrors the Python
-// ApplyResult struct.
+// Result is the outcome of applying one event.
 //
 // Position is the WAL position the event came from; on a successful
 // apply this is the receipt the SDK returns to clients.

--- a/server/go/internal/auth/actor.go
+++ b/server/go/internal/auth/actor.go
@@ -5,9 +5,7 @@ package auth
 import "strings"
 
 // Kind is the prefix-encoded category of an Actor identity.
-//
-// Mirrors the prefix scheme documented in
-// docs/go-port/shared/auth-interceptor.md "Trusted-actor contract":
+// See docs/go-port/shared/auth-interceptor.md "Trusted-actor contract":
 //
 //   - user:<id> -- a real authenticated user.
 //   - system:<svc> -- internal service identity; bypasses tenant-membership
@@ -36,7 +34,7 @@ const (
 )
 
 // String returns the canonical prefix for the kind without the trailing
-// colon. Mirrors the Python prefix strings used in
+// colon.
 func (k Kind) String() string {
 	switch k {
 	case KindUser:
@@ -53,21 +51,20 @@ func (k Kind) String() string {
 }
 
 // Actor is a prefix-encoded caller identity. It is a value type whose
-// String form (kind:id) is exactly what the Python server stores in the WAL
+// String form (kind:id) is exactly what the server stores in the WAL
 // and in ACL subjects.
 //
 // Construct via User / System / Admin / Group. Parse via ParseActor for
 // strings coming off the wire or out of the WAL.
 //
 // The zero value is the "unknown" actor and is never equal to a valid one;
-// callers should treat it the way the Python server treats a None
-// identity -- no claimed prefix, no privileges.
+// callers should treat it as carrying no claimed prefix and no privileges.
 type Actor struct {
 	kind Kind
 	id   string
 }
 
-// User returns a user:<id> actor. Mirrors Actor.user(id) in the Python SDK.
+// User returns a user:<id> actor.
 func User(id string) Actor { return Actor{kind: KindUser, id: id} }
 
 // System returns a system:<id> actor.

--- a/server/go/internal/auth/authoritative_test.go
+++ b/server/go/internal/auth/authoritative_test.go
@@ -75,7 +75,7 @@ func TestAuthoritative_FallbackToClaimed(t *testing.T) {
 // TestAuthoritative_GroupSubjectIsTreatedAsUser pins that a group:
 // prefix coming through as a credential subject is NOT trusted as a
 // caller "group" identity (groups are ACL subjects only). It falls
-// through to the user:<subject> wrapping, mirroring Python.
+// through to the user:<subject> wrapping.
 func TestAuthoritative_GroupSubjectIsTreatedAsUser(t *testing.T) {
 	id := Identity{Method: MethodSession, Subject: "group:admins"}
 	ctx := WithIdentity(context.Background(), id)

--- a/server/go/internal/auth/identity.go
+++ b/server/go/internal/auth/identity.go
@@ -5,7 +5,7 @@ package auth
 import "context"
 
 // Identity is the verified caller's claims as established by the
-// interceptor. It mirrors AuthContext in
+// interceptor.
 //
 // Subject is the raw verified identifier (JWT sub, API-key name, or
 // session user_id). It is NOT prefix-normalised here; normalisation to a
@@ -19,8 +19,7 @@ import "context"
 // methods. It is a generic map so handlers don't take a hard dependency on
 // any particular JWT library.
 type Identity struct {
-	// Method is "oauth" | "api_key" | "session" | "mtls". Constants below match
-	// the Python AuthContext.method values verbatim.
+	// Method is "oauth" | "api_key" | "session" | "mtls". Constants below.
 	Method   string
 	Subject  string
 	Scopes   []string
@@ -28,9 +27,8 @@ type Identity struct {
 	Metadata map[string]any
 }
 
-// Auth method names. These strings are part of the public contract --
-// metrics and logs key off them, mirroring the Python AuthContext.method
-// field.
+// Auth method names. These strings are part of the public contract —
+// metrics and logs key off them.
 const (
 	MethodOAuth   = "oauth"
 	MethodAPIKey  = "api_key"
@@ -57,10 +55,8 @@ var identityKey = contextKey{}
 // WithIdentity returns a new context that carries id as the trusted
 // Identity. The interceptor calls this exactly once per request, after
 // successful authentication. Tests that need to simulate an authenticated
-// request also call this directly -- there is no global ContextVar
-// equivalent in Go (and ContextVars are exactly what the Python port is
-// trying to leave behind, see
-// docs/go-port/shared/auth-interceptor.md "Wire-level mechanics" tail).
+// request also call this directly. See
+// docs/go-port/shared/auth-interceptor.md "Wire-level mechanics".
 func WithIdentity(ctx context.Context, id Identity) context.Context {
 	return context.WithValue(ctx, identityKey, id)
 }

--- a/server/go/internal/auth/oauth.go
+++ b/server/go/internal/auth/oauth.go
@@ -238,7 +238,7 @@ func verifyStandardClaims(claims map[string]any, now time.Time, wantIssuer, want
 }
 
 // audienceMatches accepts either a string aud or a list-of-strings aud,
-// matching the OIDC spec and what jwt.decode does in Python.
+// per the OIDC spec.
 func audienceMatches(raw any, want string) bool {
 	switch v := raw.(type) {
 	case string:

--- a/server/go/internal/errs/errs.go
+++ b/server/go/internal/errs/errs.go
@@ -1,9 +1,9 @@
 // Package errs is the typed-error chokepoint for the Go gRPC server.
 //
 // Every handler that needs to emit a gRPC status code MUST do so through this
-// package, so the Python -> Go contract stays in one place. The exported
-// sentinels each implement GRPCStatus() *status.Status, so they round-trip
-// through google.golang.org/grpc/status.FromError and
+// package, so the error contract stays in one place. The exported sentinels
+// each implement GRPCStatus() *status.Status, so they round-trip through
+// google.golang.org/grpc/status.FromError and
 // google.golang.org/grpc/status.Code without the caller needing to know the
 // concrete type.
 //
@@ -12,10 +12,10 @@
 // docs/go-port/rpcs/*.md reference this file for code semantics; do not
 // duplicate the mapping there.
 //
-// Out-of-scope (deliberate parity with Python):
+// Out-of-scope (intentional):
 //
-//   - google.rpc.ErrorInfo / google.rpc.RetryInfo proto details. The Python
-//     server does not emit these; adding them would de-sync the contract.
+//   - google.rpc.ErrorInfo / google.rpc.RetryInfo proto details. The server
+//     does not emit these; adding them would de-sync the contract.
 //   - codes.Unknown. If a contract test ever observes Unknown it is a P0
 //     bug -- see error-mapping.md "Open questions / risks" item 4.
 package errs
@@ -82,11 +82,10 @@ func (e *codeError) Is(target error) bool {
 	return e.code == t.code
 }
 
-// Sentinel errors. One per gRPC code currently emitted by the Python server
+// Sentinel errors. One per gRPC code currently emitted by the server
 // (per docs/go-port/shared/error-mapping.md "Code catalogue"). Codes the
-// Python server does not raise (OUT_OF_RANGE, CANCELLED, ABORTED, DATA_LOSS)
-// are intentionally not declared here; if a future RPC needs them, add them
-// in the same row as the Python source mapping.
+// server does not raise (OUT_OF_RANGE, CANCELLED, ABORTED, DATA_LOSS) are
+// intentionally not declared here; add them when a future RPC needs them.
 //
 // ErrInternal and ErrDeadlineExceeded are listed in the spec as "not raised
 // by the server today" but are exported here because handlers may need to
@@ -146,7 +145,7 @@ var (
 )
 
 // Errorf builds a status-bearing error in one call. Use this in handlers
-// instead of status.Errorf so the Python -> Go contract stays in one place.
+// instead of status.Errorf so the error contract stays in one place.
 //
 // The returned error implements GRPCStatus() and Is(*codeError), so the
 // caller's tests can do errors.Is(err, errs.ErrNotFound).
@@ -176,9 +175,9 @@ func Code(err error) codes.Code {
 	return status.Code(err)
 }
 
-// PreserveStatusOrSwallow mirrors the Python "re-raise gRPC aborts, swallow
-// the rest" pattern documented in docs/go-port/shared/error-mapping.md
-// "Swallow patterns" item 1.
+// PreserveStatusOrSwallow is the "re-raise gRPC aborts, swallow the rest"
+// chokepoint documented in docs/go-port/shared/error-mapping.md "Swallow
+// patterns" item 1.
 //
 // Behavior:
 //
@@ -189,8 +188,7 @@ func Code(err error) codes.Code {
 //   - err is a naked Go error (no status, i.e. status.Code(err) ==
 //     codes.Unknown) -> write err.Error() into dst via dst.SetError, return
 //     nil. The handler then returns its zero/empty response with the gRPC
-//     status implicitly OK -- matching the Python ResponseProto(success=
-//     false, error=str(e)) shape.
+//     status implicitly OK (ResponseProto success=false, error=msg shape).
 //
 // dst MUST be the response proto being returned (it has SetError generated
 // by go-protobuf for any message with an `error` string field). If dst is

--- a/server/go/internal/errs/map.go
+++ b/server/go/internal/errs/map.go
@@ -1,4 +1,4 @@
-// Python exception -> gRPC code translation table.
+// Exception-class-name -> gRPC code translation table.
 //
 // Source of truth: docs/go-port/shared/error-mapping.md, "Exception -> code
 // mapping".
@@ -8,7 +8,7 @@
 // FromGoError (sentinel-keyed). Handlers should prefer building errors with
 // errs.Errorf or returning a sentinel directly; this map exists for the
 // applier's swallow / re-raise decision and for cross-language contract
-// tests that replay Python error fixtures.
+// tests that replay error fixtures by class name.
 
 package errs
 
@@ -17,10 +17,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// pythonExceptionCodes is the canonical Python-class-name -> gRPC code
-// table. Keys are the Python class names exactly as they appear in the
-// source (`raise FooError(...)`); values are the gRPC code the server
-// eventually emits. See error-mapping.md for the full catalogue.
+// pythonExceptionCodes is the canonical exception-class-name -> gRPC code
+// table. Keys are the class names exactly as they appear in the source
+// (`raise FooError(...)`); values are the gRPC code the server eventually
+// emits. See error-mapping.md for the full catalogue.
 var pythonExceptionCodes = map[string]codes.Code{
 	// AccessDeniedError -> PERMISSION_DENIED.
 	"AccessDeniedError": codes.PermissionDenied,
@@ -94,21 +94,19 @@ var pythonExceptionCodes = map[string]codes.Code{
 	"ValidationError":           codes.InvalidArgument,
 	"SchemaFingerprintMismatch": codes.FailedPrecondition,
 
-	// PermissionError (Python builtin) swallowed inside admin paths.
+	// PermissionError (builtin) swallowed inside admin paths.
 	// Route to PermissionDenied.
 	"PermissionError": codes.PermissionDenied,
 }
 
-// FromPythonException returns the gRPC code that the Python server emits
-// (or would emit, modulo swallow patterns) for the given Python exception
-// class name. Returns codes.Unknown if the class name is not in the table;
-// callers should treat Unknown as "swallow / in-band" -- mirroring the
-// Python broad-except behavior.
+// FromPythonException returns the gRPC code the server emits (or would emit,
+// modulo swallow patterns) for the given exception class name. Returns
+// codes.Unknown if the class name is not in the table; callers should treat
+// Unknown as "swallow / in-band".
 //
-// Cross-language contract tests use this to replay Python error fixtures:
-// the test harness sends the exception class name over the wire and the Go
-// server's classifier produces the same status code the Python server
-// would have produced.
+// Cross-language contract tests use this to replay error fixtures by class
+// name: the test harness sends the exception class name over the wire and
+// the server's classifier produces the corresponding status code.
 func FromPythonException(name string) codes.Code {
 	if c, ok := pythonExceptionCodes[name]; ok {
 		return c

--- a/server/go/internal/errs/trailers.go
+++ b/server/go/internal/errs/trailers.go
@@ -66,9 +66,8 @@ func SetRedirectTrailer(ctx context.Context, ownerNode string) error {
 }
 
 // SetRetryAfter attaches the retry-after trailer with the given duration,
-// rounded UP to the nearest second (zero rounds to 1; matches the Python
-// quota interceptor's str(int(math.ceil(seconds))) shape -- the SDK uses
-// the value as a sleep target, so rounding down would cause an immediate
+// rounded UP to the nearest second (zero rounds to 1; the SDK uses the
+// value as a sleep target, so rounding down would cause an immediate
 // re-hit on the rate limiter).
 //
 // Negative durations are clamped to 1 second.
@@ -86,9 +85,8 @@ func SetRetryAfter(ctx context.Context, d time.Duration) error {
 	return grpc.SetTrailer(ctx, md)
 }
 
-// SetRetryAfterSeconds is the integer-seconds form, matching the Python
-// quota interceptor's call site exactly. Provided so the auth/quota
-// interceptor port can be a one-line change.
+// SetRetryAfterSeconds is the integer-seconds form of SetRetryAfter.
+// Provided so the auth/quota interceptor can use a direct integer.
 //
 // seconds < 1 is clamped to 1 (see SetRetryAfter rationale).
 func SetRetryAfterSeconds(ctx context.Context, seconds int) error {

--- a/server/go/internal/globalstore/globalstore.go
+++ b/server/go/internal/globalstore/globalstore.go
@@ -4,19 +4,17 @@
 // tenant_usage. It is the only place CLAUDE.md invariant #4 permits
 // cross-tenant state to be read or written.
 //
-// Spec: docs/go-port/shared/global-store.md. Source-of-truth Python:
+// Spec: docs/go-port/shared/global-store.md.
 //
 // # Carve-out from invariant #1 ("all writes go through the WAL")
 //
-// `globalstore` has no WAL. The Python implementation also reflects
-// this — `global.db` is the durable record for cross-tenant state.
-// Don't add WAL coupling here; the carve-out is documented in the spec
-// and in PLAN.md §6.
+// `globalstore` has no WAL. `global.db` is the durable record for
+// cross-tenant state. Don't add WAL coupling here; the carve-out is
+// documented in the spec and in PLAN.md §6.
 //
 // # Concurrency
 //
-// MaxOpenConns(1) is non-negotiable: it mirrors the Python
-// single-thread executor (one writer, no contention) and avoids
+// MaxOpenConns(1) is non-negotiable: one writer, no contention, avoids
 // SQLITE_BUSY retry loops in hot paths. SetMaxIdleConns matches so the
 // pool never closes the lone connection between calls.
 //
@@ -116,9 +114,9 @@ func New(opts Options) (*GlobalStore, error) {
 		return nil, fmt.Errorf("globalstore: open %q: %w", path, err)
 	}
 
-	// MaxOpenConns(1) is the parity-with-Python invariant. SetMaxIdleConns
-	// matches so the connection survives between calls; ConnMaxLifetime=0
-	// keeps it alive for the process lifetime.
+	// MaxOpenConns(1): single writer, serialized at the connection level.
+	// SetMaxIdleConns matches so the connection survives between calls;
+	// ConnMaxLifetime=0 keeps it alive for the process lifetime.
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 	db.SetConnMaxLifetime(0)

--- a/server/go/internal/globalstore/globalstore_test.go
+++ b/server/go/internal/globalstore/globalstore_test.go
@@ -42,9 +42,9 @@ func newStore(t *testing.T, nowFn func() int64) *globalstore.GlobalStore {
 	return gs
 }
 
-// TestMaxOpenConns is the parity-critical assertion: the underlying
-// pool must be pinned to exactly one connection. Catches a regression
-// where someone bumps SetMaxOpenConns thinking SQLite "scales".
+// TestMaxOpenConns asserts the underlying pool is pinned to exactly one
+// connection. Catches a regression where someone bumps SetMaxOpenConns
+// thinking SQLite "scales".
 func TestMaxOpenConns(t *testing.T) {
 	gs := newStore(t, nil)
 	stats := gs.DB().Stats()
@@ -286,10 +286,9 @@ func TestTenantCRUD(t *testing.T) {
 	}
 }
 
-// TestTenantIdempotentCreate documents the Python contract: a duplicate
-// CreateTenant raises an integrity error which the gRPC layer
-// translates to ALREADY_EXISTS. We surface that directly via
-// errs.ErrAlreadyExists.
+// TestTenantIdempotentCreate documents the contract: a duplicate
+// CreateTenant raises an integrity error which the gRPC layer translates
+// to ALREADY_EXISTS, surfaced directly via errs.ErrAlreadyExists.
 func TestTenantIdempotentCreate(t *testing.T) {
 	gs := newStore(t, nil)
 	ctx := context.Background()
@@ -305,7 +304,7 @@ func TestTenantIdempotentCreate(t *testing.T) {
 // TestCreateTenantWithOwner_Atomic verifies the registry row + owner
 // membership row land in a single transaction: success leaves both, and
 // a duplicate tenant_id leaves the prior owner intact without mutating
-// state. Closes the Python-parity orphan-tenant hazard.
+// state. Closes the orphan-tenant hazard.
 func TestCreateTenantWithOwner_Atomic(t *testing.T) {
 	gs := newStore(t, nil)
 	ctx := context.Background()

--- a/server/go/internal/globalstore/legalhold.go
+++ b/server/go/internal/globalstore/legalhold.go
@@ -7,9 +7,8 @@
 //   - legal_holds is the *audit/informational* table that records who
 //     placed the hold, when, and why.
 //
-// They're independent today (the Python global_store has both
-// `set_legal_hold` and `set_legal_hold_record`); see the Open Question
-// in docs/go-port/shared/global-store.md about unifying them.
+// They're independent today; see the Open Question in
+// docs/go-port/shared/global-store.md about unifying them.
 
 package globalstore
 

--- a/server/go/internal/globalstore/members.go
+++ b/server/go/internal/globalstore/members.go
@@ -15,9 +15,8 @@ import (
 )
 
 // AddTenantMember inserts a (tenant_id, user_id, role) row. Empty role
-// defaults to "member" (matches Python). Returns ErrAlreadyExists if
-// the membership already exists — Python lets the IntegrityError
-// bubble; the Go boundary code wants a typed error.
+// defaults to "member". Returns ErrAlreadyExists if the membership
+// already exists.
 func (g *GlobalStore) AddTenantMember(ctx context.Context, tenantID, userID, role string) error {
 	if role == "" {
 		role = "member"

--- a/server/go/internal/globalstore/quota.go
+++ b/server/go/internal/globalstore/quota.go
@@ -1,5 +1,4 @@
-// tenant_quotas + tenant_usage CRUD. Mirrors the Python helpers at
-// through :1333 (reset_period).
+// tenant_quotas + tenant_usage CRUD.
 //
 // IMPORTANT: tenant_usage.period_start_ms is the start of the current
 // UTC calendar month in MILLISECONDS. Every other timestamp in

--- a/server/go/internal/globalstore/tenants.go
+++ b/server/go/internal/globalstore/tenants.go
@@ -15,13 +15,11 @@ import (
 )
 
 // DefaultRegion is the region pin assigned when CreateTenant is called
-// with an empty Region. Matches the Python signature
-// `create_tenant(... region: str = "us-east-1")`.
+// with an empty Region.
 const DefaultRegion = "us-east-1"
 
 // CreateTenant inserts a new tenant_registry row. Returns
-// ErrAlreadyExists on duplicate tenant_id (matches Python's
-// IntegrityError → ALREADY_EXISTS at the gRPC boundary).
+// ErrAlreadyExists on duplicate tenant_id.
 //
 // Empty `region` is filled with DefaultRegion.
 func (g *GlobalStore) CreateTenant(ctx context.Context, tenantID, name, region string) (*Tenant, error) {
@@ -52,9 +50,9 @@ func (g *GlobalStore) CreateTenant(ctx context.Context, tenantID, name, region s
 
 // CreateTenantWithOwner atomically inserts the tenant_registry row and
 // the creator's tenant_members owner row in a single SQLite transaction.
-// Either both land or neither does — the orphan-tenant hazard that the
-// Python parity port carried (registry row written without an owner if
-// the process crashed between the two INSERTs) is closed here.
+// Either both land or neither does — the orphan-tenant hazard
+// (registry row written without an owner if the process crashed between
+// the two INSERTs) is closed here.
 //
 // Returns ErrAlreadyExists on duplicate tenant_id; the membership insert
 // is not attempted in that case. Empty `region` is filled with
@@ -118,8 +116,7 @@ func (g *GlobalStore) GetTenant(ctx context.Context, tenantID string) (*Tenant, 
 }
 
 // ListTenants returns all tenants with the given status, ordered by
-// created_at. No pagination — matches the Python signature
-// `list_tenants(status='active') -> list[dict]`.
+// created_at. No pagination.
 func (g *GlobalStore) ListTenants(ctx context.Context, status string) ([]*Tenant, error) {
 	rows, err := g.db.QueryContext(ctx,
 		`SELECT tenant_id, name, status, created_at, region

--- a/server/go/internal/globalstore/users.go
+++ b/server/go/internal/globalstore/users.go
@@ -40,9 +40,8 @@ func (g *GlobalStore) CreateUser(ctx context.Context, userID, email, name string
 	}, nil
 }
 
-// GetUser returns the user, or (nil, nil) if not present. The "no
-// error" sentinel mirrors the Python `dict | None` contract — callers
-// decide whether to upgrade missing-row to NOT_FOUND.
+// GetUser returns the user, or (nil, nil) if not present. Callers
+// decide whether to upgrade a missing row to NOT_FOUND.
 func (g *GlobalStore) GetUser(ctx context.Context, userID string) (*User, error) {
 	row := g.db.QueryRowContext(ctx,
 		`SELECT user_id, email, name, status, created_at, updated_at

--- a/server/go/internal/payload/translate.go
+++ b/server/go/internal/payload/translate.go
@@ -49,9 +49,8 @@ import (
 //   - String key matching a field name is translated to its id
 //     (back-compat for pre-fix SDKs; new SDKs send id-keyed and
 //     skip this path).
-//   - Unknown name keys are dropped silently (Python parity:
-//     ingress is permissive so legacy clients sending deprecated
-//     fields don't break writes).
+//   - Unknown name keys are dropped silently (ingress is permissive
+//     so legacy clients sending deprecated fields don't break writes).
 //   - Field-kind coercion (only when schema is known):
 //   - BYTES: structpb has no bytes type; the wire carries base64
 //     strings. Decode to []byte for storage.
@@ -131,8 +130,7 @@ func StructToPayload(reg *schema.Registry, nodeTypeName string, s *structpb.Stru
 
 		f := nameToField[key]
 		if f == nil {
-			// Unknown name: drop silently. Matches Python
-			// name_to_id_keys (ingress is permissive).
+			// Unknown name: drop silently (ingress is permissive).
 			continue
 		}
 		coerced, err := coerceForKind(f, value)
@@ -177,7 +175,7 @@ func PayloadToStruct(reg *schema.Registry, nodeTypeName string, p map[uint32]any
 				v, err = encodeForKind(f, raw)
 			} else {
 				// Unknown id on egress is preserved verbatim
-				// (forward-compat) — matches Python id_to_name_keys.
+				// (forward-compat).
 				v, err = newValue(raw)
 			}
 		} else {
@@ -203,8 +201,7 @@ func PayloadToStruct(reg *schema.Registry, nodeTypeName string, p map[uint32]any
 //     client bug and should surface as INVALID_ARGUMENT — silently
 //     dropping it would change the result set.
 //
-// Mirrors translate_filter_name_to_id in the Python port, with the
-// stricter unknown-key behavior the Go server enforces (see
+// Unknown filter keys are an error, not a silent drop (see
 // docs/go-port/shared/payload-translation.md "QueryNodes filter").
 func FilterNamesToIDs(reg *schema.Registry, nodeTypeName string, filter map[string]any) (map[uint32]any, error) {
 	if len(filter) == 0 {
@@ -253,8 +250,6 @@ func FilterNamesToIDs(reg *schema.Registry, nodeTypeName string, filter map[stri
 //
 // Unknown ids are preserved verbatim (as their decimal string) so a
 // row written by a future schema revision is not lossy on read.
-// Unknown ids preserved as decimal-string keys is identical to the
-// Python id_to_name_keys fallthrough.
 //
 // When reg / nodeTypeName resolves to no schema, every id is rendered
 // as its decimal string.
@@ -317,9 +312,8 @@ func parseFieldID(s string) (uint32, bool) {
 // wrong wire value (e.g. BYTES field carrying a non-string).
 //
 // Nil or NullValue is preserved as nil so callers can distinguish "key
-// present, value null" from "key absent" — matches the Python contract
-// where FieldDef.validate_value treats None as "not provided" (and the
-// applier silently no-ops on it).
+// present, value null" from "key absent" (the applier silently no-ops
+// on null).
 func coerceForKind(f *schema.FieldDef, v *structpb.Value) (any, error) {
 	if v == nil {
 		return nil, nil

--- a/server/go/internal/schema/compat.go
+++ b/server/go/internal/schema/compat.go
@@ -1,6 +1,6 @@
 // Compatibility engine for entdb-schema check / diff.
 //
-// Mirrors the deleted Python compat.py engine. Compares two *Registry
+// Compares two *Registry
 // instances and reports every per-rule difference, classifying each as
 // breaking (block PR) or non-breaking (informational) per the rules
 // documented on each ChangeKind constant.
@@ -896,8 +896,7 @@ func normaliseOnExit(v OnSubjectExit) OnSubjectExit {
 
 // dataPolicyRank orders data policies from "weakest" (lowest leakage
 // risk if downgraded) to "strongest". Used to classify
-// tightening vs loosening. The ordering mirrors the Python
-// data_policy.py downgrade table and is documented on each constant:
+// tightening vs loosening. The ordering is documented on each constant:
 //
 //	ephemeral < business < personal < healthcare < financial < audit
 //

--- a/server/go/internal/schema/fingerprint.go
+++ b/server/go/internal/schema/fingerprint.go
@@ -12,25 +12,23 @@ import (
 
 // computeFingerprint produces the canonical schema fingerprint:
 //
-//	canonical = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
-//	hash = sha256(canonical).hexdigest()
-//	return f"sha256:{hash}"
+//	canonical = sort-keys compact JSON of the registry's to_dict form
+//	hash      = sha256(canonical).hexdigest()
+//	return "sha256:" + hash
 //
 // We can't rely on encoding/json because Go preserves struct-field
-// declaration order rather than sorting keys, and Python's
-// separators=(",",":") drops the default ", "/": " spaces. We marshal
-// the registry into the same shape as Python's to_dict(), then
-// re-emit it with a custom canonical encoder.
+// declaration order rather than sorting keys, and the canonical format
+// omits whitespace between separators. We marshal the registry into
+// the to_dict() shape, then re-emit it with a custom canonical encoder.
 //
 // Floats: registry data does not include floats today, but the encoder
 // supports them for forward compatibility (using strconv with
-// 'g'/-1 precision, which matches Python's repr-derived output for
-// integral floats — round-trip safety is the contract, not byte
-// equality with Python for arbitrary floats).
+// 'g'/-1 precision for integral floats — round-trip safety is the
+// contract).
 func (r *Registry) computeFingerprint() (string, error) {
 	doc := r.toFile()
 	// Round-trip through encoding/json into a generic value so we can
-	// re-emit with sorted keys exactly as Python does.
+	// re-emit with sorted keys in canonical order.
 	raw, err := json.Marshal(doc)
 	if err != nil {
 		return "", fmt.Errorf("schema: marshal for fingerprint: %w", err)
@@ -48,8 +46,8 @@ func (r *Registry) computeFingerprint() (string, error) {
 }
 
 // CanonicalJSON marshals the registry into the byte-for-byte
-// deterministic shape used by the fingerprint (Python's
-// json.dumps(sort_keys=True, separators=(",", ":"))). entdb-schema
+// deterministic shape used by the fingerprint (sort-keys, no-whitespace
+// compact JSON). entdb-schema
 // uses this for snapshot output so two invocations on the same
 // registry produce identical bytes — see issue #488 determinism
 // requirements (§Determinism, points 7-8).
@@ -83,20 +81,16 @@ func CanonicalEncodeJSON(v any) ([]byte, error) {
 	return []byte(sb.String()), nil
 }
 
-// canonicalEncode writes v to sb using Python's
-// `json.dumps(sort_keys=True, separators=(",", ":"))` byte format:
-//   - Object keys sorted by Unicode code point (Python sorted() default).
+// canonicalEncode writes v to sb in sort-keys, no-whitespace compact
+// JSON format:
+//   - Object keys sorted by Unicode code point.
 //   - No whitespace between separators.
-//   - Strings escaped using the standard ensure_ascii=True semantics
-//     used by Python by default, which matches Go's encoding/json
-//     escaping for ASCII payloads. Schema metadata is ASCII today
-//     (names, descriptions in English), so we use json.Marshal of the
-//     leaf string which is a strict superset (Go always escapes the
-//     same control chars and uses the same backslash sequences).
+//   - Strings escaped via json.Marshal (ASCII payloads; schema metadata
+//     is ASCII today — names and descriptions in English).
 //
-// If the schema gains non-ASCII content we will need a custom string
-// encoder that matches Python's `\uXXXX` escapes — flagged in the
-// fingerprint parity test.
+// If the schema gains non-ASCII content a custom string encoder will
+// be needed to emit `\uXXXX` escapes — flagged in the fingerprint
+// parity test.
 func canonicalEncode(sb *strings.Builder, v any) error {
 	switch x := v.(type) {
 	case nil:
@@ -115,7 +109,7 @@ func canonicalEncode(sb *strings.Builder, v any) error {
 		sb.Write(b)
 	case float64:
 		// json.Unmarshal lands all numbers in float64. Emit integers
-		// without trailing ".0" to match Python's JSON output.
+		// without trailing ".0" for canonical output.
 		if x == float64(int64(x)) {
 			sb.WriteString(strconv.FormatInt(int64(x), 10))
 		} else {

--- a/server/go/internal/schema/loader.go
+++ b/server/go/internal/schema/loader.go
@@ -22,8 +22,8 @@ type schemaFile struct {
 	EdgeTypes []EdgeTypeDef `json:"edge_types"`
 }
 
-// LoadFromJSON parses the Python-emitted SchemaRegistry.to_json shape
-// into a fresh, mutable *Registry. The returned registry is not yet
+// LoadFromJSON parses the SchemaRegistry JSON shape into a fresh,
+// mutable *Registry. The returned registry is not yet
 // frozen — callers (typically server boot) call Freeze() once all
 // supplemental registrations are done.
 //
@@ -53,10 +53,10 @@ func LoadFromJSON(data []byte) (*Registry, error) {
 	return r, nil
 }
 
-// MarshalJSON emits the registry in Python SchemaRegistry.to_dict order
-// (node_types sorted by type_id, edge_types sorted by edge_id). The
-// output is suitable for round-tripping through LoadFromJSON and as
-// input to the fingerprint canonicaliser.
+// MarshalJSON emits the registry in canonical order (node_types sorted
+// by type_id, edge_types sorted by edge_id). The output is suitable
+// for round-tripping through LoadFromJSON and as input to the
+// fingerprint canonicaliser.
 //
 // MarshalJSON is also implicitly called by encoding/json so callers can
 // json.Marshal(reg) directly.
@@ -97,7 +97,7 @@ func (r *Registry) toFile() schemaFile {
 		if e.Props == nil {
 			e.Props = []FieldDef{}
 		}
-		// Python always emits on_subject_exit (defaults to "both").
+		// on_subject_exit is always emitted (defaults to "both").
 		if e.OnSubjectExit == "" {
 			e.OnSubjectExit = OnSubjectExitBoth
 		}

--- a/server/go/internal/schema/schema_test.go
+++ b/server/go/internal/schema/schema_test.go
@@ -1,6 +1,5 @@
-// Tests for the schema package. Covers JSON round-trip parity with the
-// Python SchemaRegistry.to_json shape, freeze semantics, fingerprint
-// determinism, and field-id <-> name lookup.
+// Tests for the schema package. Covers JSON round-trip, freeze
+// semantics, fingerprint determinism, and field-id <-> name lookup.
 
 package schema
 
@@ -54,10 +53,9 @@ const pythonSampleJSON = `{
   ]
 }`
 
-// Reference fingerprint computed by Python's SchemaRegistry.freeze()
-// over the same logical content as pythonSampleJSON. Keep in sync with
-// the Python fixture; if Python's emission ever changes the two must
-// be regenerated together.
+// pythonReferenceFingerprint is the expected fingerprint for pythonSampleJSON.
+// Keep in sync with the cross-language fixture; if the canonical encoder
+// changes the two must be regenerated together.
 const pythonReferenceFingerprint = "sha256:5822499c748bb30ab35473658f8000f9cba89250d6bafdeabc6ca833fcc85fe2"
 
 func TestLoadFromJSON_Sample(t *testing.T) {
@@ -171,10 +169,10 @@ func TestFingerprint_DeterministicAcrossLoads(t *testing.T) {
 }
 
 func TestFingerprint_PythonByteParity(t *testing.T) {
-	// This test pins byte-for-byte parity with Python's
-	// SchemaRegistry.freeze() output for the shared fixture. If it
-	// breaks, the canonical encoder in fingerprint.go has drifted from
-	// json.dumps(sort_keys=True, separators=(",", ":")).
+	// This test pins byte-for-byte parity with the expected reference
+	// fingerprint for the shared fixture. If it breaks, the canonical
+	// encoder in fingerprint.go has drifted from the sort-keys,
+	// no-whitespace compact JSON format.
 	r, err := LoadFromJSON([]byte(pythonSampleJSON))
 	if err != nil {
 		t.Fatalf("load: %v", err)
@@ -185,7 +183,7 @@ func TestFingerprint_PythonByteParity(t *testing.T) {
 	}
 	if fp != pythonReferenceFingerprint {
 		t.Errorf(
-			"fingerprint mismatch:\n  Go    = %s\n  Python= %s",
+			"fingerprint mismatch:\n  got  = %s\n  want = %s",
 			fp, pythonReferenceFingerprint,
 		)
 	}

--- a/server/go/internal/schema/types.go
+++ b/server/go/internal/schema/types.go
@@ -8,9 +8,8 @@
 // The single source of truth for type metadata is the proto
 // descriptor surface (CLAUDE.md invariant #5); JSON is the bootstrap
 // channel used when the Go server does not import the proto module
-// directly. The Python SDK's SchemaRegistry serialises to the same
-// JSON shape and Fingerprint() is byte-stable across implementations
-// for the same registry contents.
+// directly. Fingerprint() is byte-stable for the same registry
+// contents across all implementations.
 package schema
 
 import (
@@ -49,8 +48,8 @@ func (k FieldKind) Valid() bool {
 	return false
 }
 
-// AclPermission mirrors schema/types.py AclPermission. Stored on
-// AclEntry; ACL evaluation lives in the acl package, not here.
+// AclPermission is the permission type for AclEntry. ACL evaluation
+// lives in the acl package, not here.
 type AclPermission string
 
 const (
@@ -60,8 +59,8 @@ const (
 	PermissionAdmin  AclPermission = "admin"
 )
 
-// OnSubjectExit mirrors schema/types.py OnSubjectExit. Drives GDPR
-// edge-cleanup behaviour when a data subject is deleted/anonymized.
+// OnSubjectExit drives GDPR edge-cleanup behaviour when a data subject
+// is deleted/anonymized.
 type OnSubjectExit string
 
 const (
@@ -70,8 +69,8 @@ const (
 	OnSubjectExitBoth OnSubjectExit = "both"
 )
 
-// DataPolicy mirrors entdb_server/data_policy.py DataPolicy. Wire
-// values match the Python enum so the JSON contract round-trips.
+// DataPolicy is the data-classification tier for a node or edge type.
+// Wire values are stable and round-trip through the JSON contract.
 type DataPolicy string
 
 const (
@@ -89,9 +88,8 @@ type AclEntry struct {
 	Permission AclPermission `json:"permission"`
 }
 
-// FieldDef is the Go counterpart of schema/types.py FieldDef. Field
-// names match the Python JSON keys (snake_case) so a Python-emitted
-// schema file boots a Go server unchanged.
+// FieldDef describes a single field on a node or edge type. JSON field
+// names use snake_case as defined by the schema JSON contract.
 //
 // Invariants enforced by Validate:
 //   - FieldID in [1, 65535]
@@ -116,7 +114,7 @@ type FieldDef struct {
 
 // Validate checks the field invariants. Returns an error rather than
 // panicking so loader callers can collect every violation in a single
-// pass (mirrors Python __post_init__ but composable with the loader).
+// pass.
 func (f *FieldDef) Validate() error {
 	if f.FieldID == 0 {
 		return fmt.Errorf("field_id must be positive, got %d", f.FieldID)
@@ -139,15 +137,14 @@ func (f *FieldDef) Validate() error {
 	return nil
 }
 
-// CompositeUniqueDef is the Go counterpart of schema/types.py
-// CompositeUniqueDef. Wire field names match the Python JSON keys so
-// the contract round-trips.
+// CompositeUniqueDef declares a named multi-field unique constraint.
+// Wire field names are stable and round-trip through the JSON contract.
 type CompositeUniqueDef struct {
 	Name     string   `json:"name"`
 	FieldIDs []uint32 `json:"field_ids"`
 }
 
-// Validate enforces the same three invariants as Python __post_init__.
+// Validate enforces the CompositeUniqueDef invariants.
 func (c *CompositeUniqueDef) Validate() error {
 	if c.Name == "" {
 		return errors.New("CompositeUniqueDef name cannot be empty")
@@ -171,12 +168,12 @@ func (c *CompositeUniqueDef) Validate() error {
 	return nil
 }
 
-// NodeTypeDef is the Go counterpart of schema/types.py NodeTypeDef.
+// NodeTypeDef describes a node type in the schema registry.
 type NodeTypeDef struct {
 	TypeID int32  `json:"type_id"`
 	Name   string `json:"name"`
-	// Fields is always emitted (even when empty) to match Python
-	// NodeTypeDef.to_dict, which always includes the "fields" key.
+	// Fields is always emitted (even when empty) — the JSON contract
+	// always includes the "fields" key.
 	Fields          []FieldDef           `json:"fields"`
 	Deprecated      bool                 `json:"deprecated,omitempty"`
 	Description     string               `json:"description,omitempty"`
@@ -187,10 +184,10 @@ type NodeTypeDef struct {
 	CompositeUnique []CompositeUniqueDef `json:"composite_unique,omitempty"`
 }
 
-// Validate checks the same invariants as Python __post_init__:
-// positive type_id, non-empty name, no duplicate field_ids/names, and
-// composite_unique constraints reference known fields with unique
-// names and unique field-id signatures.
+// Validate checks NodeTypeDef invariants: positive type_id, non-empty
+// name, no duplicate field_ids/names, and composite_unique constraints
+// reference known fields with unique names and unique field-id
+// signatures.
 func (n *NodeTypeDef) Validate() error {
 	if n.TypeID <= 0 {
 		return fmt.Errorf("type_id must be positive, got %d", n.TypeID)
@@ -273,9 +270,8 @@ func (n *NodeTypeDef) GetFieldByID(id uint32) *FieldDef {
 	return nil
 }
 
-// EdgeTypeDef is the Go counterpart of schema/types.py EdgeTypeDef.
-// JSON keys match Python's to_dict (which serialises from_type_id /
-// to_type_id, not the NodeTypeDef pointer).
+// EdgeTypeDef describes an edge type in the schema registry. JSON keys
+// use from_type_id / to_type_id (integer IDs, not NodeTypeDef pointers).
 type EdgeTypeDef struct {
 	EdgeID        int32       `json:"edge_id"`
 	Name          string      `json:"name"`
@@ -286,13 +282,13 @@ type EdgeTypeDef struct {
 	Deprecated    bool        `json:"deprecated,omitempty"`
 	Description   string      `json:"description,omitempty"`
 	DataPolicy    *DataPolicy `json:"data_policy,omitempty"`
-	// OnSubjectExit is always emitted (defaults to "both"); mirrors
-	// Python EdgeTypeDef.to_dict which writes the key unconditionally.
+	// OnSubjectExit is always emitted (defaults to "both"); the JSON
+	// contract writes this key unconditionally.
 	OnSubjectExit OnSubjectExit `json:"on_subject_exit"`
 }
 
-// Validate checks the same invariants as Python __post_init__:
-// positive edge_id, non-empty name, no duplicate prop field_ids.
+// Validate checks EdgeTypeDef invariants: positive edge_id, non-empty
+// name, no duplicate prop field_ids.
 func (e *EdgeTypeDef) Validate() error {
 	if e.EdgeID <= 0 {
 		return fmt.Errorf("edge_id must be positive, got %d", e.EdgeID)
@@ -312,8 +308,8 @@ func (e *EdgeTypeDef) Validate() error {
 		propIDs[p.FieldID] = struct{}{}
 	}
 	if e.OnSubjectExit == "" {
-		// Python defaults to BOTH; preserve that on parse but do not
-		// rewrite the source field — the loader normalises.
+		// Defaults to BOTH; do not rewrite the source field —
+		// the loader normalises.
 	}
 	return nil
 }

--- a/server/go/internal/store/acl.go
+++ b/server/go/internal/store/acl.go
@@ -208,8 +208,7 @@ func (s *CanonicalStore) RemoveGroupMember(ctx context.Context, tenantID, groupI
 // group_users for tenantID. Used by the RemoveGroupMember handler to
 // snapshot `found` before the WAL append (the applier owns the actual
 // DELETE; the handler returns the pre-read membership state to the
-// caller as the response.success flag, mirroring Python's pre-WAL
-// canonical_store return value).
+// caller as the response.success flag).
 func (s *CanonicalStore) IsGroupMember(ctx context.Context, tenantID, groupID, memberActorID string) (bool, error) {
 	db, err := s.readDB(tenantID)
 	if err != nil {

--- a/server/go/internal/store/canonical.go
+++ b/server/go/internal/store/canonical.go
@@ -72,8 +72,7 @@ type Options struct {
 
 // CanonicalStore is the per-tenant SQLite materialized view of the WAL.
 // One *sql.DB per tenant_id, lazy-opened on first use, single-writer
-// per tenant (matches the Python parity pattern at canonical_store.py
-// :683-717 + :642).
+// per tenant.
 //
 // Method receivers are value-stable; the struct is safe for concurrent
 // goroutine use. Writers hold the per-tenant write mutex (see

--- a/server/go/internal/store/errors.go
+++ b/server/go/internal/store/errors.go
@@ -22,8 +22,7 @@ import (
 )
 
 // Sentinel errors returned by store methods. Each wraps an internal/errs
-// sentinel so the gRPC layer maps them to the same codes the Python
-// server emits.
+// sentinel so the gRPC layer maps them to the correct codes.
 var (
 	// ErrNodeNotFound is returned when GetNode / UpdateNode / DeleteNode
 	// targets a node that does not exist. Wraps errs.ErrNotFound.

--- a/server/go/internal/store/readsplit_raw_regression_test.go
+++ b/server/go/internal/store/readsplit_raw_regression_test.go
@@ -151,9 +151,8 @@ func TestReadSplitWaitForOffsetObservesAppliedWrite(t *testing.T) {
 
 	// Reader: block until the applier is INSIDE the pre-commit window
 	// (so on the pre-fix code the offsetCond has already been
-	// broadcast), then do the exact read-your-write the Python SDK does
-	// by default — WaitForOffset(target) followed immediately by a
-	// re-routed GetNode on the read pool.
+	// broadcast), then do a read-your-write — WaitForOffset(target)
+	// followed immediately by a re-routed GetNode on the read pool.
 	select {
 	case <-inWindow:
 	case <-time.After(5 * time.Second):

--- a/server/go/internal/store/txn.go
+++ b/server/go/internal/store/txn.go
@@ -12,7 +12,7 @@ import (
 //
 // We deliberately use *sql.Conn (not *sql.Tx) because database/sql's
 // BeginTx issues a plain "BEGIN" / "BEGIN DEFERRED" depending on driver
-// and we need the explicit IMMEDIATE lock-mode for parity with Python.
+// and we need the explicit IMMEDIATE lock-mode.
 //
 // Callers MUST call either Commit or Rollback exactly once. The
 // per-tenant write mutex is held for the lifetime of the BatchTxn so

--- a/server/go/internal/tenant/check.go
+++ b/server/go/internal/tenant/check.go
@@ -118,8 +118,7 @@ func CheckTenant(ctx context.Context, tenantID string, gs *globalstore.GlobalSto
 
 	// 2. Tenant existence + region pinning. Both require globalstore.
 	//    Missing globalstore => skip both checks (single-node bring-up
-	//    path); same as the Python `if self.global_store is not None`
-	//    guard.
+	//    path).
 	if gs == nil {
 		return nil
 	}

--- a/server/go/internal/testseed/seed.go
+++ b/server/go/internal/testseed/seed.go
@@ -3,15 +3,15 @@
 // and tests/python/e2e/) expect to find on a freshly-booted server.
 //
 // The harness contract is documented in docs/go-port/shared/test-harness.md
-// (the `--seed-tenant` and `--seed-profile` rows). The Python in-process
-// fixture for the contract suite lives at tests/python/integration/conftest.py
+// (the `--seed-tenant` and `--seed-profile` rows). The in-process fixture
+// for the contract suite lives at tests/python/integration/conftest.py
 // and seeds the same shape via direct globalstore/canonicalstore writes +
 // a follow-up ExecuteAtomic call. This package reproduces that state for
 // the Go subprocess harness.
 //
 // Profiles:
 //   - "contract": User/Task/AssignedTo schema + alice/bob users +
-//     seed node + seed-1 receipt. Mirrors the Python contract fixture.
+//     seed node + seed-1 receipt.
 //   - "e2e": User/Product/Order schema (typeIDs 8001/8002/8003) + edge
 //     types (Purchased/PlacedOrder/OrderContains, 8101/8102/8103) +
 //     a single `e2e-runner` user as tenant owner. No seed node — the
@@ -219,7 +219,7 @@ func RegisterE2ESchema(reg *schema.Registry) error {
 const seedWaitTimeout = 30 * time.Second
 
 // SeedTenantContract applies the contract-fixture seed for tenantID.
-// Order mirrors the Python conftest:
+// Steps:
 //
 //  1. tenant_registry row (tenantID, "Acme Corp", region default).
 //  2. user_registry rows: alice + bob.

--- a/server/go/internal/wal/cloud_common.go
+++ b/server/go/internal/wal/cloud_common.go
@@ -10,15 +10,12 @@ package wal
 //     first-class binary header map the way Kafka does. To keep the
 //     wal.Record.Headers contract (and the HeaderIdempotencyKey
 //     round-trip) intact we embed headers in the payload envelope when
-//     the backend can't carry them natively. This mirrors the retired
-//     Python source (kinesis.py / pubsub.py _headers/_data wrapping).
+//     the backend can't carry them natively.
 //   - At-least-once redelivery: backends that ack-on-commit (SQS,
 //     Service Bus) keep an in-memory map from StreamPos.Offset to the
 //     backend-native ack handle so Commit can resolve it.
 //
-// The envelope is intentionally the same JSON shape the Python source
-// used so a stream written by the (now retired) Python server and read
-// by the Go server — or vice versa during a migration — round-trips.
+// The envelope uses the JSON shape {"_headers": {...}, "_data": ...}.
 
 import (
 	"context"
@@ -32,8 +29,7 @@ import (
 )
 
 // headerEnvelope is the JSON wrapper used to smuggle headers through a
-// transport with no native header map. Byte-for-byte the shape the
-// Python kinesis.py / pubsub.py used: {"_headers": {...}, "_data": ...}.
+// transport with no native header map: {"_headers": {...}, "_data": ...}.
 type headerEnvelope struct {
 	Headers map[string]string `json:"_headers"`
 	Data    string            `json:"_data"`
@@ -41,11 +37,10 @@ type headerEnvelope struct {
 
 // wrapHeaders returns value unchanged when there are no headers (so a
 // plain payload stays a plain payload — only records that actually
-// carry headers pay the envelope cost, exactly like the Python source).
-// When headers are present it wraps them into the JSON envelope.
+// carry headers pay the envelope cost). When headers are present it
+// wraps them into the JSON envelope.
 //
-// Header values are decoded as UTF-8 (errors replaced) to match the
-// Python `.decode("utf-8", errors="replace")` behaviour; the WAL
+// Header values are decoded as UTF-8 (errors replaced); the WAL
 // idempotency key and applier-set headers are always UTF-8 text.
 func wrapHeaders(value []byte, headers map[string][]byte) []byte {
 	if len(headers) == 0 {
@@ -91,12 +86,11 @@ func unwrapHeaders(data []byte) ([]byte, map[string][]byte) {
 }
 
 // decodeUTF8 returns b as a string, replacing invalid UTF-8 with the
-// Unicode replacement char (matching the Python source's
-// .decode("utf-8", errors="replace")). Go's []byte->string conversion
-// already substitutes U+FFFD for invalid sequences when the bytes are
-// later range-iterated/re-encoded; round-tripping through []rune makes
-// the substitution eager and explicit so the stored/transmitted form
-// is deterministic.
+// Unicode replacement char. Go's []byte->string conversion already
+// substitutes U+FFFD for invalid sequences when the bytes are later
+// range-iterated/re-encoded; round-tripping through []rune makes the
+// substitution eager and explicit so the stored/transmitted form is
+// deterministic.
 func decodeUTF8(b []byte) string {
 	if utf8.Valid(b) {
 		return string(b)

--- a/server/go/internal/wal/event.go
+++ b/server/go/internal/wal/event.go
@@ -31,10 +31,9 @@ const (
 // stamped a fingerprint yet. TsMs defaults to the current wall clock
 // when zero (see NewEvent / Encode).
 //
-// Ops is intentionally typed as []map[string]any: until the op proto
-// lands (see docs/go-port/shared/wal-producer.md "Op typing"), the
-// Python side stores ops as list[dict[str, Any]] and the Go port must
-// preserve the same encoded byte layout for cross-impl contract tests.
+// Ops is intentionally typed as []map[string]any to preserve the
+// encoded byte layout required by cross-impl contract tests (see
+// docs/go-port/shared/wal-producer.md "Op typing").
 type Event struct {
 	TenantID          string           `json:"tenant_id"`
 	Scope             Scope            `json:"scope,omitempty"`

--- a/server/go/internal/wal/eventhubs.go
+++ b/server/go/internal/wal/eventhubs.go
@@ -71,8 +71,7 @@ type eventHubEvent struct {
 	EnqueuedMs     int64
 }
 
-// EventHubsConfig captures the Event Hubs-specific knobs (parity with
-// the Python EventHubsConfig).
+// EventHubsConfig captures the Event Hubs-specific knobs.
 type EventHubsConfig struct {
 	// ConnectionString is the Event Hubs namespace connection string.
 	ConnectionString string
@@ -80,13 +79,13 @@ type EventHubsConfig struct {
 	EventHubName string
 	// ConsumerGroup is the Event Hubs consumer group (default "$Default").
 	ConsumerGroup string
-	// MaxBatchSize bounds a single receive. Python default 100.
+	// MaxBatchSize bounds a single receive (default 100).
 	MaxBatchSize int
-	// MaxWaitTime bounds a single receive call. Python default 5s.
+	// MaxWaitTime bounds a single receive call (default 5s).
 	MaxWaitTime time.Duration
 }
 
-// DefaultEventHubsConfig returns a config matching the Python defaults.
+// DefaultEventHubsConfig returns a config with sensible defaults.
 func DefaultEventHubsConfig(connStr, hubName, consumerGroup string) EventHubsConfig {
 	if strings.TrimSpace(consumerGroup) == "" {
 		consumerGroup = azeventhubs.DefaultConsumerGroup

--- a/server/go/internal/wal/kafka.go
+++ b/server/go/internal/wal/kafka.go
@@ -28,8 +28,7 @@ package wal
 //
 // Idempotent retry: like InMemory, we cache (topic, key, idempotency-key)
 // -> StreamPos so a retried Append within the lifetime of the producer
-// returns the original receipt without writing a duplicate record. This
-// mirrors memory.go and the Python applier's apply-time dedupe; the
+// returns the original receipt without writing a duplicate record; the
 // sarama idempotent producer config also prevents broker-side
 // duplicates on retry within a single producer session.
 //
@@ -59,28 +58,26 @@ type KafkaConfig struct {
 	// metrics. Defaults to "entdb-server-go" when empty.
 	ClientID string
 	// Acks is the producer ack level. We default to "all"
-	// (sarama.WaitForAll) to match Python's default. Any non-"all"
-	// value falls back to leader-only acks (matches the Python
-	// `int(acks)` path for "1"/"0").
+	// (sarama.WaitForAll). Any non-"all" value falls back to
+	// leader-only acks ("1"/"0").
 	Acks string
 	// EnableIdempotence enables the broker-side idempotent producer
 	// (prevents duplicates on retry within a producer session).
 	EnableIdempotence bool
 	// MaxInFlight is the producer's max in-flight requests per
-	// connection. Python defaults to 5; sarama requires this to be 1
-	// when idempotence is enabled, so we cap appropriately at Connect
-	// time.
+	// connection. Defaults to 5; sarama requires this to be 1 when
+	// idempotence is enabled, so we cap appropriately at Connect time.
 	MaxInFlight int
 	// LingerMs is the batch-collection window for the producer.
 	LingerMs int
 	// RequestTimeoutMs bounds a single produce request.
 	RequestTimeoutMs int
-	// AutoOffsetReset controls where a new consumer group starts.
-	// "earliest" (default, matches Python) or "latest".
+	// AutoOffsetReset controls where a new consumer group starts:
+	// "earliest" (default) or "latest".
 	AutoOffsetReset string
 	// EnableAutoCommit toggles the broker-side auto-commit loop.
-	// Python defaults this to FALSE (manual commit per record); the Go
-	// backend MUST match so re-delivery semantics align.
+	// Must be false (manual commit per record) so re-delivery semantics
+	// align with the applier's at-least-once contract.
 	EnableAutoCommit bool
 	// SessionTimeoutMs is the consumer-group session timeout.
 	SessionTimeoutMs int
@@ -198,18 +195,15 @@ func (k *Kafka) producerConfig() *sarama.Config {
 	case "0":
 		config.Producer.RequiredAcks = sarama.NoResponse
 	default:
-		// "1" or anything else: leader-only ack. Mirrors Python's
-		// int(acks) path for non-"all" values.
+		// "1" or anything else: leader-only ack.
 		config.Producer.RequiredAcks = sarama.WaitForLocal
 	}
 
 	config.Producer.Idempotent = k.config.EnableIdempotence
 	if k.config.EnableIdempotence {
 		// sarama requires MaxOpenRequests == 1 when Idempotent is on
-		// (otherwise NewSyncProducer returns an error). aiokafka /
-		// franz-go cap to 5 internally; matching to 1 here is the
-		// safest interpretation and still gives the durability story
-		// the Python path documents.
+		// (otherwise NewSyncProducer returns an error); matching to 1
+		// is the safest interpretation.
 		config.Net.MaxOpenRequests = 1
 	} else {
 		config.Net.MaxOpenRequests = k.config.MaxInFlight
@@ -223,13 +217,12 @@ func (k *Kafka) producerConfig() *sarama.Config {
 	// across partitions. Matches aiokafka's DefaultPartitioner and
 	// the franz-go default.
 	config.Producer.Partitioner = sarama.NewHashPartitioner
-	// 10 MiB. aiokafka's max_request_size default is ~1 MiB but
-	// Python overrides via config; matching the franz-go side's
-	// implicit ceiling and our applied-event payload budget.
+	// 10 MiB — matching the franz-go side's implicit ceiling and our
+	// applied-event payload budget.
 	config.Producer.MaxMessageBytes = 10 << 20
 	config.Producer.Timeout = time.Duration(k.config.RequestTimeoutMs) * time.Millisecond
 	// linger.ms equivalent: sarama batches via Flush.Frequency on the
-	// SyncProducer. Keep small to match Python's 5ms.
+	// SyncProducer (5ms default).
 	config.Producer.Flush.Frequency = time.Duration(k.config.LingerMs) * time.Millisecond
 
 	return config
@@ -246,8 +239,7 @@ func (k *Kafka) consumerConfig() *sarama.Config {
 	} else {
 		config.Consumer.Offsets.Initial = sarama.OffsetOldest
 	}
-	// Manual commit. Python sets enable_auto_commit=False; we match
-	// by disabling sarama's auto-commit loop.
+	// Manual commit: disable sarama's auto-commit loop.
 	config.Consumer.Offsets.AutoCommit.Enable = false
 	config.Consumer.Group.Session.Timeout = time.Duration(k.config.SessionTimeoutMs) * time.Millisecond
 	config.Consumer.Group.Heartbeat.Interval = time.Duration(k.config.HeartbeatIntervalMs) * time.Millisecond

--- a/server/go/internal/wal/kinesis.go
+++ b/server/go/internal/wal/kinesis.go
@@ -93,11 +93,11 @@ type KinesisConfig struct {
 	// or "LATEST".
 	IteratorType string
 	// MaxRecordsPerGet bounds a single GetRecords call. Kinesis caps
-	// this at 10000; Python default is 100.
+	// this at 10000; default is 100.
 	MaxRecordsPerGet int32
 }
 
-// DefaultKinesisConfig returns a config matching the Python defaults.
+// DefaultKinesisConfig returns a config with sensible defaults.
 func DefaultKinesisConfig(streamName, region string) KinesisConfig {
 	return KinesisConfig{
 		StreamName:       streamName,

--- a/server/go/internal/wal/memory.go
+++ b/server/go/internal/wal/memory.go
@@ -109,10 +109,8 @@ func (m *InMemory) Append(
 		return StreamPos{}, fmt.Errorf("%w: closed", ErrConnection)
 	}
 
-	// Application-layer idempotent retry. Mirrors the dedupe the
-	// Python applier does at apply time; we do it at append time too
-	// because (a) the spec calls for it on PLAN.md, and (b) it lets
-	// callers safely retry without polluting the log.
+	// Application-layer idempotent retry: we dedupe at append time so
+	// callers can safely retry without polluting the log (per PLAN.md).
 	idempKey := ""
 	if h, ok := headers[HeaderIdempotencyKey]; ok && len(h) > 0 {
 		idempKey = string(h)

--- a/server/go/internal/wal/pubsub.go
+++ b/server/go/internal/wal/pubsub.go
@@ -71,8 +71,7 @@ type pubsubMessage struct {
 	PublishTimeMs int64
 }
 
-// PubSubConfig captures the Pub/Sub-specific knobs (parity with the
-// Python PubSubConfig).
+// PubSubConfig captures the Pub/Sub-specific knobs.
 type PubSubConfig struct {
 	// ProjectID is the GCP project.
 	ProjectID string
@@ -86,11 +85,11 @@ type PubSubConfig struct {
 	Endpoint string
 	// OrderingEnabled turns on ordering-key delivery (per-tenant order).
 	OrderingEnabled bool
-	// MaxMessages bounds a single Pull. Python default 100.
+	// MaxMessages bounds a single Pull (default 100).
 	MaxMessages int32
 }
 
-// DefaultPubSubConfig returns a config matching the Python defaults.
+// DefaultPubSubConfig returns a config with sensible defaults.
 func DefaultPubSubConfig(projectID, topicID, subscriptionID string) PubSubConfig {
 	return PubSubConfig{
 		ProjectID:       projectID,

--- a/server/go/internal/wal/servicebus.go
+++ b/server/go/internal/wal/servicebus.go
@@ -122,15 +122,14 @@ type serviceBusMessage struct {
 	EnqueuedMs     int64
 }
 
-// ServiceBusConfig captures the Service Bus-specific knobs (parity with
-// the Python ServiceBusConfig).
+// ServiceBusConfig captures the Service Bus-specific knobs.
 type ServiceBusConfig struct {
 	// ConnectionString is the Service Bus namespace connection string
 	// (Endpoint=sb://...;SharedAccessKeyName=...;SharedAccessKey=...).
 	ConnectionString string
 	// QueueName is the session-enabled queue backing the WAL.
 	QueueName string
-	// MaxWaitTime bounds a single Receive call. Python default 5s.
+	// MaxWaitTime bounds a single Receive call (default 5s).
 	MaxWaitTime time.Duration
 	// SessionAcceptTimeout bounds a single AcceptNextSession call. If a
 	// session does not become available within this window the accept
@@ -139,7 +138,7 @@ type ServiceBusConfig struct {
 	SessionAcceptTimeout time.Duration
 }
 
-// DefaultServiceBusConfig returns a config matching the Python defaults.
+// DefaultServiceBusConfig returns a config with sensible defaults.
 func DefaultServiceBusConfig(connStr, queueName string) ServiceBusConfig {
 	return ServiceBusConfig{
 		ConnectionString:     connStr,

--- a/server/go/internal/wal/sqs.go
+++ b/server/go/internal/wal/sqs.go
@@ -60,8 +60,8 @@ type SqsAPI interface {
 	GetQueueAttributes(ctx context.Context, in *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
 }
 
-// SqsConfig captures the SQS-specific knobs (parity with the Python
-// SqsConfig: queue url, region, endpoint, visibility, long-poll wait).
+// SqsConfig captures the SQS-specific knobs: queue url, region,
+// endpoint, visibility, long-poll wait.
 type SqsConfig struct {
 	// QueueURL is the FIFO queue URL (must end in ".fifo"). Falls back
 	// to the Append/Poll topic arg when empty.
@@ -72,14 +72,14 @@ type SqsConfig struct {
 	EndpointURL string
 	// MaxMessages bounds a ReceiveMessage call. SQS hard-caps at 10.
 	MaxMessages int32
-	// WaitTimeSeconds is the long-poll wait (0-20). Python default 1.
+	// WaitTimeSeconds is the long-poll wait (0-20). Default 1.
 	WaitTimeSeconds int32
 	// VisibilityTimeout seconds an in-flight message is hidden before
-	// redelivery if not committed (deleted). Python default 30.
+	// redelivery if not committed (deleted). Default 30.
 	VisibilityTimeout int32
 }
 
-// DefaultSqsConfig returns a config matching the Python defaults.
+// DefaultSqsConfig returns a config with sensible defaults.
 func DefaultSqsConfig(queueURL, region string) SqsConfig {
 	return SqsConfig{
 		QueueURL:          queueURL,

--- a/server/go/internal/wal/wal.go
+++ b/server/go/internal/wal/wal.go
@@ -56,7 +56,7 @@ var (
 	ErrTimeout = errors.New("wal: timeout")
 
 	// ErrSerialization signals an event payload could not be encoded
-	// or decoded. Mirrors WalSerializationError in the Python tree.
+	// or decoded.
 	ErrSerialization = errors.New("wal: serialization error")
 )
 


### PR DESCRIPTION
## What

Follow-up to #554. Now that the Python server is retired ([ADR-017](docs/adr/017-python-server-retired.md)) and the EPIC #407 Go port is complete, this removes the remaining **conceptual** references to the dead Python implementation and the **port-era annotations** from `server/go` comments:

- Conceptual Python framing: `Mirrors the Python enum`, `the Python handler does X`, `Python parity`, `Python "read"`, etc. (~445 occurrences).
- Port-era tags: `W2 —`, `W2.03 —`, `W7 —`, `Wave 2`, `EPIC #407`, `Phase 0`, `Phase 4A.2` (25 occurrences).

## How (what was preserved)

- **Concrete facts kept**, re-attributed to the current system — e.g. `// PermRead — implies READ. Python "read".` → `// PermRead — implies READ. Stored as "read".` (these strings are the stored `node_access.permission` values).
- **Divergence rationale kept**, rephrased to state the current invariant instead of "vs Python".
- **Left intact**: `tests/python/integration/*` live paths, `docs/`/ADR/`docs/go-port` references, `GDPR Article NN`, `CLAUDE.md invariant #N`, and the ADR-024 rate-limit **Phase 1/2/3** terms (verified those survived).

Comment-only — no behavior change. **141 files, +893/−1210.**

## Verification
- `go vet` / `go build` / `go test ./...` (server/go) — pass
- `gofmt -l` on changed files — clean
- `cd sdk/go/entdb && go vet/test` — pass · `ruff check`/`format --check` — clean
- `pytest tests/python/integration/` — **103 passed**
- Docker E2E skipped (comment-only → byte-identical binary).

> Stacked on #554 (base = `chore/go-remove-python-citations`); merge #554 first. Two follow-ups intentionally left out of scope: residual "the Go port" phrasing and library-comparison mentions (`aiokafka`/`franz-go`) in `wal/kafka.go`.