### PR TITLE
feat(#566): composite (multi-field) unique constraints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Quick orientation (one-liners, not normative — the ADR is normative):
 - [ADR-027](docs/adr/027-parallel-wal-apply-across-tenants.md) — parallel WAL apply across distinct tenants; amends ADR-016's no-fan-out clause (Accepted; landed dark — serial by default `--apply-concurrency=1`)
 - [ADR-028](docs/adr/028-typed-payload-wire-values.md) — typed `field_id`-keyed payload wire values (`map<uint32, EntValue>`), retiring `google.protobuf.Struct` so int64 stops corrupting >2^53 (Accepted; design frozen, implementation pending — Bug C)
 - [ADR-029](docs/adr/029-keyset-cursor-pagination.md) — keyset cursor pagination (`page_token`/`next_page_token`) with SDK auto-follow, replacing the silent 100-row read truncation (Accepted; design frozen, implementation pending — Bug A)
+- [ADR-030](docs/adr/030-composite-unique-constraints.md) — composite (multi-field) unique constraints via `(entdb.node).composite_unique`; tuple expression index enforced in the applier; `ALREADY_EXISTS` structured detail parsed into the typed `UniqueConstraintError` (Accepted; implemented — issue #566)
 
 ## Project Structure
 

--- a/docs/adr/030-composite-unique-constraints.md
+++ b/docs/adr/030-composite-unique-constraints.md
@@ -1,0 +1,268 @@
+# ADR-030: Composite (multi-field) unique constraints
+
+**Status:** Accepted
+**Decided:** 2026-05-25
+**Tags:** schema, proto, indexing, integrity, sdk
+**Implementation:** `(entdb.node).composite_unique` proto option; schema registry (`server/go/internal/schema/`); composite expression index + violation translation (`server/go/internal/store/`); applier enforcement (`server/go/internal/apply/`); SDK error parsing (`sdk/go/entdb/`, `sdk/python/entdb_sdk/`). Issue #566.
+
+## Decision
+
+A node type may declare one or more **composite (multi-field) unique
+constraints**: a named set of two-or-more fields whose tuple of values
+must be unique across all nodes of that type within a tenant. They are
+declared in proto, resolved to `field_id` tuples at schema load, backed
+by a SQLite UNIQUE expression index over the `json_extract` tuple, and
+enforced atomically by the applier inside the WAL apply transaction. A
+violation surfaces as a gRPC `ALREADY_EXISTS` carrying a structured
+detail string both SDKs parse into a typed `UniqueConstraintError`.
+
+This extends single-field uniqueness ([ADR-025](025-single-shape-sdk-api.md):
+`(entdb.field).unique = true`) to the multi-field case without adding a
+second enforcement mechanism — the same expression-index pattern, the
+same applier-write-path, the same typed error.
+
+### Proto declaration
+
+`(entdb.node).composite_unique` is a `repeated UniqueConstraint`
+message-level option (field number 24 on `NodeOpts`; field 23 / the old
+`keys` is reserved). Additive and backward-compatible — existing schemas
+omit it.
+
+```proto
+message OAuthIdentity {
+  option (entdb.node).type_id = 201;
+  option (entdb.node).composite_unique = {
+    name: "provider_user_id"
+    fields: ["provider", "provider_user_id"]
+  };
+
+  string provider         = 1 [(entdb.field) = { required: true }];
+  string provider_user_id = 2 [(entdb.field) = { required: true }];
+  string email            = 3 [(entdb.field) = { unique: true }];
+}
+```
+
+`UniqueConstraint { repeated string fields; string name; }` carries
+proto field **names**; the SDK codegen resolves each to its stable
+`field_id` ([ADR-018](018-field-id-keyed-payloads.md)) at registration
+time and a typo fails loudly there rather than silently dropping the
+constraint. `name` is optional — when omitted the SDK derives a stable
+name from the field ids. A constraint must reference **at least two**
+fields; single-field uniqueness stays on `(entdb.field).unique = true`
+(one way per operation, [ADR-025](025-single-shape-sdk-api.md)).
+
+### Schema registry
+
+`CompositeUniqueDef { Name string; FieldIDs []uint32 }` lives on
+`NodeTypeDef.CompositeUnique`, round-trips through the schema JSON
+contract (`composite_unique` key), and contributes to the schema
+fingerprint. `Validate` enforces: non-empty name, ≥2 distinct field ids,
+every field id known on the type, unique constraint names, and unique
+field-id signatures (no two constraints over the same field set).
+`Registry.CompositeUnique(type_id)` exposes them in declaration order.
+
+### Index DDL
+
+For each constraint the store mints a partial UNIQUE expression index:
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_t201_cprovider_user_id
+  ON nodes(tenant_id,
+           json_extract(payload_json, '$."1"'),
+           json_extract(payload_json, '$."2"'))
+  WHERE type_id = 201;
+```
+
+Same shape as the single-field unique index
+([ADR-025](025-single-shape-sdk-api.md)) and the query index
+([ADR-023](023-declarative-query-indexes.md)), with two differences:
+
+1. The index spans the **tuple** of `json_extract` expressions, in
+   declaration order.
+2. The name prefix is `idx_unique_t<type>_c<constraint>` (the `c`
+   distinguishes composite from the single-field `_f<field>` form).
+
+The index name is parseable back to its coordinates, and that round-trip
+is load-bearing — see "Violation translation".
+
+### Enforcement is in the applier, on the txn connection
+
+Per [ADR-016](016-handlers-append-applier-writes.md) only the applier
+writes SQLite. The applier ensures the unique / composite / query
+indexes for a type **on the BatchTxn's own connection, before** the
+`INSERT`/`UPDATE`, so the constraint fires synchronously inside the same
+transaction. Running the DDL on a separate handle would deadlock against
+the BatchTxn's held writer lock; the in-txn ensure path therefore does
+NOT use the process-local index cache (a batch that creates an index and
+then rolls back — because the very INSERT it guards trips the
+constraint — drops the index with the txn, and a cache hit would then
+skip re-creation and silently leave the constraint unenforced).
+`CREATE ... IF NOT EXISTS` against an already-committed index is a cheap
+metadata check, so re-running it per first-touch is correct and
+inexpensive.
+
+This also closes a pre-existing gap: [ADR-023](023-declarative-query-indexes.md)
+described the applier ensuring unique + query indexes before each write,
+but the WAL apply path did not actually do so. It does now, for
+single-field unique, composite unique, and query indexes alike.
+
+### Violation translation and the wire contract
+
+A constraint trip is an **expected, deterministic outcome** — replaying
+the same event against the same materialised state always reproduces it
+— so it is handled exactly like a CAS precondition miss
+([ADR-016](016-handlers-append-applier-writes.md), issue #500): the
+applier rolls back the batch, memoizes the structured detail in the
+idempotency cache with status `UNIQUE_VIOLATION`, and advances the WAL
+offset **without halting** the consumer. The `ExecuteAtomic` handler
+(when `wait_applied`) lifts the memoized detail into a gRPC
+`ALREADY_EXISTS` status; a retry with the same idempotency key replays
+the identical typed error.
+
+`modernc.org/sqlite` reports an expression-index UNIQUE violation as
+``UNIQUE constraint failed: index '<index_name>'``. The index name is
+the authoritative source of *which* declared constraint fired, so the
+store parses it (rather than guessing from the payload), resolves the
+coordinates via the registry, and renders the colliding values from the
+field-id-keyed payload.
+
+The emitted detail strings are **verbatim wire contract** — pinned by
+the SDK parsers (`parseUniqueConstraintFromStatus` /
+`_parse_composite_unique_constraint_detail`):
+
+```
+single-field:
+  Unique constraint violation: tenant=<t> type_id=<T> field_id=<F> value=<repr> already exists
+composite:
+  Composite unique constraint violation: tenant=<t> type_id=<T> constraint='<name>' fields=[<F>, ...] values=[<repr>, ...] already exists
+```
+
+`fields` / `values` are rendered as Python-literal lists and scalar
+values as Python `repr()` (single-quoted strings, bare numerics) so
+`ast.literal_eval` round-trips them on the Python side and the Go regex
+parses them. Values are rendered from the `jsonnum`-decoded payload, so
+an `int64` above 2^53 renders as its exact integer literal, never float
+scientific notation — composite keys over big integers compare and
+report losslessly ([ADR-028](028-typed-payload-wire-values.md)).
+
+### SDK surface
+
+Both SDKs map composite and single-field violations onto the **one**
+`UniqueConstraintError` type (one way per operation,
+[ADR-025](025-single-shape-sdk-api.md)). The composite form populates
+`constraint_name` / `field_ids` / `values` and `IsComposite()` /
+`is_composite` returns true; the single-field form populates
+`field_id` / `value`. No `GetByCompositeKey` lookup is added — issue
+#566 asks only for enforcement, and a typed composite-key fetch can be a
+later additive surface if a use case appears.
+
+## Context
+
+There was no way to declare uniqueness spanning multiple fields. Clients
+needing composite uniqueness (e.g. `(provider, provider_user_id)` for
+OAuth identities) had to enforce it with a non-atomic query-then-create,
+which loses under concurrency: concurrent creates of the same composite
+key all pass the dup-check and insert, producing duplicate rows. This is
+security-relevant for identity data — two principals claiming the same
+external identity. Single-field unique already enforced atomically via a
+unique expression index; the natural fix is the same mechanism over a
+tuple.
+
+## Alternatives considered
+
+- **Synthesize the composite key into one single-field unique column.**
+  The documented pre-#566 workaround. Rejected as the native answer: it
+  pushes key derivation and collision-formatting into every client,
+  duplicates the value on disk, and can't express the constraint in the
+  schema where the integrity rule belongs.
+- **Enforce at the gRPC handler with a pre-INSERT existence check.**
+  Rejected — it is exactly the racy query-then-create the issue is
+  about, and it violates [ADR-016](016-handlers-append-applier-writes.md)
+  (handlers append; only the applier writes).
+- **A dedicated composite-key table (`(tenant, type, key_hash) → node`).**
+  Rejected. A second write target means a second consistency story
+  between `nodes` and the key table; the SQLite expression index is one
+  atomic INSERT.
+- **Halt the consumer on a constraint trip (treat as poison).**
+  Rejected. A unique violation is a legitimate, deterministic client
+  outcome, not corruption; halting would wedge the WAL on user error.
+  The deterministic-failure memoization path (issue #500) already models
+  exactly this — reuse it.
+- **A new `ReceiptStatus` enum value for the violation.** Rejected as
+  unnecessary for the contract: the authoritative typed surface is the
+  `ExecuteAtomic` `ALREADY_EXISTS` gRPC status. `GetReceiptStatus`
+  surfaces a polled violation as `RECEIPT_STATUS_FAILED` with the detail
+  in `error` — additive, no proto break.
+- **A typed `GetByCompositeKey` lookup in this ADR.** Deferred. Out of
+  scope for #566 (enforcement only); add later if a fetch-by-tuple use
+  case appears, without a parallel error path.
+
+## Consequences
+
+**What this locks in:**
+
+- `NodeOpts.composite_unique` (field 24) and the `UniqueConstraint`
+  message are the stable schema annotation; field 23 / `keys` stays
+  reserved.
+- `CompositeUniqueDef` (name + field-id tuple) on `NodeTypeDef`,
+  serialised under the `composite_unique` JSON key, part of the
+  fingerprint.
+- Index name `idx_unique_t<type>_c<constraint>`; the name is parsed back
+  to coordinates, so the minting and parsing helpers must stay in
+  lock-step (they share `compositeIndexSuffix`).
+- The two ALREADY_EXISTS detail formats above are wire contract;
+  changing them breaks the shipped SDK parsers.
+- The applier's in-txn "ensure field indexes" hook covers single-field
+  unique, composite unique, and query indexes before every
+  `CreateNode` / `UpdateNode`.
+
+**What this makes easy:**
+
+- Declaring a multi-field integrity rule with one proto annotation,
+  enforced atomically under concurrency.
+- Catching the violation by exception type (not string match), with the
+  constraint name / field ids / colliding values available.
+
+**What this makes harder:**
+
+- Adding a composite constraint to a type that already has duplicate
+  tuples is BREAKING — the `CREATE UNIQUE INDEX` fails. The compat
+  checker flags `COMPOSITE_UNIQUE_ADDED` / `..._CHANGED` as breaking;
+  back-filling / de-duplicating is the operator's responsibility before
+  the constraint can be added (same posture as adding single-field
+  `unique`).
+- Dropping a constraint requires a manual `DROP INDEX` (same as
+  single-field unique / query indexes).
+
+**Failure modes:**
+
+- The lazy in-txn DDL runs on the first create/update of a type after
+  start-up. A type that only ever sees updates won't have its index
+  created until a create — mitigated by ensuring on both `CreateNode`
+  and `UpdateNode` ([ADR-023](023-declarative-query-indexes.md) carries
+  the same note).
+- If `wait_applied` is false (or the client raced the applier), the
+  caller polls `GetReceiptStatus`, which reports the violation as
+  `RECEIPT_STATUS_FAILED` with the detail in `error`; the
+  ALREADY_EXISTS gRPC surface requires the wait_applied path.
+
+## References
+
+- Issue #566 — composite unique constraints request + identity-race
+  motivation.
+- [ADR-025](025-single-shape-sdk-api.md) — single-field unique via
+  expression index; one-way-per-operation rule (one
+  `UniqueConstraintError`, no parallel composite lookup).
+- [ADR-023](023-declarative-query-indexes.md) — the lazy expression
+  index pattern reused here; this ADR also implements the
+  ensure-before-write hook ADR-023 described.
+- [ADR-022](022-fts5-full-text-search.md) — same lazy-index pattern for
+  FTS5 virtual tables.
+- [ADR-018](018-field-id-keyed-payloads.md) — field-id-keyed payloads;
+  constraints store and index on `'$."<field_id>"'`, never the proto
+  name.
+- [ADR-028](028-typed-payload-wire-values.md) — lossless int64; composite
+  keys over big integers compare and report exactly.
+- [ADR-016](016-handlers-append-applier-writes.md) — handlers append,
+  applier writes; the deterministic-failure memoization path (issue
+  #500) the unique-violation path reuses.

--- a/sdk/go/entdb/cmd/entdb/snapshot_test.go
+++ b/sdk/go/entdb/cmd/entdb/snapshot_test.go
@@ -61,8 +61,9 @@ func TestCmdSnapshot_StdoutHappyPath(t *testing.T) {
 		t.Errorf("missing wrapper keys: %v", env)
 	}
 	schema := env["schema"].(map[string]any)
-	if len(schema["node_types"].([]any)) != 1 {
-		t.Error("expected Product node in output")
+	// testpb carries Product (201) + OAuthIdentity (202).
+	if len(schema["node_types"].([]any)) != 2 {
+		t.Error("expected Product + OAuthIdentity nodes in output")
 	}
 	if len(schema["edge_types"].([]any)) != 1 {
 		t.Error("expected PurchaseEdge in output")

--- a/sdk/go/entdb/internal/testpb/testpb.go
+++ b/sdk/go/entdb/internal/testpb/testpb.go
@@ -43,12 +43,27 @@ var PurchaseEdgeDesc protoreflect.MessageDescriptor
 // used by negative tests.
 var NotAnEntityDesc protoreflect.MessageDescriptor
 
+// OAuthIdentityDesc is a node type carrying a composite unique
+// constraint (ADR-030 / issue #566):
+//
+//	message OAuthIdentity {
+//	    option (entdb.node) = {
+//	        type_id: 202
+//	        composite_unique: { name: "provider_user_id"
+//	                            fields: ["provider", "provider_user_id"] }
+//	    };
+//	    string provider         = 1;
+//	    string provider_user_id = 2;
+//	}
+var OAuthIdentityDesc protoreflect.MessageDescriptor
+
 func init() {
 	fd := buildFile()
 	ProductDesc = fd.Messages().ByName("Product")
 	PurchaseEdgeDesc = fd.Messages().ByName("PurchaseEdge")
 	NotAnEntityDesc = fd.Messages().ByName("NotAnEntity")
-	if ProductDesc == nil || PurchaseEdgeDesc == nil || NotAnEntityDesc == nil {
+	OAuthIdentityDesc = fd.Messages().ByName("OAuthIdentity")
+	if ProductDesc == nil || PurchaseEdgeDesc == nil || NotAnEntityDesc == nil || OAuthIdentityDesc == nil {
 		panic("testpb: missing test message descriptors")
 	}
 }
@@ -284,6 +299,44 @@ func buildFile() protoreflect.FileDescriptor {
 		Options: edgeOpts,
 	}
 
+	// OAuthIdentity message — (entdb.node) with a composite_unique
+	// constraint. NodeOpts is { type_id: 202 (field 1, varint),
+	// composite_unique: [...] (field 24, repeated message) }.
+	// UniqueConstraint is { fields: [...] (field 1, repeated string),
+	// name: "..." (field 2, string) }.
+	ucInner := append(
+		encodeStringField(1, "provider"),
+		encodeStringField(1, "provider_user_id")...,
+	)
+	ucInner = append(ucInner, encodeStringField(2, "provider_user_id")...)
+	oauthNodeOpts := append(
+		encodeVarintField(1, 202),
+		encodeLengthDelimitedField(24, ucInner)...,
+	)
+	oauthOptsRaw := encodeLengthDelimitedField(50100, oauthNodeOpts)
+	oauthOpts := &descriptorpb.MessageOptions{}
+	oauthOpts.ProtoReflect().SetUnknown(protoreflect.RawFields(oauthOptsRaw))
+	oauthMsg := &descriptorpb.DescriptorProto{
+		Name:    proto.String("OAuthIdentity"),
+		Options: oauthOpts,
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     proto.String("provider"),
+				Number:   proto.Int32(1),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				JsonName: proto.String("provider"),
+			},
+			{
+				Name:     proto.String("provider_user_id"),
+				Number:   proto.Int32(2),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				JsonName: proto.String("providerUserId"),
+			},
+		},
+	}
+
 	// NotAnEntity — no EntDB annotations.
 	notEntityMsg := &descriptorpb.DescriptorProto{
 		Name: proto.String("NotAnEntity"),
@@ -302,7 +355,7 @@ func buildFile() protoreflect.FileDescriptor {
 		Name:        proto.String(name),
 		Package:     proto.String(pkg),
 		Syntax:      proto.String(syntax),
-		MessageType: []*descriptorpb.DescriptorProto{productMsg, edgeMsg, notEntityMsg},
+		MessageType: []*descriptorpb.DescriptorProto{productMsg, edgeMsg, oauthMsg, notEntityMsg},
 	}
 
 	fd, err := protodesc.NewFile(fdp, nil)
@@ -320,6 +373,12 @@ func encodeVarintField(fieldNum, value uint64) []byte {
 	out = appendVarint(out, tag)
 	out = appendVarint(out, value)
 	return out
+}
+
+// encodeStringField returns the wire-format bytes for a single
+// string-typed field “(fieldNum, value)“ (length-delimited).
+func encodeStringField(fieldNum uint64, value string) []byte {
+	return encodeLengthDelimitedField(fieldNum, []byte(value))
 }
 
 // encodeLengthDelimitedField returns the wire-format bytes for a

--- a/sdk/go/entdb/marshal.go
+++ b/sdk/go/entdb/marshal.go
@@ -129,6 +129,58 @@ func findLengthDelimited(buf []byte, fieldNum uint64) ([]byte, bool) {
 	return nil, false
 }
 
+// findAllLengthDelimited scans a protobuf wire-format byte stream and
+// returns the payloads of EVERY length-delimited (wire type 2) field
+// matching fieldNum, in wire order. Used to pull each entry of a
+// repeated submessage / repeated string field (e.g. NodeOpts.
+// composite_unique and UniqueConstraint.fields) out of the parent.
+func findAllLengthDelimited(buf []byte, fieldNum uint64) [][]byte {
+	var out [][]byte
+	for len(buf) > 0 {
+		tag, n := decodeVarint(buf)
+		if n == 0 {
+			return out
+		}
+		buf = buf[n:]
+		wire := tag & 0x7
+		num := tag >> 3
+		switch wire {
+		case 0: // varint
+			_, n = decodeVarint(buf)
+			if n == 0 {
+				return out
+			}
+			buf = buf[n:]
+		case 1: // 64-bit fixed
+			if len(buf) < 8 {
+				return out
+			}
+			buf = buf[8:]
+		case 2: // length-delimited
+			ln, n := decodeVarint(buf)
+			if n == 0 {
+				return out
+			}
+			buf = buf[n:]
+			if uint64(len(buf)) < ln {
+				return out
+			}
+			if num == fieldNum {
+				out = append(out, buf[:ln])
+			}
+			buf = buf[ln:]
+		case 5: // 32-bit fixed
+			if len(buf) < 4 {
+				return out
+			}
+			buf = buf[4:]
+		default:
+			return out
+		}
+	}
+	return out
+}
+
 // findVarint scans a protobuf wire-format byte stream for a varint
 // (wire type 0) field with the given field number and returns its
 // value. Used to pull “type_id“/“edge_id“ out of the inner

--- a/sdk/go/entdb/schema_extract.go
+++ b/sdk/go/entdb/schema_extract.go
@@ -28,6 +28,17 @@ const (
 	fieldOptsUniqueField       = 13
 )
 
+// NodeOpts extension field numbers consumed by the extractor (from
+// sdk/entdb_sdk/proto/entdb_options.proto). composite_unique is the
+// repeated UniqueConstraint message (ADR-030 / issue #566).
+const (
+	nodeOptsCompositeUniqueField = 24 // repeated UniqueConstraint composite_unique = 24
+
+	// UniqueConstraint submessage field numbers.
+	uniqueConstraintFieldsField = 1 // repeated string fields = 1
+	uniqueConstraintNameField   = 2 // string name = 2
+)
+
 // EdgeOpts has its (from_type, to_type) wired into the message
 // descriptor name, not the option — there is no canonical edge-type
 // proto on the wire today, so SchemaJSON reports edges with empty
@@ -133,7 +144,11 @@ func walkMessages(
 			if nodeID == 0 {
 				return fmt.Errorf("entdb: %s has (entdb.node) but type_id is 0", md.FullName())
 			}
-			*nodes = append(*nodes, buildNodeEntry(md, nodeID))
+			entry, err := buildNodeEntry(md, nodeID)
+			if err != nil {
+				return err
+			}
+			*nodes = append(*nodes, entry)
 		case hasEdge:
 			if edgeID == 0 {
 				return fmt.Errorf("entdb: %s has (entdb.edge) but edge_id is 0", md.FullName())
@@ -148,12 +163,98 @@ func walkMessages(
 	return nil
 }
 
-func buildNodeEntry(md protoreflect.MessageDescriptor, typeID int32) map[string]any {
-	return map[string]any{
+func buildNodeEntry(md protoreflect.MessageDescriptor, typeID int32) (map[string]any, error) {
+	out := map[string]any{
 		"type_id": int64(typeID),
 		"name":    string(md.Name()),
 		"fields":  extractFields(md),
 	}
+	cu, err := extractCompositeUnique(md)
+	if err != nil {
+		return nil, err
+	}
+	if len(cu) > 0 {
+		out["composite_unique"] = cu
+	}
+	return out, nil
+}
+
+// extractCompositeUnique reads NodeOpts.composite_unique (ADR-030).
+// Each UniqueConstraint carries proto field NAMES; this resolves them
+// to stable field_ids (ADR-018) against the message's field set. A
+// name that does not resolve, or a constraint with fewer than two
+// fields, is an error so a typo fails at extract time rather than
+// silently dropping the integrity rule (mirrors the Python SDK).
+func extractCompositeUnique(md protoreflect.MessageDescriptor) ([]map[string]any, error) {
+	opts := md.Options()
+	if opts == nil {
+		return nil, nil
+	}
+	raw, err := proto.Marshal(opts)
+	if err != nil {
+		return nil, nil
+	}
+	nodeOpts, ok := findLengthDelimited(raw, uint64(extNodeOpts))
+	if !ok {
+		return nil, nil
+	}
+	entries := findAllLengthDelimited(nodeOpts, uint64(nodeOptsCompositeUniqueField))
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	// Build a proto-field-name -> field_id map for resolution.
+	nameToID := map[string]uint32{}
+	fds := md.Fields()
+	for i := 0; i < fds.Len(); i++ {
+		fd := fds.Get(i)
+		nameToID[string(fd.Name())] = uint32(fd.Number())
+	}
+	out := make([]map[string]any, 0, len(entries))
+	for _, e := range entries {
+		names := findAllStrings(e, uint64(uniqueConstraintFieldsField))
+		if len(names) < 2 {
+			return nil, fmt.Errorf(
+				"entdb: %s composite_unique must reference at least 2 fields, got %v",
+				md.FullName(), names,
+			)
+		}
+		fieldIDs := make([]int64, 0, len(names))
+		for _, nm := range names {
+			fid, ok := nameToID[nm]
+			if !ok {
+				return nil, fmt.Errorf(
+					"entdb: %s composite_unique references unknown field %q",
+					md.FullName(), nm,
+				)
+			}
+			fieldIDs = append(fieldIDs, int64(fid))
+		}
+		name, _ := findString(e, uint64(uniqueConstraintNameField))
+		if name == "" {
+			parts := make([]string, 0, len(fieldIDs))
+			for _, f := range fieldIDs {
+				parts = append(parts, fmt.Sprintf("f%d", f))
+			}
+			name = strings.Join(parts, "_")
+		}
+		out = append(out, map[string]any{
+			"name":      name,
+			"field_ids": fieldIDs,
+		})
+	}
+	return out, nil
+}
+
+// findAllStrings returns every length-delimited (string) field matching
+// fieldNum, decoded as UTF-8, in wire order — the repeated-string
+// counterpart of findString.
+func findAllStrings(buf []byte, fieldNum uint64) []string {
+	payloads := findAllLengthDelimited(buf, fieldNum)
+	out := make([]string, 0, len(payloads))
+	for _, p := range payloads {
+		out = append(out, string(p))
+	}
+	return out
 }
 
 func buildEdgeEntry(md protoreflect.MessageDescriptor, edgeID int32) map[string]any {

--- a/sdk/go/entdb/schema_extract_test.go
+++ b/sdk/go/entdb/schema_extract_test.go
@@ -65,10 +65,11 @@ func TestExtractSchemaJSON_ExtractsNodesAndEdgesFromTestPB(t *testing.T) {
 	schema := env["schema"].(map[string]any)
 
 	nodes := schema["node_types"].([]any)
-	if len(nodes) != 1 {
-		t.Fatalf("want 1 node, got %d", len(nodes))
+	// Product (201) + OAuthIdentity (202).
+	if len(nodes) != 2 {
+		t.Fatalf("want 2 nodes, got %d", len(nodes))
 	}
-	prod := nodes[0].(map[string]any)
+	prod := nodes[0].(map[string]any) // sorted by type_id, Product first
 	if prod["name"] != "Product" {
 		t.Errorf("name = %q, want Product", prod["name"])
 	}
@@ -140,6 +141,58 @@ func TestExtractSchemaJSON_FieldKindsMappedFromProtoTypes(t *testing.T) {
 	}
 }
 
+// ── Composite unique extraction (ADR-030 / issue #566) ──────────────
+
+func TestExtractSchemaJSON_ExtractsCompositeUnique(t *testing.T) {
+	out, err := ExtractSchemaJSON(fdsFromTestPB(t))
+	if err != nil {
+		t.Fatalf("ExtractSchemaJSON: %v", err)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	nodes := env["schema"].(map[string]any)["node_types"].([]any)
+
+	var oauth map[string]any
+	for _, n := range nodes {
+		nm := n.(map[string]any)
+		if nm["name"] == "OAuthIdentity" {
+			oauth = nm
+		}
+	}
+	if oauth == nil {
+		t.Fatalf("OAuthIdentity node not extracted; nodes=%v", nodes)
+	}
+
+	cuRaw, ok := oauth["composite_unique"]
+	if !ok {
+		t.Fatalf("composite_unique missing on OAuthIdentity: %v", oauth)
+	}
+	cu := cuRaw.([]any)
+	if len(cu) != 1 {
+		t.Fatalf("want 1 composite constraint, got %d: %v", len(cu), cu)
+	}
+	c := cu[0].(map[string]any)
+	if c["name"] != "provider_user_id" {
+		t.Errorf("constraint name = %q, want provider_user_id", c["name"])
+	}
+	ids := c["field_ids"].([]any)
+	if len(ids) != 2 || int(ids[0].(float64)) != 1 || int(ids[1].(float64)) != 2 {
+		t.Errorf("field_ids = %v, want [1 2] (resolved from proto field names)", ids)
+	}
+
+	// A node without composite_unique must NOT carry the key.
+	for _, n := range nodes {
+		nm := n.(map[string]any)
+		if nm["name"] == "Product" {
+			if _, ok := nm["composite_unique"]; ok {
+				t.Error("Product (no composite_unique) should omit the key")
+			}
+		}
+	}
+}
+
 // ── Output is deterministic (stable order across runs) ──────────────
 
 func TestExtractSchemaJSON_OutputIsDeterministic(t *testing.T) {
@@ -181,15 +234,16 @@ func TestExtractSchemaJSON_HandlesMultipleFilesInSet(t *testing.T) {
 	var env map[string]any
 	_ = json.Unmarshal(out, &env)
 
-	// Both files share the same type_id=201 and edge_id=301. They
-	// land twice in the output (the SDK doesn't deduplicate; that's
-	// the customer's problem if their proto packages collide). What
-	// we verify here is that walking ranges over BOTH files rather
-	// than stopping at the first.
+	// Both files share the same node/edge ids. They land twice in the
+	// output (the SDK doesn't deduplicate; that's the customer's
+	// problem if their proto packages collide). What we verify here is
+	// that walking ranges over BOTH files rather than stopping at the
+	// first. Each file carries two node types (Product + OAuthIdentity)
+	// and one edge type (PurchaseEdge).
 	nodes := env["schema"].(map[string]any)["node_types"].([]any)
 	edges := env["schema"].(map[string]any)["edge_types"].([]any)
-	if len(nodes) != 2 {
-		t.Errorf("want 2 nodes (one per file), got %d", len(nodes))
+	if len(nodes) != 4 {
+		t.Errorf("want 4 nodes (two per file), got %d", len(nodes))
 	}
 	if len(edges) != 2 {
 		t.Errorf("want 2 edges (one per file), got %d", len(edges))

--- a/server/go/internal/api/composite_unique_test.go
+++ b/server/go/internal/api/composite_unique_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package api_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// newCompositeFixture wires the standard ExecuteAtomic harness with an
+// OAuthIdentity(type_id=201) node type carrying a (provider,
+// provider_user_id) composite unique constraint (issue #566).
+func newCompositeFixture(t *testing.T) *xaFixture {
+	t.Helper()
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+
+	reg := schema.NewRegistry()
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID: 201,
+		Name:   "OAuthIdentity",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "provider", Kind: schema.KindString},
+			{FieldID: 2, Name: "provider_user_id", Kind: schema.KindString},
+		},
+		CompositeUnique: []schema.CompositeUniqueDef{
+			{Name: "provider_user_id", FieldIDs: []uint32{1, 2}},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true, Registry: reg})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(context.Background(), xaTenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithWALProducer(w),
+		api.WithWALTopic(xaTopic),
+		api.WithSchemaRegistry(reg),
+	)
+	a, err := apply.New(apply.Options{
+		Store:       cs,
+		Consumer:    w,
+		Topic:       xaTopic,
+		GroupID:     xaGroupID,
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	return &xaFixture{t: t, wal: w, store: cs, registry: reg, srv: srv, applier: a}
+}
+
+func createOAuthIdentity(idem, provider, providerUserID string) *pb.ExecuteAtomicRequest {
+	return &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: xaTenant, Actor: xaActorStr},
+		IdempotencyKey: idem,
+		WaitApplied:    true,
+		WaitTimeoutMs:  2000,
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: 201,
+				TypedData: map[uint32]*pb.EntValue{
+					1: {V: &pb.EntValue_StringValue{StringValue: provider}},
+					2: {V: &pb.EntValue_StringValue{StringValue: providerUserID}},
+				},
+			}},
+		}},
+	}
+}
+
+// TestExecuteAtomic_CompositeUniqueViolation is the end-to-end handler
+// test: the second create of the same (provider, provider_user_id)
+// tuple surfaces as a gRPC ALREADY_EXISTS carrying the verbatim
+// structured detail the SDK parsers consume (issue #566).
+func TestExecuteAtomic_CompositeUniqueViolation(t *testing.T) {
+	t.Parallel()
+	f := newCompositeFixture(t)
+	f.runApplier(t)
+
+	// First create wins.
+	resp, err := f.srv.ExecuteAtomic(context.Background(), createOAuthIdentity("oa-1", "google", "uid-1"))
+	if err != nil {
+		t.Fatalf("first ExecuteAtomic: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("first create Success=false: %q / %q", resp.GetError(), resp.GetErrorCode())
+	}
+
+	// Second create of the same tuple must surface ALREADY_EXISTS.
+	_, err = f.srv.ExecuteAtomic(context.Background(), createOAuthIdentity("oa-2", "google", "uid-1"))
+	if err == nil {
+		t.Fatalf("duplicate ExecuteAtomic: expected ALREADY_EXISTS error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error is not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.AlreadyExists {
+		t.Fatalf("code: got %v, want AlreadyExists; msg=%q", st.Code(), st.Message())
+	}
+	want := "Composite unique constraint violation: tenant=" + xaTenant + " type_id=201 " +
+		"constraint='provider_user_id' fields=[1, 2] values=['google', 'uid-1'] already exists"
+	if st.Message() != want {
+		t.Fatalf("detail mismatch:\n got=%q\nwant=%q", st.Message(), want)
+	}
+}

--- a/server/go/internal/api/execute_atomic.go
+++ b/server/go/internal/api/execute_atomic.go
@@ -256,6 +256,13 @@ func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest
 	// Honour ctx cancellation.
 	appliedStatus := pb.ReceiptStatus_RECEIPT_STATUS_PENDING
 	var preFailure *pb.PreconditionFailure
+	// uniqueViolationDetail, when non-empty, is the structured
+	// ALREADY_EXISTS message the applier memoized for a tripped
+	// single-field/composite unique constraint (issue #566). Unlike a
+	// CAS miss (which is surfaced in-band), a unique violation surfaces
+	// as a real gRPC ALREADY_EXISTS status so the SDKs raise a typed
+	// UniqueConstraintError — see the SDK parsers.
+	var uniqueViolationDetail string
 	if req.GetWaitApplied() && posStr != "" && s.store != nil {
 		timeoutMs := int32(executeAtomicDefaultMs)
 		if v := req.GetWaitTimeoutMs(); v > 0 {
@@ -285,11 +292,23 @@ func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest
 			case rec.Present && rec.Status == store.IdempotencyStatusFailedPrecondition:
 				appliedStatus = pb.ReceiptStatus_RECEIPT_STATUS_FAILED_PRECONDITION
 				preFailure = decodePreconditionFailureJSON(rec.FailureJSON)
+			case rec.Present && rec.Status == store.IdempotencyStatusUniqueViolation:
+				uniqueViolationDetail = decodeUniqueViolationDetailJSON(rec.FailureJSON)
 			default:
 				appliedStatus = pb.ReceiptStatus_RECEIPT_STATUS_APPLIED
 			}
 		}
 		cancel()
+	}
+
+	// A tripped unique constraint surfaces as a gRPC ALREADY_EXISTS
+	// status (issue #566) carrying the structured detail verbatim, so
+	// the SDK error parsers produce a typed UniqueConstraintError. We
+	// only have the detail when wait_applied raced the applier to the
+	// memoized row; without it the client polls GetReceiptStatus.
+	if uniqueViolationDetail != "" {
+		outcome = "already_exists"
+		return nil, errs.Errorf(codes.AlreadyExists, "%s", uniqueViolationDetail)
 	}
 
 	resp := &pb.ExecuteAtomicResponse{
@@ -344,6 +363,25 @@ func waitForIdempotencyRecord(ctx context.Context, st *store.CanonicalStore, ten
 			delay *= 2
 		}
 	}
+}
+
+// decodeUniqueViolationDetailJSON parses the failure_json blob the
+// applier memoizes for a UNIQUE_VIOLATION row (issue #566) and returns
+// the structured ALREADY_EXISTS detail string. The blob is the
+// JSON-encoded apply.UniqueViolation ({"Detail": "..."}); an empty or
+// undecodable blob yields "" so the caller falls back to the generic
+// path.
+func decodeUniqueViolationDetailJSON(blob string) string {
+	if blob == "" {
+		return ""
+	}
+	var uv struct {
+		Detail string `json:"Detail"`
+	}
+	if err := json.Unmarshal([]byte(blob), &uv); err != nil {
+		return ""
+	}
+	return uv.Detail
 }
 
 // decodePreconditionFailureJSON parses the failure_json column blob

--- a/server/go/internal/api/get_receipt_status.go
+++ b/server/go/internal/api/get_receipt_status.go
@@ -91,6 +91,16 @@ func (s *Server) GetReceiptStatus(ctx context.Context, req *pb.GetReceiptStatusR
 			// decoded; an empty failure_json collapses to status-only.
 			resp.Status = pb.ReceiptStatus_RECEIPT_STATUS_FAILED_PRECONDITION
 			resp.PreconditionFailure = decodePreconditionFailureJSON(rec.FailureJSON)
+		case store.IdempotencyStatusUniqueViolation:
+			// Issue #566 — a polling caller (one that lost the
+			// wait_applied race in ExecuteAtomic) sees the memoized
+			// unique-constraint trip as RECEIPT_STATUS_FAILED with the
+			// structured ALREADY_EXISTS detail in `error`. The
+			// authoritative typed surface is the ExecuteAtomic
+			// ALREADY_EXISTS status; this poll path mirrors it without a
+			// new enum value (additive, no proto break).
+			resp.Status = pb.ReceiptStatus_RECEIPT_STATUS_FAILED
+			resp.Error = decodeUniqueViolationDetailJSON(rec.FailureJSON)
 		default:
 			resp.Status = pb.ReceiptStatus_RECEIPT_STATUS_APPLIED
 		}

--- a/server/go/internal/apply/applier.go
+++ b/server/go/internal/apply/applier.go
@@ -335,7 +335,7 @@ func (a *Applier) finalizeBatch(ctx context.Context, records []Record, results [
 		if err := a.consumer.Commit(ctx, a.groupID, rec); err != nil {
 			return fmt.Errorf("apply: commit offset: %w", err)
 		}
-		if res.Status == StatusApplied || res.Status == StatusSkipped || res.Status == StatusFailedPrecondition {
+		if res.Status == StatusApplied || res.Status == StatusSkipped || res.Status == StatusFailedPrecondition || res.Status == StatusUniqueViolation {
 			if err := a.store.UpdateAppliedOffset(ctx, res.TenantID, rec.Position.Topic, rec.Position.Partition, rec.Position.Offset); err != nil {
 				// Persisting the offset is best-effort; the in-memory
 				// tracker has already been updated by the in-txn
@@ -462,6 +462,17 @@ func (a *Applier) applyEvent(ctx context.Context, ev *Event, res *Result) error 
 			}
 			return nil
 		}
+		// Replay a cached unique-constraint trip identically (issue #566).
+		if cachedStatus == store.IdempotencyStatusUniqueViolation {
+			res.Status = StatusUniqueViolation
+			if cachedFailure.Valid && cachedFailure.String != "" {
+				var uv UniqueViolation
+				if jerr := json.Unmarshal([]byte(cachedFailure.String), &uv); jerr == nil {
+					res.UniqueViolation = &uv
+				}
+			}
+			return nil
+		}
 		res.Status = StatusSkipped
 		return nil
 	} else if !isNoRows(err) {
@@ -485,6 +496,17 @@ func (a *Applier) applyEvent(ctx context.Context, ev *Event, res *Result) error 
 				_ = tx.Rollback()
 				committed = true // suppress deferred rollback
 				return a.memoizePreconditionFailure(ctx, ev, res, pf)
+			}
+			// Unique-constraint trip: same deterministic-failure
+			// treatment as a CAS miss — roll the batch back, memoize the
+			// structured detail, advance the offset (no halt). The
+			// handler lifts the memoized detail into a gRPC
+			// ALREADY_EXISTS so the SDK sees a typed
+			// UniqueConstraintError (issue #566).
+			if uv := AsUniqueViolation(err); uv != nil {
+				_ = tx.Rollback()
+				committed = true // suppress deferred rollback
+				return a.memoizeUniqueViolation(ctx, ev, res, uv)
 			}
 			return err
 		}
@@ -543,6 +565,34 @@ func (a *Applier) memoizePreconditionFailure(ctx context.Context, ev *Event, res
 	// (store.WaitForOffset) wake on the failed batch.
 	if err := a.store.UpdateAppliedOffset(ctx, ev.TenantID, res.Position.Topic, res.Position.Partition, res.Position.Offset); err != nil {
 		return fmt.Errorf("apply: precondition-failure offset: %w", err)
+	}
+	return nil
+}
+
+// memoizeUniqueViolation persists the UNIQUE_VIOLATION row in a fresh
+// write-txn and returns nil so the consumer loop advances the offset —
+// a constraint trip is a deterministic outcome, exactly like a CAS
+// miss. The structured ALREADY_EXISTS detail is stored verbatim in
+// failure_json so the handler (and any same-idem-key retry) replays the
+// identical typed error. Mirrors memoizePreconditionFailure.
+func (a *Applier) memoizeUniqueViolation(ctx context.Context, ev *Event, res *Result, uv *UniqueViolation) error {
+	res.Status = StatusUniqueViolation
+	res.UniqueViolation = uv
+	res.TenantID = ev.TenantID
+
+	failureJSON, err := json.Marshal(uv)
+	if err != nil {
+		failureJSON = []byte("")
+	}
+	if err := a.store.RecordIdempotencyOutcome(ctx, ev.TenantID, ev.IdempotencyKey, res.Position.String(), store.IdempotencyStatusUniqueViolation, string(failureJSON)); err != nil {
+		// A parallel retry that won the race to memoize first is treated
+		// as a successful memoization (same as the precondition path).
+		if !errors.Is(err, store.ErrIdempotencyViolation) {
+			return fmt.Errorf("apply: memoize unique violation: %w", err)
+		}
+	}
+	if err := a.store.UpdateAppliedOffset(ctx, ev.TenantID, res.Position.Topic, res.Position.Partition, res.Position.Offset); err != nil {
+		return fmt.Errorf("apply: unique-violation offset: %w", err)
 	}
 	return nil
 }

--- a/server/go/internal/apply/errors.go
+++ b/server/go/internal/apply/errors.go
@@ -36,7 +36,46 @@ var (
 	// op_index / field / expected / observed coordinates via the typed
 	// wrapper below. See GitHub issue #500.
 	ErrPreconditionFailed = fmt.Errorf("%w: precondition failed", errs.ErrFailedPrecondition)
+
+	// ErrUniqueViolation is the sentinel returned when a create/update
+	// op trips a declared single-field or composite unique constraint.
+	// Like ErrPreconditionFailed this is an EXPECTED, deterministic
+	// outcome (re-applying the same event against the same materialised
+	// state always reproduces it), NOT a poison: the applier aborts the
+	// batch, memoizes the structured detail in the idempotency cache
+	// with status UNIQUE_VIOLATION, and advances the WAL offset without
+	// halting. The ExecuteAtomic handler lifts the memoized detail into
+	// a gRPC ALREADY_EXISTS status so the SDKs parse it as a typed
+	// UniqueConstraintError. See issue #566 and the composite-unique ADR.
+	ErrUniqueViolation = fmt.Errorf("%w: unique constraint violation", errs.ErrAlreadyExists)
 )
+
+// UniqueViolation is the typed wrapper carried alongside
+// ErrUniqueViolation. Detail is the fully-formatted ALREADY_EXISTS
+// string the store built (see store.BuildUniqueViolationDetail) — it is
+// memoized verbatim and replayed to the client, so the wire format is
+// owned entirely by the store and this struct just transports it.
+type UniqueViolation struct {
+	// Detail is the structured ALREADY_EXISTS message the SDK parsers
+	// consume. Format is pinned by the SDK contract tests.
+	Detail string
+}
+
+// Error implements error.
+func (e *UniqueViolation) Error() string { return "entdb: " + e.Detail }
+
+// Unwrap allows errors.Is(err, ErrUniqueViolation) on the typed wrapper.
+func (e *UniqueViolation) Unwrap() error { return ErrUniqueViolation }
+
+// AsUniqueViolation extracts a *UniqueViolation from err via errors.As,
+// returning nil when the chain has no such value.
+func AsUniqueViolation(err error) *UniqueViolation {
+	var uv *UniqueViolation
+	if errors.As(err, &uv) {
+		return uv
+	}
+	return nil
+}
 
 // PreconditionFailure is the typed wrapper carried alongside
 // ErrPreconditionFailed. It captures the coordinates of a CAS miss in a

--- a/server/go/internal/apply/ops_create_node.go
+++ b/server/go/internal/apply/ops_create_node.go
@@ -65,6 +65,14 @@ func (a *Applier) applyCreateNode(ctx context.Context, tx *BatchTxn, ev *Event, 
 		now = a.now()
 	}
 
+	// Ensure the unique / composite-unique / query expression indexes
+	// for this type exist on the txn's own connection BEFORE the INSERT,
+	// so a declared constraint fires synchronously inside this batch
+	// (ADR-023 + the composite-unique ADR / issue #566).
+	if err := a.store.EnsureFieldIndexesTx(ctx, tx, int32(typeID)); err != nil {
+		return fmt.Errorf("apply create_node: ensure indexes: %w", err)
+	}
+
 	conn := tx.Conn()
 	if _, err := conn.ExecContext(ctx, `
 		INSERT INTO nodes (tenant_id, node_id, type_id, payload_json,
@@ -73,6 +81,13 @@ func (a *Applier) applyCreateNode(ctx context.Context, tx *BatchTxn, ev *Event, 
 		ev.TenantID, nodeID, typeID, string(payloadJSON),
 		now, now, ev.Actor, string(aclJSON),
 	); err != nil {
+		// A declared unique/composite constraint trip is an EXPECTED,
+		// deterministic outcome — translate it to the typed
+		// *UniqueViolation so the per-event loop memoizes + replays it
+		// (ALREADY_EXISTS) instead of halting the consumer.
+		if detail, ok := a.store.BuildUniqueViolationDetail(ev.TenantID, payload, err); ok {
+			return &UniqueViolation{Detail: detail}
+		}
 		return fmt.Errorf("apply create_node: insert: %w", err)
 	}
 	// Refresh visibility: owner + each ACL principal.

--- a/server/go/internal/apply/ops_update_node.go
+++ b/server/go/internal/apply/ops_update_node.go
@@ -45,11 +45,12 @@ func (a *Applier) applyUpdateNode(ctx context.Context, tx *BatchTxn, ev *Event, 
 
 	conn := tx.Conn()
 	row := conn.QueryRowContext(ctx,
-		`SELECT payload_json FROM nodes WHERE tenant_id = ? AND node_id = ?`,
+		`SELECT type_id, payload_json FROM nodes WHERE tenant_id = ? AND node_id = ?`,
 		ev.TenantID, nodeID,
 	)
 	var existingJSON string
-	if err := row.Scan(&existingJSON); err != nil {
+	var typeID int32
+	if err := row.Scan(&typeID, &existingJSON); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// Missing target is a no-op.
 			// A precondition on a missing node is treated as a miss
@@ -91,10 +92,19 @@ func (a *Applier) applyUpdateNode(ctx context.Context, tx *BatchTxn, ev *Event, 
 	if now == 0 {
 		now = a.now()
 	}
+	// Ensure indexes exist before the UPDATE so a value-changing patch
+	// that collides with another row trips the constraint here (the
+	// node's type_id is read alongside the payload above).
+	if err := a.store.EnsureFieldIndexesTx(ctx, tx, typeID); err != nil {
+		return fmt.Errorf("apply update_node: ensure indexes: %w", err)
+	}
 	if _, err := conn.ExecContext(ctx,
 		`UPDATE nodes SET payload_json = ?, updated_at = ? WHERE tenant_id = ? AND node_id = ?`,
 		string(mergedJSON), now, ev.TenantID, nodeID,
 	); err != nil {
+		if detail, ok := a.store.BuildUniqueViolationDetail(ev.TenantID, merged, err); ok {
+			return &UniqueViolation{Detail: detail}
+		}
 		return fmt.Errorf("apply update_node: update: %w", err)
 	}
 	return nil

--- a/server/go/internal/apply/result.go
+++ b/server/go/internal/apply/result.go
@@ -23,6 +23,12 @@ const (
 	// precondition did not match observed state. Result.Precondition
 	// carries the typed failure detail. See GitHub issue #500.
 	StatusFailedPrecondition
+	// StatusUniqueViolation means a create/update op tripped a declared
+	// single-field or composite unique constraint. Result.UniqueViolation
+	// carries the structured ALREADY_EXISTS detail. Like
+	// FAILED_PRECONDITION it aborts the batch but advances the WAL
+	// offset (deterministic outcome). See issue #566.
+	StatusUniqueViolation
 )
 
 // String returns the wire form ("APPLIED" / "SKIPPED" / "FAILED" /
@@ -37,6 +43,8 @@ func (s Status) String() string {
 		return "FAILED"
 	case StatusFailedPrecondition:
 		return "FAILED_PRECONDITION"
+	case StatusUniqueViolation:
+		return "UNIQUE_VIOLATION"
 	default:
 		return "UNKNOWN"
 	}
@@ -71,6 +79,11 @@ type Result struct {
 	// wait_applied=true; otherwise served from the idempotency cache
 	// via GetReceiptStatus.
 	Precondition *PreconditionFailure
+
+	// UniqueViolation carries the structured ALREADY_EXISTS detail when
+	// Status is StatusUniqueViolation. The handler lifts it into a gRPC
+	// ALREADY_EXISTS status; the idempotency cache replays it on retry.
+	UniqueViolation *UniqueViolation
 }
 
 // EdgeRef is the in-result representation of a created edge. Used for

--- a/server/go/internal/apply/unique_violation_test.go
+++ b/server/go/internal/apply/unique_violation_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// newFixtureWithRegistry builds the same in-memory WAL + store + applier
+// wiring as newFixture, but with a schema.Registry so the applier
+// ensures unique/composite indexes and translates a constraint trip
+// into the structured ALREADY_EXISTS detail (issue #566).
+func newFixtureWithRegistry(t *testing.T, reg *schema.Registry) *fixture {
+	t.Helper()
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	dir := t.TempDir()
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true, Registry: reg})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+
+	a, err := apply.New(apply.Options{
+		Store:       cs,
+		Global:      gs,
+		Consumer:    w,
+		Topic:       testTopic,
+		GroupID:     testGroupID,
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	if err := cs.OpenTenant(context.Background(), testTenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	return &fixture{t: t, wal: w, store: cs, global: gs, applier: a}
+}
+
+func compositeRegistry(t *testing.T) *schema.Registry {
+	t.Helper()
+	reg := schema.NewRegistry()
+	nt := &schema.NodeTypeDef{
+		TypeID: 201,
+		Name:   "OAuthIdentity",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "provider", Kind: schema.KindString},
+			{FieldID: 2, Name: "provider_user_id", Kind: schema.KindString},
+			{FieldID: 3, Name: "serial", Kind: schema.KindInteger},
+		},
+		CompositeUnique: []schema.CompositeUniqueDef{
+			{Name: "provider_user_id", FieldIDs: []uint32{1, 2}},
+		},
+	}
+	if err := reg.RegisterNode(nt); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+	return reg
+}
+
+// TestApplier_CompositeUniqueViolation drives a duplicate composite-key
+// create through the full WAL→applier path and asserts the violation is
+// memoized as UNIQUE_VIOLATION with the verbatim structured detail —
+// without halting the consumer (a third, distinct create still applies).
+func TestApplier_CompositeUniqueViolation(t *testing.T) {
+	t.Parallel()
+	f := newFixtureWithRegistry(t, compositeRegistry(t))
+
+	first := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "c1", TsMs: 1700000000000,
+		Ops: []map[string]any{mkCreateNode("id1", 201, map[string]any{"1": "google", "2": "uid-1"})},
+	}
+	dup := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "c2", TsMs: 1700000000001,
+		Ops: []map[string]any{mkCreateNode("id2", 201, map[string]any{"1": "google", "2": "uid-1"})},
+	}
+	third := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "c3", TsMs: 1700000000002,
+		Ops: []map[string]any{mkCreateNode("id3", 201, map[string]any{"1": "github", "2": "uid-9"})},
+	}
+	f.appendEvent(t, first)
+	f.appendEvent(t, dup)
+	f.appendEvent(t, third)
+
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "c3")
+
+	// The duplicate must be memoized as UNIQUE_VIOLATION with the
+	// verbatim detail string.
+	rec, err := f.store.CheckIdempotencyStatus(context.Background(), testTenant, "c2")
+	if err != nil {
+		t.Fatalf("CheckIdempotencyStatus: %v", err)
+	}
+	if !rec.Present || rec.Status != store.IdempotencyStatusUniqueViolation {
+		t.Fatalf("dup idempotency = %+v, want UNIQUE_VIOLATION", rec)
+	}
+	var uv struct {
+		Detail string `json:"Detail"`
+	}
+	if err := json.Unmarshal([]byte(rec.FailureJSON), &uv); err != nil {
+		t.Fatalf("failure_json decode: %v", err)
+	}
+	want := "Composite unique constraint violation: tenant=tenant_a type_id=201 " +
+		"constraint='provider_user_id' fields=[1, 2] values=['google', 'uid-1'] already exists"
+	if uv.Detail != want {
+		t.Fatalf("detail mismatch:\n got=%q\nwant=%q", uv.Detail, want)
+	}
+
+	// The duplicate row must NOT have been written.
+	if _, err := f.store.GetNode(context.Background(), testTenant, "id2"); err == nil {
+		t.Fatalf("duplicate node id2 was written despite the constraint")
+	}
+	// The consumer did not halt: the third, distinct create applied.
+	if _, err := f.store.GetNode(context.Background(), testTenant, "id3"); err != nil {
+		t.Fatalf("third create did not apply (consumer halted?): %v", err)
+	}
+	// The first (winning) row is present.
+	if _, err := f.store.GetNode(context.Background(), testTenant, "id1"); err != nil {
+		t.Fatalf("winning row id1 missing: %v", err)
+	}
+}
+
+// TestApplier_CompositeUniqueViolation_BigInt pins ADR-028 lossless
+// rendering through the full applier path: a composite key whose value
+// is an int64 above 2^53 must surface in the detail as the exact integer
+// literal.
+func TestApplier_CompositeUniqueViolation_BigInt(t *testing.T) {
+	t.Parallel()
+	f := newFixtureWithRegistry(t, compositeRegistry(t))
+
+	const big int64 = 9223372036854775807
+	first := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "b1", TsMs: 1700000000000,
+		Ops: []map[string]any{mkCreateNode("b-id1", 201, map[string]any{"1": "google", "2": big})},
+	}
+	dup := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "b2", TsMs: 1700000000001,
+		Ops: []map[string]any{mkCreateNode("b-id2", 201, map[string]any{"1": "google", "2": big})},
+	}
+	f.appendEvent(t, first)
+	f.appendEvent(t, dup)
+
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "b2")
+
+	rec, err := f.store.CheckIdempotencyStatus(context.Background(), testTenant, "b2")
+	if err != nil {
+		t.Fatalf("CheckIdempotencyStatus: %v", err)
+	}
+	if !rec.Present || rec.Status != store.IdempotencyStatusUniqueViolation {
+		t.Fatalf("dup idempotency = %+v, want UNIQUE_VIOLATION", rec)
+	}
+	if !strings.Contains(rec.FailureJSON, "9223372036854775807") {
+		t.Fatalf("big int not rendered losslessly: %s", rec.FailureJSON)
+	}
+	if strings.Contains(rec.FailureJSON, "e+") || strings.Contains(rec.FailureJSON, "E+") {
+		t.Fatalf("big int rendered in scientific notation: %s", rec.FailureJSON)
+	}
+}

--- a/server/go/internal/store/idempotency.go
+++ b/server/go/internal/store/idempotency.go
@@ -21,6 +21,14 @@ const (
 	// key replays the cached failure without re-evaluating the
 	// predicate against possibly-changed state. See GitHub issue #500.
 	IdempotencyStatusFailedPrecondition = "FAILED_PRECONDITION"
+
+	// IdempotencyStatusUniqueViolation is the memoized unique-constraint
+	// trip (single-field or composite, issue #566). failure_json holds
+	// the structured ALREADY_EXISTS detail string the SDK parsers
+	// consume; a retry with the same idem key replays the same typed
+	// error without re-attempting the write. Same deterministic-outcome
+	// rationale as FAILED_PRECONDITION.
+	IdempotencyStatusUniqueViolation = "UNIQUE_VIOLATION"
 )
 
 // IdempotencyRecord is the result of CheckIdempotencyStatus. Present is
@@ -127,18 +135,28 @@ func (s *CanonicalStore) RecordIdempotencyTx(ctx context.Context, b *BatchTxn, r
 // failureJSON is opaque to the store — the caller (apply package)
 // owns the encoding.
 func (s *CanonicalStore) RecordIdempotencyFailure(ctx context.Context, tenantID, requestID, streamPos, failureJSON string) error {
+	return s.RecordIdempotencyOutcome(ctx, tenantID, requestID, streamPos, IdempotencyStatusFailedPrecondition, failureJSON)
+}
+
+// RecordIdempotencyOutcome inserts a memoized deterministic-failure row
+// (status + failure_json) keyed by (tenant_id, requestID), in its OWN
+// transaction. Generalises RecordIdempotencyFailure across the
+// deterministic-failure statuses: FAILED_PRECONDITION (CAS miss, issue
+// #500) and UNIQUE_VIOLATION (constraint trip, issue #566). The caller
+// owns the failure_json encoding; the store treats it as opaque.
+func (s *CanonicalStore) RecordIdempotencyOutcome(ctx context.Context, tenantID, requestID, streamPos, status, failureJSON string) error {
 	now := s.now()
 	return s.withWrite(ctx, tenantID, func(conn *sql.Conn) error {
 		_, err := conn.ExecContext(ctx, `
 			INSERT INTO applied_events (tenant_id, idempotency_key, stream_pos, applied_at, status, failure_json)
 			VALUES (?, ?, ?, ?, ?, ?)`,
-			tenantID, requestID, streamPos, now, IdempotencyStatusFailedPrecondition, failureJSON,
+			tenantID, requestID, streamPos, now, status, failureJSON,
 		)
 		if err != nil {
 			if isUniqueViolation(err) {
 				return fmt.Errorf("%w: %s/%s", ErrIdempotencyViolation, tenantID, requestID)
 			}
-			return fmt.Errorf("store: RecordIdempotencyFailure: %w", err)
+			return fmt.Errorf("store: RecordIdempotencyOutcome: %w", err)
 		}
 		return nil
 	})

--- a/server/go/internal/store/indexes.go
+++ b/server/go/internal/store/indexes.go
@@ -97,14 +97,7 @@ func (s *CanonicalStore) EnsureCompositeUniqueIndex(ctx context.Context, tenantI
 	s.indexCache.mu.Unlock()
 
 	for _, c := range constraints {
-		safe := safeIdent(c.Name)
-		if safe == "" {
-			parts := make([]string, 0, len(c.FieldIDs))
-			for _, f := range c.FieldIDs {
-				parts = append(parts, fmt.Sprintf("%d", f))
-			}
-			safe = "f" + strings.Join(parts, "_")
-		}
+		safe := compositeIndexSuffix(c.Name, c.FieldIDs)
 		extracts := make([]string, 0, len(c.FieldIDs))
 		for _, f := range c.FieldIDs {
 			extracts = append(extracts, fmt.Sprintf(`json_extract(payload_json, '$."%d"')`, f))
@@ -225,6 +218,87 @@ func safeIdent(name string) string {
 		}
 	}
 	return strings.Trim(b.String(), "_")
+}
+
+// uniqueIndexDDL returns the CREATE UNIQUE INDEX statement for a
+// single-field unique constraint. Shared by the lazy (separate-conn)
+// and the in-txn ensure paths so the index name + expression stay
+// byte-identical.
+func uniqueIndexDDL(typeID int32, fid uint32) string {
+	return fmt.Sprintf(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_t%d_f%d `+
+			`ON nodes(tenant_id, json_extract(payload_json, '$."%d"')) `+
+			`WHERE type_id = %d`,
+		typeID, fid, fid, typeID,
+	)
+}
+
+// compositeUniqueIndexDDL returns the CREATE UNIQUE INDEX statement for
+// a composite constraint. Mirrors EnsureCompositeUniqueIndex exactly.
+func compositeUniqueIndexDDL(typeID int32, c CompositeUnique) string {
+	safe := compositeIndexSuffix(c.Name, c.FieldIDs)
+	extracts := make([]string, 0, len(c.FieldIDs))
+	for _, f := range c.FieldIDs {
+		extracts = append(extracts, fmt.Sprintf(`json_extract(payload_json, '$."%d"')`, f))
+	}
+	return fmt.Sprintf(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_t%d_c%s `+
+			`ON nodes(tenant_id, %s) WHERE type_id = %d`,
+		typeID, safe, strings.Join(extracts, ", "), typeID,
+	)
+}
+
+// queryIndexDDL returns the non-unique query-index statement.
+func queryIndexDDL(typeID int32, fid uint32) string {
+	return fmt.Sprintf(
+		`CREATE INDEX IF NOT EXISTS idx_query_t%d_f%d `+
+			`ON nodes(tenant_id, json_extract(payload_json, '$."%d"')) `+
+			`WHERE type_id = %d`,
+		typeID, fid, fid, typeID,
+	)
+}
+
+// EnsureFieldIndexesTx creates the unique / composite-unique / query
+// expression indexes for typeID inside an already-open BatchTxn, using
+// the txn's own connection. This is the applier's hook (ADR-023 / the
+// composite-unique ADR): the unique indexes MUST exist on the write
+// connection BEFORE the INSERT so the constraint fires synchronously
+// within the same transaction. Running the DDL on a separate handle
+// (as the lazy Ensure*Index methods do) would deadlock against the
+// BatchTxn's held writer lock.
+//
+// Deliberately NOT cached in indexCache: a batch that creates an index
+// and then rolls back (e.g. because the INSERT it guards trips the very
+// constraint just created) drops the index along with the txn. A cache
+// hit on the next batch would then skip re-creation and silently leave
+// the constraint unenforced. CREATE ... IF NOT EXISTS against an
+// already-committed index is a cheap metadata-only check, so re-running
+// the DDL per first-touch is correct and inexpensive. FTS tables are
+// NOT created here — the applier maintains those via fts.go.
+//
+// No-ops when no schema.Registry is configured (raw-CRUD test paths).
+func (s *CanonicalStore) EnsureFieldIndexesTx(ctx context.Context, tx *BatchTxn, typeID int32) error {
+	if s.registry == nil {
+		return nil
+	}
+	conn := tx.Conn()
+	for _, fid := range s.registry.UniqueFieldIDs(typeID) {
+		if _, err := conn.ExecContext(ctx, uniqueIndexDDL(typeID, fid)); err != nil {
+			return fmt.Errorf("store: create unique index (tx) t%d_f%d: %w", typeID, fid, err)
+		}
+	}
+	for _, c := range s.registry.CompositeUnique(typeID) {
+		cu := CompositeUnique{Name: c.Name, FieldIDs: c.FieldIDs}
+		if _, err := conn.ExecContext(ctx, compositeUniqueIndexDDL(typeID, cu)); err != nil {
+			return fmt.Errorf("store: create composite unique index (tx) t%d_%s: %w", typeID, c.Name, err)
+		}
+	}
+	for _, fid := range s.registry.IndexedFieldIDs(typeID) {
+		if _, err := conn.ExecContext(ctx, queryIndexDDL(typeID, fid)); err != nil {
+			return fmt.Errorf("store: create query index (tx) t%d_f%d: %w", typeID, fid, err)
+		}
+	}
+	return nil
 }
 
 // ensureFieldIndexes is the convenience wrapper used by writers before

--- a/server/go/internal/store/nodes.go
+++ b/server/go/internal/store/nodes.go
@@ -490,6 +490,13 @@ func (s *CanonicalStore) CreateNodeRaw(ctx context.Context, tenantID string, in 
 		)
 		if err != nil {
 			if isUniqueViolation(err) {
+				// Surface the structured ALREADY_EXISTS detail the SDK
+				// parsers consume (issue #566) when the violated index is
+				// a declared single-field/composite unique constraint;
+				// fall back to the generic message otherwise.
+				if detail, ok := s.BuildUniqueViolationDetail(tenantID, payload, err); ok {
+					return fmt.Errorf("%w: %s", ErrUniqueConstraint, detail)
+				}
 				return fmt.Errorf("%w: %s/%s", ErrUniqueConstraint, tenantID, in.NodeID)
 			}
 			return fmt.Errorf("store: insert node: %w", err)

--- a/server/go/internal/store/unique_violation.go
+++ b/server/go/internal/store/unique_violation.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// This file owns the translation of a raw SQLite UNIQUE-constraint
+// failure into the structured ALREADY_EXISTS detail strings the SDKs
+// parse (Go: parseUniqueConstraintFromStatus; Python:
+// _parse_unique_constraint_detail / _parse_composite_unique_constraint_detail).
+//
+// modernc.org/sqlite reports an expression-index UNIQUE violation as:
+//
+//	UNIQUE constraint failed: index 'idx_unique_t<T>_f<F>'      (single-field)
+//	UNIQUE constraint failed: index 'idx_unique_t<T>_c<name>'   (composite)
+//
+// The index NAME is the source of truth for WHICH declared constraint
+// fired, so we parse it rather than guessing from the payload. The
+// names are minted by EnsureUniqueIndex / EnsureCompositeUniqueIndex in
+// indexes.go and the two must stay in lock-step.
+
+// sqliteIndexNameRE captures the index name out of a modernc.org/sqlite
+// UNIQUE-violation error message. The driver wraps the message in its
+// own prefix/suffix ("constraint failed: UNIQUE constraint failed:
+// index '<name>' (2067)"); we only need the quoted index name.
+var sqliteIndexNameRE = regexp.MustCompile(`index '([^']+)'`)
+
+// uniqueViolationParts is the parsed coordinates of a UNIQUE-constraint
+// failure, ready to be lowered into the structured ALREADY_EXISTS
+// detail. Composite is true when the violated index is a composite
+// (multi-field) constraint; for single-field violations ConstraintName
+// is empty and FieldIDs holds exactly one id.
+type uniqueViolationParts struct {
+	Composite      bool
+	TypeID         int32
+	ConstraintName string
+	FieldIDs       []uint32
+}
+
+// parseUniqueIndexName decodes an index name minted by indexes.go back
+// into its constraint coordinates. Returns ok=false when the name is
+// not one of our unique-index names (e.g. a UNIQUE failure on a
+// built-in table constraint such as applied_events). The registry is
+// consulted to map a single-field index back to its field_id and a
+// composite index back to its declared field_id tuple — the index name
+// only carries the type_id and (for composites) the constraint name.
+func (s *CanonicalStore) parseUniqueIndexName(name string) (uniqueViolationParts, bool) {
+	// Single-field: idx_unique_t<T>_f<F>
+	if m := singleFieldIndexRE.FindStringSubmatch(name); m != nil {
+		t, err1 := strconv.Atoi(m[1])
+		f, err2 := strconv.Atoi(m[2])
+		if err1 == nil && err2 == nil {
+			return uniqueViolationParts{
+				Composite: false,
+				TypeID:    int32(t),
+				FieldIDs:  []uint32{uint32(f)},
+			}, true
+		}
+		return uniqueViolationParts{}, false
+	}
+	// Composite: idx_unique_t<T>_c<safeName>
+	if m := compositeIndexRE.FindStringSubmatch(name); m != nil {
+		t, err := strconv.Atoi(m[1])
+		if err != nil {
+			return uniqueViolationParts{}, false
+		}
+		typeID := int32(t)
+		safe := m[2]
+		// Resolve the safe-name suffix back to the declared constraint
+		// via the registry so we recover the real (un-sanitized) name
+		// and the field_id tuple in declaration order.
+		if s.registry != nil {
+			for _, c := range s.registry.CompositeUnique(typeID) {
+				if compositeIndexSuffix(c.Name, c.FieldIDs) == safe {
+					return uniqueViolationParts{
+						Composite:      true,
+						TypeID:         typeID,
+						ConstraintName: c.Name,
+						FieldIDs:       append([]uint32(nil), c.FieldIDs...),
+					}, true
+				}
+			}
+		}
+		// No registry match — surface what we can (the safe suffix as a
+		// best-effort name). Still flagged composite so the SDK routes
+		// to the composite branch.
+		return uniqueViolationParts{
+			Composite:      true,
+			TypeID:         typeID,
+			ConstraintName: safe,
+		}, true
+	}
+	return uniqueViolationParts{}, false
+}
+
+var (
+	singleFieldIndexRE = regexp.MustCompile(`^idx_unique_t(\d+)_f(\d+)$`)
+	compositeIndexRE   = regexp.MustCompile(`^idx_unique_t(\d+)_c(.+)$`)
+)
+
+// indexNameFromSQLiteError extracts the quoted index name from a
+// modernc.org/sqlite UNIQUE-violation error message. Returns "" when no
+// index name is present (e.g. a primary-key collision).
+func indexNameFromSQLiteError(err error) string {
+	if err == nil {
+		return ""
+	}
+	m := sqliteIndexNameRE.FindStringSubmatch(err.Error())
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// BuildUniqueViolationDetail turns a raw SQLite UNIQUE-constraint error
+// into the structured ALREADY_EXISTS detail string the SDKs parse, plus
+// a bool reporting whether it recognised the violation as one of our
+// declared (single-field or composite) unique constraints.
+//
+// payload is the field-id-keyed map being written (the colliding row's
+// values); tenantID identifies the shard. When the error is not a
+// recognised unique-index violation, ok is false and the caller should
+// fall back to the generic ErrUniqueConstraint message.
+//
+// Output formats (verbatim — pinned by the SDK parsers):
+//
+//	single-field:
+//	  Unique constraint violation: tenant=<t> type_id=<T> field_id=<F> value=<repr> already exists
+//	composite:
+//	  Composite unique constraint violation: tenant=<t> type_id=<T> constraint='<name>' fields=[<F>, ...] values=[<repr>, ...] already exists
+func (s *CanonicalStore) BuildUniqueViolationDetail(tenantID string, payload map[string]any, err error) (detail string, ok bool) {
+	idxName := indexNameFromSQLiteError(err)
+	if idxName == "" {
+		return "", false
+	}
+	parts, ok := s.parseUniqueIndexName(idxName)
+	if !ok {
+		return "", false
+	}
+	if parts.Composite {
+		return formatCompositeUniqueDetail(tenantID, parts, payload), true
+	}
+	if len(parts.FieldIDs) != 1 {
+		return "", false
+	}
+	fid := parts.FieldIDs[0]
+	val := lookupPayloadValue(payload, fid)
+	return fmt.Sprintf(
+		"Unique constraint violation: tenant=%s type_id=%d field_id=%d value=%s already exists",
+		tenantID, parts.TypeID, fid, pyRepr(val),
+	), true
+}
+
+// formatCompositeUniqueDetail renders the composite ALREADY_EXISTS
+// detail. fields/values are rendered as Python-literal lists so the
+// SDK's ast.literal_eval / Go regex both parse them.
+func formatCompositeUniqueDetail(tenantID string, parts uniqueViolationParts, payload map[string]any) string {
+	fieldStrs := make([]string, 0, len(parts.FieldIDs))
+	valStrs := make([]string, 0, len(parts.FieldIDs))
+	for _, fid := range parts.FieldIDs {
+		fieldStrs = append(fieldStrs, strconv.FormatUint(uint64(fid), 10))
+		valStrs = append(valStrs, pyRepr(lookupPayloadValue(payload, fid)))
+	}
+	return fmt.Sprintf(
+		"Composite unique constraint violation: tenant=%s type_id=%d constraint=%s fields=[%s] values=[%s] already exists",
+		tenantID, parts.TypeID, pyReprString(parts.ConstraintName),
+		strings.Join(fieldStrs, ", "), strings.Join(valStrs, ", "),
+	)
+}
+
+// lookupPayloadValue fetches the field_id-keyed value out of the
+// payload map. Payloads are keyed by the stringified field_id (CLAUDE.md
+// invariant #6 / ADR-018). Returns nil when the field is absent.
+func lookupPayloadValue(payload map[string]any, fid uint32) any {
+	if payload == nil {
+		return nil
+	}
+	return payload[strconv.FormatUint(uint64(fid), 10)]
+}
+
+// pyRepr renders v as a Python repr()-compatible literal so the SDK
+// parsers can round-trip it via ast.literal_eval. The applier decodes
+// payloads with jsonnum so integral values arrive as int64 (ADR-028)
+// and survive losslessly here — big ints are NOT collapsed to float
+// scientific notation.
+func pyRepr(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "None"
+	case string:
+		return pyReprString(x)
+	case bool:
+		if x {
+			return "True"
+		}
+		return "False"
+	case int:
+		return strconv.FormatInt(int64(x), 10)
+	case int32:
+		return strconv.FormatInt(int64(x), 10)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case uint32:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint64:
+		return strconv.FormatUint(x, 10)
+	case float64:
+		// Integral float64 with no fractional part still renders as an
+		// int-looking literal would mis-type on the SDK side, so keep a
+		// trailing ".0" for true floats. jsonnum already promotes exact
+		// integers to int64, so a float64 reaching here is genuinely
+		// fractional or out of int64 range.
+		if x == math.Trunc(x) && !math.IsInf(x, 0) {
+			return strconv.FormatFloat(x, 'f', 1, 64)
+		}
+		return strconv.FormatFloat(x, 'g', -1, 64)
+	default:
+		// Lists / maps / bytes: fall back to a quoted Go rendering. These
+		// are not valid composite-key field kinds (the schema rejects
+		// non-scalar unique fields) so this branch is diagnostic only.
+		return pyReprString(fmt.Sprintf("%v", x))
+	}
+}
+
+// pyReprString renders s as a single-quoted Python string literal,
+// escaping backslashes and single quotes so ast.literal_eval round-trips
+// it. Matches CPython's repr() for the common (no control-char) case.
+func pyReprString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('\'')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '\\':
+			b.WriteString(`\\`)
+		case '\'':
+			b.WriteString(`\'`)
+		default:
+			b.WriteByte(c)
+		}
+	}
+	b.WriteByte('\'')
+	return b.String()
+}
+
+// compositeIndexSuffix returns the index-name suffix EnsureCompositeUniqueIndex
+// mints for a constraint, so parseUniqueIndexName can match a SQLite
+// index name back to its declared constraint. Kept here next to the
+// parser and exercised by indexes.go to guarantee the two agree.
+func compositeIndexSuffix(name string, fieldIDs []uint32) string {
+	safe := safeIdent(name)
+	if safe != "" {
+		return safe
+	}
+	parts := make([]string, 0, len(fieldIDs))
+	for _, f := range fieldIDs {
+		parts = append(parts, strconv.FormatUint(uint64(f), 10))
+	}
+	return "f" + strings.Join(parts, "_")
+}

--- a/server/go/internal/store/unique_violation_test.go
+++ b/server/go/internal/store/unique_violation_test.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// newStoreWithRegistry builds a tmpdir-backed store wired to a frozen
+// registry so the unique-violation translator can resolve composite
+// constraint coordinates.
+func newStoreWithRegistry(t *testing.T, reg *schema.Registry) *store.CanonicalStore {
+	t.Helper()
+	dir := t.TempDir()
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true, Registry: reg})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// oauthIdentityRegistry models the issue-#566 motivating type:
+// OAuthIdentity(type_id=201) with a (provider, provider_user_id)
+// composite unique constraint plus a single-field unique email.
+func oauthIdentityRegistry(t *testing.T) *schema.Registry {
+	t.Helper()
+	reg := schema.NewRegistry()
+	nt := &schema.NodeTypeDef{
+		TypeID: 201,
+		Name:   "OAuthIdentity",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "provider", Kind: schema.KindString},
+			{FieldID: 2, Name: "provider_user_id", Kind: schema.KindString},
+			{FieldID: 3, Name: "email", Kind: schema.KindString, Unique: true},
+			{FieldID: 4, Name: "external_serial", Kind: schema.KindInteger},
+		},
+		CompositeUnique: []schema.CompositeUniqueDef{
+			{Name: "provider_user_id", FieldIDs: []uint32{1, 2}},
+		},
+	}
+	if err := reg.RegisterNode(nt); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+	return reg
+}
+
+// insertViaTxn inserts a node row directly on a BatchTxn connection,
+// ensuring indexes first, and returns the RAW SQLite error (with the
+// "index '...'" clause intact) so BuildUniqueViolationDetail can be
+// exercised against the on-the-wire driver message. The txn is committed
+// on success and rolled back on a constraint trip — mirroring the
+// applier's batch lifecycle.
+func insertViaTxn(t *testing.T, cs *store.CanonicalStore, tenant, nodeID string, typeID int32, payloadJSON string) error {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := cs.BeginBatch(ctx, tenant)
+	if err != nil {
+		t.Fatalf("BeginBatch: %v", err)
+	}
+	if err := cs.EnsureFieldIndexesTx(ctx, tx, typeID); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("EnsureFieldIndexesTx: %v", err)
+	}
+	_, insErr := tx.Conn().ExecContext(ctx,
+		`INSERT INTO nodes (tenant_id,node_id,type_id,payload_json,created_at,updated_at,owner_actor,acl_blob) VALUES (?,?,?,?,?,?,?,?)`,
+		tenant, nodeID, typeID, payloadJSON, 1, 1, "u", "[]")
+	if insErr != nil {
+		_ = tx.Rollback()
+		return insErr
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return nil
+}
+
+func TestBuildUniqueViolationDetail_Composite(t *testing.T) {
+	reg := oauthIdentityRegistry(t)
+	cs := newStoreWithRegistry(t, reg)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	// First insert seeds the (google, uid-1) tuple; the txn helper ensures
+	// the composite index exists.
+	if err := insertViaTxn(t, cs, "t1", "n1", 201, `{"1":"google","2":"uid-1","3":"a@x.com"}`); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	// Duplicate composite tuple (distinct email so only the composite
+	// constraint trips).
+	err := insertViaTxn(t, cs, "t1", "n2", 201, `{"1":"google","2":"uid-1","3":"b@x.com"}`)
+	if err == nil {
+		t.Fatalf("expected duplicate composite insert to fail")
+	}
+
+	detail, ok := cs.BuildUniqueViolationDetail("t1", map[string]any{"1": "google", "2": "uid-1"}, err)
+	if !ok {
+		t.Fatalf("BuildUniqueViolationDetail did not recognise the violation: %v", err)
+	}
+	want := "Composite unique constraint violation: tenant=t1 type_id=201 " +
+		"constraint='provider_user_id' fields=[1, 2] values=['google', 'uid-1'] already exists"
+	if detail != want {
+		t.Fatalf("detail mismatch:\n got=%q\nwant=%q", detail, want)
+	}
+}
+
+func TestBuildUniqueViolationDetail_SingleField(t *testing.T) {
+	reg := oauthIdentityRegistry(t)
+	cs := newStoreWithRegistry(t, reg)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if err := insertViaTxn(t, cs, "t1", "n1", 201, `{"1":"google","2":"uid-1","3":"dup@x.com"}`); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	// Same email (single-field unique on field 3) but distinct composite
+	// tuple so ONLY the single-field constraint trips.
+	err := insertViaTxn(t, cs, "t1", "n2", 201, `{"1":"github","2":"uid-9","3":"dup@x.com"}`)
+	if err == nil {
+		t.Fatalf("expected duplicate email insert to fail")
+	}
+	detail, ok := cs.BuildUniqueViolationDetail("t1", map[string]any{"1": "github", "2": "uid-9", "3": "dup@x.com"}, err)
+	if !ok {
+		t.Fatalf("BuildUniqueViolationDetail did not recognise the violation: %v", err)
+	}
+	want := "Unique constraint violation: tenant=t1 type_id=201 field_id=3 value='dup@x.com' already exists"
+	if detail != want {
+		t.Fatalf("detail mismatch:\n got=%q\nwant=%q", detail, want)
+	}
+}
+
+// TestBuildUniqueViolationDetail_BigIntComposite pins ADR-028 lossless
+// behaviour: an int64 above 2^53 must render as the exact integer
+// literal, never float scientific notation, so the SDK round-trips it.
+func TestBuildUniqueViolationDetail_BigIntComposite(t *testing.T) {
+	reg := schema.NewRegistry()
+	nt := &schema.NodeTypeDef{
+		TypeID: 301,
+		Name:   "BigKey",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "provider", Kind: schema.KindString},
+			{FieldID: 2, Name: "serial", Kind: schema.KindInteger},
+		},
+		CompositeUnique: []schema.CompositeUniqueDef{
+			{Name: "provider_serial", FieldIDs: []uint32{1, 2}},
+		},
+	}
+	if err := reg.RegisterNode(nt); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+	cs := newStoreWithRegistry(t, reg)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	const big int64 = 9223372036854775807 // math.MaxInt64, well above 2^53
+	if err := insertViaTxn(t, cs, "t1", "n1", 301, `{"1":"google","2":9223372036854775807}`); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	err := insertViaTxn(t, cs, "t1", "n2", 301, `{"1":"google","2":9223372036854775807}`)
+	if err == nil {
+		t.Fatalf("expected duplicate big-int composite insert to fail")
+	}
+	detail, ok := cs.BuildUniqueViolationDetail("t1", map[string]any{"1": "google", "2": big}, err)
+	if !ok {
+		t.Fatalf("BuildUniqueViolationDetail did not recognise the violation: %v", err)
+	}
+	if !strings.Contains(detail, "9223372036854775807") {
+		t.Fatalf("big int not rendered losslessly: %q", detail)
+	}
+	if strings.Contains(detail, "e+") || strings.Contains(detail, "E+") {
+		t.Fatalf("big int rendered in scientific notation: %q", detail)
+	}
+	want := "Composite unique constraint violation: tenant=t1 type_id=301 " +
+		"constraint='provider_serial' fields=[1, 2] values=['google', 9223372036854775807] already exists"
+	if detail != want {
+		t.Fatalf("detail mismatch:\n got=%q\nwant=%q", detail, want)
+	}
+}
+
+// TestBuildUniqueViolationDetail_Unrecognised confirms a non-unique-index
+// error (e.g. a primary-key collision, which names no index) is not
+// misclassified as a declared unique violation.
+func TestBuildUniqueViolationDetail_Unrecognised(t *testing.T) {
+	reg := oauthIdentityRegistry(t)
+	cs := newStoreWithRegistry(t, reg)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if err := insertViaTxn(t, cs, "t1", "dup", 201, `{"1":"google","2":"uid-1"}`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Re-insert the SAME node_id -> PRIMARY KEY collision, which SQLite
+	// reports without an "index '...'" clause.
+	err := insertViaTxn(t, cs, "t1", "dup", 201, `{"1":"yahoo","2":"uid-2"}`)
+	if err == nil {
+		t.Fatalf("expected PK collision")
+	}
+	if _, ok := cs.BuildUniqueViolationDetail("t1", map[string]any{}, err); ok {
+		t.Fatalf("PK collision should NOT be recognised as a declared unique violation")
+	}
+}
+
+// TestEnsureFieldIndexesTx_CreatesCompositeIndex verifies the applier's
+// in-txn ensure path actually mints the composite unique index so the
+// constraint fires inside the same transaction.
+func TestEnsureFieldIndexesTx_CreatesCompositeIndex(t *testing.T) {
+	reg := oauthIdentityRegistry(t)
+	cs := newStoreWithRegistry(t, reg)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	tx, err := cs.BeginBatch(ctx, "t1")
+	if err != nil {
+		t.Fatalf("BeginBatch: %v", err)
+	}
+	if err := cs.EnsureFieldIndexesTx(ctx, tx, 201); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("EnsureFieldIndexesTx: %v", err)
+	}
+	// Two distinct rows with the same composite tuple inside the SAME txn
+	// must collide.
+	conn := tx.Conn()
+	exec := func(id, p string) error {
+		_, e := conn.ExecContext(ctx,
+			`INSERT INTO nodes (tenant_id,node_id,type_id,payload_json,created_at,updated_at,owner_actor,acl_blob) VALUES (?,?,?,?,?,?,?,?)`,
+			"t1", id, 201, p, 1, 1, "u", "[]")
+		return e
+	}
+	if err := exec("a", `{"1":"google","2":"uid-1"}`); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("insert a: %v", err)
+	}
+	dupErr := exec("b", `{"1":"google","2":"uid-1"}`)
+	_ = tx.Rollback()
+	if dupErr == nil {
+		t.Fatalf("expected composite collision inside txn")
+	}
+	if name := indexNameForTest(dupErr); !strings.Contains(name, "idx_unique_t201_cprovider_user_id") {
+		t.Fatalf("collision did not name the composite index: %v", dupErr)
+	}
+}
+
+// indexNameForTest is a small accessor over the error string so the test
+// asserts on the index the violation named.
+func indexNameForTest(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/server/go/internal/testseed/seed.go
+++ b/server/go/internal/testseed/seed.go
@@ -53,6 +53,12 @@ const (
 	UserTypeID   = 1
 	TaskTypeID   = 2
 	AssignedToID = 100
+
+	// OAuthIdentityTypeID is the contract-suite type carrying a
+	// (provider, provider_user_id) composite unique constraint plus a
+	// single-field unique email — exercises issue #566 end-to-end.
+	// Field IDs: 1=provider, 2=provider_user_id, 3=email.
+	OAuthIdentityTypeID = 201
 )
 
 // E2E-suite fixture constants — keep in lock-step with
@@ -110,6 +116,21 @@ func RegisterContractSchema(reg *schema.Registry) error {
 	}
 	if err := reg.RegisterEdge(edge); err != nil {
 		return fmt.Errorf("testseed: register AssignedTo: %w", err)
+	}
+	oauth := &schema.NodeTypeDef{
+		TypeID: OAuthIdentityTypeID,
+		Name:   "OAuthIdentity",
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Name: "provider", Kind: schema.KindString},
+			{FieldID: 2, Name: "provider_user_id", Kind: schema.KindString},
+			{FieldID: 3, Name: "email", Kind: schema.KindString, Unique: true},
+		},
+		CompositeUnique: []schema.CompositeUniqueDef{
+			{Name: "provider_user_id", FieldIDs: []uint32{1, 2}},
+		},
+	}
+	if err := reg.RegisterNode(oauth); err != nil {
+		return fmt.Errorf("testseed: register OAuthIdentity: %w", err)
 	}
 	return nil
 }

--- a/server/go/internal/testseed/seed_test.go
+++ b/server/go/internal/testseed/seed_test.go
@@ -267,4 +267,13 @@ func TestRegisterContractSchema_DefinesExpectedTypes(t *testing.T) {
 	if et := reg.EdgeType("AssignedTo"); et == nil || et.EdgeID != AssignedToID {
 		t.Fatalf("AssignedTo edge missing or wrong id: %+v", et)
 	}
+	oauth := reg.NodeType("OAuthIdentity")
+	if oauth == nil || oauth.TypeID != OAuthIdentityTypeID {
+		t.Fatalf("OAuthIdentity type missing or wrong id: %+v", oauth)
+	}
+	cu := reg.CompositeUnique(OAuthIdentityTypeID)
+	if len(cu) != 1 || cu[0].Name != "provider_user_id" ||
+		len(cu[0].FieldIDs) != 2 || cu[0].FieldIDs[0] != 1 || cu[0].FieldIDs[1] != 2 {
+		t.Fatalf("OAuthIdentity composite unique = %+v, want provider_user_id [1 2]", cu)
+	}
 }

--- a/tests/python/integration/test_composite_unique.py
+++ b/tests/python/integration/test_composite_unique.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Integration tests for composite (multi-field) unique constraints.
+
+Issue #566. The seeded contract schema carries an
+``OAuthIdentity`` (type_id=201) node type with a
+``(provider, provider_user_id)`` composite unique constraint plus a
+single-field unique ``email``. These tests drive the full
+WAL -> applier -> SQLite composite-index path against the live Go
+server and assert the violation surfaces as a gRPC ``ALREADY_EXISTS``
+carrying the structured detail the SDK parsers consume.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import grpc
+import pytest
+from grpc import aio as grpc_aio
+
+from entdb_sdk._generated import entdb_pb2 as pb
+from entdb_sdk._generated.entdb_pb2_grpc import EntDBServiceStub
+
+TENANT = "acme"
+ACTOR = "user:alice"
+OAUTH_TYPE_ID = 201
+
+
+def _ctx() -> pb.RequestContext:
+    return pb.RequestContext(tenant_id=TENANT, actor=ACTOR)
+
+
+async def _create_oauth(
+    stub: EntDBServiceStub,
+    *,
+    provider: str,
+    provider_user_id: str,
+    email: str,
+    idem: str,
+):
+    op = pb.CreateNodeOp(
+        type_id=OAUTH_TYPE_ID,
+        id=f"oauth-{uuid.uuid4().hex[:8]}",
+        typed_data={
+            1: pb.EntValue(string_value=provider),
+            2: pb.EntValue(string_value=provider_user_id),
+            3: pb.EntValue(string_value=email),
+        },
+    )
+    req = pb.ExecuteAtomicRequest(
+        context=_ctx(),
+        idempotency_key=idem,
+        operations=[pb.Operation(create_node=op)],
+        wait_applied=True,
+        wait_timeout_ms=5000,
+    )
+    return await stub.ExecuteAtomic(req)
+
+
+@pytest.fixture
+async def stub(grpc_endpoint):
+    async with grpc_aio.insecure_channel(grpc_endpoint) as ch:
+        yield EntDBServiceStub(ch)
+
+
+async def test_composite_unique_violation_already_exists(stub) -> None:
+    """A duplicate (provider, provider_user_id) tuple surfaces as a
+    gRPC ALREADY_EXISTS with the structured composite detail."""
+    uid = uuid.uuid4().hex[:8]
+    r1 = await _create_oauth(
+        stub,
+        provider="google",
+        provider_user_id=f"uid-{uid}",
+        email=f"a-{uid}@x.com",
+        idem=f"oa-{uid}-1",
+    )
+    assert r1.success, r1.error
+
+    with pytest.raises(grpc.aio.AioRpcError) as exc_info:
+        await _create_oauth(
+            stub,
+            provider="google",
+            provider_user_id=f"uid-{uid}",  # same composite tuple
+            email=f"b-{uid}@x.com",  # distinct email -> only composite trips
+            idem=f"oa-{uid}-2",
+        )
+    err = exc_info.value
+    assert err.code() == grpc.StatusCode.ALREADY_EXISTS
+    detail = err.details()
+    assert "Composite unique constraint violation" in detail
+    assert "constraint='provider_user_id'" in detail
+    assert "fields=[1, 2]" in detail
+    assert "type_id=201" in detail
+    assert f"tenant={TENANT}" in detail
+    assert "already exists" in detail
+
+
+async def test_single_field_unique_violation_already_exists(stub) -> None:
+    """A duplicate single-field unique email surfaces as a gRPC
+    ALREADY_EXISTS with the single-field detail (distinct composite
+    tuple, so only the email constraint trips)."""
+    uid = uuid.uuid4().hex[:8]
+    email = f"dup-{uid}@x.com"
+    r1 = await _create_oauth(
+        stub,
+        provider="google",
+        provider_user_id=f"g-{uid}",
+        email=email,
+        idem=f"sf-{uid}-1",
+    )
+    assert r1.success, r1.error
+
+    with pytest.raises(grpc.aio.AioRpcError) as exc_info:
+        await _create_oauth(
+            stub,
+            provider="github",  # distinct composite tuple
+            provider_user_id=f"h-{uid}",
+            email=email,  # duplicate single-field unique
+            idem=f"sf-{uid}-2",
+        )
+    err = exc_info.value
+    assert err.code() == grpc.StatusCode.ALREADY_EXISTS
+    detail = err.details()
+    assert "Unique constraint violation" in detail
+    assert "field_id=3" in detail
+    assert email in detail
+
+
+async def test_composite_unique_distinct_tuples_both_apply(stub) -> None:
+    """Distinct composite tuples both apply — the constraint only
+    rejects exact-tuple duplicates."""
+    uid = uuid.uuid4().hex[:8]
+    r1 = await _create_oauth(
+        stub,
+        provider="google",
+        provider_user_id=f"x-{uid}",
+        email=f"x1-{uid}@x.com",
+        idem=f"d-{uid}-1",
+    )
+    assert r1.success, r1.error
+    # Same provider, different provider_user_id -> distinct tuple.
+    r2 = await _create_oauth(
+        stub,
+        provider="google",
+        provider_user_id=f"y-{uid}",
+        email=f"x2-{uid}@x.com",
+        idem=f"d-{uid}-2",
+    )
+    assert r2.success, r2.error

--- a/tests/python/unit/test_sdk_v3_shape.py
+++ b/tests/python/unit/test_sdk_v3_shape.py
@@ -212,6 +212,51 @@ class TestCanonicalFlow:
         assert err.type_id == 9001
         assert err.field_id == 1
         assert err.value == "WIDGET-1"
+        assert not err.is_composite
+
+    @pytest.mark.asyncio
+    async def test_duplicate_create_raises_typed_composite_unique_error(self, db):
+        """A composite (multi-field) collision surfaces as the same
+        ``UniqueConstraintError`` with ``is_composite`` set and the
+        constraint coordinates populated (issue #566).
+
+        The server emits a distinct ALREADY_EXISTS detail for composite
+        constraints; the SDK parser routes it to the composite branch.
+        Big-int values must round-trip losslessly (ADR-028).
+        """
+        from entdb_sdk._grpc_client import GrpcClient
+
+        class _FakeRpcError(grpc.RpcError):
+            def code(self):
+                return grpc.StatusCode.ALREADY_EXISTS
+
+            def details(self):
+                return (
+                    "Composite unique constraint violation: tenant=acme "
+                    "type_id=201 constraint='provider_user_id' fields=[1, 2] "
+                    "values=['google', 9223372036854775807] already exists"
+                )
+
+        real_grpc = GrpcClient(host="localhost", port=50051)
+        real_grpc._stub = AsyncMock()
+        real_grpc._retry = AsyncMock(side_effect=_FakeRpcError())
+        db._grpc = real_grpc
+
+        scope = db.tenant("acme").actor(Actor.user("alice"))
+        plan = scope.plan()
+        plan.create(ts.Product(sku="WIDGET-1", name="Dup"))
+
+        with pytest.raises(UniqueConstraintError) as exc_info:
+            await plan.commit(wait_applied=True)
+
+        err = exc_info.value
+        assert err.is_composite
+        assert err.tenant_id == "acme"
+        assert err.type_id == 201
+        assert err.constraint_name == "provider_user_id"
+        assert err.field_ids == (1, 2)
+        # Lossless big int (ADR-028): not collapsed to float / 2**53.
+        assert err.values == ("google", 9223372036854775807)
 
 
 # ── 2. Storage descriptors are the only way to pick a storage mode ──


### PR DESCRIPTION
## What

Implements composite (multi-field) unique constraints (#566, **ADR-030**). The SDK error-parsing side was already scaffolded (Go `parseUniqueConstraintFromStatus`, Python `_parse_composite_unique_constraint_detail`) but the **applier never enforced any unique constraint** — neither single-field nor composite. This wires real enforcement into the WAL apply path.

## How

- **Declaration:** message-level `(entdb.node).composite_unique` (pre-existing proto option) parsed by the schema registry into per-type constraint sets.
- **Store:** a SQLite UNIQUE expression index per constraint over the `json_extract(payload_json,'$."<fid>"')` tuple (mirrors the single-field unique index; int64 values handled losslessly per ADR-028).
- **Applier:** `applyCreateNode`/`applyUpdateNode` now ensure the indexes and translate a SQLite `UNIQUE constraint failed: index '<name>'` into `codes.AlreadyExists` with the exact structured detail the SDK parsers expect — the index name (`idx_unique_t<T>_f<F>` vs `idx_unique_t<T>_c<name>`) is the authoritative discriminator, mapped back to coordinates via the registry.
- **ADR-030** documents the design (checked against ADR-022/023/025/028).

Emitted detail strings (verbatim, `ast.literal_eval`-parseable values, big-int lossless):
- single: `Unique constraint violation: tenant=<t> type_id=<T> field_id=<F> value=<repr> already exists`
- composite: `Composite unique constraint violation: tenant=<t> type_id=<T> constraint='<name>' fields=[<F>, ...] values=[<repr>, ...] already exists`

## Tests

Detail-builder unit tests (composite/single/big-int/unrecognized), end-to-end WAL→applier duplicate → violation (+ no applier halt), ExecuteAtomic → gRPC `AlreadyExists` with verbatim detail, Go SDK composite extraction, Python typed-error + 3 live-server cases. Full local CI green (server, Go SDK, 549 Python, ruff, docs coverage pinned-go) + Docker E2E.

Closes #566.