### PR TITLE
fix(#568): exclude mailbox nodes from plain by-id reads + E2E/integration coverage

### DIFF
--- a/sdk/go/entdb/integration_test.go
+++ b/sdk/go/entdb/integration_test.go
@@ -260,6 +260,45 @@ func TestIntegration_GetEdgesFromAutoFollowsRealCursor(t *testing.T) {
 	// no truncation; a stuck prefix (e.g. 100) would have failed the poll.
 }
 
+// TestIntegration_MailboxReadAndPrivacy proves USER_MAILBOX writes are
+// readable via the mailbox scope and excluded from an ordinary tenant
+// read (#568), end-to-end through the real server via the Go SDK.
+func TestIntegration_MailboxReadAndPrivacy(t *testing.T) {
+	ctx := context.Background()
+	const mailUser = "mailbox-user-1"
+
+	res, err := itClient.transport.ExecuteAtomic(ctx, itTenant, itActor, "it-mailbox",
+		[]Operation{{
+			Type: OpCreateNode, TypeID: itUserType, NodeID: "mbox-1",
+			StorageMode: StorageModeUserMailbox, TargetUserID: mailUser,
+			Data: map[string]any{"1": "inbox@x", "2": "Mailbox Node"},
+		}})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("commit not successful: %+v", res)
+	}
+
+	// Visible via the mailbox scope.
+	eventually(t, "mailbox node visible via GetMailboxNode", func() bool {
+		n, gerr := itClient.transport.GetMailboxNode(ctx, itTenant, itActor, mailUser, itUserType, "mbox-1")
+		if gerr != nil {
+			t.Fatalf("GetMailboxNode: %v", gerr)
+		}
+		return n != nil && n.NodeID == "mbox-1"
+	})
+
+	// Excluded from an ordinary tenant read (privacy boundary, ADR-020).
+	n, err := itClient.transport.GetNode(ctx, itTenant, itActor, itUserType, "mbox-1")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if n != nil {
+		t.Fatalf("mailbox-private node leaked into a tenant read: %+v", n)
+	}
+}
+
 // TestIntegration_GetNodeByKeyRealServer proves the unique-key lookup
 // wire path (#572 typed value) works against the real server.
 func TestIntegration_GetNodeByKeyRealServer(t *testing.T) {

--- a/server/go/internal/api/get_node.go
+++ b/server/go/internal/api/get_node.go
@@ -157,6 +157,15 @@ func (s *Server) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNo
 		return nil, errs.Errorf(errs.Code(err), "GetNode: %v", err)
 	}
 
+	// Privacy boundary (#568): a plain tenant read (no target_user) must
+	// not surface a USER_MAILBOX node even by id — otherwise a leaked or
+	// guessed id exposes a user's private mailbox content, while the scan
+	// path (QueryNodes/SearchNodes) already excludes it. Mailbox nodes are
+	// reachable only through the mailbox scope (target_user set).
+	if req.GetTargetUser() == "" && n.StorageMode == int32(store.StorageModeUserMailbox) {
+		return &pb.GetNodeResponse{Found: false}, nil
+	}
+
 	// 7. Cross-tenant per-node ACL re-check. The role test above only
 	//    confirmed the actor has SOME access in the tenant; now we
 	//    confirm the specific node grants them read. This fires AFTER

--- a/server/go/internal/api/get_nodes.go
+++ b/server/go/internal/api/get_nodes.go
@@ -228,6 +228,12 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 			if n == nil {
 				return // genuine miss -> missing_ids
 			}
+			// Privacy boundary (#568): a plain tenant batch read must not
+			// surface a USER_MAILBOX node by id — report it as missing,
+			// matching GetNode and the scan-path exclusion.
+			if targetUser == "" && n.StorageMode == int32(store.StorageModeUserMailbox) {
+				return // mailbox-private -> missing_ids on a tenant read
+			}
 			if actorIDs != nil {
 				ok, aerr := s.store.CanAccess(ctx, tenantID, id, actorIDs)
 				if aerr != nil {

--- a/server/go/internal/api/mailbox_reads_test.go
+++ b/server/go/internal/api/mailbox_reads_test.go
@@ -68,6 +68,40 @@ func TestGetNode_MailboxScope(t *testing.T) {
 	}
 }
 
+// TestGetNode_MailboxExcludedFromTenantRead pins the privacy boundary:
+// a plain tenant read (no target_user) must NOT surface a USER_MAILBOX
+// node even by its exact id — otherwise a leaked/guessed id leaks private
+// mailbox content, while the scan path already excludes it.
+func TestGetNode_MailboxExcludedFromTenantRead(t *testing.T) {
+	srv, cs, tenantID := newSearchTestServer(t)
+	ctx := context.Background()
+	seedMailboxNode(t, cs, tenantID, "alice", "ma", "alpha", "alice body")
+
+	// No target_user → mailbox-private node is invisible (Found=false).
+	resp, err := srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "system:test"},
+		NodeId:  "ma",
+	})
+	if err != nil {
+		t.Fatalf("GetNode(ma, no scope): %v", err)
+	}
+	if resp.GetFound() {
+		t.Fatal("GetNode(ma) with no target_user returned a mailbox-private node (privacy leak)")
+	}
+
+	// GetNodes (batch) by id must also report it as missing, not return it.
+	batch, err := srv.GetNodes(ctx, &pb.GetNodesRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "system:test"},
+		NodeIds: []string{"ma"},
+	})
+	if err != nil {
+		t.Fatalf("GetNodes([ma], no scope): %v", err)
+	}
+	if len(batch.GetNodes()) != 0 {
+		t.Fatalf("GetNodes returned %d mailbox-private nodes on a tenant read; want 0", len(batch.GetNodes()))
+	}
+}
+
 func TestGetNodes_MailboxScope(t *testing.T) {
 	srv, cs, tenantID := newSearchTestServer(t)
 	ctx := context.Background()

--- a/tests/python/e2e/test_pagination_mailbox.py
+++ b/tests/python/e2e/test_pagination_mailbox.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""End-to-end coverage (Python SDK ↔ docker-stack server) for the read
+features shipped in v1.24–v1.32:
+
+  - keyset cursor auto-follow on query() and edges_out() (ADR-029 / #564,
+    #580) — a read returns the COMPLETE set across pages, not a 100-row
+    prefix;
+  - USER_MAILBOX reads + the tenant-read privacy exclusion (#568).
+
+These run against the real built image via run-e2e.sh, exercising the
+full Python-SDK → gRPC → applier → SQLite path that the in-process Go
+integration suite (Go SDK) does not cover.
+"""
+
+import e2e_schema_pb2 as pb
+
+from entdb_sdk.keys import Mailbox
+
+# pytest asyncio_mode = auto → no decorators needed.
+
+
+async def test_query_auto_follows_complete_set(db_client, fresh_tenant, actor) -> None:
+    """query() with no explicit limit returns ALL matching rows by
+    following the keyset cursor — not the 100-row page default (#564)."""
+    scope = db_client.tenant(fresh_tenant).actor(actor)
+    n = 150  # > the server's 100-row default page
+
+    for batch_start in range(0, n, 50):
+        plan = scope.plan()
+        for i in range(batch_start, min(batch_start + 50, n)):
+            plan.create(pb.User(email=f"pg-{i:04d}@x", name=f"U{i}"), as_=f"u{i}")
+        result = await plan.commit(wait_applied=True)
+        assert result.success, f"seed commit failed: {result.error}"
+
+    users = await scope.query(pb.User)  # default limit=0 ⇒ complete set
+    got = [u for u in users if str(u.payload.get("email", "")).startswith("pg-")]
+    assert len(got) == n, f"auto-follow returned {len(got)} of {n} — truncation"
+    # No duplicates across pages.
+    assert len({u.node_id for u in got}) == n
+
+
+async def test_edges_out_auto_follows_complete_set(db_client, fresh_tenant, actor) -> None:
+    """edges_out() follows the edge keyset cursor over a high-fan-out node
+    (#580) — all edges, not a prefix."""
+    scope = db_client.tenant(fresh_tenant).actor(actor)
+    n = 120  # > default edge page
+
+    plan = scope.plan()
+    plan.create(pb.User(email="hub@x", name="Hub"), as_="hub")
+    for i in range(n):
+        plan.create(
+            pb.Product(sku=f"P-{i:04d}", name=f"P{i}", price=1.0, category="other"),
+            as_=f"p{i}",
+        )
+    for i in range(n):
+        plan.edge_create(pb.Purchased, "$hub", f"$p{i}", props={"quantity": 1})
+    result = await plan.commit(wait_applied=True)
+    assert result.success, f"seed commit failed: {result.error}"
+    hub_id = result.created_node_ids[0]  # hub is the first create
+
+    edges = await scope.edges_out(hub_id, edge_type=pb.Purchased)
+    assert len(edges) == n, f"edge auto-follow returned {len(edges)} of {n} — truncation"
+
+
+async def test_mailbox_read_and_tenant_privacy(db_client, fresh_tenant, actor) -> None:
+    """A USER_MAILBOX node is visible via the mailbox scope and EXCLUDED
+    from an ordinary tenant read (#568 privacy boundary)."""
+    scope = db_client.tenant(fresh_tenant).actor(actor)
+    mailbox_user = "mail-user-1"
+
+    plan = scope.plan()
+    plan.create(pb.User(email="tenant@x", name="Tenant Node"), as_="tenant_node")
+    plan.create(
+        pb.User(email="inbox@x", name="Mailbox Node"),
+        as_="mbox",
+        storage=Mailbox(user_id=mailbox_user),
+    )
+    result = await plan.commit(wait_applied=True)
+    assert result.success, f"commit failed: {result.error}"
+
+    # Mailbox scope sees the mailbox node.
+    mbox = await scope.query_in_mailbox(pb.User, mailbox_user)
+    mbox_emails = {u.payload.get("email") for u in mbox}
+    assert "inbox@x" in mbox_emails, "mailbox node not visible via mailbox scope"
+
+    # Ordinary tenant read EXCLUDES the mailbox-private node.
+    tenant_nodes = await scope.query(pb.User)
+    tenant_emails = {u.payload.get("email") for u in tenant_nodes}
+    assert "tenant@x" in tenant_emails, "tenant node missing from tenant read"
+    assert "inbox@x" not in tenant_emails, "mailbox-private node leaked into tenant read"


### PR DESCRIPTION
## What

The Go-SDK real-server integration suite I added caught a **privacy gap** shipped in v1.32.0: `QueryNodes`/`SearchNodes` exclude USER_MAILBOX nodes from a plain tenant read (no `target_user`), but `GetNode`/`GetNodes` **by id returned them** — a leaked or guessed node id would expose a user's private mailbox content. Now a plain tenant by-id read treats a USER_MAILBOX node as not-found, consistent with the scan path; mailbox content is reachable only via the mailbox scope (`target_user` set).

## Test coverage added (the point of this PR)

- **E2E** (`tests/python/e2e/test_pagination_mailbox.py`, Python SDK ↔ docker stack): `query()` + `edges_out()` keyset auto-follow return the complete set over 150 / 120 rows; mailbox read via the mailbox scope + the tenant-read privacy exclusion. (22 → 25 E2E cases.)
- **Go SDK integration** (real server): mailbox round-trip + privacy — the test that caught this bug (5 → 6 integration tests).
- **Server unit**: `GetNode`/`GetNodes` by-id mailbox exclusion.

## Verification

Full local CI green — server vet+test, Go SDK unit + integration (`-tags=integration`), 564 Python, ruff, docs coverage, and the Docker-stack E2E (25 passed).

Refs #568.