### PR TITLE
fix(#573): read RPCs surface genuine store faults instead of empty+OK

### DIFF
--- a/server/go/internal/api/get_connected_nodes.go
+++ b/server/go/internal/api/get_connected_nodes.go
@@ -39,8 +39,11 @@ import (
 	"context"
 	"time"
 
+	"google.golang.org/grpc/codes"
+
 	"github.com/elloloop/tenant-shard-db/server/go/internal/acl"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
@@ -121,11 +124,16 @@ func (s *Server) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNode
 	if !aclActor.IsZero() && !aclActor.IsSystem() {
 		visibleSrc, err := filter.FilterReadable(ctx, tenantID, aclActor, []string{req.GetNodeId()})
 		if err != nil {
+			// Genuine ACL-store fault (#573) — not "not visible". Surface it.
 			resultStatus = "error"
-			return &pb.GetConnectedNodesResponse{Nodes: []*pb.Node{}, HasMore: false}, nil
+			if c := errs.Code(err); c != codes.Unknown {
+				return nil, errs.Errorf(c, "GetConnectedNodes: %v", err)
+			}
+			return nil, errs.Internal(ctx, "GetConnectedNodes: acl", err)
 		}
 		if len(visibleSrc) == 0 {
 			// Source not accessible. Return empty — do NOT leak existence.
+			// This is an intentional empty result, not a fault.
 			return &pb.GetConnectedNodesResponse{Nodes: []*pb.Node{}, HasMore: false}, nil
 		}
 	}
@@ -133,20 +141,23 @@ func (s *Server) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNode
 	edgeTypeID := req.GetEdgeTypeId()
 	collected, err := s.bfsConnected(ctx, tenantID, req.GetNodeId(), edgeTypeID, aclActor, filter, limit, offset)
 	if err != nil {
-		// Collapse internal errors to nodes=[]; the metric is recorded
-		// as "error" so the swallow doesn't inflate the success counter.
+		// Surface genuine post-open faults (#573) instead of masking the
+		// traversal failure as an empty graph. Preserve typed sentinels.
 		resultStatus = "error"
-		return &pb.GetConnectedNodesResponse{Nodes: []*pb.Node{}, HasMore: false}, nil
+		if c := errs.Code(err); c != codes.Unknown {
+			return nil, errs.Errorf(c, "GetConnectedNodes: %v", err)
+		}
+		return nil, errs.Internal(ctx, "GetConnectedNodes: traverse", err)
 	}
 
 	out := make([]*pb.Node, 0, len(collected))
 	for _, n := range collected {
 		pn, perr := s.storeNodeToProto("", n)
 		if perr != nil {
-			// A single bad row collapses the whole response to empty.
-			// Recording as error so the metric reflects the swallow.
+			// A row that will not marshal is corrupt stored state, not an
+			// absent result — surface it rather than dropping rows.
 			resultStatus = "error"
-			return &pb.GetConnectedNodesResponse{Nodes: []*pb.Node{}, HasMore: false}, nil
+			return nil, errs.Internal(ctx, "GetConnectedNodes: marshal row", perr)
 		}
 		out = append(out, pn)
 	}

--- a/server/go/internal/api/get_edges_from.go
+++ b/server/go/internal/api/get_edges_from.go
@@ -29,15 +29,19 @@
 //     in SQL: ordering is not contractually pinned.
 //   - Side effects: none. No WAL append, no SQLite write, no metric
 //     other than the standard request counter.
-//   - Error contract: any failure below the tenant gate is swallowed
-//     into an empty GetEdgesResponse with codes.OK. The metric outcome
-//     is "error" so swallowed faults don't inflate the ok counter.
+//   - Error contract (#573): the tenant is lazy-opened first, so a
+//     genuine post-open store fault (IO error, corruption, scan failure)
+//     is surfaced as a sanitized codes.Internal rather than masked as an
+//     empty GetEdgesResponse with codes.OK — empty+OK is reserved for a
+//     genuinely empty edge set. The metric outcome is "error" on faults.
 
 package api
 
 import (
 	"context"
 	"time"
+
+	"google.golang.org/grpc/codes"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
@@ -104,9 +108,15 @@ func (s *Server) GetEdgesFrom(ctx context.Context, req *pb.GetEdgesRequest) (*pb
 	// slice + compute has_more here.
 	edges, err := s.store.GetEdgesFrom(ctx, tenantID, req.GetNodeId(), edgeTypeFilter, 0)
 	if err != nil {
-		// Swallow store errors — return empty response with codes.OK.
+		// Surface genuine post-open faults (#573): the tenant is already
+		// lazy-opened above, so this is a real IO/corruption error — not
+		// "no edges". Masking it as edges=[]+OK is silent data loss.
+		// Preserve typed sentinels; sanitize naked store errors.
 		outcome = "error"
-		return &pb.GetEdgesResponse{Edges: []*pb.Edge{}}, nil
+		if c := errs.Code(err); c != codes.Unknown {
+			return nil, errs.Errorf(c, "GetEdgesFrom: %v", err)
+		}
+		return nil, errs.Internal(ctx, "GetEdgesFrom: store", err)
 	}
 
 	limit := int(req.GetLimit())

--- a/server/go/internal/api/get_edges_to.go
+++ b/server/go/internal/api/get_edges_to.go
@@ -25,15 +25,17 @@
 //     limit+1 rows (we ask SQLite for limit+1 to bound memory at the
 //     storage layer while still emitting the same wire shape).
 //   - offset is currently UNUSED (flagged in the spec "Open questions").
-//   - Internal storage errors are SWALLOWED into an empty
-//     GetEdgesResponse with codes.OK. Metric label is "error" so the
-//     swallow does not inflate the ok counter.
+//   - Genuine post-open storage faults are surfaced as a sanitized
+//     codes.Internal (#573); empty+OK is reserved for a genuinely empty
+//     incoming-edge set. Metric label is "error" on faults.
 
 package api
 
 import (
 	"context"
 	"time"
+
+	"google.golang.org/grpc/codes"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
@@ -110,11 +112,14 @@ func (s *Server) GetEdgesTo(
 	// full result set in memory for high-fan-in targets.
 	rows, err := s.store.GetEdgesTo(ctx, tenantID, req.GetNodeId(), edgeType, limit+1)
 	if err != nil {
-		// Swallow ALL internal errors into edges=[] with grpc.OK.
-		// Operators can still tell the "no edges" case apart from
-		// "store fault" via the metric label, which is "error" here.
+		// Surface genuine post-open faults (#573): the tenant is already
+		// lazy-opened above, so this is a real IO/corruption error — not
+		// "no edges". Preserve typed sentinels; sanitize naked store errors.
 		outcome = "error"
-		return &pb.GetEdgesResponse{}, nil
+		if c := errs.Code(err); c != codes.Unknown {
+			return nil, errs.Errorf(c, "GetEdgesTo: %v", err)
+		}
+		return nil, errs.Internal(ctx, "GetEdgesTo: store", err)
 	}
 
 	hasMore := len(rows) > limit

--- a/server/go/internal/api/get_nodes.go
+++ b/server/go/internal/api/get_nodes.go
@@ -48,6 +48,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -173,8 +174,20 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 	ids := req.GetNodeIds()
 	results := make([]*store.Node, len(ids))
 	denied := make([]bool, len(ids))
-	hadFatal := false
+	// firstErr captures the first genuine fault across the fan-out (#573):
+	// a GetNode/CanAccess store error or a per-id panic. Such a fault is
+	// distinct from a real miss (node absent → n == nil) and must NOT be
+	// reported as a missing id — that masks data loss. A real miss leaves
+	// firstErr nil and the id flows to missing_ids as before.
+	var firstErr error
 	var fatalMu sync.Mutex
+	recordErr := func(err error) {
+		fatalMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+		}
+		fatalMu.Unlock()
+	}
 
 	sem := make(chan struct{}, getNodesFanout)
 	var wg sync.WaitGroup
@@ -187,19 +200,30 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 				<-sem
 				wg.Done()
 				if r := recover(); r != nil {
-					// Per-id panic -- treat as "missing".
-					fatalMu.Lock()
-					hadFatal = true
-					fatalMu.Unlock()
+					recordErr(fmt.Errorf("panic resolving id %q: %v", id, r))
 				}
 			}()
 			n, gerr := s.store.GetNode(ctx, tenantID, id)
-			if gerr != nil || n == nil {
-				return // miss -> nil entry -> missing_ids
+			if gerr != nil {
+				// NotFound is a genuine miss (the store signals an absent
+				// node via ErrNodeNotFound) → missing_ids. Any other error
+				// is a real fault (#573) → surface it.
+				if errs.Code(gerr) == codes.NotFound {
+					return
+				}
+				recordErr(gerr)
+				return
+			}
+			if n == nil {
+				return // genuine miss -> missing_ids
 			}
 			if actorIDs != nil {
 				ok, aerr := s.store.CanAccess(ctx, tenantID, id, actorIDs)
-				if aerr != nil || !ok {
+				if aerr != nil {
+					recordErr(aerr)
+					return
+				}
+				if !ok {
 					denied[i] = true
 					return
 				}
@@ -209,15 +233,15 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 	}
 	wg.Wait()
 
-	if hadFatal {
-		// At least one panic during the fan-out. When partial state
-		// cannot be trusted, return "all missing" and flag the metric
-		// as error.
+	if firstErr != nil {
+		// A genuine fault occurred in at least one fan-out worker; partial
+		// state cannot be trusted. Surface it (#573) rather than masking it
+		// as all-missing + OK. Preserve typed sentinels; sanitize the rest.
 		resultStatus = "error"
-		return &pb.GetNodesResponse{
-			Nodes:      []*pb.Node{},
-			MissingIds: append([]string{}, ids...),
-		}, nil
+		if c := errs.Code(firstErr); c != codes.Unknown {
+			return nil, errs.Errorf(c, "GetNodes: %v", firstErr)
+		}
+		return nil, errs.Internal(ctx, "GetNodes: store", firstErr)
 	}
 
 	nodes := make([]*pb.Node, 0, len(ids))
@@ -229,10 +253,10 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 		}
 		pn, perr := s.storeNodeToProto("", results[i])
 		if perr != nil {
-			// Conversion failure on a single row -- fold into
-			// missing_ids rather than failing the whole batch.
-			missing = append(missing, id)
-			continue
+			// A row that will not marshal is corrupt stored state, not an
+			// absent node — surface it rather than folding into missing_ids.
+			resultStatus = "error"
+			return nil, errs.Internal(ctx, "GetNodes: marshal row", perr)
 		}
 		nodes = append(nodes, pn)
 	}

--- a/server/go/internal/api/read_fault_test.go
+++ b/server/go/internal/api/read_fault_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Regression tests for #573: read RPCs must surface a genuine post-open
+// store fault as a non-OK status, not mask it as empty+OK (which makes a
+// broken store indistinguishable from "no results" — silent data loss).
+//
+// A fault is injected by dropping the underlying table through a second
+// raw connection to the tenant's SQLite file (the store keeps its own
+// pool open, so its next query fails with "no such table"). This hits the
+// post-open read path specifically — the tenant is already lazy-opened,
+// so this is NOT the not-open case (which is correctly lazy-opened).
+
+package api_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// dropTenantTable drops a table from a tenant DB via a second connection,
+// faulting the store's subsequent reads. The "sqlite" driver (modernc) is
+// registered transitively through the store package import.
+func dropTenantTable(t *testing.T, cs *store.CanonicalStore, tenantID, table string) {
+	t.Helper()
+	path, err := cs.TenantDBPath(tenantID)
+	if err != nil {
+		t.Fatalf("TenantDBPath: %v", err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec("DROP TABLE " + table); err != nil {
+		t.Fatalf("drop table %s: %v", table, err)
+	}
+}
+
+func TestGetNodes_StoreFaultSurfacesInternal(t *testing.T) {
+	t.Parallel()
+	const tenantID = "acme"
+	gs := newGlobalStore(t)
+	if _, err := gs.CreateTenant(context.Background(), tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	if err := gs.AddTenantMember(context.Background(), tenantID, "alice", "owner"); err != nil {
+		t.Fatalf("AddTenantMember: %v", err)
+	}
+	cs := newStoreWithTenant(t, tenantID)
+	seedNodeForGetNodes(t, cs, tenantID, "n1", "user:alice")
+	srv := api.New(api.WithGlobalStore(gs), api.WithStore(cs))
+	dropTenantTable(t, cs, tenantID, "nodes")
+
+	_, err := srv.GetNodes(context.Background(), &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		NodeIds: []string{"n1"},
+	})
+	// The pre-fix behavior returned all-missing + codes.OK, masking the
+	// fault as if the node simply didn't exist. Post-fix: a non-OK status.
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetNodes on broken store: code = %s, want Internal (%v)", status.Code(err), err)
+	}
+}
+
+func TestQueryNodes_StoreFaultSurfacesInternal(t *testing.T) {
+	t.Parallel()
+	f := newQueryNodesFixture(t)
+	f.seedNode("n1", "user:alice", "a@x", 1)
+	dropTenantTable(t, f.cs, f.tenantID, "nodes")
+
+	_, err := f.srv.QueryNodes(context.Background(), &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: f.tenantID, Actor: "user:alice"},
+		TypeId:  1,
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("QueryNodes on broken store: code = %s, want Internal (%v)", status.Code(err), err)
+	}
+}
+
+func TestGetEdgesFrom_StoreFaultSurfacesInternal(t *testing.T) {
+	t.Parallel()
+	srv, cs := newEdgesServer(t, "tenant-fault-from")
+	ctx := context.Background()
+	if _, err := cs.CreateEdge(ctx, "tenant-fault-from", store.EdgeInput{
+		EdgeTypeID: 7, FromNodeID: "src", ToNodeID: "dst",
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+	dropTenantTable(t, cs, "tenant-fault-from", "edges")
+
+	_, err := srv.GetEdgesFrom(ctx, edgesFromReq("tenant-fault-from", "src"))
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetEdgesFrom on broken store: code = %s, want Internal (%v)", status.Code(err), err)
+	}
+}
+
+func TestGetEdgesTo_StoreFaultSurfacesInternal(t *testing.T) {
+	t.Parallel()
+	srv, cs := newEdgesServer(t, "tenant-fault-to")
+	ctx := context.Background()
+	if _, err := cs.CreateEdge(ctx, "tenant-fault-to", store.EdgeInput{
+		EdgeTypeID: 7, FromNodeID: "src", ToNodeID: "dst",
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+	dropTenantTable(t, cs, "tenant-fault-to", "edges")
+
+	_, err := srv.GetEdgesTo(ctx, edgesFromReq("tenant-fault-to", "dst"))
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetEdgesTo on broken store: code = %s, want Internal (%v)", status.Code(err), err)
+	}
+}
+
+func TestGetConnectedNodes_StoreFaultSurfacesInternal(t *testing.T) {
+	t.Parallel()
+	srv, cs, ctx := connectedTestServer(t)
+	// Seed the source as a real node owned by alice so the source-visibility
+	// gate passes (owner match), letting the BFS run and hit the dropped
+	// edges table — the fault path under test.
+	if _, err := cs.CreateNodeRaw(ctx, "acme", store.NodeInput{
+		NodeID: "src", TypeID: 1, OwnerActor: "user:alice",
+		Payload: map[string]any{"1": "src"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+	mustCreateEdge(t, cs, "acme", 7, "src", "child")
+	dropTenantTable(t, cs, "acme", "edges")
+
+	_, err := srv.GetConnectedNodes(ctx, &pb.GetConnectedNodesRequest{
+		Context:    &pb.RequestContext{TenantId: "acme", Actor: "user:alice"},
+		NodeId:     "src",
+		EdgeTypeId: 7,
+		Limit:      50,
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetConnectedNodes on broken store: code = %s, want Internal (%v)", status.Code(err), err)
+	}
+}
+
+func TestSearchNodes_StoreFaultSurfacesInternal(t *testing.T) {
+	t.Parallel()
+	srv, cs, tenantID := newSearchTestServer(t)
+	seedIndexedNode(t, cs, tenantID, "n1", "user:alice",
+		map[string]any{"1": "hello", "2": "world"}, nil)
+	// Drop the base nodes table the FTS JOIN reads from → genuine scan
+	// fault (distinct from the malformed-query InvalidArgument path).
+	dropTenantTable(t, cs, tenantID, "nodes")
+
+	_, err := srv.SearchNodes(context.Background(), &pb.SearchNodesRequest{
+		TenantId: tenantID,
+		Actor:    "user:alice",
+		TypeId:   searchTypeID,
+		Query:    "hello",
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("SearchNodes on broken store: code = %s, want Internal (%v)", status.Code(err), err)
+	}
+}

--- a/server/go/internal/api/search_nodes.go
+++ b/server/go/internal/api/search_nodes.go
@@ -136,10 +136,19 @@ func (s *Server) SearchNodes(
 
 	rows, ferr := s.store.SearchNodes(ctx, tenantID, typeID, q, searchableFIDs, limit, offset)
 	if ferr != nil {
-		// Swallow + empty + log "error" outcome. Operators see the
-		// elevated metric label; clients see codes.OK.
 		outcome = "error"
-		return &pb.SearchNodesResponse{Nodes: []*pb.Node{}}, nil
+		// A malformed FTS5 MATCH query is a CLIENT error: surface it as
+		// InvalidArgument so the caller learns the query was bad, rather
+		// than the old empty+OK that masqueraded as "no matches" (#573).
+		if isFTSQueryError(ferr) {
+			return nil, errs.Errorf(codes.InvalidArgument, "SearchNodes: malformed query: %v", ferr)
+		}
+		// Otherwise this is a genuine post-open fault (IO, corruption,
+		// scan) — surface it. Preserve typed sentinels; sanitize the rest.
+		if c := errs.Code(ferr); c != codes.Unknown {
+			return nil, errs.Errorf(c, "SearchNodes: %v", ferr)
+		}
+		return nil, errs.Internal(ctx, "SearchNodes: store", ferr)
 	}
 
 	// 5. ACL post-filter — only when the actor is classified
@@ -155,10 +164,11 @@ func (s *Server) SearchNodes(
 	for _, n := range rows {
 		pn, perr := nodeRowToProto(n)
 		if perr != nil {
-			// Per-row marshal failure is the same swallow path as the
-			// outer FTS error: log via metric, return empty for the row.
+			// A row that will not marshal is a corrupt stored payload, not
+			// an absent result — surfacing it (#573) beats silently dropping
+			// the row from the result set.
 			outcome = "error"
-			continue
+			return nil, errs.Internal(ctx, "SearchNodes: marshal row", perr)
 		}
 		out = append(out, pn)
 	}
@@ -296,4 +306,31 @@ func nodeRowToProto(n *store.Node) (*pb.Node, error) {
 	}
 
 	return out, nil
+}
+
+// isFTSQueryError reports whether a store.SearchNodes error came from an
+// invalid FTS5 MATCH expression (a client-query problem) rather than a
+// genuine storage fault. FTS5 reports query-syntax problems with stable
+// message signatures; a real IO/corruption error does not match these,
+// so it falls through to the Internal path (#573). String inspection is
+// the only seam — modernc/SQLite does not return a distinct error code
+// for FTS5 syntax errors.
+func isFTSQueryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, sig := range []string{
+		"fts5: syntax error",
+		"fts5: ",
+		"unterminated string",
+		"malformed match",
+		"unknown special query",
+		"no such column", // column-filtered MATCH against an unknown column
+	} {
+		if strings.Contains(msg, sig) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/go/internal/api/search_nodes_test.go
+++ b/server/go/internal/api/search_nodes_test.go
@@ -323,32 +323,25 @@ func TestSearchNodes_QueryTooLong(t *testing.T) {
 	}
 }
 
-// TestSearchNodes_MalformedFTSQueryReturnsEmpty: any error after the
-// validation gates is swallowed and the handler returns codes.OK with
-// an empty node list. Flipping to INTERNAL is a future contract-test
-// update.
-func TestSearchNodes_MalformedFTSQueryReturnsEmpty(t *testing.T) {
+// TestSearchNodes_MalformedFTSQueryRejected: a malformed FTS5 MATCH
+// query is a client error and is surfaced as INVALID_ARGUMENT, not
+// masked as empty+OK (#573). This lets the caller learn the query was
+// bad instead of mistaking it for "no matches".
+func TestSearchNodes_MalformedFTSQueryRejected(t *testing.T) {
 	t.Parallel()
 	srv, cs, tenantID := newSearchTestServer(t)
 	seedIndexedNode(t, cs, tenantID, "n1", "user:alice",
 		map[string]any{"1": "hello", "2": "world"}, nil)
 
-	// FTS5 rejects an unbalanced quote. The store layer surfaces an
-	// error; the handler must swallow it.
-	resp, err := srv.SearchNodes(context.Background(), &pb.SearchNodesRequest{
+	// FTS5 rejects an unbalanced quote with a syntax error.
+	_, err := srv.SearchNodes(context.Background(), &pb.SearchNodesRequest{
 		TenantId: tenantID,
 		Actor:    "user:alice",
 		TypeId:   searchTypeID,
 		Query:    `"unbalanced`,
 	})
-	if err != nil {
-		t.Fatalf("SearchNodes: expected swallow-to-OK, got err: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("SearchNodes: nil response")
-	}
-	if got := len(resp.GetNodes()); got != 0 {
-		t.Fatalf("SearchNodes: expected 0 nodes on malformed query, got %d", got)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("SearchNodes malformed query: code = %s, want InvalidArgument (%v)", status.Code(err), err)
 	}
 }
 


### PR DESCRIPTION
## What

Proactive-sweep bug (#573, severity:med — silent data-loss surface). Several read RPCs swallowed a **genuine** post-open store fault (SQLite IO error, on-disk corruption, scan failure, per-id panic) into an empty response with `codes.OK`. A caller could not distinguish "no results" from "the store is broken", so downstream silently dropped data and no alert fired. The tenant is already lazy-opened before these reads (v1.19.0), so a post-open error is always a real fault — never the not-open case.

## How

Genuine faults now surface as a sanitized `codes.Internal` (`errs.Internal` — no path/schema leak, SEC-5), preserving typed sentinels. `empty+OK` is reserved for a genuinely empty result set.

- **GetEdgesFrom / GetEdgesTo** — store error → Internal.
- **GetConnectedNodes** — source-gate ACL fault, BFS traversal fault, and per-row marshal failure → Internal. The intentional *"source not accessible → empty (no existence leak)"* path is preserved.
- **SearchNodes** — a genuine FTS/scan fault → Internal; a **malformed FTS5 MATCH query is a client error** and now returns `InvalidArgument` (was masked as empty+OK, indistinguishable from "no matches").
- **GetNodes** — a per-id `GetNode`/`CanAccess` error or a fan-out panic is no longer reported as a *missing id* (which masked data loss) — it surfaces as Internal. A real miss (`ErrNodeNotFound`) still flows to `missing_ids`, and an explicit ACL denial still flows to `missing_ids`, unchanged.

## Tests

`read_fault_test.go` injects a real fault by dropping the underlying table through a second raw connection to the tenant SQLite file (the store's own pool then faults on its next read), asserting `codes.Internal` for QueryNodes, GetNodes, GetEdgesFrom/To, GetConnectedNodes, and SearchNodes. The SearchNodes malformed-query test now asserts `InvalidArgument`.

Full local CI green: Go server (vet+test), 539 Python integration+unit, ruff, and the Docker-stack E2E suite. Server-only change — no proto/SDK/docs.

Closes #573.