### PR TITLE
feat(adr-028): SDKs emit/read typed payload — end-to-end lossless int64

### DIFF
--- a/sdk/go/entdb/wire.go
+++ b/sdk/go/entdb/wire.go
@@ -3,6 +3,7 @@ package entdb
 
 import (
 	"fmt"
+	"strconv"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -23,11 +24,17 @@ func nodeFromProto(n *pb.Node) *Node {
 		return nil
 	}
 	owner, _ := ParseActor(n.GetOwnerActor())
+	// Prefer the typed payload (ADR-028, v1.20+ server) so int64 >2^53
+	// is lossless; fall back to the Struct payload for older servers.
+	pl := typedToMap(n.GetTypedPayload())
+	if pl == nil {
+		pl = structToMap(n.GetPayload())
+	}
 	return &Node{
 		TenantID:   n.GetTenantId(),
 		NodeID:     n.GetNodeId(),
 		TypeID:     int(n.GetTypeId()),
-		Payload:    structToMap(n.GetPayload()),
+		Payload:    pl,
 		CreatedAt:  n.GetCreatedAt(),
 		UpdatedAt:  n.GetUpdatedAt(),
 		OwnerActor: owner,
@@ -46,9 +53,18 @@ func edgeFromProto(e *pb.Edge) *Edge {
 		EdgeTypeID: int(e.GetEdgeTypeId()),
 		FromNodeID: e.GetFromNodeId(),
 		ToNodeID:   e.GetToNodeId(),
-		Props:      structToMap(e.GetProps()),
+		Props:      edgePropsMap(e),
 		CreatedAt:  e.GetCreatedAt(),
 	}
+}
+
+// edgePropsMap prefers the typed edge props (ADR-028) over the Struct
+// props, so int64 edge properties read back losslessly on v1.20+ servers.
+func edgePropsMap(e *pb.Edge) map[string]any {
+	if p := typedToMap(e.GetTypedProps()); p != nil {
+		return p
+	}
+	return structToMap(e.GetProps())
 }
 
 // aclFromProto converts a list of *pb.AclEntry into the SDK's
@@ -101,6 +117,99 @@ func mapToStruct(m map[string]any) (*structpb.Struct, error) {
 		return nil, fmt.Errorf("entdb: encode struct: %w", err)
 	}
 	return s, nil
+}
+
+// mapToTyped builds the typed, field_id-keyed payload (ADR-028) from the
+// SDK's id-keyed map. int64 values are carried as EntValue.int_value so
+// they survive >2^53 losslessly — unlike the google.protobuf.Struct path.
+// Sent ALONGSIDE the legacy Struct (dual-write) so a new SDK still works
+// against a pre-v1.20 server. Non-digit keys are skipped (the SDK keys by
+// field id). Returns nil for empty input.
+func mapToTyped(m map[string]any) map[uint32]*pb.EntValue {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[uint32]*pb.EntValue, len(m))
+	for k, v := range m {
+		id, err := strconv.ParseUint(k, 10, 32)
+		if err != nil {
+			continue
+		}
+		out[uint32(id)] = valueToEnt(v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// valueToEnt lowers a single Go scalar to its typed EntValue. Integers
+// stay int64 (lossless); other scalars follow their Go type; anything
+// else falls back to a JSON value.
+func valueToEnt(v any) *pb.EntValue {
+	switch x := v.(type) {
+	case nil:
+		return &pb.EntValue{}
+	case int64:
+		return &pb.EntValue{V: &pb.EntValue_IntValue{IntValue: x}}
+	case int:
+		return &pb.EntValue{V: &pb.EntValue_IntValue{IntValue: int64(x)}}
+	case int32:
+		return &pb.EntValue{V: &pb.EntValue_IntValue{IntValue: int64(x)}}
+	case uint64:
+		return &pb.EntValue{V: &pb.EntValue_IntValue{IntValue: int64(x)}}
+	case uint:
+		return &pb.EntValue{V: &pb.EntValue_IntValue{IntValue: int64(x)}}
+	case float64:
+		return &pb.EntValue{V: &pb.EntValue_DoubleValue{DoubleValue: x}}
+	case float32:
+		return &pb.EntValue{V: &pb.EntValue_DoubleValue{DoubleValue: float64(x)}}
+	case bool:
+		return &pb.EntValue{V: &pb.EntValue_BoolValue{BoolValue: x}}
+	case string:
+		return &pb.EntValue{V: &pb.EntValue_StringValue{StringValue: x}}
+	case []byte:
+		return &pb.EntValue{V: &pb.EntValue_BytesValue{BytesValue: x}}
+	default:
+		sv, err := structpb.NewValue(x)
+		if err != nil {
+			return &pb.EntValue{}
+		}
+		return &pb.EntValue{V: &pb.EntValue_JsonValue{JsonValue: sv}}
+	}
+}
+
+// typedToMap converts a wire typed payload (ADR-028) back to the SDK's
+// id-keyed map, preserving int64 exactly. Preferred over the Struct
+// payload on read when the server populated it (v1.20+).
+func typedToMap(m map[uint32]*pb.EntValue) map[string]any {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for id, v := range m {
+		out[strconv.FormatUint(uint64(id), 10)] = entToValue(v)
+	}
+	return out
+}
+
+func entToValue(v *pb.EntValue) any {
+	switch k := v.GetV().(type) {
+	case *pb.EntValue_IntValue:
+		return k.IntValue
+	case *pb.EntValue_DoubleValue:
+		return k.DoubleValue
+	case *pb.EntValue_BoolValue:
+		return k.BoolValue
+	case *pb.EntValue_StringValue:
+		return k.StringValue
+	case *pb.EntValue_BytesValue:
+		return k.BytesValue
+	case *pb.EntValue_JsonValue:
+		return k.JsonValue.AsInterface()
+	default:
+		return nil
+	}
 }
 
 // aclToProto converts the SDK's []ACLEntry into the wire
@@ -156,6 +265,7 @@ func operationsToProto(ops []Operation) ([]*pb.Operation, error) {
 				Id:           op.NodeID,
 				As:           op.Alias,
 				Data:         data,
+				TypedData:    mapToTyped(op.Data),
 				Acl:          aclToProto(op.ACL),
 				StorageMode:  storageModeToProto(op.StorageMode),
 				TargetUserId: op.TargetUserID,
@@ -166,9 +276,10 @@ func operationsToProto(ops []Operation) ([]*pb.Operation, error) {
 				return nil, err
 			}
 			upd := &pb.UpdateNodeOp{
-				TypeId: int32(op.TypeID),
-				Id:     op.NodeID,
-				Patch:  patch,
+				TypeId:     int32(op.TypeID),
+				Id:         op.NodeID,
+				Patch:      patch,
+				TypedPatch: mapToTyped(op.Patch),
 			}
 			if op.Precondition != nil {
 				eq, err := structpb.NewValue(op.Precondition.Equals)

--- a/sdk/go/entdb/wire_test.go
+++ b/sdk/go/entdb/wire_test.go
@@ -5,45 +5,33 @@ import (
 	"testing"
 )
 
-// TestPayloadRoundTrip_Int64Spectrum_BugC characterizes the int64
-// data-integrity landmine (Bug C) at the Go SDK boundary. A payload
-// integer value must survive the encode/decode round-trip
-// (mapToStruct -> structToMap) with both its value AND its int64 type
-// intact, across the full int64 range.
-//
-// Today the SDK lowers payloads into a google.protobuf.Struct, whose
-// numbers are IEEE-754 doubles (wire.go: structpb.NewStruct / AsMap), so
-// every integer comes back as a float64 and values above 2^53 lose
-// precision (e.g. 2^53+1 -> 2^53). The fix (a typed field_id->Value wire
-// carrier; ADR pending) must make these round-trip exactly as int64.
-//
-// LANDED RED on purpose (Bug C characterization). Skipped so CI stays
-// green; remove the t.Skip when the typed-value carrier lands.
+// TestPayloadRoundTrip_Int64Spectrum_BugC is the Go SDK regression for
+// Bug C (#563): a payload integer must survive the typed encode/decode
+// round-trip (mapToTyped -> typedToMap) with value AND int64 type intact,
+// across the full int64 range. The typed EntValue carrier (ADR-028)
+// replaces the lossy google.protobuf.Struct path. (The Struct path stays
+// lossy by design — asserted in TestPayloadRoundTrip_StructStillLossy.)
 func TestPayloadRoundTrip_Int64Spectrum_BugC(t *testing.T) {
-	t.Skip("Bug C: int64 payload corruption via google.protobuf.Struct (double-backed); un-skip when the typed field_id->Value wire carrier lands — ADR pending")
 	cases := []int64{
 		(1 << 53) + 1,          // 9007199254740993 — first unsafe odd int
 		10_000_000_000_000_001, // 10^16 + 1
 		(1 << 62) + 1,
 		math.MaxInt64 - 1,
 		math.MaxInt64,
+		math.MinInt64,
 		-(1 << 53) - 1,
 	}
 	for _, want := range cases {
-		s, err := mapToStruct(map[string]any{"1": want})
-		if err != nil {
-			t.Errorf("mapToStruct(%d): %v", want, err)
-			continue
-		}
-		out := structToMap(s)
+		typed := mapToTyped(map[string]any{"1": want})
+		out := typedToMap(typed)
 		got, ok := out["1"].(int64)
 		if !ok {
-			t.Errorf("field 1: wrote int64(%d), read back %v (%T) — SDK must preserve the int64 type, not coerce to float64 (Bug C)",
+			t.Errorf("field 1: wrote int64(%d), read back %v (%T) — typed path must preserve int64",
 				want, out["1"], out["1"])
 			continue
 		}
 		if got != want {
-			t.Errorf("field 1: wrote %d, read back %d — int64 corrupted via Struct (Bug C)", want, got)
+			t.Errorf("field 1: wrote %d, read back %d — int64 corrupted (Bug C)", want, got)
 		}
 	}
 }

--- a/sdk/python/entdb_sdk/_generated/__init__.py
+++ b/sdk/python/entdb_sdk/_generated/__init__.py
@@ -14,6 +14,7 @@ from .entdb_pb2 import (
     DeleteNodeOp,
     DeleteWhereOp,
     Edge,
+    EntValue,
     # Execute
     ExecuteAtomicRequest,
     ExecuteAtomicResponse,
@@ -164,6 +165,7 @@ __all__ = [
     "GetEdgesRequest",
     "GetEdgesResponse",
     "Edge",
+    "EntValue",
     "SearchMailboxRequest",
     "SearchMailboxResponse",
     "MailboxSearchResult",

--- a/sdk/python/entdb_sdk/_grpc_client.py
+++ b/sdk/python/entdb_sdk/_grpc_client.py
@@ -42,6 +42,7 @@ from ._generated import (
     DeleteUserRequest,
     DeleteWhereOp,
     EntDBServiceStub,
+    EntValue,
     ExecuteAtomicRequest,
     ExportUserDataRequest,
     FieldFilter,
@@ -146,6 +147,68 @@ def _dict_to_struct(d):
 def _struct_to_dict(s):
     """Convert protobuf Struct to Python dict."""
     return json_format.MessageToDict(s) if s and s.fields else {}
+
+
+def _value_to_entvalue(v: Any) -> EntValue:
+    """Lower a Python scalar to a typed EntValue (ADR-028).
+
+    Integers are carried as int_value so they survive >2^53 losslessly —
+    unlike google.protobuf.Struct, whose numbers are IEEE-754 doubles.
+    bool is checked before int (bool subclasses int in Python).
+    """
+    ev = EntValue()
+    if v is None:
+        return ev  # unset oneof == explicit null
+    if isinstance(v, bool):
+        ev.bool_value = v
+    elif isinstance(v, int):
+        ev.int_value = v
+    elif isinstance(v, float):
+        ev.double_value = v
+    elif isinstance(v, str):
+        ev.string_value = v
+    elif isinstance(v, (bytes, bytearray)):
+        ev.bytes_value = bytes(v)
+    else:
+        ev.json_value.CopyFrom(json_format.ParseDict({"v": v}, Struct()).fields["v"])
+    return ev
+
+
+def _entvalue_to_python(ev: EntValue) -> Any:
+    """Unbox a typed EntValue to a Python value, preserving int64."""
+    kind = ev.WhichOneof("v")
+    if kind == "int_value":
+        return ev.int_value
+    if kind == "double_value":
+        return ev.double_value
+    if kind == "bool_value":
+        return ev.bool_value
+    if kind == "string_value":
+        return ev.string_value
+    if kind == "bytes_value":
+        return ev.bytes_value
+    if kind == "json_value":
+        return _python_from_value(ev.json_value)
+    return None  # unset == null
+
+
+def _populate_typed(typed_map, data: dict) -> None:
+    """Populate a proto map<uint32, EntValue> from an id-keyed payload
+    dict. Non-digit keys are skipped (the SDK keys payloads by field id).
+    """
+    for k, v in data.items():
+        try:
+            fid = int(k)
+        except (TypeError, ValueError):
+            continue
+        typed_map[fid].CopyFrom(_value_to_entvalue(v))
+
+
+def _typed_to_dict(typed_map) -> dict:
+    """Convert a proto map<uint32, EntValue> into an id-keyed Python dict,
+    preserving int64. Returns {} for an empty map.
+    """
+    return {str(fid): _entvalue_to_python(ev) for fid, ev in typed_map.items()}
 
 
 def _acl_proto_to_list(acl_entries):
@@ -491,7 +554,9 @@ def _node_from_proto(n: Any, registry: Any = None) -> Node:
     registry is supplied (or the type is not registered) the payload
     is passed through unchanged.
     """
-    raw = _struct_to_dict(n.payload)
+    # Prefer typed_payload (ADR-028, v1.20+ server) so int64 >2^53 is
+    # lossless; fall back to the Struct payload for older servers.
+    raw = _typed_to_dict(n.typed_payload) if len(n.typed_payload) else _struct_to_dict(n.payload)
     payload = _payload_id_to_name(raw, n.type_id, registry) if registry is not None else raw
     return Node(
         tenant_id=n.tenant_id,
@@ -548,7 +613,7 @@ def _edge_from_proto(e: Any, registry: Any = None) -> Edge:
     supplied registry. When no registry is supplied (or the edge type
     is not registered) the props pass through unchanged.
     """
-    raw_props = _struct_to_dict(e.props)
+    raw_props = _typed_to_dict(e.typed_props) if len(e.typed_props) else _struct_to_dict(e.props)
     props = (
         _edge_props_id_to_name(raw_props, e.edge_type_id, registry)
         if registry is not None
@@ -1009,6 +1074,9 @@ class GrpcClient:
                 data = create.get("data")
                 if data:
                     create_op.data.update(data)
+                    # Dual-write typed_data (ADR-028) so int64 >2^53 is
+                    # lossless on v1.20+ servers; old servers read `data`.
+                    _populate_typed(create_op.typed_data, data)
                 acl = create.get("acl")
                 if acl:
                     create_op.acl.extend(
@@ -1049,6 +1117,7 @@ class GrpcClient:
                 patch = update.get("patch")
                 if patch:
                     update_op.patch.update(patch)
+                    _populate_typed(update_op.typed_patch, patch)
                 if update.get("field_mask"):
                     update_op.field_mask.extend(update["field_mask"])
                 # GitHub issues #500/#525 — optional single-field CAS

--- a/tests/python/unit/test_typed_payload.py
+++ b/tests/python/unit/test_typed_payload.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+"""Python SDK regression for Bug C (#563): the typed payload path
+(ADR-028) must round-trip int64 > 2^53 losslessly, unlike the legacy
+google.protobuf.Struct path whose numbers are IEEE-754 doubles."""
+
+from __future__ import annotations
+
+import pytest
+
+from entdb_sdk._generated import CreateNodeOp
+from entdb_sdk._grpc_client import (
+    _entvalue_to_python,
+    _populate_typed,
+    _typed_to_dict,
+    _value_to_entvalue,
+)
+
+INT64_SPECTRUM = [
+    0,
+    1,
+    -1,
+    (1 << 53) + 1,  # 9007199254740993 — first unsafe odd int
+    10_000_000_000_000_001,  # 10^16 + 1
+    (1 << 62) + 1,
+    (1 << 63) - 1,  # MaxInt64
+    -(1 << 63),  # MinInt64
+    -((1 << 53) + 1),
+]
+
+
+@pytest.mark.parametrize("want", INT64_SPECTRUM)
+def test_value_entvalue_int64_roundtrip(want: int) -> None:
+    got = _entvalue_to_python(_value_to_entvalue(want))
+    assert isinstance(got, int), f"expected int, got {type(got)}"
+    assert got == want
+
+
+def test_populate_and_read_typed_map_preserves_types() -> None:
+    big = (1 << 53) + 1
+    op = CreateNodeOp()
+    _populate_typed(op.typed_data, {"3": big, "1": "hello", "2": 3.5, "4": True})
+    out = _typed_to_dict(op.typed_data)
+    assert out["3"] == big and isinstance(out["3"], int)
+    assert out["1"] == "hello"
+    assert out["2"] == 3.5
+    assert out["4"] is True
+
+
+def test_non_digit_keys_skipped() -> None:
+    op = CreateNodeOp()
+    _populate_typed(op.typed_data, {"email": "x", "5": 9})
+    out = _typed_to_dict(op.typed_data)
+    assert out == {"5": 9}


### PR DESCRIPTION
Completes the int64 fix (Bug C / #563) on the SDK side, pairing with the v1.20.0 server. **Both SDKs ship together.**

Go + Python SDKs now:
- **dual-write** `typed_data`/`typed_patch` (EntValue) alongside the legacy Struct `data`/`patch` — so a new SDK still works against a pre-v1.20 server (which reads the Struct), while a v1.20+ server reads the lossless typed map;
- **prefer** `typed_payload`/`typed_props` on read, falling back to Struct for older servers.

int64 >2^53 now round-trips losslessly end-to-end (client → server → client). Tests: Go `TestPayloadRoundTrip_Int64Spectrum_BugC` (typed path) and Python `test_typed_payload` (full spectrum incl. MaxInt64/MinInt64).

Local CI green: server, Go SDK, Python integration (103 + 1 xfail), ruff. E2E running.

Closes #563.