### PR TITLE
test(api): de-flake TestSetLegalHold_Release_SpawnsNoGoroutine

### DIFF
--- a/server/go/internal/api/set_legal_hold_test.go
+++ b/server/go/internal/api/set_legal_hold_test.go
@@ -93,7 +93,10 @@ func TestSetLegalHold_Release_DurablyEnqueuesLift(t *testing.T) {
 // a request-scoped goroutine. We measure the live goroutine count across
 // the OFF call: a detached `go func()` sweep would leave it elevated.
 func TestSetLegalHold_Release_SpawnsNoGoroutine(t *testing.T) {
-	t.Parallel()
+	// Deliberately NOT t.Parallel(): this test measures the process-wide
+	// goroutine count, so it must run isolated from the parallel test
+	// batch whose transient goroutines would otherwise pollute the
+	// before/after delta (the cause of past CI flakes).
 
 	f := newAdminWALFixture(t)
 	gs := f.gs
@@ -113,11 +116,20 @@ func TestSetLegalHold_Release_SpawnsNoGoroutine(t *testing.T) {
 		t.Fatalf("SetLegalHold(release): %v", err)
 	}
 
-	// A detached sweep goroutine would still be alive here. Allow brief
-	// settle for the synchronous applier-driven enqueue to finish.
-	time.Sleep(100 * time.Millisecond)
-	runtime.GC()
-	after := runtime.NumGoroutine()
+	// A detached sweep goroutine would stay alive and keep the count
+	// elevated; transient runtime/GC goroutines clear within a few
+	// milliseconds. Poll for the count to settle back to baseline so that
+	// only a genuine leak (one that persists past the deadline) fails.
+	deadline := time.Now().Add(2 * time.Second)
+	after := before
+	for {
+		runtime.GC()
+		after = runtime.NumGoroutine()
+		if after <= before+1 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 	// Allow tiny scheduler noise but not a leaked long-lived sweep.
 	if after > before+1 {
 		t.Fatalf("goroutine count grew %d -> %d across the OFF RPC; "+


### PR DESCRIPTION
## Problem

`TestSetLegalHold_Release_SpawnsNoGoroutine` asserts that the legal-hold **OFF** RPC enqueues the lift durably instead of spawning a detached request-scoped goroutine. It checks this via `runtime.NumGoroutine()` before/after — but ran under `t.Parallel()`, so the **process-wide** count was polluted by the concurrently-running parallel test batch. Transient goroutines from unrelated tests intermittently tripped it in CI (`goroutine count grew 297 -> 299`), while it always passed locally/in isolation.

## Fix

- **Drop `t.Parallel()`** — a goroutine-counting test must run isolated from the parallel batch (Go defers `t.Parallel()` tests until after the sequential ones, so this test now sees a stable baseline).
- **Poll for the count to settle** back to baseline within a 2s deadline instead of a single post-sleep sample: a genuinely leaked sweep goroutine persists past the deadline (still fails), while transient runtime/GC goroutines clear.
- The durable-queue assertion (the real contract) is unchanged.

## Verification
Full `internal/api` package run **5×** (which exercises the parallel-batch interaction) — all pass; `go vet` clean; `gofmt` clean.