### PR TITLE
test(sdk): de-flake test_wall_clock_budget_stops_early teardown

### DIFF
--- a/tests/python/unit/test_grpc_retry.py
+++ b/tests/python/unit/test_grpc_retry.py
@@ -260,8 +260,19 @@ class TestRetryLoop:
         # (default 30s) trip on the first backoff decision, so even
         # though max_retries=50 the loop bails after a single retry
         # decision rather than running the full schedule.
-        ticks = iter([0.0, 100.0, 200.0, 300.0, 400.0])
-        monkeypatch.setattr("entdb_sdk._grpc_client.time.monotonic", lambda: next(ticks))
+        # Successive ticks, but hold the last value once exhausted so an
+        # incidental monotonic() call during teardown (or under xdist) does
+        # NOT raise StopIteration -> "generator raised StopIteration"
+        # (RuntimeError, PEP 479), which intermittently flaked the suite.
+        ticks = [0.0, 100.0, 200.0, 300.0, 400.0]
+        calls = {"n": 0}
+
+        def fake_monotonic():
+            i = min(calls["n"], len(ticks) - 1)
+            calls["n"] += 1
+            return ticks[i]
+
+        monkeypatch.setattr("entdb_sdk._grpc_client.time.monotonic", fake_monotonic)
 
         async def fake_sleep(_d):
             raise AssertionError("budget should trip before sleeping")


### PR DESCRIPTION
The monotonic clock in this test was patched with a finite `iter([...])`. An incidental `monotonic()` call during teardown (surfaced under pytest-xdist) exhausted the iterator and raised `StopIteration` → `RuntimeError: generator raised StopIteration` (PEP 479), intermittently failing the **Unit Tests** job (it blocked #561 and #562). Hold the last tick after exhaustion so extra calls are harmless. Test logic unchanged (still trips the 30s budget on the first decision).