### PR TITLE
docs(adr): ADR-028 typed payload values + ADR-029 keyset cursor; land Bug C/A characterization tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ Quick orientation (one-liners, not normative — the ADR is normative):
 - [ADR-025](docs/adr/025-single-shape-sdk-api.md) — single-shape SDK API (proto messages everywhere, typed unique-key tokens via codegen, expression-index uniqueness)
 - [ADR-026](docs/adr/026-per-tenant-read-write-connection-split.md) — per-tenant read/write SQLite connection split (Accepted; landed dark — split off by default `--read-pool-size=1`; the post-commit broadcast fix is always active)
 - [ADR-027](docs/adr/027-parallel-wal-apply-across-tenants.md) — parallel WAL apply across distinct tenants; amends ADR-016's no-fan-out clause (Accepted; landed dark — serial by default `--apply-concurrency=1`)
+- [ADR-028](docs/adr/028-typed-payload-wire-values.md) — typed `field_id`-keyed payload wire values (`map<uint32, EntValue>`), retiring `google.protobuf.Struct` so int64 stops corrupting >2^53 (Accepted; design frozen, implementation pending — Bug C)
+- [ADR-029](docs/adr/029-keyset-cursor-pagination.md) — keyset cursor pagination (`page_token`/`next_page_token`) with SDK auto-follow, replacing the silent 100-row read truncation (Accepted; design frozen, implementation pending — Bug A)
 
 ## Project Structure
 

--- a/docs/adr/028-typed-payload-wire-values.md
+++ b/docs/adr/028-typed-payload-wire-values.md
@@ -1,0 +1,160 @@
+# ADR-028: Typed, `field_id`-keyed payload wire values (retire `google.protobuf.Struct`)
+
+**Status:** Accepted — design frozen 2026-05-23; **implementation pending.**
+Characterization tests are already landed (RED, skipped) pinning the
+post-fix contract:
+`server/go/internal/payload/translate_test.go::TestPayload_Int64Spectrum_BugC`
+and `sdk/go/entdb/wire_test.go::TestPayloadRoundTrip_Int64Spectrum_BugC`.
+**Decided:** 2026-05-23
+**Tags:** wire-format, payload, proto, schema, data-integrity, migration
+**Complements:** [ADR-006](006-proto-schema-definition.md) (proto is the
+type system) and [ADR-018](018-field-id-keyed-payloads.md) (payloads keyed
+by `field_id`) — this ADR changes the *value encoding* only; the
+`field_id` keying and rename-free property of ADR-018 are preserved and
+in fact strengthened (native numeric keys).
+**Implementation:** pending — `proto/entdb/v1/entdb.proto` (payload fields),
+`server/go/internal/payload/translate.go`, `sdk/go/entdb/wire.go`,
+`sdk/python/entdb_sdk/client.py`. Both SDKs ship together.
+
+## Decision
+
+Node/edge payloads stop crossing the wire as `google.protobuf.Struct` and
+instead use a **typed, `field_id`-keyed map**:
+
+```proto
+message EntValue {
+  oneof v {
+    int64                  int_value    = 1;  // INTEGER / TIMESTAMP — lossless
+    double                 double_value = 2;  // DOUBLE
+    bool                   bool_value   = 3;  // BOOLEAN
+    string                 string_value = 4;  // STRING / ENUM
+    bytes                  bytes_value  = 5;  // BYTES — no base64-in-a-string
+    google.protobuf.Struct json_value   = 6;  // JSON (genuinely dynamic)
+  }
+  // absence of `v` == explicit null.
+}
+
+// field_id -> typed value. The map key IS the proto field number / field_id
+// (ADR-018), now native uint32 instead of a stringified JSON key.
+map<uint32, EntValue> typed_data = 8;   // CreateNodeOp / Node
+map<uint32, EntValue> typed_patch = 9;  // UpdateNodeOp
+// ... symmetric additions for edge props.
+```
+
+Integer payload values are carried as a real `int64`, so the full int64
+range round-trips exactly. The server's safe-integer guard
+(`translate.go:347`, reject `> 2^53`) and the float64 guess-and-coerce
+dance (`coerceForKind` / `encodeForKind`) are **removed** — the wire no
+longer lies about the type, so the server no longer has to reconstruct it.
+
+At rest, the applier MUST persist integer values losslessly (store as a
+JSON integer / `json.Number`, never a float64) so `payload_json` keeps the
+exact value the typed wire delivered.
+
+## Context
+
+Bug C: payloads cross the wire as `google.protobuf.Struct`
+(`entdb.proto:249` `data = 7`, plus `patch`, edge props). `Struct` numbers
+are IEEE-754 **doubles** by the protobuf spec, so any int64 above 2^53
+corrupts **at the wire boundary**, in both SDKs and the server:
+
+- `2^53 + 1` silently rounds to `2^53` and slips *past* the
+  reject-`> 2^53` guard, so it is stored corrupted;
+- larger magnitudes (`10^16+1`, `2^62+1`, `MaxInt64`) are rejected
+  outright — a value the client legitimately wrote cannot be stored;
+- the schema-less / JSON path has no guard at all, so the whole range
+  corrupts silently (the customer's spectrum probe).
+
+A standard database carries `BIGINT` as a genuine 64-bit integer because
+the type is known and the protocol is typed; none routes it through a
+float. EntDB already claims this end-to-end (ADR-006/018) — the defect is
+that the wire chose a schemaless, double-backed envelope for
+statically-typed data. No SDK-only fix is possible; the carrier is wrong.
+
+## Migration (dual-read / dual-write; both SDKs ship together)
+
+Breaking wire changes are forbidden to land abruptly, so:
+
+1. **Additive proto:** add `typed_data` / `typed_patch` (new field numbers)
+   alongside the existing `Struct data = 7` / `patch`, which are marked
+   `deprecated` but kept.
+2. **Server ingress (dual-read):** prefer `typed_data` when present;
+   otherwise fall back to the legacy `Struct data`. A request MUST NOT set
+   both for the same op (reject `INVALID_ARGUMENT` if it does).
+3. **Server egress (dual-write, transition window):** populate `typed_data`
+   always; also populate the legacy `Struct data` so pre-upgrade SDKs keep
+   reading — EXCEPT integer values outside the float64-safe range, which
+   the legacy field cannot represent and which are therefore only present
+   in `typed_data` (an old SDK reading such a node sees the legacy field
+   absent/clamped; documented as the known limitation that motivated the
+   upgrade).
+4. **SDKs:** send `typed_data`; on read, prefer `typed_data`, fall back to
+   the legacy field for old servers. Python + Go in the same PR
+   (per the repo's SDK-parity rule).
+5. **Deprecation:** after a release window with both SDKs published and
+   servers upgraded, drop the legacy `Struct` payload fields in a
+   subsequent major.
+
+## Alternatives considered
+
+- **String-encode integer fields inside the existing `Struct`** (protobuf's
+  int64-as-JSON-string convention). Rejected — a short fix: stringly-typed,
+  schema-dependent (the server must know each field is INTEGER to know to
+  parse it), and it *breaks schema-less numeric-field-id mode* (can't tell
+  an int field from a genuine string field without a schema). Violates the
+  "no short fixes" bar.
+- **Raise the safe-integer guard / accept the float64 loss.** Rejected —
+  it is silent data corruption; raising a threshold doesn't make doubles
+  hold int64.
+- **Keep `Struct`, add a parallel typed sidecar map only for ints.**
+  Rejected — two carriers for one concept; doubles the test matrix and the
+  ingress ambiguity ADR-018 already warned about.
+- **Separate `field_id` registry decoupled from proto numbers.** Already
+  rejected by ADR-018; unchanged here.
+
+## Consequences
+
+**Locks in:**
+- The payload value carrier is a typed `oneof`; `field_id` keys are native
+  `uint32` (ADR-018 keying preserved, stringification dropped).
+- INTEGER/TIMESTAMP fields support the full int64 range, losslessly, end to
+  end — wire, applier, and `payload_json` at rest.
+- The reject-`> 2^53` guard and the float64 coercion code are deleted.
+
+**Makes easy:**
+- Correct large integers (nanosecond timestamps, byte quotas, MaxInt64
+  sentinels) — the class of value that silently corrupted before.
+- Native `bytes` (drops the base64-in-a-string hack).
+- Schema-less mode is now *lossless* for integers (the value is
+  self-describing on the wire; no schema needed to preserve type).
+
+**Makes harder / tradeoffs:**
+- A breaking wire change with a real migration window and dual-read/write
+  complexity (above). Worth it; this is a data-integrity defect.
+- `json_value` (the JSON field kind) still uses `google.protobuf.Struct`
+  and is therefore still double-backed *inside* a JSON blob. Accepted: JSON
+  is dynamically typed by definition; callers who need a lossless int use
+  an INTEGER field, not a JSON sub-value. Documented, not hidden.
+- Hand-rolled clients must construct `EntValue` oneofs (already "use an
+  SDK" per ADR-018).
+
+**Failure modes:**
+- A request sets both `typed_data` and legacy `data` for one op →
+  `INVALID_ARGUMENT` (no silent precedence surprise).
+- An old SDK reads a node whose integer exceeds the float64-safe range →
+  the legacy `Struct` field cannot carry it; the value lives only in
+  `typed_data`. This is the explicit incompatibility the upgrade resolves.
+
+## References
+
+- [ADR-006](006-proto-schema-definition.md) — proto as the type system;
+  this ADR makes the wire obey it for values.
+- [ADR-018](018-field-id-keyed-payloads.md) — `field_id` keying + rename-free
+  property; preserved, with native numeric keys.
+- [ADR-016](016-handlers-append-applier-writes.md) — applier is the only
+  writer; it must persist int64 losslessly to `payload_json`.
+- Bug C characterization tests (landed RED/skipped):
+  `server/go/internal/payload/translate_test.go::TestPayload_Int64Spectrum_BugC`,
+  `sdk/go/entdb/wire_test.go::TestPayloadRoundTrip_Int64Spectrum_BugC`.
+- Related: [ADR-029](029-keyset-cursor-pagination.md) (the sibling
+  read-contract fix frozen the same day).

--- a/docs/adr/029-keyset-cursor-pagination.md
+++ b/docs/adr/029-keyset-cursor-pagination.md
@@ -1,0 +1,136 @@
+# ADR-029: Keyset cursor pagination for reads (`page_token` / `next_page_token`)
+
+**Status:** Accepted — design frozen 2026-05-23; **implementation pending.**
+Characterization test landed (strict `xfail`) pinning the post-fix
+contract:
+`tests/python/integration/test_query_range.py::test_query_does_not_silently_truncate`.
+**Decided:** 2026-05-23
+**Tags:** api, pagination, query, sdk, consistency, read-path
+**Complements:** [ADR-023](023-declarative-query-indexes.md) (declarative
+query indexes — the index that backs `order_by` also backs keyset seeks)
+and [ADR-025](025-single-shape-sdk-api.md) (single-shape SDK API — the
+cursor lives behind the same helpers).
+**Implementation:** pending — `proto/entdb/v1/entdb.proto` (read
+request/response messages), `server/go/internal/api/{query_nodes,
+get_edges_from,get_edges_to,search_nodes,...}.go`,
+`server/go/internal/store/`, `sdk/go/entdb/`, `sdk/python/entdb_sdk/`.
+Both SDKs ship together.
+
+## Decision
+
+Reads adopt **keyset (seek) cursor pagination** in the
+[AIP-158](https://google.aip.dev/158) shape:
+
+- Requests carry `page_size` and `page_token`.
+- Responses carry `next_page_token` (empty when the last page is reached).
+- The token is **opaque** to clients and encodes a **keyset cursor**: the
+  `(order_by value, node_id)` tuple of the last row returned, plus the
+  sort direction and a fingerprint of the query (type_id + filters +
+  order_by) so a token cannot be replayed against a different query.
+- Continuation is a seek, not a skip:
+  `WHERE (order_by_col, node_id) > (cursor)` (or `<` for descending),
+  `ORDER BY order_by_col, node_id`, `LIMIT page_size`. `node_id` (unique)
+  is always appended as the final sort key so the ordering is a **total
+  order** and the cursor is unambiguous.
+- Applies to `QueryNodes`, `SearchNodes`, `GetEdgesFrom`/`GetEdgesTo`, and
+  the `List*` RPCs.
+
+`page_size` defaults to 100 (unchanged) and is clamped to `MaxPageSize`
+(1000). The point is no longer the per-page cap — it is that **the client
+can always retrieve the remainder via `next_page_token`.**
+
+**SDK helpers auto-follow the cursor.** `List*` / `query` helpers loop
+`next_page_token` to return the complete set by default (or expose a lazy
+iterator / async generator for streaming). A read of N rows returns N rows,
+never a silent prefix.
+
+The legacy `offset` field is retained for backward compatibility but
+**deprecated**; new code uses the cursor.
+
+## Context
+
+Bug A: reads silently truncate. `QueryNodes` defaults to
+`defaultQueryLimit = 100` (`query_nodes.go:56`); the Go SDK's `QueryNodes`
+transport has **no limit/offset/cursor parameter at all**
+(`sdk/go/entdb/client.go:37`), and the Python `list_*` / `query` helpers
+default to `limit=100` and never paginate. So `ListPasskeyCredentials`,
+`list_users`, etc. return 100 of N with no error and no way to get the
+rest. `MaxPageSize=1000` is irrelevant because no caller sets a limit, and
+even at 1000 there is no cursor to go further.
+
+A standard database never silently truncates: `SELECT` returns all matching
+rows, and the modern best practice for stable, scalable chunking is keyset
+(seek) pagination, not `LIMIT/OFFSET`. For a gRPC API the established
+convention is AIP-158 `page_token` / `next_page_token`. EntDB's read model
+is an ordered SQLite table (a materialized view of the WAL); `node_id` is
+unique and `order_by` over stable columns already exists — keyset is a
+clean fit and is stable under the append-only write model.
+
+## Invariants (must hold)
+
+1. **Total order for the cursor.** The effective sort is
+   `(order_by_col, node_id)`; `node_id` is unique, so no two rows share a
+   cursor position and continuation can never skip or duplicate a row, even
+   under concurrent inserts/deletes between pages.
+2. **Token integrity.** `page_token` encodes the query fingerprint; a token
+   presented with a different `type_id` / filters / `order_by` is rejected
+   with `INVALID_ARGUMENT` rather than silently returning wrong rows.
+3. **No silent truncation.** A response that omits rows MUST set a
+   non-empty `next_page_token`. The SDK helpers MUST follow it to
+   completion unless the caller explicitly opts into manual paging.
+
+## Alternatives considered
+
+- **Offset-loop in the SDK helpers** (page via the existing `offset`).
+  Rejected — a short fix: `OFFSET` is O(n) to skip and, under concurrent
+  writes, skips or duplicates rows across pages. Violates the "no short
+  fixes" / standard-DB-best-practice bar.
+- **Just raise `defaultQueryLimit` / `MaxPageSize`.** Rejected — still a
+  hard cap, doesn't scale past it, and large single responses collide with
+  the 4 MiB gRPC message limit and server memory.
+- **Unbounded streaming response (server streams all rows).** Rejected for
+  the unary read RPCs — unbounded message/memory; a separate streaming RPC
+  could be added later but is out of scope for fixing the truncation.
+- **Keep returning a prefix, document the cap.** Rejected — the defect is
+  precisely that callers don't know rows were dropped.
+
+## Consequences
+
+**Locks in:**
+- The read contract is `page_size` + `page_token` → `next_page_token`, with
+  an opaque keyset token over `(order_by, node_id)`.
+- `order_by` columns must be indexable / totally orderable with `node_id`
+  as tiebreaker (ties into ADR-023 declarative indexes).
+- SDK `List*`/`query` helpers return the complete set by default.
+
+**Makes easy:**
+- Correct, stable pagination over arbitrarily large result sets.
+- Cheap deep pages (seek, not skip).
+
+**Makes harder / tradeoffs:**
+- Additive proto + server + both-SDK work, and token encode/decode +
+  validation logic.
+- Keyset cannot jump to an arbitrary page number (no "page 7 of 200"); only
+  next/continue. Accepted — random-access paging is not a requirement and
+  is exactly what makes `OFFSET` slow and unstable.
+- Changing a query's filters/sort invalidates an in-flight token (by
+  design, invariant 2).
+
+**Failure modes:**
+- Token presented against a mismatched query → `INVALID_ARGUMENT`.
+- Caller uses both `offset` and `page_token` → `INVALID_ARGUMENT` (pick one;
+  `offset` is deprecated).
+
+## References
+
+- [AIP-158](https://google.aip.dev/158) — pagination shape adopted.
+- [ADR-023](023-declarative-query-indexes.md) — indexes backing `order_by`
+  also back keyset seeks.
+- [ADR-025](025-single-shape-sdk-api.md) — the cursor lives behind the
+  single-shape SDK helpers.
+- [ADR-005](005-event-sourcing-wal.md) — the read model is an ordered
+  materialized view, which makes keyset stable.
+- Bug A characterization test (landed `xfail`):
+  `tests/python/integration/test_query_range.py::test_query_does_not_silently_truncate`.
+- Related: [ADR-028](028-typed-payload-wire-values.md) (the sibling
+  data-integrity fix frozen the same day).

--- a/sdk/go/entdb/wire_test.go
+++ b/sdk/go/entdb/wire_test.go
@@ -1,0 +1,49 @@
+package entdb
+
+import (
+	"math"
+	"testing"
+)
+
+// TestPayloadRoundTrip_Int64Spectrum_BugC characterizes the int64
+// data-integrity landmine (Bug C) at the Go SDK boundary. A payload
+// integer value must survive the encode/decode round-trip
+// (mapToStruct -> structToMap) with both its value AND its int64 type
+// intact, across the full int64 range.
+//
+// Today the SDK lowers payloads into a google.protobuf.Struct, whose
+// numbers are IEEE-754 doubles (wire.go: structpb.NewStruct / AsMap), so
+// every integer comes back as a float64 and values above 2^53 lose
+// precision (e.g. 2^53+1 -> 2^53). The fix (a typed field_id->Value wire
+// carrier; ADR pending) must make these round-trip exactly as int64.
+//
+// LANDED RED on purpose (Bug C characterization). Skipped so CI stays
+// green; remove the t.Skip when the typed-value carrier lands.
+func TestPayloadRoundTrip_Int64Spectrum_BugC(t *testing.T) {
+	t.Skip("Bug C: int64 payload corruption via google.protobuf.Struct (double-backed); un-skip when the typed field_id->Value wire carrier lands — ADR pending")
+	cases := []int64{
+		(1 << 53) + 1,          // 9007199254740993 — first unsafe odd int
+		10_000_000_000_000_001, // 10^16 + 1
+		(1 << 62) + 1,
+		math.MaxInt64 - 1,
+		math.MaxInt64,
+		-(1 << 53) - 1,
+	}
+	for _, want := range cases {
+		s, err := mapToStruct(map[string]any{"1": want})
+		if err != nil {
+			t.Errorf("mapToStruct(%d): %v", want, err)
+			continue
+		}
+		out := structToMap(s)
+		got, ok := out["1"].(int64)
+		if !ok {
+			t.Errorf("field 1: wrote int64(%d), read back %v (%T) — SDK must preserve the int64 type, not coerce to float64 (Bug C)",
+				want, out["1"], out["1"])
+			continue
+		}
+		if got != want {
+			t.Errorf("field 1: wrote %d, read back %d — int64 corrupted via Struct (Bug C)", want, got)
+		}
+	}
+}

--- a/server/go/internal/payload/translate_test.go
+++ b/server/go/internal/payload/translate_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 
@@ -194,6 +195,54 @@ func TestStructToPayload_TimestampOutOfRange(t *testing.T) {
 	_, err := StructToPayload(reg, "User", s)
 	if err == nil || !errors.Is(err, errs.ErrInvalidArgument) {
 		t.Fatalf("expected INVALID_ARGUMENT for out-of-range timestamp, got %v", err)
+	}
+}
+
+// TestPayload_Int64Spectrum_BugC characterizes the int64 data-integrity
+// landmine (Bug C). A typed INTEGER payload value MUST survive the wire
+// round-trip (PayloadToStruct -> StructToPayload) exactly, across the
+// full int64 range. Today the wire carrier is google.protobuf.Struct,
+// whose numbers are IEEE-754 doubles, so:
+//
+//   - 2^53+1 silently rounds to 2^53 and slips PAST the safe-range guard
+//     (translate.go:347 only rejects > 2^53), so it is stored corrupted;
+//   - larger magnitudes (10^16+1, 2^62+1, MaxInt64) are rejected outright
+//     by the guard, i.e. a value the client legitimately wrote cannot be
+//     stored at all.
+//
+// Either way the value read back is not the value written. The fix (a
+// typed field_id->Value wire carrier that holds a real int64; ADR
+// pending) must make every case round-trip exactly and drop the guard.
+//
+// LANDED RED on purpose (Bug C characterization). Skipped so CI stays
+// green; remove the t.Skip when the typed-value carrier lands.
+func TestPayload_Int64Spectrum_BugC(t *testing.T) {
+	t.Skip("Bug C: int64 payload corruption via google.protobuf.Struct (double-backed); un-skip when the typed field_id->Value wire carrier lands — ADR pending")
+	reg := fixtureRegistry(t)
+	// field_id 3 == "age", schema.KindInteger.
+	cases := []int64{
+		(1 << 53) + 1,          // 9007199254740993 — first unsafe odd int
+		10_000_000_000_000_001, // 10^16 + 1
+		(1 << 62) + 1,          // large but well within int64
+		math.MaxInt64 - 1,      // sentinel-adjacent
+		math.MaxInt64,          // MaxInt64 sentinel
+		-(1 << 53) - 1,         // negative side of the boundary
+	}
+	for _, want := range cases {
+		s, err := PayloadToStruct(reg, "User", map[uint32]any{3: want})
+		if err != nil {
+			t.Errorf("PayloadToStruct(age=%d): %v", want, err)
+			continue
+		}
+		got, err := StructToPayload(reg, "User", s)
+		if err != nil {
+			t.Errorf("StructToPayload(age=%d): %v — a legitimate int64 was rejected, not stored", want, err)
+			continue
+		}
+		if got[3] != any(want) {
+			t.Errorf("age round-trip: wrote %d, read back %v (%T) — int64 corrupted via Struct (Bug C)",
+				want, got[3], got[3])
+		}
 	}
 }
 

--- a/tests/python/integration/test_query_range.py
+++ b/tests/python/integration/test_query_range.py
@@ -169,3 +169,44 @@ async def test_contains_rejected(stub) -> None:
             )
         )
     assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Bug A: List*/QueryNodes silently truncate at the 100-row default and "
+    "the SDK helpers do not paginate (the Go SDK QueryNodes has no limit/offset/"
+    "cursor param at all). Un-xfail when keyset cursor pagination + SDK "
+    "auto-follow lands — ADR pending.",
+)
+async def test_query_does_not_silently_truncate(grpc_endpoint) -> None:
+    """A read must return ALL rows the caller wrote, not silently cap at 100.
+
+    Characterizes the customer-reported symptom ("List returned 100 of 250").
+    Seeds 150 rows isolated by a unique half-open email range so the
+    server-side filtered set is exactly 150, then issues the read the way
+    the SDK list/query helpers do — with no explicit limit, so the server
+    falls back to defaultQueryLimit=100 (query_nodes.go) — and there is no
+    cursor to fetch the remainder. The fix (keyset cursor + helper
+    auto-follow) must let this return all 150.
+    """
+    n = 150
+    prefix = f"pag-{uuid.uuid4().hex[:6]}-"
+    upper = prefix + "~"  # 0x7E > any digit/'@'/'x' in the seeded suffixes
+    async with grpc_aio.insecure_channel(grpc_endpoint) as ch:
+        s = EntDBServiceStub(ch)
+        await _seed_users(s, [f"{prefix}{i:04d}@x" for i in range(n)])
+        resp = await s.QueryNodes(
+            pb.QueryNodesRequest(
+                context=_ctx(),
+                type_id=1,
+                order_by="node_id",
+                descending=False,
+                # No explicit limit — mirrors the SDK list/query helpers.
+                filters=[
+                    pb.FieldFilter(field="email", op=pb.FilterOp.GTE, value=_value(prefix)),
+                    pb.FieldFilter(field="email", op=pb.FilterOp.LT, value=_value(upper)),
+                ],
+            )
+        )
+        got = [node for node in resp.nodes if _email(node).startswith(prefix)]
+        assert len(got) == n, f"wrote {n} rows, read back {len(got)} — silent truncation (Bug A)"


### PR DESCRIPTION
Freezes the design decisions for the two outstanding data bugs and lands their characterization tests (RED, guarded so CI stays green; they auto-activate when the fix lands).

## ADR-028 — typed, field_id-keyed payload wire values
Retires `google.protobuf.Struct` as the payload carrier (its numbers are IEEE-754 doubles, so int64 >2^53 corrupts at the wire boundary — Bug C) in favor of `map<uint32, EntValue>`. Complements ADR-006/018. Breaking wire change with a dual-read/write migration.

## ADR-029 — keyset cursor pagination
Adopts AIP-158 `page_token`/`next_page_token` (keyset over `(sort, node_id)`) with SDK helpers auto-following the cursor, replacing the silent 100-row read truncation (Bug A).

## Characterization tests (landed, guarded)
- `TestPayload_Int64Spectrum_BugC` (server, `t.Skip`)
- `TestPayloadRoundTrip_Int64Spectrum_BugC` (Go SDK, `t.Skip`)
- `test_query_does_not_silently_truncate` (Python integration, strict `xfail`)

Each was demonstrated failing for the right reason, then guarded.