### PR TITLE
chore(go): gofmt the three pre-existing unformatted files

### DIFF
--- a/server/go/internal/api/error_sanitization_test.go
+++ b/server/go/internal/api/error_sanitization_test.go
@@ -75,11 +75,11 @@ func captureSlog(t *testing.T) *syncBuffer {
 // leakSubstrings are fragments of the underlying driver/store error that
 // MUST NOT appear in any client-visible message.
 var leakSubstrings = []string{
-	"sql:",          // database/sql sentinel text
+	"sql:", // database/sql sentinel text
 	"database is closed",
-	"sqlite",        // driver name / table-name fingerprinting
-	"globalstore:",  // internal package context
-	"get user",      // internal op label (logged, never sent)
+	"sqlite",       // driver name / table-name fingerprinting
+	"globalstore:", // internal package context
+	"get user",     // internal op label (logged, never sent)
 }
 
 // TestCreateUser_InternalErrorIsSanitized is the SEC-5 regression pin.

--- a/server/go/internal/auth/apikey_persistent.go
+++ b/server/go/internal/auth/apikey_persistent.go
@@ -16,7 +16,7 @@ import (
 type StoredAPIKey struct {
 	KeyID     string
 	Name      string
-	Hash      string   // argon2id PHC string
+	Hash      string // argon2id PHC string
 	Scopes    []string
 	ExpiresAt int64 // Unix seconds; 0 == never
 }

--- a/server/go/internal/globalstore/apikeys_test.go
+++ b/server/go/internal/globalstore/apikeys_test.go
@@ -95,10 +95,10 @@ func TestAPIKeyListActiveFiltersRevokedAndExpired(t *testing.T) {
 			t.Fatalf("PutAPIKey %s: %v", id, err)
 		}
 	}
-	mustPut("ek_live", 0)               // never expires
-	mustPut("ek_future", clock+10_000)  // not yet expired
-	mustPut("ek_expired", clock-1)      // already expired
-	mustPut("ek_revoked", 0)            // will be revoked below
+	mustPut("ek_live", 0)              // never expires
+	mustPut("ek_future", clock+10_000) // not yet expired
+	mustPut("ek_expired", clock-1)     // already expired
+	mustPut("ek_revoked", 0)           // will be revoked below
 
 	flipped, err := gs.RevokeAPIKey(ctx, "ek_revoked")
 	if err != nil {


### PR DESCRIPTION
## What

Three files were gofmt-unclean on `main` (pre-existing, unrelated to recent comment cleanups):

- `server/go/internal/auth/apikey_persistent.go`
- `server/go/internal/api/error_sanitization_test.go`
- `server/go/internal/globalstore/apikeys_test.go`

Each had end-of-line comments over-aligned with extra spaces, which `gofmt` collapses to a single space. Applied `gofmt -w`; **`gofmt -l` is now clean across the entire `server/go` tree.**

Pure formatting — no logic, identifier, or import changes.

## Verification
- `gofmt -l .` (server/go) — clean
- `go vet` / `go build` / `go test` on affected packages — pass