### PR TITLE
docs: post-v2.0.1 audit; fix docs-site build; remove stray plugin binary

### DIFF
--- a/docs-site/src/pages/docs/compliance/audit.astro
+++ b/docs-site/src/pages/docs/compliance/audit.astro
@@ -367,7 +367,7 @@ aws s3api put-object-lock-configuration \\
 
   <h3>Archive lag &mdash; <code>entdb_archive_lag_events</code></h3>
   <p>
-    Gauge, labelled <code>{topic, partition}</code>. It is the number of
+    Gauge, labelled <code>{'{topic, partition}'}</code>. It is the number of
     WAL records the archiver has polled from a partition but not yet
     durably written to S3 + committed. A healthy archiver drives it to 0
     after each cycle. <strong>A sustained non-zero lag means the archiver

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -81,7 +81,7 @@ WIRE:        {"1": "alice@example.com", "2": "Alice"}
 APP CODE:    {"email": "alice@example.com", "name": "Alice"}
 ```
 
-Schemaless ingress (server doesn't know the type's schema): only digit-string keys are accepted; name-keyed entries return `INVALID_ARGUMENT`.
+Per [ADR-031](adr/031-self-describing-name-free-schema.md), the server is id-only end to end: name-keyed entries are **always** rejected with `INVALID_ARGUMENT`. The SDKs do every name↔id translation client-side from the proto descriptor before the bytes leave the process.
 
 ### Idempotency
 
@@ -116,7 +116,7 @@ Actor prefixes:
 | Status | When |
 |---|---|
 | `OK` | Success |
-| `INVALID_ARGUMENT` | Malformed request, schema mismatch, name-keyed payload on schemaless type |
+| `INVALID_ARGUMENT` | Malformed request, schema mismatch, name-keyed payload/filter/precondition (ADR-031: server is id-only) |
 | `NOT_FOUND` | Node, tenant, user not found |
 | `ALREADY_EXISTS` | Duplicate `tenant_id`, duplicate unique-field value, etc. |
 | `PERMISSION_DENIED` | ACL check failed; actor not a tenant member; admin gate failed |
@@ -170,11 +170,15 @@ On egress, the wire shape is symmetric: `[]byte` re-encoded as base64, `int64` w
 | `delete_edge` | `DeleteEdgeOp` | Delete an edge. |
 | `delete_where` | `DeleteWhereOp` | Predicate sweeper: delete every node of a type matching all `where` filters, best-effort capped by `limit`, in one op (issue [#504](https://github.com/elloloop/tenant-shard-db/issues/504)). |
 
-`DeleteWhereOp.where` reuses the same `FieldFilter` / `FilterOp` shape as `QueryNodesRequest.filters`, so no new wire concept is introduced. As with `QueryNodes` filters, the filter `field` is normally a payload `field_id` resolved client-side from a name; against a **schema-less server** only digit-string keys translate (a name key returns `INVALID_ARGUMENT` — see [Field IDs, not field names](#field-ids-not-field-names) and the [schema-lockdown guide](guides/schema-lockdown.md#delete_where-and-querynodes-on-schema-less-deployments), issue [#545](https://github.com/elloloop/tenant-shard-db/issues/545)). `limit <= 0` selects the server default cap; the server clamps to a hard ceiling so a runaway predicate cannot pin the single applier goroutine for a tenant. Deleted ids are not returned (v1 scope, #504) — callers needing the ids keep using the `QueryNodes` + `DeleteNodeOp` loop.
+`DeleteWhereOp.where` reuses the same `FieldFilter` / `FilterOp` shape as `QueryNodesRequest.filters`, so no new wire concept is introduced. As with `QueryNodes` filters, `FieldFilter.field` is a payload `field_id` (decimal string); the SDKs translate any developer-facing name → id client-side from the proto before sending. Per [ADR-031](adr/031-self-describing-name-free-schema.md) the server is id-only, so a non-digit `field` returns `INVALID_ARGUMENT` regardless of registry state — see [Field IDs, not field names](#field-ids-not-field-names) and the [schema-lockdown guide](guides/schema-lockdown.md), issue [#545](https://github.com/elloloop/tenant-shard-db/issues/545). `limit <= 0` selects the server default cap; the server clamps to a hard ceiling so a runaway predicate cannot pin the single applier goroutine for a tenant. Deleted ids are not returned (v1 scope, #504) — callers needing the ids keep using the `QueryNodes` + `DeleteNodeOp` loop.
 
 ## Schema RPC
 
-`GetSchema` returns the **server's** registered schema (loaded at boot from `.schema-snapshot.json`). It's read-only — there is no `RegisterSchema` RPC. Clients use the schema for client-side validation; the SDKs maintain their own local registry via `register_proto_schema(my_pb2)` (Python) or generated code (Go).
+`GetSchema` returns the **server's** registered schema (ids + attributes only — names live client-side in the proto). It's read-only: there is no `RegisterSchema` RPC.
+
+Per [ADR-031](adr/031-self-describing-name-free-schema.md), the server **boots empty** (no schema, no data) and learns its schema from the writes themselves: every `ExecuteAtomic` carries an optional `SchemaDescriptor`, and when the client fingerprint differs from the server's the handler prepends a `register_schema` WAL op that the applier materializes (registry + per-tenant indexes) **before** the data ops. Because the schema lives in the WAL, the registry is rebuilt deterministically on replay; a fresh server reaches the same registry after replaying the same log. `GetSchema` returns whatever has accumulated to that point.
+
+The SDKs auto-attach the descriptor when their fingerprint doesn't match the cached server fingerprint and omit it once it does (re-sending only on a `SCHEMA_MISMATCH` response). Clients also maintain their own local registry via `register_proto_schema(my_pb2)` (Python) or generated code (Go) — that registry is the source of truth for names; the server never sees them.
 
 ## Where to find each handler
 

--- a/docs/go-port/shared/payload-translation.md
+++ b/docs/go-port/shared/payload-translation.md
@@ -48,6 +48,15 @@ they are `map[uint32]any` — the key is the field's stable numeric `field_id`
 
 ## Boundary
 
+> **Updated by [ADR-031](../../adr/031-self-describing-name-free-schema.md)
+> (2026-05-25):** server-side **ingress** translation was removed. The
+> server is now id-only end to end and rejects name-keyed payloads,
+> filters, and preconditions with `INVALID_ARGUMENT`. The SDKs do every
+> name↔id translation client-side from the proto descriptor (`fd.Number()`
+> IS the `field_id` per ADR-006) before the bytes leave the process.
+> The egress description below is still accurate (no server-side
+> translation); the **Ingress** point is historical.
+
 Translation happens at **exactly two points** inside the gRPC handler layer.
 Nowhere else.
 

--- a/docs/go-port/shared/schema-registry.md
+++ b/docs/go-port/shared/schema-registry.md
@@ -210,9 +210,12 @@ is pure data + lookup.
   via the registry's unique-field bookkeeping; falls back to
   `NOT_FOUND` if the type has no unique field with that id.
 - **SearchNodes / QueryNodes** — consult `IndexedFieldIDs` and
-  `SearchableFieldIDs` to pick an index-backed plan vs a full scan;
-  also rely on `Node(typeID).GetField(name)` for filter-name → field-id
-  rewriting when a client sends a name-keyed filter.
+  `SearchableFieldIDs` to pick an index-backed plan vs a full scan.
+  (Pre-[ADR-031](../../adr/031-self-describing-name-free-schema.md) the
+  server also did filter-name → field-id rewriting; that path is gone.
+  `FieldFilter.field` is now an `field_id` (decimal string); name keys
+  are rejected with `INVALID_ARGUMENT`. SDKs do the translation
+  client-side from the proto.)
 - **CreateUser / CreateTenant / admin RPCs** — use `DataPolicy` and
   `SubjectField` to label new nodes for GDPR tracking.
 

--- a/docs/go-port/shared/wal-producer.md
+++ b/docs/go-port/shared/wal-producer.md
@@ -34,7 +34,10 @@ Required fields (validated in `from_dict`, `applier.py:256`):
 
 `ops[i]` is an open-ended dict keyed by `"op"`. Op types handled by the
 applier today: `create_node`, `update_node`, `delete_node`, `create_edge`,
-`delete_edge`, plus admin/GDPR/transfer/revocation ops registered in
+`delete_edge`, `delete_where`, `register_schema` (the self-describing
+schema op prepended by the ExecuteAtomic handler when client/server
+fingerprints differ — see [ADR-031](../../adr/031-self-describing-name-free-schema.md)),
+plus admin/GDPR/transfer/revocation ops registered in
 `Applier.apply_event` (`applier.py:1327`). The Go event struct must keep
 `ops` as a free-form list (`[]map[string]any` or, preferably, a
 `[]*pb.Op` once op types are protobufed) — handlers will mutate ops

--- a/docs/guides/schema-lockdown.md
+++ b/docs/guides/schema-lockdown.md
@@ -112,7 +112,7 @@ version tag, don't run `:latest` in CI.
 ### `go install`
 
 ```bash
-go install github.com/elloloop/tenant-shard-db/server/go/cmd/entdb-schema@v1.0.0
+go install github.com/elloloop/tenant-shard-db/server/go/cmd/entdb-schema@v2.0.1
 ```
 
 Useful for local dev. For CI we recommend the pre-built binary or the
@@ -518,11 +518,13 @@ been established by writes.
 
 ## `delete_where` and `QueryNodes` on schema-less deployments
 
-Some deployments run `entdb-server` **without** a registered schema —
-no `.schema-snapshot.json`, no `--seed-profile`, the registry empty by
-design (a thin keyed-blob store, or an early bootstrap stage before the
-schema is locked). That mode is fully supported for predicate
-operations, with one rule you must know.
+Per [ADR-031](../adr/031-self-describing-name-free-schema.md) every
+server boots with an **empty** registry; it stays empty until the first
+self-describing write registers a type. So in the window before any
+schema write — or in a deployment that intentionally runs as a thin
+keyed-blob store and never sends one — the server has nothing to consult
+when translating predicates. That mode is fully supported, with one rule
+you must know.
 
 EntDB payloads are keyed on the wire and on disk by numeric
 `field_id`, never by name ([ADR-018](../adr/018-field-id-keyed-payloads.md)).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -249,20 +249,20 @@ If your recovery floor needs to be shorter than "replay from offset 0," configur
 
 ## Schema operations
 
-The `entdb-schema` CLI ([guide](guides/schema-lockdown.md)) is the operator tool for runtime schema lockdown.
+The `entdb-schema` CLI ([guide](guides/schema-lockdown.md)) is the operator tool for runtime schema lockdown. Per [ADR-032](adr/032-schema-evolution-compat-rules.md) it ships a `buf breaking`-style verb that customers run identically in local dev and CI.
 
 ```bash
-# Snapshot what the running server has registered
-entdb-schema snapshot --from-server localhost:50051 > .schema-snapshot.json
+# Snapshot what the running server has registered (commit as the baseline)
+entdb-schema snapshot --from-server localhost:50051 > schema.lock.json
 
-# Compare against a committed baseline (CI)
-entdb-schema check --baseline .schema-snapshot.json --from-server localhost:50051
+# The CI gate — exits non-zero on a breaking change (loosen-safe / tighten-breaking)
+entdb-schema breaking --baseline schema.lock.json --from-file new.json
 
-# Diff two snapshots
-entdb-schema diff --old .schema-snapshot.json --new /tmp/new.json
+# Free-form diff between two snapshots
+entdb-schema diff --old schema.lock.json --new /tmp/new.json
 ```
 
-A schema compatibility check is the canonical CI gate. See `docs/guides/schema-lockdown.md` for the full workflow.
+`check` is preserved as an alias for `breaking` (same exit-code contract). See `docs/guides/schema-lockdown.md` for the full workflow + the loosen-safe/tighten-breaking matrix.
 
 ## Tenant onboarding
 
@@ -335,7 +335,7 @@ Auth interceptor rejected the request. Check the credential carrier:
 
 ### `INVALID_ARGUMENT: payload ... contains name-keyed field "..."` 
 
-The SDK predates v1.12.2's client-side name→id translation (see [ADR-018](adr/018-field-id-keyed-payloads.md)) or is operating on an unregistered type. Upgrade the SDK, or register the schema on the server.
+Per [ADR-031](adr/031-self-describing-name-free-schema.md), the server is id-only and **always** rejects name-keyed payloads/filters/preconditions (ADR-018: `field_id` is the storage key). Either upgrade to a v2.x SDK — which does client-side name→id translation from the proto and auto-attaches the `SchemaDescriptor` so the server learns the type — or, for hand-rolled clients, send `field_id`-keyed `data`/`patch` and decimal-string `FieldFilter.field` directly.
 
 ### Schema-compatibility CI failure
 

--- a/docs/schema-evolution.md
+++ b/docs/schema-evolution.md
@@ -8,7 +8,7 @@ EntDB uses protobuf for schema definition ([ADR-006](adr/006-proto-schema-defini
 2. **Never remove or reuse IDs.** Once a field number is in use, it can be deprecated but never reassigned.
 3. **Names are display-only.** Renaming a proto field doesn't touch the wire / disk format. Rename freely.
 4. **Field order doesn't matter.** Fields are identified by number.
-5. **Schema lockdown is CI-enforced.** `entdb-schema check` against a committed `.schema-snapshot.json` catches breaking changes before they merge.
+5. **Schema lockdown is CI-enforced.** `entdb-schema breaking` against a committed `schema.lock.json` catches breaking changes before they merge ([ADR-032](adr/032-schema-evolution-compat-rules.md)). Same `buf breaking`-style command runs identically in local dev and CI.
 
 ## Field types
 
@@ -167,41 +167,46 @@ If you need to add a required field, declare it required from the start; existin
 
 ### One-time setup
 
-Snapshot the schema and commit the snapshot:
+Capture the baseline snapshot once and commit it. Per [ADR-031](adr/031-self-describing-name-free-schema.md) the server boots **empty** — schema is registered via self-describing writes, so the snapshot is empty until your app drives its first write through the SDK. So:
 
 ```bash
-# Boot the server with your registered schema
+# 1. Boot a fresh server (empty registry by design)
 entdb-server -addr=:50051 -data-dir=/tmp/init -wal-backend=memory &
 SERVER_PID=$!
 sleep 1
 
-# Snapshot
-entdb-schema snapshot --from-server localhost:50051 > .schema-snapshot.json
+# 2. Drive at least one write per type from your app (the SDK auto-attaches
+#    a SchemaDescriptor; the applier materializes register_schema into the
+#    server's registry). Whatever your normal init / smoke-test does works.
+
+# 3. Snapshot the now-populated registry and commit it as the baseline.
+entdb-schema snapshot --from-server localhost:50051 > schema.lock.json
 
 kill $SERVER_PID
-git add .schema-snapshot.json
+git add schema.lock.json
 git commit -m "chore: lock initial schema snapshot"
 ```
 
 ### Every PR
 
-Run a compatibility check in CI:
+Run the compatibility gate in CI:
 
 ```bash
-entdb-schema check \
-  --baseline .schema-snapshot.json \
+entdb-schema breaking \
+  --baseline schema.lock.json \
   --from-server localhost:50051 \
   --format json
 ```
 
-Exit code 0 = compatible; non-zero = breaking change detected. The full GitHub Actions setup is in `docs/guides/schema-lockdown.md`.
+Exit code 0 = compatible; 1 = breaking change detected. The full GitHub Actions setup is in `docs/guides/schema-lockdown.md`.
 
 ### Subcommands
 
 | Command | Purpose |
 |---|---|
 | `entdb-schema snapshot` | Emit the current schema as a deterministic JSON envelope |
-| `entdb-schema check` | Verify the current schema is compatible with a baseline |
+| `entdb-schema breaking` | The `buf breaking`-style gate — exits non-zero on a breaking change (ADR-032) |
+| `entdb-schema check` | Alias for `breaking` (same exit-code contract; preserved for older scripts) |
 | `entdb-schema diff` | Show differences between two snapshots |
 | `entdb-schema validate` | Run cross-reference validation over a registry |
 | `entdb-schema version` | Print version |

--- a/tools/protoc-gen-entdb-keys/.gitignore
+++ b/tools/protoc-gen-entdb-keys/.gitignore
@@ -1,1 +1,3 @@
 bin/
+# Compiled plugin binary — do not commit
+protoc-gen-entdb-keys


### PR DESCRIPTION
Three v2.0.1 follow-ups batched.

## 1. Stray binary cleanup

`tools/protoc-gen-entdb-keys/protoc-gen-entdb-keys` (compiled plugin artifact) slipped into PR #603. Removed from tracking and added to the package `.gitignore` so it can't recur.

## 2. Docs-site build fix

The "Deploy Documentation" workflow has been **red on every push to main for at least 6 commits** with `ReferenceError: topic is not defined` in `/docs/compliance/audit`. Astro was parsing `<code>{topic, partition}</code>` as a JSX-style expression instead of the literal Prometheus label. Escaped via the standard Astro pattern `{'{...}'}`.

**Verified locally:** `pnpm build` produces all 26 pages cleanly, including the audit page that previously failed.

## 3. Full docs audit post-ADR-031 / ADR-032 / v2.0.x

Went through every doc looking for content that contradicts current reality:

- **`docs/api-reference.md`** — `GetSchema` was actively wrong (claimed "loaded at boot from `.schema-snapshot.json`"). Rewritten to reflect ADR-031: empty boot, schema established by self-describing writes, rebuilt-from-WAL. Name-keyed payload/filter/precondition descriptions updated — the server is id-only **regardless of registry state**, not just on "schemaless" types.
- **`docs/guides/schema-lockdown.md`** — `@v1.0.0` install command bumped to `@v2.0.1`; the "schema-less deployment" section rewritten to reflect ADR-031's empty-boot reality (instead of the dead `--seed-profile`).
- **`docs/operations.md`** — schema CLI commands switched to the ADR-032 `breaking` verb + canonical `schema.lock.json`; the name-keyed `INVALID_ARGUMENT` troubleshooting entry updated for v2.x SDK behaviour.
- **`docs/schema-evolution.md`** — core principle line points at `breaking` + ADR-032; the initial-snapshot workflow was broken under ADR-031 (it said "boot the server with your registered schema" but the server now boots **empty**) — rewritten to: boot → drive writes to register types → snapshot; subcommand table extended with `breaking`, with `check` preserved as an alias.
- **`docs/go-port/shared/wal-producer.md`** — applier op list extended with `register_schema`.
- **`docs/go-port/shared/schema-registry.md`** — filter-name → field-id server-side rewriting marked removed (ADR-031).
- **`docs/go-port/shared/payload-translation.md`** — clear ADR-031 callout at the "Boundary" section: ingress translation removed, server is id-only, SDKs do the translation.

`docs-site` was already updated by the /v2 PR (#603); this pass is markdown only.

## Verification

`make ci` green locally end-to-end: all 4 Go modules + Python integration (115) + unit (449) + e2e (25) + ruff. `pnpm build` on `docs-site/` builds all 26 pages.