### PR TITLE
feat(#574): explicit-fields update — set a field to its zero value via the typed API

### DIFF
--- a/docs/generated/sdk-go.md
+++ b/docs/generated/sdk-go.md
@@ -938,6 +938,22 @@ func (p *Plan) Update(nodeID string, msg proto.Message)
     is read from the message's “(entdb.node)“ option — callers do not pass it
     separately.
 
+func (p *Plan) UpdateFields(nodeID string, msg proto.Message, fields ...string)
+    UpdateFields accumulates an update-node operation for an EXPLICIT set of
+    fields, including fields whose value is the proto3 zero value (false / 0
+    / ""). Use it when you need to set a field BACK to its zero value — the
+    default Plan.Update sends only non-default fields (proto3 cannot tell "set
+    to zero" from "unset" for scalars), so a true→false / non-empty→"" / n→0
+    update is otherwise silently dropped (#574).
+
+        // clear the verified flag (Update would drop the false)
+        plan.UpdateFields("node-1", &auth.TotpCredential{}, "verified")
+
+    field names are proto field names (the SDK resolves them to field ids).
+    Naming a field reads its current value off msg — set the ones you want to
+    change on msg first, then list them here. At least one field is required;
+    an unknown field name panics at call time.
+
 func (p *Plan) UpdateIf(nodeID string, msg proto.Message, field string, equals any)
     UpdateIf accumulates a conditional update-node operation with a single-field
     equality precondition (CAS). The applier compares the node's current

--- a/docs/generated/sdk-python.md
+++ b/docs/generated/sdk-python.md
@@ -113,4 +113,4 @@ Extracted from `sdk/python/entdb_sdk` — `__all__` plus the public methods of `
 | `delete_where(node_type, where, *, limit=...)` | Delete every node of a type matching a predicate, in one op. |
 | `edge_create(edge_type, from_id, to_id, *, props=...)` | Create an edge. |
 | `edge_delete(edge_type, from_id, to_id)` | Delete an edge. |
-| `update(node_id, msg, *, precondition=...)` | Update a node from a proto message. |
+| `update(node_id, msg, *, fields=..., precondition=...)` | Update a node from a proto message. |

--- a/sdk/go/entdb/marshal.go
+++ b/sdk/go/entdb/marshal.go
@@ -231,6 +231,47 @@ func marshalSetFieldsForWire(msg proto.Message) (int32, map[string]any, error) {
 	return marshalForWire(msg)
 }
 
+// marshalExplicitFieldsForWire builds an update patch from an explicit
+// list of proto field names, INCLUDING any whose value is the proto3
+// zero value (false / 0 / ""). This is the escape hatch for #574: the
+// default Update only sends *set* (non-default) fields because proto3
+// cannot distinguish "set to zero" from "unset" for scalars, so a field
+// can never be updated TO its zero value through it. Naming the field
+// here reads it via reflection's Get (which returns the zero) and forces
+// it into the patch, so the server applies the zero.
+func marshalExplicitFieldsForWire(msg proto.Message, fields []string) (int32, map[string]any, error) {
+	if msg == nil {
+		return 0, nil, fmt.Errorf("entdb: nil message")
+	}
+	typeID, err := typeIDFromMessage(msg)
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(fields) == 0 {
+		return 0, nil, fmt.Errorf("entdb: no fields specified (use Update for set-fields-only)")
+	}
+	m := msg.ProtoReflect()
+	desc := m.Descriptor()
+	fds := desc.Fields()
+	patch := make(map[string]any, len(fields))
+	for _, name := range fields {
+		name = strings.TrimSpace(name)
+		fd := fds.ByName(protoreflect.Name(name))
+		if fd == nil {
+			fd = fds.ByJSONName(name)
+		}
+		if fd == nil {
+			return 0, nil, fmt.Errorf("entdb: message %q has no field %q", desc.FullName(), name)
+		}
+		converted, cerr := protoValueToGo(fd, m.Get(fd))
+		if cerr != nil {
+			return 0, nil, cerr
+		}
+		patch[strconv.Itoa(int(fd.Number()))] = converted
+	}
+	return typeID, patch, nil
+}
+
 // fieldIDFromMessage resolves a developer-facing proto field name to
 // its stable field number. ADR-006 makes the proto field number the
 // EntDB field_id, so CAS preconditions can stay name-based in SDK code

--- a/sdk/go/entdb/plan.go
+++ b/sdk/go/entdb/plan.go
@@ -125,6 +125,34 @@ func (p *Plan) Update(nodeID string, msg proto.Message) {
 	})
 }
 
+// UpdateFields accumulates an update-node operation for an EXPLICIT set
+// of fields, including fields whose value is the proto3 zero value
+// (false / 0 / ""). Use it when you need to set a field BACK to its zero
+// value — the default [Plan.Update] sends only non-default fields (proto3
+// cannot tell "set to zero" from "unset" for scalars), so a true→false /
+// non-empty→"" / n→0 update is otherwise silently dropped (#574).
+//
+//	// clear the verified flag (Update would drop the false)
+//	plan.UpdateFields("node-1", &auth.TotpCredential{}, "verified")
+//
+// field names are proto field names (the SDK resolves them to field ids).
+// Naming a field reads its current value off msg — set the ones you want
+// to change on msg first, then list them here. At least one field is
+// required; an unknown field name panics at call time.
+func (p *Plan) UpdateFields(nodeID string, msg proto.Message, fields ...string) {
+	p.ensureNotCommitted()
+	typeID, patch, err := marshalExplicitFieldsForWire(msg, fields)
+	if err != nil {
+		panic(fmt.Errorf("entdb: Plan.UpdateFields: %w", err))
+	}
+	p.operations = append(p.operations, Operation{
+		Type:   OpUpdateNode,
+		TypeID: int(typeID),
+		NodeID: nodeID,
+		Patch:  patch,
+	})
+}
+
 // UpdateIf accumulates a conditional update-node operation with a
 // single-field equality precondition (CAS). The applier compares the
 // node's current “field“ against “equals“ before applying the

--- a/sdk/go/entdb/plan_updatefields_test.go
+++ b/sdk/go/entdb/plan_updatefields_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+package entdb
+
+import (
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/sdk/go/entdb/internal/testpb"
+)
+
+// TestPlan_UpdateFields_IncludesZeroValue pins the #574 fix: UpdateFields
+// forces named fields into the patch even at their proto3 zero value, so a
+// field can be updated TO 0 / "" / false — which plain Update cannot
+// express (it sends only set, non-default fields).
+func TestPlan_UpdateFields_IncludesZeroValue(t *testing.T) {
+	client := newClientWithTransport("localhost:50051", &mockTransport{})
+	plan := client.Tenant("acme").Actor(UserActor("alice")).Plan()
+
+	p := testpb.NewProductMsg()
+	p.SetFields("", "", 0) // price_cents (field 3) at its zero value
+
+	plan.UpdateFields("node-1", p, "price_cents")
+	if len(plan.operations) != 1 {
+		t.Fatalf("ops = %d, want 1", len(plan.operations))
+	}
+	op := plan.operations[0]
+	if op.Type != OpUpdateNode || op.NodeID != "node-1" {
+		t.Fatalf("op = %+v", op)
+	}
+	v, ok := op.Patch["3"]
+	if !ok {
+		t.Fatal("UpdateFields must include the named zero-valued field (price_cents=3)")
+	}
+	if v != int64(0) {
+		t.Errorf("patch[3] = %v (%T), want int64(0)", v, v)
+	}
+
+	// Contrast: plain Update omits the zero field entirely (proto3 default).
+	plan2 := client.Tenant("acme").Actor(UserActor("alice")).Plan()
+	plan2.Update("node-1", p)
+	if _, ok := plan2.operations[0].Patch["3"]; ok {
+		t.Error("plain Update should omit the zero-valued price_cents")
+	}
+}
+
+func TestPlan_UpdateFields_UnknownFieldPanics(t *testing.T) {
+	client := newClientWithTransport("localhost:50051", &mockTransport{})
+	plan := client.Tenant("acme").Actor(UserActor("alice")).Plan()
+	p := testpb.NewProductMsg()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for unknown field name")
+		}
+	}()
+	plan.UpdateFields("node-1", p, "no_such_field")
+}
+
+func TestPlan_UpdateFields_NoFieldsPanics(t *testing.T) {
+	client := newClientWithTransport("localhost:50051", &mockTransport{})
+	plan := client.Tenant("acme").Actor(UserActor("alice")).Plan()
+	p := testpb.NewProductMsg()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when no fields are named")
+		}
+	}()
+	plan.UpdateFields("node-1", p)
+}

--- a/sdk/python/entdb_sdk/client.py
+++ b/sdk/python/entdb_sdk/client.py
@@ -149,6 +149,56 @@ def _proto_payload_from_set_fields(msg: Any) -> dict[str, Any]:
     return out
 
 
+def _proto_payload_from_named_fields(msg: Any, fields: list[str]) -> dict[str, Any]:
+    """Return a name-keyed payload for an EXPLICIT list of field names,
+    INCLUDING any at their proto3 zero value (#574).
+
+    Unlike :func:`_proto_payload_from_set_fields` (which uses
+    ``ListFields()`` and so only yields explicitly-set, non-default
+    fields), this reads each named field off the message directly — so a
+    field can be updated TO ``0`` / ``""`` / ``False``, which the
+    set-fields path cannot express because proto3 omits zero-valued
+    scalars on the wire.
+    """
+    from google.protobuf.descriptor import FieldDescriptor
+    from google.protobuf.json_format import MessageToDict
+
+    if not fields:
+        raise ValueError("update(fields=...) requires at least one field name")
+
+    by_name = {fd.name: fd for fd in msg.DESCRIPTOR.fields}
+    by_json = {fd.json_name: fd for fd in msg.DESCRIPTOR.fields}
+    out: dict[str, Any] = {}
+    for name in fields:
+        fd = by_name.get(name) or by_json.get(name)
+        if fd is None:
+            known = {f.name for f in msg.DESCRIPTOR.fields}
+            suggestions = [n for n in known if name.lower() in n.lower()][:3]
+            raise UnknownFieldError(name, msg.DESCRIPTOR.name, suggestions)
+
+        is_message = fd.type == FieldDescriptor.TYPE_MESSAGE
+        is_repeated = fd.label == FieldDescriptor.LABEL_REPEATED
+        if is_message or is_repeated:
+            # Defer composite shapes to MessageToDict, same as the
+            # set-fields path; explicit-zero is a scalar concern.
+            sub = MessageToDict(msg, preserving_proto_field_name=True)
+            out[fd.name] = sub.get(fd.name)
+            continue
+
+        value = getattr(msg, fd.name)
+        if fd.type == FieldDescriptor.TYPE_BYTES:
+            import base64
+
+            out[fd.name] = (
+                base64.b64encode(value).decode("ascii")
+                if isinstance(value, (bytes, bytearray))
+                else value
+            )
+        else:
+            out[fd.name] = value
+    return out
+
+
 def _names_to_ids(name_to_id: dict[str, int], payload: dict[str, Any]) -> dict[str, Any]:
     """Re-key a name-keyed payload to id-keyed for the wire.
 
@@ -446,6 +496,7 @@ class Plan:
         node_id: str,
         msg: Any,
         *,
+        fields: list[str] | None = None,
         precondition: tuple[str, Any] | None = None,
     ) -> Plan:
         """Update a node from a proto message.
@@ -461,10 +512,25 @@ class Plan:
         sends ``{"price_cents": 1499}`` as the patch and leaves every
         other field untouched.
 
+        To set a field BACK to its zero value (``0`` / ``""`` /
+        ``False``), name it in ``fields`` — proto3 omits zero-valued
+        scalars, so the default set-fields path cannot express it and the
+        update is otherwise silently dropped (#574)::
+
+            plan.update(node_id, TotpCredential(), fields=["verified"])
+
+        sends ``{"verified": False}`` explicitly. When ``fields`` is
+        given the patch is EXACTLY those fields (read off ``msg``,
+        including zeros); set the values you want on ``msg`` first.
+
         Args:
             node_id: Id of the node to update.
             msg: A proto message instance whose descriptor carries an
                 ``(entdb.node)`` option.
+            fields: Optional explicit list of proto field names to update,
+                including ones at their zero value. Mutually exclusive in
+                spirit with the default set-fields behavior — when given,
+                only these fields form the patch.
             precondition: Optional ``(field, expected_value)`` tuple
                 for CAS semantics (GitHub issue #500). When set, the
                 applier compares the node's current ``field`` against
@@ -488,7 +554,10 @@ class Plan:
 
         type_id = _node_type_id_from_descriptor(msg.DESCRIPTOR)
         name_to_id = _name_to_id_from_proto(msg.DESCRIPTOR)
-        patch = _proto_payload_from_set_fields(msg)
+        if fields is not None:
+            patch = _proto_payload_from_named_fields(msg, fields)
+        else:
+            patch = _proto_payload_from_set_fields(msg)
         patch = _names_to_ids(name_to_id, patch)
 
         update_op: dict[str, Any] = {

--- a/tests/python/integration/test_sdk_client.py
+++ b/tests/python/integration/test_sdk_client.py
@@ -99,6 +99,36 @@ class TestPlanBuilder:
         # Product.name is field_id 2.
         assert op["update_node"]["patch"] == {"2": "Updated Name"}
 
+    def test_plan_update_fields_includes_zero_value(self):
+        """update(fields=...) forces a named field into the patch even at
+        its proto3 zero value, so a field can be set BACK to 0/""/False
+        (#574). price_cents is field_id 3."""
+        client = _mock_client()
+        plan = Plan(client, tenant_id="t1", actor="user:alice")
+
+        plan.update("node_123", ts.Product(), fields=["price_cents"])
+
+        op = plan._operations[0]["update_node"]
+        assert op["patch"] == {"3": 0}
+
+    def test_plan_update_omits_zero_without_fields(self):
+        """The default set-fields path drops a zero-valued scalar (proto3
+        omits it) — this is the bug update(fields=...) works around."""
+        client = _mock_client()
+        plan = Plan(client, tenant_id="t1", actor="user:alice")
+
+        plan.update("node_123", ts.Product(price_cents=0))
+
+        assert "3" not in plan._operations[0]["update_node"]["patch"]
+
+    def test_plan_update_fields_unknown_field_raises(self):
+        from entdb_sdk.errors import UnknownFieldError
+
+        client = _mock_client()
+        plan = Plan(client, tenant_id="t1", actor="user:alice")
+        with pytest.raises(UnknownFieldError):
+            plan.update("node_123", ts.Product(), fields=["no_such_field"])
+
     def test_plan_delete_node(self):
         """Plan can delete nodes — type witness is the proto class."""
         client = _mock_client()


### PR DESCRIPTION
## What

The typed update path sends only the **set** (non-default) fields of the message, because proto3 omits zero-valued scalars on the wire. So a field could never be updated **to** its zero value (`false` / `0` / `""`) through the typed API — the patch omitted it and the change was silently dropped. Confirmed downstream (elloloop/identity#140): a `TotpCredential.verified` true→false update was a no-op.

## How

Both SDKs gain an explicit-fields update that names which fields to include, read off the message via reflection so zeros are included:

- **Go:** `Plan.UpdateFields(nodeID, msg, fields...)` — builds the patch from the named fields via protoreflect `Get` (returns the zero), not `Range`.
- **Python:** `plan.update(node_id, msg, fields=[...])` — builds the patch from the named fields directly, not `ListFields()`.

**No server change:** the applier's update merge applies every patch entry verbatim (`merged[k] = v`), zeros included, and the typed wire value (ADR-028) carries `0`/`""`/`false` losslessly. The fix is purely the SDK no longer dropping the field before it reaches the wire. Both SDKs ship together.

## Tests

- **Go:** `UpdateFields` includes a zero-valued field in the patch while plain `Update` omits it; unknown-field and no-fields panic.
- **Python:** `update(fields=[...])` emits `{"3": 0}`; default `update` omits it; unknown field raises `UnknownFieldError`.
- Full local CI green: Go SDK (vet+test), 542 Python integration+unit, ruff, docs coverage (pinned go 1.25), Docker-stack E2E.

Closes #574.