### PR TITLE
fix: stable total order on ListSharedWithMe offset path

### DIFF
--- a/server/go/internal/globalstore/shared.go
+++ b/server/go/internal/globalstore/shared.go
@@ -54,7 +54,7 @@ func (g *GlobalStore) ListSharedToUser(ctx context.Context, userID string, limit
 	rows, err := g.db.QueryContext(ctx,
 		`SELECT user_id, source_tenant, node_id, permission, shared_at
 		 FROM shared_index WHERE user_id = ?
-		 ORDER BY shared_at DESC LIMIT ? OFFSET ?`,
+		 ORDER BY shared_at DESC, source_tenant DESC, node_id DESC LIMIT ? OFFSET ?`,
 		userID, limit, offset,
 	)
 	if err != nil {

--- a/server/go/internal/store/visibility.go
+++ b/server/go/internal/store/visibility.go
@@ -253,7 +253,7 @@ func (s *CanonicalStore) ListSharedWithMe(ctx context.Context, tenantID string, 
 		  AND na.actor_id IN (%s)
 		  AND na.permission != 'deny'
 		  AND (na.expires_at IS NULL OR na.expires_at > ?)
-		ORDER BY na.granted_at DESC
+		ORDER BY na.granted_at DESC, n.node_id DESC
 		LIMIT ? OFFSET ?`, ph,
 	)
 	args := make([]any, 0, 4+len(actorIDs))


### PR DESCRIPTION
## What

`TestListSharedWithMe_Pagination` fails under repeated runs (deterministically with `-count`): a seeded node appears 0 times across two offset pages. Shipped in v1.31.0 (#580).

## Cause

The keyset path (`ListSharedWithMePaged`) orders by `(granted_at, tenant, node_id)` — a total order. But the **deprecated offset path** (`store.ListSharedWithMe`, `globalstore.ListSharedToUser`) ordered by `granted_at`/`shared_at DESC` with **no unique tiebreaker**. With several grants sharing a timestamp, SQLite's order is unstable across successive `OFFSET` windows, so a row can be skipped or duplicated between pages.

## Fix

Append the `node_id` (+ `source_tenant`) tiebreaker to both offset-path queries so the order is total and stable, matching the keyset path. Server-only.

Verified: the test passes 30× consecutively; full server suite green.