### PR TITLE
fix(#582): fail-stop on corrupt acl_blob instead of silently dropping all grants

### DIFF
--- a/server/go/internal/apply/acladapter.go
+++ b/server/go/internal/apply/acladapter.go
@@ -114,20 +114,25 @@ func (r *StoreReaders) GrantsForNode(ctx context.Context, tenantID, nodeID strin
 			g.ExpiresAt = &ms
 		}
 		// Decode typed-cap arrays.
+		// Fail closed on a corrupt typed-cap array (#582): silently
+		// dropping caps would mis-evaluate access. Surface the error so
+		// the ACL read fails rather than returning a wrong grant set.
 		if coreJSON != "" {
 			var raw []int32
-			if err := json.Unmarshal([]byte(coreJSON), &raw); err == nil {
-				for _, v := range raw {
-					g.CoreCaps = append(g.CoreCaps, acl.CoreCapability(v))
-				}
+			if err := json.Unmarshal([]byte(coreJSON), &raw); err != nil {
+				return nil, fmt.Errorf("apply: GrantsForNode: decode core_caps for %s/%s: %w", tenantID, nodeID, err)
+			}
+			for _, v := range raw {
+				g.CoreCaps = append(g.CoreCaps, acl.CoreCapability(v))
 			}
 		}
 		if extJSON != "" {
 			var raw []int32
-			if err := json.Unmarshal([]byte(extJSON), &raw); err == nil {
-				for _, v := range raw {
-					g.ExtCapIDs = append(g.ExtCapIDs, acl.ExtCapID(v))
-				}
+			if err := json.Unmarshal([]byte(extJSON), &raw); err != nil {
+				return nil, fmt.Errorf("apply: GrantsForNode: decode ext_caps for %s/%s: %w", tenantID, nodeID, err)
+			}
+			for _, v := range raw {
+				g.ExtCapIDs = append(g.ExtCapIDs, acl.ExtCapID(v))
 			}
 		}
 		out = append(out, g)

--- a/server/go/internal/apply/ops_transfer_ownership.go
+++ b/server/go/internal/apply/ops_transfer_ownership.go
@@ -43,7 +43,15 @@ func (a *Applier) applyTransferOwnership(ctx context.Context, tx *BatchTxn, ev *
 	}
 	var acl []aclEntry
 	if aclJSON != "" {
-		_ = json.Unmarshal([]byte(aclJSON), &acl)
+		// Do NOT swallow this: a corrupt acl_blob means refreshVisibility
+		// would rebuild node_visibility from an EMPTY ACL, silently
+		// revoking every shared grant on the node (#582). Fail-stop
+		// instead — the applier's halt-on-poison surfaces the corruption
+		// rather than masking it as a mass-revoke.
+		if err := json.Unmarshal([]byte(aclJSON), &acl); err != nil {
+			return fmt.Errorf("apply transfer_ownership: decode acl_blob for %s/%s: %w",
+				ev.TenantID, nodeID, err)
+		}
 	}
 	if _, err := conn.ExecContext(ctx,
 		`UPDATE nodes SET owner_actor = ? WHERE tenant_id = ? AND node_id = ?`,

--- a/server/go/internal/apply/transfer_ownership_acl_test.go
+++ b/server/go/internal/apply/transfer_ownership_acl_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// TestApplier_TransferOwnership_CorruptACLHalts pins #582: a corrupt
+// acl_blob must fail-stop the transfer (halt-on-poison), NOT silently
+// rebuild node_visibility from an empty ACL — which would revoke every
+// shared grant on the node. Pre-fix the unmarshal error was swallowed and
+// the transfer applied with an empty ACL.
+func TestApplier_TransferOwnership_CorruptACLHalts(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	ctx := context.Background()
+
+	// Seed a node with a real ACL grant (non-empty acl_blob), bypassing
+	// the WAL — the transfer op below only reads the stored state.
+	if _, err := f.store.CreateNodeRaw(ctx, testTenant, store.NodeInput{
+		NodeID: "xfer", TypeID: 1, OwnerActor: "user:alice",
+		ACL: []store.ACLEntry{{Principal: "user:carol", Permission: "read"}},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+
+	// Corrupt the acl_blob via a second connection to the tenant DB.
+	path, err := f.store.TenantDBPath(testTenant)
+	if err != nil {
+		t.Fatalf("TenantDBPath: %v", err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	if _, err := db.Exec(`UPDATE nodes SET acl_blob = '{not valid json' WHERE node_id = 'xfer'`); err != nil {
+		t.Fatalf("corrupt acl_blob: %v", err)
+	}
+	_ = db.Close()
+
+	// The transfer must halt the applier rather than apply with an empty ACL.
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "xfer",
+		Ops: []map[string]any{{
+			"op": string(apply.OpTransferOwnership), "node_id": "xfer", "new_owner": "user:bob",
+		}},
+	})
+
+	ctx2, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx2) }()
+
+	var runErr error
+	select {
+	case runErr = <-done:
+	case <-time.After(2 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("applier did not halt within 2s (corrupt acl_blob should halt the transfer)")
+	}
+	// Halt-on-poison surfaces the decode error rather than masking it; the
+	// exact wrapping is cosmetic — the load-bearing guarantee is that the
+	// apply STOPS instead of proceeding with an empty ACL.
+	if runErr == nil {
+		t.Fatal("applier returned nil; the corrupt acl_blob should have halted the transfer")
+	}
+
+	// The transfer did NOT apply: owner unchanged ⇒ grants not silently dropped.
+	n, err := f.store.GetNode(ctx, testTenant, "xfer")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if n.OwnerActor != "user:alice" {
+		t.Fatalf("owner changed to %q despite the poison — the empty-ACL mass-revoke path ran", n.OwnerActor)
+	}
+}


### PR DESCRIPTION
## What

Proactive-sweep bug (#582). `TransferOwnership` read the node's existing `acl_blob` and unmarshaled it with the error **discarded**. `refreshVisibility` then `DELETE`s the node's `node_visibility` rows and re-inserts owner + each ACL entry — so a corrupt `acl_blob` rebuilt the index from an **empty** ACL, silently revoking every shared grant on the node (a security-relevant mass-revoke that fired no error).

## How

Propagate the decode error so the applier **halts** (halt-on-poison, default true) on a corrupt blob rather than masking it. The transfer does not apply; the owner stays unchanged; grants are preserved.

Audited the same class in `acladapter.GrantsForNode` — the typed-cap arrays (`core_caps`/`ext_caps`) were also decoded with `err == nil` ignores that silently drop caps and mis-evaluate access. Those now **fail closed** too.

## Tests

Seed a node with an ACL grant, corrupt its `acl_blob` via a second connection to the tenant DB, append a `TransferOwnership` op, and assert the applier halts (non-nil) with the owner **unchanged** — i.e. the empty-ACL mass-revoke path no longer runs.

Full local CI green: Go server (vet+test) + 108 Python integration + Docker-stack E2E. Server-only.

Closes #582.