### PR TITLE
docs: regenerate sdk-go reference with the pinned go 1.25 toolchain

### DIFF
--- a/docs/generated/sdk-go.md
+++ b/docs/generated/sdk-go.md
@@ -320,7 +320,7 @@ func (a *Admin) CreateTenant(ctx context.Context, actor, tenantID, name string, 
     Pass WithRegion to pin the tenant to a specific geographic region (e.g.
     “WithRegion("eu-west-1")“); when omitted the server defaults the
     tenant to its own served region. The pinned region is reflected on
-    TenantDetail.Region.
+    [TenantDetail.Region].
 
 func (a *Admin) CreateUser(ctx context.Context, actor, userID, email, name string) (*UserInfo, error)
     CreateUser registers a new user in the global registry. “email“ is unique


### PR DESCRIPTION
## Problem

The **Docs Coverage & Examples** CI gate regenerates `docs/generated/` (via `go doc -all` in `scripts/generate_api_docs.py`) with **go 1.25** — the version pinned in `go.mod` and across the workflows — then fails if the result differs from the committed files. The committed `sdk-go.md` had been generated with a newer go, whose `go doc` renders the `[TenantDetail.Region]` doc link **without** the brackets. So every PR (including unrelated ones) failed this gate on a single stale line.

## Fix

Regenerated `docs/generated/` with go 1.25 so the committed reference matches the pinned toolchain. The only change is restoring the doc link:

```diff
-    TenantDetail.Region.
+    [TenantDetail.Region].
```

Generated file only — no hand edits.

## Note
Root cause is a `go doc` doc-link rendering change between go versions; the committed docs must be generated with the pinned toolchain (go 1.25). If/when the repo bumps its go version, `docs/generated/` should be regenerated in the same PR. Verified the regen produces no other diffs.