### PR TITLE
fix(api): lazy-open tenant on read RPCs; stop misreporting not-open tenants

### DIFF
--- a/server/go/internal/api/get_edges_from.go
+++ b/server/go/internal/api/get_edges_from.go
@@ -40,6 +40,7 @@ import (
 	"time"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
@@ -76,6 +77,21 @@ func (s *Server) GetEdgesFrom(ctx context.Context, req *pb.GetEdgesRequest) (*pb
 	// destinations has a single chokepoint to bind against and so we
 	// honour the trusted-actor invariant explicitly.
 	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetContext().GetActor()))
+
+	// Open the per-tenant view before reading. The SQLite store is a
+	// materialized view of the WAL (ADR-016); "tenant not opened" means
+	// the applier has not materialized this tenant in-process yet, not a
+	// client error. Lazy-open it (as GetNode does) so a valid tenant is
+	// not silently reported as an empty edge set. A genuine open failure
+	// (region pin / crypto-shred -> FailedPrecondition; IO -> Internal)
+	// surfaces its real typed code; only post-open query faults fall
+	// through to the best-effort swallow below.
+	if s.store != nil {
+		if err := s.store.OpenTenant(ctx, tenantID); err != nil {
+			outcome = "error"
+			return nil, errs.Errorf(errs.Code(err), "GetEdgesFrom: open tenant: %v", err)
+		}
+	}
 
 	// edge_type_id filter: falsy (== 0) means "no filter".
 	var edgeTypeFilter *int32

--- a/server/go/internal/api/get_edges_from_test.go
+++ b/server/go/internal/api/get_edges_from_test.go
@@ -237,40 +237,64 @@ func TestGetEdgesFrom_EdgeTypeFilter(t *testing.T) {
 	}
 }
 
-// TestGetEdgesFrom_StoreErrorSwallowedToEmpty: tenant gate passes but
-// the canonicalstore call fails (here: tenant DB not opened on the
-// store handle). The handler collapses that to an empty response with
-// codes.OK.
-func TestGetEdgesFrom_StoreErrorSwallowedToEmpty(t *testing.T) {
+// TestGetEdgesFrom_NotOpenTenant_LazyOpensAndReadsData: a registered
+// tenant whose per-tenant SQLite handle has NOT been opened in this
+// process must not be reported as a false-empty edge set. The store is a
+// materialized view of the WAL (ADR-016); "not opened" only means the
+// applier hasn't materialized the tenant in-process yet, so the handler
+// lazy-opens it and returns the edges already persisted to disk.
+//
+// Two phases over the SAME RootDir prove this: phase 1 seeds an edge
+// through a store that opens the tenant, then closes it; phase 2 serves
+// GetEdgesFrom from a FRESH store where the tenant was never opened.
+func TestGetEdgesFrom_NotOpenTenant_LazyOpensAndReadsData(t *testing.T) {
 	t.Parallel()
-
-	// Wire globalstore + a registered tenant so the gate succeeds, but
-	// use a fresh store where OpenTenant has NOT been called -> the
-	// store-side read returns ErrTenantNotOpen.
-	gs := newGlobalStore(t)
 	ctx := context.Background()
-	if _, err := gs.CreateTenant(ctx, "tenant-broken", "T", "us-east-1"); err != nil {
+	dir := t.TempDir()
+	const tenantID = "tenant-reopen"
+
+	// Phase 1: seed one edge, then close the store.
+	seedCS, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New (seed): %v", err)
+	}
+	if err := seedCS.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant (seed): %v", err)
+	}
+	if _, err := seedCS.CreateEdge(ctx, tenantID, store.EdgeInput{
+		EdgeTypeID: 7,
+		FromNodeID: "src",
+		ToNodeID:   "dst",
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+	if err := seedCS.Close(); err != nil {
+		t.Fatalf("seed store Close: %v", err)
+	}
+
+	// Phase 2: a fresh store over the same dir — tenant NOT opened.
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New (fresh): %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(ctx, tenantID, "T", "us-east-1"); err != nil {
 		t.Fatalf("CreateTenant: %v", err)
 	}
-	cs := newEdgesStore(t) // intentionally NOT opened for tenant-broken
-
 	srv := api.New(
 		api.WithGlobalStore(gs),
 		api.WithStore(cs),
 		api.WithSharding(&tenant.Sharding{NodeID: "node-a"}),
 	)
 
-	resp, err := srv.GetEdgesFrom(ctx, edgesFromReq("tenant-broken", "src"))
+	resp, err := srv.GetEdgesFrom(ctx, edgesFromReq(tenantID, "src"))
 	if err != nil {
-		t.Fatalf("GetEdgesFrom: must swallow store err to OK + empty resp, got %v", err)
+		t.Fatalf("GetEdgesFrom on not-open tenant: want OK, got %v", err)
 	}
-	if resp == nil {
-		t.Fatalf("GetEdgesFrom: nil response")
-	}
-	if len(resp.GetEdges()) != 0 {
-		t.Fatalf("edges: got %d, want 0 (swallowed)", len(resp.GetEdges()))
-	}
-	if resp.GetHasMore() {
-		t.Fatalf("has_more: got true, want false")
+	if got := len(resp.GetEdges()); got != 1 {
+		t.Fatalf("edges: got %d, want 1 — lazy-open must read the persisted "+
+			"edge, not a false-empty result", got)
 	}
 }

--- a/server/go/internal/api/get_edges_to.go
+++ b/server/go/internal/api/get_edges_to.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 )
@@ -76,6 +77,19 @@ func (s *Server) GetEdgesTo(
 	if s.store == nil {
 		outcome = "error"
 		return &pb.GetEdgesResponse{}, nil
+	}
+
+	// Open the per-tenant view before reading. The SQLite store is a
+	// materialized view of the WAL (ADR-016); "tenant not opened" means
+	// the applier has not materialized this tenant in-process yet, not a
+	// client error. Lazy-open it (as GetNode does) so a valid tenant is
+	// not silently reported as an empty edge set. A genuine open failure
+	// (region pin / crypto-shred -> FailedPrecondition; IO -> Internal)
+	// surfaces its real typed code; only post-open query faults fall
+	// through to the best-effort swallow below.
+	if err := s.store.OpenTenant(ctx, tenantID); err != nil {
+		outcome = "error"
+		return nil, errs.Errorf(errs.Code(err), "GetEdgesTo: open tenant: %v", err)
 	}
 
 	limit := int(req.GetLimit())

--- a/server/go/internal/api/get_edges_to_test.go
+++ b/server/go/internal/api/get_edges_to_test.go
@@ -276,34 +276,58 @@ func TestGetEdgesTo_EdgeTypeFilter(t *testing.T) {
 	}
 }
 
-// TestGetEdgesTo_StoreErrorReturnsEmpty pins the swallow-and-empty
-// contract: any internal storage fault collapses to GetEdgesResponse{}
-// with codes.OK and metric label "error". Driven here by skipping
-// OpenTenant so the read-side pool returns ErrTenantNotOpen.
-func TestGetEdgesTo_StoreErrorReturnsEmpty(t *testing.T) {
+// TestGetEdgesTo_NotOpenTenant_LazyOpensAndReadsData: a tenant whose
+// per-tenant SQLite handle has NOT been opened in this process must not
+// be reported as a false-empty edge set. The store is a materialized
+// view of the WAL (ADR-016); "not opened" only means the applier hasn't
+// materialized the tenant in-process yet, so the handler lazy-opens it
+// and returns the edges already persisted to disk.
+//
+// Two phases over the SAME RootDir prove this: phase 1 seeds an edge
+// through a store that opens the tenant, then closes it; phase 2 serves
+// GetEdgesTo from a FRESH store where the tenant was never opened.
+func TestGetEdgesTo_NotOpenTenant_LazyOpensAndReadsData(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+	dir := t.TempDir()
+	const tenantID = "tenant-reopen"
 
-	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	// Phase 1: seed one edge into "dst", then close the store.
+	seedCS, err := store.New(store.Options{RootDir: dir, WALMode: true})
 	if err != nil {
-		t.Fatalf("store.New: %v", err)
+		t.Fatalf("store.New (seed): %v", err)
+	}
+	if err := seedCS.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant (seed): %v", err)
+	}
+	if _, err := seedCS.CreateEdge(ctx, tenantID, store.EdgeInput{
+		EdgeTypeID: 7,
+		FromNodeID: "src",
+		ToNodeID:   "dst",
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+	if err := seedCS.Close(); err != nil {
+		t.Fatalf("seed store Close: %v", err)
+	}
+
+	// Phase 2: a fresh store over the same dir — tenant NOT opened.
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New (fresh): %v", err)
 	}
 	t.Cleanup(func() { _ = cs.Close() })
-	// Deliberately skip OpenTenant — the read-side pool lookup will
-	// error and the handler must collapse that to edges=[].
 
 	srv := api.New(api.WithStore(cs))
-	resp, err := srv.GetEdgesTo(ctx, edgesToReq("tenant-unopened", "n", 0, 0))
+	resp, err := srv.GetEdgesTo(ctx, edgesToReq(tenantID, "dst", 0, 0))
 	if err != nil {
-		t.Fatalf("GetEdgesTo: must return OK + empty body, not gRPC error: %v", err)
+		t.Fatalf("GetEdgesTo on not-open tenant: want OK, got %v", err)
 	}
 	if resp == nil {
 		t.Fatalf("response is nil")
 	}
-	if got := len(resp.GetEdges()); got != 0 {
-		t.Errorf("Edges: got %d, want 0 on store error", got)
-	}
-	if resp.GetHasMore() {
-		t.Errorf("HasMore: got true, want false on store error")
+	if got := len(resp.GetEdges()); got != 1 {
+		t.Fatalf("edges: got %d, want 1 — lazy-open must read the persisted "+
+			"edge, not a false-empty result", got)
 	}
 }

--- a/server/go/internal/api/get_nodes.go
+++ b/server/go/internal/api/get_nodes.go
@@ -115,6 +115,20 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 		}, nil
 	}
 
+	// Open the per-tenant view before reading. The SQLite store is a
+	// materialized view of the WAL (ADR-016); "tenant not opened" means
+	// the applier has not materialized this tenant in-process yet, not a
+	// client error. Lazy-open it (as the single-node GetNode does) so a
+	// valid tenant is not silently reported as all-missing, and so the
+	// after_offset fence and cross-tenant grant probe below observe a
+	// live handle. A genuine open failure surfaces its real typed code.
+	if s.store != nil {
+		if err := s.store.OpenTenant(ctx, tenantID); err != nil {
+			resultStatus = "error"
+			return nil, errs.Errorf(errs.Code(err), "GetNodes: open tenant: %v", err)
+		}
+	}
+
 	// Cross-tenant role check (BATCH-LEVEL). Returns one of: roleLocal
 	// (no global), roleMember (member or system actor), roleCrossTenant
 	// (non-member with node_access grants), or PERMISSION_DENIED

--- a/server/go/internal/api/query_nodes.go
+++ b/server/go/internal/api/query_nodes.go
@@ -83,6 +83,18 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 		return nil, errs.Errorf(codes.Unimplemented, "canonical store not configured")
 	}
 
+	// Open the per-tenant view before reading. The SQLite store is a
+	// materialized view of the WAL (ADR-016); "tenant not opened" just
+	// means the applier has not materialized this tenant in-process yet,
+	// not a client error. Lazy-open it (as GetNode does) so a valid
+	// tenant is never reported as an empty result set. A genuine open
+	// failure (region pin / crypto-shred -> FailedPrecondition; IO ->
+	// Internal) surfaces its real typed code.
+	if err := s.store.OpenTenant(ctx, tenantID); err != nil {
+		resultStatus = "error"
+		return nil, errs.Errorf(errs.Code(err), "QueryNodes: open tenant: %v", err)
+	}
+
 	typeID := req.GetTypeId()
 	if typeID == 0 {
 		resultStatus = "error"
@@ -120,6 +132,21 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	// SEC-4 (#135): cap oversized page requests before building protos.
 	limit = clampPageSize(limit)
 
+	// Read-after-write barrier (#121). QueryNodesRequest carries
+	// after_offset / wait_timeout_ms (proto fields 10/11) but the handler
+	// historically ignored them; honour them now so a client that just
+	// wrote can fence the query against the applier, matching GetNode /
+	// GetNodes. A fence timeout is non-fatal — proceed with a stale read.
+	if off := req.GetAfterOffset(); off != "" {
+		timeout := 30 * time.Second
+		if ms := req.GetWaitTimeoutMs(); ms > 0 {
+			timeout = time.Duration(ms) * time.Millisecond
+		}
+		waitCtx, cancel := context.WithTimeout(ctx, timeout)
+		_ = s.store.WaitForOffset(waitCtx, tenantID, parseStreamOffset(off))
+		cancel()
+	}
+
 	nodes, err := s.store.QueryNodes(ctx, store.QueryNodesArgs{
 		TenantID:   tenantID,
 		TypeID:     typeID,
@@ -131,6 +158,12 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	})
 	if err != nil {
 		resultStatus = "error"
+		// Preserve typed sentinels (their messages are contract, per
+		// errs/sanitize.go); only naked store/driver errors are sanitized
+		// into a generic Internal.
+		if c := errs.Code(err); c != codes.Unknown {
+			return nil, errs.Errorf(c, "QueryNodes: %v", err)
+		}
 		return nil, errs.Internal(ctx, "store: query nodes", err)
 	}
 

--- a/server/go/internal/api/query_nodes_test.go
+++ b/server/go/internal/api/query_nodes_test.go
@@ -166,6 +166,74 @@ func TestQueryNodes_EqualityFilter(t *testing.T) {
 	}
 }
 
+// TestQueryNodes_NotOpenTenant_LazyOpensAndReadsData is the regression
+// test for the "tenant not opened" defect (#121): a registered tenant
+// whose per-tenant SQLite handle has NOT been opened in this process
+// must not be reported as a generic Internal error (the old bug) nor as
+// a false-empty result. The SQLite store is a materialized view of the
+// WAL (ADR-016); "not opened" only means the applier hasn't materialized
+// the tenant in-process yet, so the handler lazy-opens it and returns
+// the rows already persisted to disk.
+//
+// Two phases over the SAME RootDir prove this: phase 1 seeds rows
+// through a store that opens the tenant, then closes it so the on-disk
+// file is the only state; phase 2 serves QueryNodes from a FRESH store
+// where the tenant was never opened.
+func TestQueryNodes_NotOpenTenant_LazyOpensAndReadsData(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	const tenantID = "tenant-reopen"
+
+	// Phase 1: seed two alice-owned nodes, then close the store.
+	seedCS, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New (seed): %v", err)
+	}
+	if err := seedCS.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant (seed): %v", err)
+	}
+	for _, id := range []string{"n1", "n2"} {
+		if _, err := seedCS.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+			NodeID:     id,
+			TypeID:     1,
+			OwnerActor: "user:alice",
+			Payload:    map[string]any{"1": "alice@example.com"},
+		}); err != nil {
+			t.Fatalf("CreateNodeRaw %s: %v", id, err)
+		}
+	}
+	if err := seedCS.Close(); err != nil {
+		t.Fatalf("seed store Close: %v", err)
+	}
+
+	// Phase 2: a fresh store over the same dir — tenant NOT opened.
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New (fresh): %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(ctx, tenantID, "Tenant Reopen", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	srv := api.New(api.WithStore(cs), api.WithGlobalStore(gs))
+
+	resp, err := srv.QueryNodes(ctx, &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		TypeId:  1,
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes on not-open tenant: want OK, got %v (code=%s)",
+			err, status.Code(err))
+	}
+	if got := len(resp.GetNodes()); got != 2 {
+		t.Fatalf("nodes: got %d, want 2 — lazy-open must read persisted rows, "+
+			"not a false-empty result", got)
+	}
+}
+
 // TestQueryNodes_RangeOperators exercises the comparison operators
 // added by issue #501. Each branch seeds the same three rows and
 // asserts that the matching subset is returned. CONTAINS / IN are

--- a/server/go/internal/api/search_nodes.go
+++ b/server/go/internal/api/search_nodes.go
@@ -112,6 +112,19 @@ func (s *Server) SearchNodes(
 		return &pb.SearchNodesResponse{Nodes: []*pb.Node{}}, nil
 	}
 
+	// Open the per-tenant view before searching. The SQLite store is a
+	// materialized view of the WAL (ADR-016); "tenant not opened" means
+	// the applier has not materialized this tenant in-process yet, not a
+	// client error. Lazy-open it (as GetNode does) so a valid tenant is
+	// not silently reported as zero hits. A genuine open failure (region
+	// pin / crypto-shred -> FailedPrecondition; IO -> Internal) surfaces
+	// its real typed code; only post-open FTS faults fall through to the
+	// best-effort swallow below.
+	if err := s.store.OpenTenant(ctx, tenantID); err != nil {
+		outcome = "error"
+		return nil, errs.Errorf(errs.Code(err), "SearchNodes: open tenant: %v", err)
+	}
+
 	limit := int(req.GetLimit())
 	if limit == 0 {
 		limit = 50


### PR DESCRIPTION
## Problem

A per-tenant SQLite handle is a materialized view of the WAL (ADR-016). "Tenant not opened" just means the applier hasn't materialized the tenant in this process yet — it is **not** a client error. But the read RPCs mishandled it:

- `QueryNodes` clobbered it to `Internal` (opaque).
- `GetEdgesFrom` / `GetEdgesTo` / `SearchNodes` silently returned an **empty** result.
- `GetNodes` (batch) treated every id as **missing**.

So a perfectly valid tenant could be reported as empty or as an opaque internal error — a silent wrong answer.

## Fix

Lazy-open the tenant on every per-tenant read RPC (as `GetNode` already did). Genuine open failures still surface their real typed code (region pin / crypto-shred → `FailedPrecondition`, IO → `Internal`). Also wires `QueryNodes`' already-declared `after_offset` / `wait_timeout_ms` read-your-writes fence, which the handler had been ignoring.

## Tests

Rewrote the two misleading "swallow-to-empty" edge tests and added a QueryNodes regression test that prove **lazy-open reads persisted rows** (seed → close → reopen fresh → read) rather than asserting the old empty behavior.

Local CI green: `go vet`/`go test` (server + SDK), 103 integration tests, E2E (22 passed, 1 skipped), ruff/gofmt clean.