### PR TITLE
feat(#564): SDK helpers auto-follow the keyset cursor (complete result set)

### DIFF
--- a/docs/generated/sdk-go.md
+++ b/docs/generated/sdk-go.md
@@ -1277,7 +1277,11 @@ type Transport interface {
 	// older servers keep reading the legacy field.
 	GetNodeByKey(ctx context.Context, tenantID, actor string, typeID, fieldID int32, value any) (*Node, error)
 	// QueryNodes retrieves nodes matching a filter.
-	QueryNodes(ctx context.Context, tenantID, actor string, typeID int, filter map[string]any) ([]*Node, error)
+	// QueryNodes returns nodes matching a filter. The transport follows
+	// the ADR-029 keyset cursor across pages so the complete set is
+	// returned, never a silent 100-row prefix. limit caps the total when
+	// positive; limit <= 0 returns every matching row.
+	QueryNodes(ctx context.Context, tenantID, actor string, typeID int, filter map[string]any, limit int) ([]*Node, error)
 	// ExecuteAtomic commits a batch of operations atomically.
 	ExecuteAtomic(ctx context.Context, tenantID, actor, idempotencyKey string, ops []Operation) (*CommitResult, error)
 	// Share grants permission on a node to another actor.

--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -11,6 +11,18 @@ import (
 	pb "github.com/elloloop/tenant-shard-db/sdk/go/entdb/internal/pb"
 )
 
+// maxQueryPageSize is the per-page row count the keyset auto-follow
+// requests (ADR-029). It matches the server's MaxPageSize so a large
+// result set is fetched in the fewest round-trips; the server clamps
+// anything larger.
+const maxQueryPageSize = 1000
+
+// maxAutoFollowPages bounds the auto-follow loop defensively so a buggy
+// server that never clears next_page_token cannot spin forever. At
+// maxQueryPageSize rows per page this still covers result sets in the
+// billions.
+const maxAutoFollowPages = 10_000_000
+
 // Transport is the low-level interface between the SDK and the
 // gRPC layer. It is intentionally NOT part of the public single-
 // shape API — user code goes through the typed [Scope] / [Plan]
@@ -35,7 +47,11 @@ type Transport interface {
 	// older servers keep reading the legacy field.
 	GetNodeByKey(ctx context.Context, tenantID, actor string, typeID, fieldID int32, value any) (*Node, error)
 	// QueryNodes retrieves nodes matching a filter.
-	QueryNodes(ctx context.Context, tenantID, actor string, typeID int, filter map[string]any) ([]*Node, error)
+	// QueryNodes returns nodes matching a filter. The transport follows
+	// the ADR-029 keyset cursor across pages so the complete set is
+	// returned, never a silent 100-row prefix. limit caps the total when
+	// positive; limit <= 0 returns every matching row.
+	QueryNodes(ctx context.Context, tenantID, actor string, typeID int, filter map[string]any, limit int) ([]*Node, error)
 	// ExecuteAtomic commits a batch of operations atomically.
 	ExecuteAtomic(ctx context.Context, tenantID, actor, idempotencyKey string, ops []Operation) (*CommitResult, error)
 	// Share grants permission on a node to another actor.
@@ -373,31 +389,63 @@ func (t *grpcTransport) GetNodeByKey(ctx context.Context, tenantID, actor string
 	return nodeFromProto(resp.GetNode()), nil
 }
 
-func (t *grpcTransport) QueryNodes(ctx context.Context, tenantID, actor string, typeID int, filter map[string]any) ([]*Node, error) {
+func (t *grpcTransport) QueryNodes(ctx context.Context, tenantID, actor string, typeID int, filter map[string]any, limit int) ([]*Node, error) {
 	client, err := t.ensureReady()
 	if err != nil {
 		return nil, err
 	}
+	// Build filters once and reuse across pages so the server's query
+	// fingerprint stays stable for the keyset cursor.
 	filters, err := filterToProto(filter)
 	if err != nil {
 		return nil, err
 	}
 	offset := t.offsets.resolve(ctx, tenantID)
-	var trailer metadata.MD
-	resp, err := client.QueryNodes(t.callContext(ctx, tenantID), &pb.QueryNodesRequest{
-		Context:       &pb.RequestContext{TenantId: tenantID, Actor: actor},
-		TypeId:        int32(typeID),
-		Filters:       filters,
-		AfterOffset:   offset,
-		WaitTimeoutMs: waitTimeoutForOffset(offset),
-	}, grpc.Trailer(&trailer))
-	if err != nil {
-		return nil, translateGRPCStatusWithTrailer(err, trailer, tenantID, t.address)
-	}
-	nodes := resp.GetNodes()
-	out := make([]*Node, 0, len(nodes))
-	for _, n := range nodes {
-		out = append(out, nodeFromProto(n))
+
+	// Auto-follow the keyset cursor (ADR-029): loop next_page_token to
+	// exhaustion (or until `limit` rows are collected) so a query returns
+	// the complete set, never a silent prefix. Fence read-after-write only
+	// on the first page; later pages read the same applied snapshot.
+	var out []*Node
+	pageToken := ""
+	capped := limit > 0
+	for page := 0; ; page++ {
+		if page > maxAutoFollowPages {
+			return nil, fmt.Errorf("entdb: QueryNodes: pagination did not terminate after %d pages", maxAutoFollowPages)
+		}
+		pageSize := int32(maxQueryPageSize)
+		if capped {
+			if rem := limit - len(out); rem < int(pageSize) {
+				pageSize = int32(rem)
+			}
+		}
+		req := &pb.QueryNodesRequest{
+			Context:   &pb.RequestContext{TenantId: tenantID, Actor: actor},
+			TypeId:    int32(typeID),
+			Filters:   filters,
+			PageSize:  pageSize,
+			PageToken: pageToken,
+		}
+		if page == 0 {
+			req.AfterOffset = offset
+			req.WaitTimeoutMs = waitTimeoutForOffset(offset)
+		}
+		var trailer metadata.MD
+		resp, err := client.QueryNodes(t.callContext(ctx, tenantID), req, grpc.Trailer(&trailer))
+		if err != nil {
+			return nil, translateGRPCStatusWithTrailer(err, trailer, tenantID, t.address)
+		}
+		for _, n := range resp.GetNodes() {
+			out = append(out, nodeFromProto(n))
+		}
+		pageToken = resp.GetNextPageToken()
+		if capped && len(out) >= limit {
+			out = out[:limit]
+			break
+		}
+		if pageToken == "" {
+			break
+		}
 	}
 	return out, nil
 }

--- a/sdk/go/entdb/client_test.go
+++ b/sdk/go/entdb/client_test.go
@@ -33,6 +33,7 @@ type mockTransport struct {
 	lastGetByKeyValue     any
 	lastQueryTypeID       int
 	lastQueryFilter       map[string]any
+	lastQueryLimit        int
 	lastCommitOperations  []Operation
 	lastCommitIdempotency string
 
@@ -75,10 +76,11 @@ func (m *mockTransport) GetNodeByKey(_ context.Context, _, _ string, typeID, fie
 	return m.getNodeByKeyResp, m.getNodeByKeyErr
 }
 
-func (m *mockTransport) QueryNodes(_ context.Context, _, _ string, typeID int, filter map[string]any) ([]*Node, error) {
+func (m *mockTransport) QueryNodes(_ context.Context, _, _ string, typeID int, filter map[string]any, limit int) ([]*Node, error) {
 	m.queryCalls++
 	m.lastQueryTypeID = typeID
 	m.lastQueryFilter = filter
+	m.lastQueryLimit = limit
 	return m.queryResp, m.queryErr
 }
 

--- a/sdk/go/entdb/grpc_transport_test.go
+++ b/sdk/go/entdb/grpc_transport_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -47,18 +48,24 @@ type fakeServer struct {
 	getNodeByKeyErr  error
 	queryResp        *pb.QueryNodesResponse
 	queryErr         error
-	searchResp       *pb.SearchNodesResponse
-	searchErr        error
-	edgesFromResp    *pb.GetEdgesResponse
-	edgesFromErr     error
-	edgesToResp      *pb.GetEdgesResponse
-	edgesToErr       error
-	shareResp        *pb.ShareNodeResponse
-	shareErr         error
-	quotaResp        *pb.GetTenantQuotaResponse
-	quotaErr         error
-	execResp         *pb.ExecuteAtomicResponse
-	execErr          error
+	// queryPages, when set, makes QueryNodes serve keyset pages: the
+	// request's page_token is the index into queryPages ("" => 0), and
+	// each page's NextPageToken points at the next index (empty on the
+	// last). Used to exercise the SDK's ADR-029 auto-follow loop.
+	queryPages    []*pb.QueryNodesResponse
+	queryReqs     []*pb.QueryNodesRequest
+	searchResp    *pb.SearchNodesResponse
+	searchErr     error
+	edgesFromResp *pb.GetEdgesResponse
+	edgesFromErr  error
+	edgesToResp   *pb.GetEdgesResponse
+	edgesToErr    error
+	shareResp     *pb.ShareNodeResponse
+	shareErr      error
+	quotaResp     *pb.GetTenantQuotaResponse
+	quotaErr      error
+	execResp      *pb.ExecuteAtomicResponse
+	execErr       error
 
 	// v1.4 surface
 	getNodesReq    *pb.GetNodesRequest
@@ -171,9 +178,21 @@ func (s *fakeServer) GetNodeByKey(ctx context.Context, req *pb.GetNodeByKeyReque
 
 func (s *fakeServer) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb.QueryNodesResponse, error) {
 	s.queryReq = req
+	s.queryReqs = append(s.queryReqs, req)
 	s.sendTrailer(ctx)
 	if s.queryErr != nil {
 		return nil, s.queryErr
+	}
+	if s.queryPages != nil {
+		idx := 0
+		if req.GetPageToken() != "" {
+			i, err := strconv.Atoi(req.GetPageToken())
+			if err != nil {
+				return nil, err
+			}
+			idx = i
+		}
+		return s.queryPages[idx], nil
 	}
 	return s.queryResp, nil
 }
@@ -615,7 +634,7 @@ func TestGrpcTransport_QueryNodes_HappyPath(t *testing.T) {
 		"price_cents": map[string]any{"$gte": 500.0},
 		"sku":         "WIDGET-1",
 	}
-	nodes, err := tr.QueryNodes(context.Background(), "acme", "user:alice", 201, filter)
+	nodes, err := tr.QueryNodes(context.Background(), "acme", "user:alice", 201, filter, 0)
 	if err != nil {
 		t.Fatalf("QueryNodes: %v", err)
 	}
@@ -640,6 +659,76 @@ func TestGrpcTransport_QueryNodes_HappyPath(t *testing.T) {
 	}
 	if !foundGte {
 		t.Errorf("expected a $gte filter on price_cents, got %+v", svc.queryReq.GetFilters())
+	}
+}
+
+// makeNodes builds n placeholder nodes for the pagination tests.
+func makeNodes(prefix string, n int) []*pb.Node {
+	out := make([]*pb.Node, n)
+	for i := 0; i < n; i++ {
+		out[i] = &pb.Node{TenantId: "acme", NodeId: prefix + strconv.Itoa(i), TypeId: 201}
+	}
+	return out
+}
+
+// TestGrpcTransport_QueryNodes_AutoFollowsCursor pins the ADR-029
+// auto-follow: a single QueryNodes call follows next_page_token across
+// pages and returns the complete set.
+func TestGrpcTransport_QueryNodes_AutoFollowsCursor(t *testing.T) {
+	svc := &fakeServer{
+		queryPages: []*pb.QueryNodesResponse{
+			{Nodes: makeNodes("a", 1000), NextPageToken: "1"},
+			{Nodes: makeNodes("b", 1000), NextPageToken: "2"},
+			{Nodes: makeNodes("c", 250), NextPageToken: ""},
+		},
+	}
+	tr := startFakeServer(t, svc)
+
+	nodes, err := tr.QueryNodes(context.Background(), "acme", "user:alice", 201, nil, 0)
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if len(nodes) != 2250 {
+		t.Fatalf("got %d nodes, want 2250 (complete set across 3 pages)", len(nodes))
+	}
+	if len(svc.queryReqs) != 3 {
+		t.Fatalf("made %d requests, want 3", len(svc.queryReqs))
+	}
+	// First page fences read-after-write; later pages carry the cursor.
+	if svc.queryReqs[0].GetPageToken() != "" {
+		t.Errorf("page 1 token = %q, want empty", svc.queryReqs[0].GetPageToken())
+	}
+	if svc.queryReqs[1].GetPageToken() != "1" || svc.queryReqs[2].GetPageToken() != "2" {
+		t.Errorf("cursor not advanced: %q, %q", svc.queryReqs[1].GetPageToken(), svc.queryReqs[2].GetPageToken())
+	}
+}
+
+// TestGrpcTransport_QueryNodes_LimitCapsTotal pins WithLimit's cap: the
+// transport stops following once `limit` rows are collected and requests
+// only the remaining count on the final page.
+func TestGrpcTransport_QueryNodes_LimitCapsTotal(t *testing.T) {
+	svc := &fakeServer{
+		queryPages: []*pb.QueryNodesResponse{
+			{Nodes: makeNodes("a", 1000), NextPageToken: "1"},
+			{Nodes: makeNodes("b", 1000), NextPageToken: "2"},
+			{Nodes: makeNodes("c", 1000), NextPageToken: ""},
+		},
+	}
+	tr := startFakeServer(t, svc)
+
+	nodes, err := tr.QueryNodes(context.Background(), "acme", "user:alice", 201, nil, 1200)
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if len(nodes) != 1200 {
+		t.Fatalf("got %d nodes, want 1200 (limit cap)", len(nodes))
+	}
+	if len(svc.queryReqs) != 2 {
+		t.Fatalf("made %d requests, want 2 (stop at cap)", len(svc.queryReqs))
+	}
+	// Second page only needs the remaining 200 rows.
+	if svc.queryReqs[1].GetPageSize() != 200 {
+		t.Errorf("page 2 page_size = %d, want 200", svc.queryReqs[1].GetPageSize())
 	}
 }
 
@@ -890,7 +979,7 @@ func TestGrpcTransport_InvalidArgumentError(t *testing.T) {
 	svc := &fakeServer{queryErr: status.Error(codes.InvalidArgument, "bad filter")}
 	tr := startFakeServer(t, svc)
 
-	_, err := tr.QueryNodes(context.Background(), "acme", "user:alice", 201, map[string]any{"x": "y"})
+	_, err := tr.QueryNodes(context.Background(), "acme", "user:alice", 201, map[string]any{"x": "y"}, 0)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/sdk/go/entdb/offsets_test.go
+++ b/sdk/go/entdb/offsets_test.go
@@ -73,7 +73,7 @@ func TestReadAfterWrite_AutoAttachesOffset(t *testing.T) {
 		t.Errorf("GetNode wait_timeout_ms = %d, want 30000", got)
 	}
 
-	if _, err := tr.QueryNodes(ctx, "acme", "user:alice", 201, nil); err != nil {
+	if _, err := tr.QueryNodes(ctx, "acme", "user:alice", 201, nil, 0); err != nil {
 		t.Fatalf("QueryNodes: %v", err)
 	}
 	if got := svc.queryReq.GetAfterOffset(); got != "42" {

--- a/sdk/go/entdb/scope.go
+++ b/sdk/go/entdb/scope.go
@@ -211,14 +211,14 @@ func Query[T proto.Message](ctx context.Context, s *Scope, filter map[string]any
 	if err != nil {
 		return nil, fmt.Errorf("entdb: Query: %w", err)
 	}
-	// queryConfig is unused on the wire today — limit/offset will
-	// land when the transport supports them. Building the config
-	// keeps the public signature forward-compatible.
+	// WithLimit caps the total rows returned; unset (0) returns the
+	// complete set via the transport's ADR-029 keyset auto-follow.
+	// WithOffset is not wired — the cursor supersedes offset paging.
 	var cfg queryConfig
 	for _, o := range opts {
 		o(&cfg)
 	}
-	nodes, err := s.client.transport.QueryNodes(ctx, s.tenantID, s.actor.String(), int(typeID), filter)
+	nodes, err := s.client.transport.QueryNodes(ctx, s.tenantID, s.actor.String(), int(typeID), filter, int(cfg.limit))
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/python/entdb_sdk/_grpc_client.py
+++ b/sdk/python/entdb_sdk/_grpc_client.py
@@ -373,6 +373,10 @@ _DEADLINE_RETRYABLE_METHODS = frozenset(
 
 _DEFAULT_TIMEOUT: float = 30.0
 
+# Server-side MaxPageSize (ADR-029). The keyset auto-follow requests pages
+# of this size to minimise round-trips; the server clamps anything larger.
+_MAX_PAGE_SIZE: int = 1000
+
 
 def _short_method(fn: Any) -> str:
     """Return the trailing RPC name from a bound stub multicallable.
@@ -1468,7 +1472,7 @@ class GrpcClient:
         actor: str,
         type_id: int,
         *,
-        limit: int = 100,
+        limit: int = 0,
         offset: int = 0,
         filter: dict[str, Any] | None = None,
         order_by: str | None = None,
@@ -1480,12 +1484,19 @@ class GrpcClient:
     ) -> tuple[list[Node], bool]:
         """Query nodes by type.
 
+        Follows the ADR-029 keyset cursor to return the complete result
+        set by default — a query never silently truncates at the 100-row
+        page default. ``limit`` caps the total when positive; ``limit <= 0``
+        (the default) returns every matching row.
+
         Args:
             tenant_id: Tenant identifier
             actor: Actor making request
             type_id: Node type ID
-            limit: Maximum nodes to return
-            offset: Pagination offset
+            limit: Maximum rows to return; ``<= 0`` (default) returns all.
+            offset: DEPRECATED legacy LIMIT/OFFSET. When > 0 the call falls
+                back to a single non-cursor request (no auto-follow), for
+                backwards compatibility. Prefer the default cursor path.
             filter: Filter dict (field_name → value for equality)
             order_by: Field to order results by
             descending: Whether to sort in descending order
@@ -1495,12 +1506,15 @@ class GrpcClient:
             timeout: Per-call timeout in seconds
 
         Returns:
-            Tuple of (nodes, has_more)
+            Tuple of (nodes, has_more). has_more is True only when a
+            positive ``limit`` capped the result before exhausting the set.
         """
         stub = self._ensure_connected()
         metadata = self._build_metadata()
 
-        # Convert filter dict to repeated FieldFilter
+        # Convert filter dict to repeated FieldFilter. typed_value carries
+        # the lossless value (ADR-028 / #572); built once and reused across
+        # pages so the server's query fingerprint stays stable.
         filters = []
         if filter:
             from google.protobuf.struct_pb2 import Value
@@ -1516,29 +1530,73 @@ class GrpcClient:
                     )
                 )
 
-        request = QueryNodesRequest(
-            context=self._make_context(tenant_id, actor, trace_id),
-            type_id=type_id,
-            limit=limit,
-            offset=offset,
-            filters=filters,
-            order_by=order_by or "",
-            descending=descending,
-            after_offset=after_offset or "",
-            wait_timeout_ms=wait_timeout_ms,
-        )
+        # Deprecated offset path: a single legacy LIMIT/OFFSET request.
+        # offset and the keyset page_token are mutually exclusive server
+        # side, so we do not auto-follow here.
+        if offset and offset > 0:
+            response = await self._retry(
+                stub.QueryNodes,
+                QueryNodesRequest(
+                    context=self._make_context(tenant_id, actor, trace_id),
+                    type_id=type_id,
+                    limit=limit or 100,
+                    offset=offset,
+                    filters=filters,
+                    order_by=order_by or "",
+                    descending=descending,
+                    after_offset=after_offset or "",
+                    wait_timeout_ms=wait_timeout_ms,
+                ),
+                timeout=timeout or _DEFAULT_TIMEOUT,
+                metadata=metadata,
+                tenant_id=tenant_id,
+            )
+            nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
+            return nodes, response.has_more
 
-        response = await self._retry(
-            stub.QueryNodes,
-            request,
-            timeout=timeout or _DEFAULT_TIMEOUT,
-            metadata=metadata,
-            tenant_id=tenant_id,
-        )
+        # Keyset auto-follow (ADR-029): loop next_page_token to exhaustion
+        # (or until `limit` rows are collected). Fence read-after-write only
+        # on the first page; later pages read the same applied snapshot.
+        nodes: list[Node] = []
+        page_token = ""
+        first = True
+        capped = limit and limit > 0
+        has_more = False
+        while True:
+            # Request only as many rows as remain under the cap (if any),
+            # so a small `limit` does not over-fetch a full page.
+            page_size = _MAX_PAGE_SIZE
+            if capped:
+                page_size = min(_MAX_PAGE_SIZE, limit - len(nodes))
+            response = await self._retry(
+                stub.QueryNodes,
+                QueryNodesRequest(
+                    context=self._make_context(tenant_id, actor, trace_id),
+                    type_id=type_id,
+                    page_size=page_size,
+                    page_token=page_token,
+                    filters=filters,
+                    order_by=order_by or "",
+                    descending=descending,
+                    after_offset=(after_offset or "") if first else "",
+                    wait_timeout_ms=wait_timeout_ms if first else 0,
+                ),
+                timeout=timeout or _DEFAULT_TIMEOUT,
+                metadata=metadata,
+                tenant_id=tenant_id,
+            )
+            first = False
+            for n in response.nodes:
+                nodes.append(_node_from_proto(n, self._registry))
+            page_token = response.next_page_token
+            if capped and len(nodes) >= limit:
+                has_more = bool(page_token) or len(nodes) > limit
+                nodes = nodes[:limit]
+                break
+            if not page_token:
+                break
 
-        nodes = [_node_from_proto(n, self._registry) for n in response.nodes]
-
-        return nodes, response.has_more
+        return nodes, has_more
 
     async def get_edges_from(
         self,

--- a/sdk/python/entdb_sdk/client.py
+++ b/sdk/python/entdb_sdk/client.py
@@ -1159,7 +1159,7 @@ class DbClient:
         *,
         filter: dict[str, Any] | None = None,
         where: list[Filter] | None = None,
-        limit: int = 100,
+        limit: int = 0,
         offset: int = 0,
         order_by: str = "created_at",
         descending: bool = True,
@@ -1181,8 +1181,12 @@ class DbClient:
                 with ``filter`` — pass one or the other.
                 ``FilterOp.NE`` forces a full type scan; B-tree
                 indexes cannot serve a not-equal predicate.
-            limit: Maximum nodes to return
-            offset: Pagination offset
+            limit: Maximum rows to return. ``0`` (the default) returns the
+                COMPLETE result set — the SDK follows the ADR-029 keyset
+                cursor across pages, so a query never silently truncates at
+                the 100-row page default. Set a positive value to cap.
+            offset: DEPRECATED legacy pagination offset. Non-zero forces a
+                single non-cursor request; prefer the default cursor path.
             order_by: Field to order results by
             descending: Whether to sort in descending order
             after_offset: Wait for this stream position before reading.
@@ -1192,7 +1196,7 @@ class DbClient:
             timeout: Per-call timeout in seconds
 
         Returns:
-            List of nodes
+            List of nodes (the complete set unless ``limit`` caps it)
         """
         self._ensure_connected()
         trace_id = trace_id or str(uuid.uuid4())

--- a/sdk/python/entdb_sdk/scope.py
+++ b/sdk/python/entdb_sdk/scope.py
@@ -214,7 +214,7 @@ class ActorScope:
         *,
         filter: dict[str, Any] | None = None,
         where: list[Filter] | None = None,
-        limit: int = 100,
+        limit: int = 0,
         offset: int = 0,
         order_by: str = "created_at",
         descending: bool = True,
@@ -234,6 +234,11 @@ class ActorScope:
 
         ``FilterOp.NE`` cannot use a B-tree index — it forces a full
         type scan. Use sparingly on large tables.
+
+        ``limit`` defaults to ``0`` = the COMPLETE result set: the SDK
+        follows the ADR-029 keyset cursor across pages so a query never
+        silently truncates at the 100-row page default. Set a positive
+        value to cap. ``offset`` is deprecated (legacy single-shot path).
         """
         kwargs: dict[str, Any] = {
             "limit": limit,

--- a/tests/python/unit/test_query_autofollow.py
+++ b/tests/python/unit/test_query_autofollow.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT
+"""ADR-029 keyset auto-follow in GrpcClient.query_nodes (#564, PR-4).
+
+A fake stub serves canned pages keyed by the incoming page_token; the
+client must loop next_page_token to return the COMPLETE set by default,
+honour a positive `limit` as a total cap, and fall back to a single
+non-cursor request when the deprecated `offset` is used.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entdb_sdk._generated import entdb_pb2 as pb
+from entdb_sdk._grpc_client import GrpcClient
+
+
+class _FakeStub:
+    """Serves pages indexed by token: page 0 is token "", page k is "k"."""
+
+    def __init__(self, pages: dict[int, tuple[int, str]]):
+        self._pages = pages
+        self.calls: list[pb.QueryNodesRequest] = []
+
+    async def QueryNodes(self, request, timeout=None, metadata=None):
+        self.calls.append(request)
+        idx = 0 if request.page_token == "" else int(request.page_token)
+        count, next_tok = self._pages[idx]
+        return pb.QueryNodesResponse(
+            next_page_token=next_tok,
+            nodes=[pb.Node(node_id=f"n{idx}-{i}", type_id=1) for i in range(count)],
+        )
+
+
+def _client_with_stub(stub: _FakeStub) -> GrpcClient:
+    c = GrpcClient()
+    c._stub = stub  # bypass connect()
+    c._registry = None
+    return c
+
+
+@pytest.mark.asyncio
+async def test_autofollows_to_complete_set():
+    # page0: 100 rows -> token "1"; page1: 50 rows -> end.
+    stub = _FakeStub({0: (100, "1"), 1: (50, "")})
+    nodes, has_more = await _client_with_stub(stub).query_nodes("acme", "user:alice", 1)
+    assert len(nodes) == 150, "auto-follow must return the complete set"
+    assert has_more is False
+    assert len(stub.calls) == 2
+    # Cursor advances; first page fences read-after-write, later pages do not.
+    assert stub.calls[0].page_token == ""
+    assert stub.calls[1].page_token == "1"
+
+
+@pytest.mark.asyncio
+async def test_limit_caps_total_and_stops_early():
+    stub = _FakeStub({0: (100, "1"), 1: (100, "2"), 2: (100, "")})
+    nodes, has_more = await _client_with_stub(stub).query_nodes("acme", "user:alice", 1, limit=120)
+    assert len(nodes) == 120
+    assert has_more is True
+    assert len(stub.calls) == 2, "should stop once the cap is reached"
+    # Second page only needs the remaining 20 rows.
+    assert stub.calls[1].page_size == 20
+
+
+@pytest.mark.asyncio
+async def test_offset_uses_legacy_single_request():
+    # A token is offered but the legacy offset path must NOT follow it.
+    stub = _FakeStub({0: (10, "should-not-follow")})
+    nodes, has_more = await _client_with_stub(stub).query_nodes("acme", "user:alice", 1, offset=5)
+    assert len(nodes) == 10
+    assert len(stub.calls) == 1
+    assert stub.calls[0].offset == 5
+    assert stub.calls[0].page_token == ""
+
+
+@pytest.mark.asyncio
+async def test_single_page_no_token_returns_once():
+    stub = _FakeStub({0: (7, "")})
+    nodes, has_more = await _client_with_stub(stub).query_nodes("acme", "user:alice", 1)
+    assert len(nodes) == 7
+    assert has_more is False
+    assert len(stub.calls) == 1


### PR DESCRIPTION
## What

Completes the **Bug A** fix (#564). The server gained keyset cursor pagination in v1.23.0, but the SDK helpers still issued a single request and returned the first page — so a query over >100 rows still silently truncated for SDK callers. Both SDKs now follow `next_page_token` to exhaustion and return the **complete result set by default** (ADR-029 invariant 3).

## How

**Go SDK**
- `Transport.QueryNodes` takes a `limit` (0 = complete set) and loops `next_page_token`, accumulating pages; it fences read-after-write only on the first page. `WithLimit` is now wired through as a total cap, so a small limit no longer over-fetches a full page. A defensive page-count ceiling guards against a server that never clears the cursor.

**Python SDK**
- `query_nodes` auto-follows the cursor; `client.query` / `scope.query` default `limit` changes from `100` to `0` (= the complete set). A positive `limit` caps the total; the deprecated `offset` falls back to a single non-cursor request for backward compatibility.

This is the standard-database contract — a query returns every matching row, not a silent prefix. Pages are fetched at the server's `MaxPageSize` (1000) to minimise round-trips.

**Behavioral note:** the Python `query` default `limit` was `100` (the buggy silent cap) and is now `0` (complete set). Callers who relied on the implicit 100-row cap should pass an explicit `limit`.

Both SDKs ship together in this PR.

## Tests

- **Python unit** (`test_query_autofollow.py`): complete-set follow across pages, `limit` cap stops early with a reduced final `page_size`, deprecated `offset` single-shot (no follow), single-page no-token.
- **Go transport** (`grpc_transport_test.go`): multi-page auto-follow over a paginating fake server (cursor advances, first page fences RAW), `limit` cap stops early with a bounded final `page_size`.
- Full local CI green: Go server + Go SDK (vet+test), 539 Python integration+unit, ruff, docs coverage (pinned go 1.25), and the Docker-stack E2E suite.

Closes #564. Refs ADR-029.