### PR TITLE
test(sdk-go): real-server integration suite + Go SDK CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,36 @@ jobs:
         working-directory: server/go
         run: go test ./...
 
+  # Go SDK: unit tests (vs the in-process fakeServer) PLUS the integration
+  # suite, which builds + boots the real entdb-server and drives the SDK
+  # against it over real gRPC — the Go mirror of the Python contract suite.
+  # Without this, SDK changes were only ever checked against canned fakes.
+  go-sdk:
+    name: Go SDK
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: |
+            sdk/go/entdb/go.sum
+            server/go/go.sum
+
+      - name: go vet (SDK)
+        working-directory: sdk/go/entdb
+        run: go vet ./...
+
+      - name: go test (SDK unit)
+        working-directory: sdk/go/entdb
+        run: go test ./...
+
+      - name: go test (SDK integration vs real entdb-server)
+        working-directory: sdk/go/entdb
+        run: go test -tags=integration -run TestIntegration .
+
   # Drift guard for the checked-in Go server proto stubs. Regenerates
   # both surfaces (entdb.v1 + console.v1) from the .proto sources and
   # fails if the working tree differs from what's committed. Triggered
@@ -403,7 +433,7 @@ jobs:
     name: All Checks Passed
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint, unit-tests, integration-tests, docs-coverage, schema-compat, go-server-build, go-server-proto-drift, docker-build, e2e-tests, security-scan]
+    needs: [lint, unit-tests, integration-tests, docs-coverage, schema-compat, go-server-build, go-sdk, go-server-proto-drift, docker-build, e2e-tests, security-scan]
     steps:
       - name: Verify required checks
         env:

--- a/sdk/go/entdb/integration_test.go
+++ b/sdk/go/entdb/integration_test.go
@@ -1,0 +1,266 @@
+//go:build integration
+
+// Go SDK integration suite — drives the SDK against a REAL entdb-server.
+//
+// The unit tests run the SDK against an in-process fakeServer with canned
+// responses; they prove the SDK's wire-translation logic but NOT that it
+// talks to the real server correctly. This suite builds and boots the
+// actual server/go/cmd/entdb-server binary on a free port and exercises
+// the Go SDK transport over real gRPC — the mirror of the Python contract
+// suite (tests/python/integration). It proves the SDK↔server wire
+// contract end-to-end: typed int64 round-trip (ADR-028), keyset cursor
+// auto-follow (ADR-029), filters, unique-key lookup, and zero-value
+// patches — exactly the things fakes cannot verify.
+//
+// Run:  go test -tags=integration ./...
+// (Builds the server; requires ../../../server/go in the same checkout.)
+
+package entdb
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	itTenant = "acme"
+	itActor  = "user:e2e-runner"
+	// e2e seed profile (server/go/internal/testseed): User type 8001 with
+	// email=1, name=2, age=3 (int), active=4 (bool); Product type 8002
+	// with a unique sku=1.
+	itUserType    = 8001
+	itProductType = 8002
+)
+
+// itClient is the live SDK client bound to the booted server.
+var itClient *DbClient
+
+func TestMain(m *testing.M) { os.Exit(runIntegration(m)) }
+
+func runIntegration(m *testing.M) int {
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "integration:", err)
+		return 1
+	}
+	// sdk/go/entdb -> repo root is three levels up.
+	repoRoot := filepath.Clean(filepath.Join(wd, "..", "..", ".."))
+	serverDir := filepath.Join(repoRoot, "server", "go")
+	if _, err := os.Stat(serverDir); err != nil {
+		fmt.Fprintf(os.Stderr, "integration: server/go not found at %s: %v\n", serverDir, err)
+		return 1
+	}
+
+	tmp, err := os.MkdirTemp("", "entdb-it-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "integration:", err)
+		return 1
+	}
+	defer os.RemoveAll(tmp)
+
+	bin := filepath.Join(tmp, "entdb-server")
+	build := exec.Command("go", "build", "-o", bin, "./cmd/entdb-server")
+	build.Dir = serverDir
+	build.Stdout, build.Stderr = os.Stderr, os.Stderr
+	if err := build.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "integration: build server: %v\n", err)
+		return 1
+	}
+
+	port, err := freePort()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "integration:", err)
+		return 1
+	}
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	srv := exec.Command(bin,
+		"--addr", addr,
+		"--data-dir", filepath.Join(tmp, "data"),
+		"--wal-backend", "memory",
+		"--seed-profile", "e2e",
+		"--seed-tenant", itTenant,
+	)
+	srv.Stdout, srv.Stderr = os.Stderr, os.Stderr
+	if err := srv.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "integration: start server: %v\n", err)
+		return 1
+	}
+	defer func() {
+		_ = srv.Process.Kill()
+		_, _ = srv.Process.Wait()
+	}()
+
+	client, err := NewClient(addr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "integration:", err)
+		return 1
+	}
+	ctx := context.Background()
+	if err := client.Connect(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "integration: connect: %v\n", err)
+		return 1
+	}
+	defer client.Close()
+
+	deadline := time.Now().Add(15 * time.Second)
+	ready := false
+	for time.Now().Before(deadline) {
+		if _, herr := client.Health(ctx); herr == nil {
+			ready = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !ready {
+		fmt.Fprintln(os.Stderr, "integration: server never became ready")
+		return 1
+	}
+
+	itClient = client
+	return m.Run()
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// TestIntegration_TypedInt64RoundTrip proves an int64 above 2^53 survives
+// the full SDK→server→SDK round trip losslessly (ADR-028 / #563 / #572) —
+// the corruption fakes could never have caught.
+func TestIntegration_TypedInt64RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	const big = int64(9007199254740993) // 2^53 + 1, the first unsafe odd int
+
+	res, err := itClient.transport.ExecuteAtomic(ctx, itTenant, itActor, "it-int64",
+		[]Operation{{
+			Type: OpCreateNode, TypeID: itUserType, NodeID: "u-int64",
+			Data: map[string]any{"1": "int64@x", "2": "Big Age", "3": big},
+		}})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("commit not successful: %+v", res)
+	}
+
+	node, err := itClient.transport.GetNode(ctx, itTenant, itActor, itUserType, "u-int64")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if node == nil {
+		t.Fatal("GetNode returned nil")
+	}
+	got, ok := node.Payload["3"]
+	if !ok {
+		t.Fatalf("payload missing field 3 (age): %v", node.Payload)
+	}
+	if got != big {
+		t.Fatalf("age round-trip = %v (%T), want int64(%d) — int64 corrupted over the real wire", got, got, big)
+	}
+}
+
+// TestIntegration_QueryNodesAutoFollowsRealCursor proves the SDK follows
+// the REAL server's keyset cursor (ADR-029 / #564) — previously only
+// verified against a fake paginating server.
+func TestIntegration_QueryNodesAutoFollowsRealCursor(t *testing.T) {
+	ctx := context.Background()
+	const n = 250 // > the server's 100-row default page
+
+	ops := make([]Operation, n)
+	for i := 0; i < n; i++ {
+		ops[i] = Operation{
+			Type: OpCreateNode, TypeID: itUserType, NodeID: fmt.Sprintf("pag-%03d", i),
+			Data: map[string]any{"1": fmt.Sprintf("pag-%03d@x", i), "2": "Pager"},
+		}
+	}
+	res, err := itClient.transport.ExecuteAtomic(ctx, itTenant, itActor, "it-pager-seed", ops)
+	if err != nil {
+		t.Fatalf("seed ExecuteAtomic: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("seed commit not successful: %+v", res)
+	}
+
+	// limit=0 => return the COMPLETE set via cursor auto-follow.
+	nodes, err := itClient.transport.QueryNodes(ctx, itTenant, itActor, itUserType, nil, 0)
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	got := 0
+	for _, nd := range nodes {
+		if id := nd.NodeID; len(id) >= 4 && id[:4] == "pag-" {
+			got++
+		}
+	}
+	if got != n {
+		t.Fatalf("auto-follow returned %d of %d seeded nodes — silent truncation against the real server", got, n)
+	}
+}
+
+// TestIntegration_GetNodeByKeyRealServer proves the unique-key lookup
+// wire path (#572 typed value) works against the real server.
+func TestIntegration_GetNodeByKeyRealServer(t *testing.T) {
+	ctx := context.Background()
+	res, err := itClient.transport.ExecuteAtomic(ctx, itTenant, itActor, "it-bykey",
+		[]Operation{{
+			Type: OpCreateNode, TypeID: itProductType, NodeID: "p-bykey",
+			Data: map[string]any{"1": "WIDGET-IT"},
+		}})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("commit not successful: %+v", res)
+	}
+
+	node, err := itClient.transport.GetNodeByKey(ctx, itTenant, itActor, itProductType, 1, "WIDGET-IT")
+	if err != nil {
+		t.Fatalf("GetNodeByKey: %v", err)
+	}
+	if node == nil || node.NodeID != "p-bykey" {
+		t.Fatalf("GetNodeByKey result = %+v, want node p-bykey", node)
+	}
+}
+
+// TestIntegration_ZeroValueUpdateRealServer proves a patch carrying an
+// explicit zero value (the wire shape Plan.UpdateFields emits, #574) sets
+// the field to its zero against the real server — not a no-op.
+func TestIntegration_ZeroValueUpdateRealServer(t *testing.T) {
+	ctx := context.Background()
+	if _, err := itClient.transport.ExecuteAtomic(ctx, itTenant, itActor, "it-zero-create",
+		[]Operation{{
+			Type: OpCreateNode, TypeID: itUserType, NodeID: "u-zero",
+			Data: map[string]any{"1": "zero@x", "2": "Zero", "4": true},
+		}}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Explicit zero in the patch (field 4 = active -> false).
+	if _, err := itClient.transport.ExecuteAtomic(ctx, itTenant, itActor, "it-zero-update",
+		[]Operation{{
+			Type: OpUpdateNode, TypeID: itUserType, NodeID: "u-zero",
+			Patch: map[string]any{"4": false},
+		}}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	node, err := itClient.transport.GetNode(ctx, itTenant, itActor, itUserType, "u-zero")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got := node.Payload["4"]; got != false {
+		t.Fatalf("active after zero-update = %v (%T), want false — explicit zero dropped over the real wire", got, got)
+	}
+}


### PR DESCRIPTION
## Why

The Go SDK had **no end-to-end coverage**, and CI ran **no Go SDK tests at all**:

- Its unit tests run against an in-process `fakeServer` with **canned responses** — they prove the SDK's wire-translation logic, not that it talks to the real server.
- The contract/integration suite is **Python-only**: it boots the real server but drives it through the *Python* SDK.
- So every Go SDK wire change (typed int64, keyset auto-follow, unique-key lookup, zero-value patches) was only ever checked against fakes encoding *my understanding* of the server.
- And the `go-server-build` job only tests `server/go` — nothing ran `go test` for `sdk/go/entdb`.

## What

A `//go:build integration` suite (so the fast unit path is unchanged) with a `TestMain` that **builds and boots the actual `entdb-server`** on a free port (e2e seed profile, memory WAL) and drives the Go SDK transport against it over real gRPC — the mirror of the Python `conftest`:

- typed **int64 > 2^53** round-trips losslessly (ADR-028 / #563 / #572);
- **QueryNodes auto-follows the real keyset cursor** over 250 rows, no truncation (ADR-029 / #564);
- **GetNodeByKey** unique-key lookup (#572 typed value);
- an **explicit zero-value patch** sets the field, not a no-op (the wire shape #574's `UpdateFields` emits).

New **`go-sdk` CI job** runs SDK vet + unit tests **and** this integration suite, now a required check.

Run locally: `cd sdk/go/entdb && go test -tags=integration -run TestIntegration .` (all 4 pass).