### PR TITLE
fix(sdk/go): self-describing schema now carries every FieldOpts/NodeOpts/EdgeOpts attribute (closes #604 + 12 related)

### DIFF
--- a/sdk/go/entdb/cmd/entdb/snapshot_test.go
+++ b/sdk/go/entdb/cmd/entdb/snapshot_test.go
@@ -61,12 +61,13 @@ func TestCmdSnapshot_StdoutHappyPath(t *testing.T) {
 		t.Errorf("missing wrapper keys: %v", env)
 	}
 	schema := env["schema"].(map[string]any)
-	// testpb carries Product (201) + OAuthIdentity (202).
-	if len(schema["node_types"].([]any)) != 2 {
-		t.Error("expected Product + OAuthIdentity nodes in output")
+	// testpb carries Product (201) + OAuthIdentity (202) + RichDoc (401).
+	if len(schema["node_types"].([]any)) != 3 {
+		t.Error("expected Product + OAuthIdentity + RichDoc nodes in output")
 	}
-	if len(schema["edge_types"].([]any)) != 1 {
-		t.Error("expected PurchaseEdge in output")
+	// testpb carries PurchaseEdge (301) + RichEdge (501).
+	if len(schema["edge_types"].([]any)) != 2 {
+		t.Error("expected PurchaseEdge + RichEdge in output")
 	}
 }
 

--- a/sdk/go/entdb/internal/testpb/testpb.go
+++ b/sdk/go/entdb/internal/testpb/testpb.go
@@ -43,6 +43,46 @@ var PurchaseEdgeDesc protoreflect.MessageDescriptor
 // used by negative tests.
 var NotAnEntityDesc protoreflect.MessageDescriptor
 
+// RichDocDesc is a node type exercising EVERY FieldOpts + NodeOpts
+// attribute the wire SchemaFieldDef / SchemaNodeTypeDef carries. It is
+// the regression fixture for the gap discovered in issue #604 (and the
+// 8 similar omissions the same diff fixes): without it the Go SDK's
+// auto-attach silently drops ref_type_id, pii, deprecated, description,
+// data_policy, subject_field, legal_basis (per node), etc.
+//
+//	message RichDoc {
+//	    option (entdb.node) = {
+//	        type_id: 401,
+//	        data_policy: DATA_POLICY_BUSINESS,
+//	        subject_field: "owner_id",
+//	        legal_basis: "user-consent",
+//	        description: "Rich doc; all NodeOpts attributes",
+//	        deprecated: true,
+//	    };
+//	    string title        = 1 [(entdb.field).description = "the title"];
+//	    string body         = 2;
+//	    string owner_id     = 3 [(entdb.field) = { kind: "ref", ref_type_id: 201 }];
+//	    string author_email = 4 [(entdb.field) = { pii: true, deprecated: true, description: "scrub on anonymise" }];
+//	}
+var RichDocDesc protoreflect.MessageDescriptor
+
+// RichEdgeDesc is an edge type exercising EVERY EdgeOpts attribute the
+// wire SchemaEdgeTypeDef carries (excluding from_type_id/to_type_id,
+// which are derived from the proto's from/to field types — a separate
+// fix tracked outside this regression set).
+//
+//	message RichEdge {
+//	    option (entdb.edge) = {
+//	        edge_id: 501,
+//	        unique_per_from: true,
+//	        data_policy: DATA_POLICY_AUDIT,
+//	        on_subject_exit: SUBJECT_EXIT_TO,
+//	        description: "Rich edge; all EdgeOpts attributes",
+//	        deprecated: true,
+//	    };
+//	}
+var RichEdgeDesc protoreflect.MessageDescriptor
+
 // OAuthIdentityDesc is a node type carrying a composite unique
 // constraint (ADR-030 / issue #566):
 //
@@ -63,7 +103,10 @@ func init() {
 	PurchaseEdgeDesc = fd.Messages().ByName("PurchaseEdge")
 	NotAnEntityDesc = fd.Messages().ByName("NotAnEntity")
 	OAuthIdentityDesc = fd.Messages().ByName("OAuthIdentity")
-	if ProductDesc == nil || PurchaseEdgeDesc == nil || NotAnEntityDesc == nil || OAuthIdentityDesc == nil {
+	RichDocDesc = fd.Messages().ByName("RichDoc")
+	RichEdgeDesc = fd.Messages().ByName("RichEdge")
+	if ProductDesc == nil || PurchaseEdgeDesc == nil || NotAnEntityDesc == nil ||
+		OAuthIdentityDesc == nil || RichDocDesc == nil || RichEdgeDesc == nil {
 		panic("testpb: missing test message descriptors")
 	}
 }
@@ -200,6 +243,60 @@ func (n *NotAnEntity) Reset() { *n = NotAnEntity{msg: dynamicpb.NewMessage(NotAn
 
 // String implements proto.Message.
 func (n *NotAnEntity) String() string { return "" }
+
+// RichDoc is a concrete proto.Message wrapper around RichDocDesc — used
+// by the regression test set covering #604 (ref_type_id) and every
+// adjacent FieldOpts / NodeOpts attribute the Go SDK had been silently
+// dropping (pii, deprecated, description, data_policy, subject_field,
+// legal_basis).
+type RichDoc struct {
+	msg *dynamicpb.Message
+}
+
+// NewRichDocMsg returns a fresh writable *RichDoc.
+func NewRichDocMsg() *RichDoc {
+	return &RichDoc{msg: dynamicpb.NewMessage(RichDocDesc)}
+}
+
+// ProtoReflect implements proto.Message.
+func (r *RichDoc) ProtoReflect() protoreflect.Message {
+	if r == nil || r.msg == nil {
+		return dynamicpb.NewMessage(RichDocDesc).ProtoReflect()
+	}
+	return r.msg.ProtoReflect()
+}
+
+// Reset implements proto.Message.
+func (r *RichDoc) Reset() { *r = RichDoc{msg: dynamicpb.NewMessage(RichDocDesc)} }
+
+// String implements proto.Message.
+func (r *RichDoc) String() string { return "" }
+
+// RichEdge is the edge-side regression fixture covering EdgeOpts
+// attributes (unique_per_from, on_subject_exit, data_policy,
+// deprecated, description) that the Go SDK had been hardcoding away.
+type RichEdge struct {
+	msg *dynamicpb.Message
+}
+
+// NewRichEdgeMsg returns a fresh writable *RichEdge.
+func NewRichEdgeMsg() *RichEdge {
+	return &RichEdge{msg: dynamicpb.NewMessage(RichEdgeDesc)}
+}
+
+// ProtoReflect implements proto.Message.
+func (e *RichEdge) ProtoReflect() protoreflect.Message {
+	if e == nil || e.msg == nil {
+		return dynamicpb.NewMessage(RichEdgeDesc).ProtoReflect()
+	}
+	return e.msg.ProtoReflect()
+}
+
+// Reset implements proto.Message.
+func (e *RichEdge) Reset() { *e = RichEdge{msg: dynamicpb.NewMessage(RichEdgeDesc)} }
+
+// String implements proto.Message.
+func (e *RichEdge) String() string { return "" }
 
 // SetProductFields populates the sku / name / price_cents fields on
 // a Product dynamic message.
@@ -351,11 +448,114 @@ func buildFile() protoreflect.FileDescriptor {
 		},
 	}
 
+	// RichDoc — node type that exercises every FieldOpts + NodeOpts
+	// attribute the wire SchemaFieldDef / SchemaNodeTypeDef carries.
+	// Regression fixture for #604 (ref_type_id) plus pii / deprecated /
+	// description per field, and data_policy / subject_field /
+	// legal_basis / deprecated / description per node.
+	//
+	// NodeOpts wire encoding: type_id=401 (field 1, varint),
+	// data_policy=BUSINESS (field 6 = 1), subject_field="owner_id"
+	// (field 7), legal_basis="user-consent" (field 9),
+	// description="Rich doc; all NodeOpts attributes" (field 10),
+	// deprecated=true (field 11 = 1).
+	richDocNodeOpts := encodeVarintField(1, 401)
+	richDocNodeOpts = append(richDocNodeOpts, encodeVarintField(6, 1)...)
+	richDocNodeOpts = append(richDocNodeOpts, encodeStringField(7, "owner_id")...)
+	richDocNodeOpts = append(richDocNodeOpts, encodeStringField(9, "user-consent")...)
+	richDocNodeOpts = append(richDocNodeOpts, encodeStringField(10, "Rich doc; all NodeOpts attributes")...)
+	richDocNodeOpts = append(richDocNodeOpts, encodeVarintField(11, 1)...)
+	richDocOptsRaw := encodeLengthDelimitedField(50100, richDocNodeOpts)
+	richDocOpts := &descriptorpb.MessageOptions{}
+	richDocOpts.ProtoReflect().SetUnknown(protoreflect.RawFields(richDocOptsRaw))
+
+	// title field: (entdb.field).description = "the title"
+	titleFieldOpts := &descriptorpb.FieldOptions{}
+	titleFieldOpts.ProtoReflect().SetUnknown(protoreflect.RawFields(
+		encodeLengthDelimitedField(50102, encodeStringField(10, "the title")),
+	))
+
+	// owner_id field: (entdb.field) = { kind: "ref", ref_type_id: 201 }
+	ownerInner := append(
+		encodeStringField(7, "ref"),
+		encodeVarintField(8, 201)...,
+	)
+	ownerFieldOpts := &descriptorpb.FieldOptions{}
+	ownerFieldOpts.ProtoReflect().SetUnknown(protoreflect.RawFields(
+		encodeLengthDelimitedField(50102, ownerInner),
+	))
+
+	// author_email field: pii=true, deprecated=true, description=...
+	authorInner := encodeVarintField(4, 1)                                       // pii
+	authorInner = append(authorInner, encodeStringField(10, "scrub on anonymise")...) // description
+	authorInner = append(authorInner, encodeVarintField(11, 1)...)               // deprecated
+	authorFieldOpts := &descriptorpb.FieldOptions{}
+	authorFieldOpts.ProtoReflect().SetUnknown(protoreflect.RawFields(
+		encodeLengthDelimitedField(50102, authorInner),
+	))
+
+	richDocMsg := &descriptorpb.DescriptorProto{
+		Name:    proto.String("RichDoc"),
+		Options: richDocOpts,
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     proto.String("title"),
+				Number:   proto.Int32(1),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				JsonName: proto.String("title"),
+				Options:  titleFieldOpts,
+			},
+			{
+				Name:     proto.String("body"),
+				Number:   proto.Int32(2),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				JsonName: proto.String("body"),
+			},
+			{
+				Name:     proto.String("owner_id"),
+				Number:   proto.Int32(3),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				JsonName: proto.String("ownerId"),
+				Options:  ownerFieldOpts,
+			},
+			{
+				Name:     proto.String("author_email"),
+				Number:   proto.Int32(4),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				JsonName: proto.String("authorEmail"),
+				Options:  authorFieldOpts,
+			},
+		},
+	}
+
+	// RichEdge — exercises every EdgeOpts attribute. EdgeOpts wire:
+	// edge_id=501 (field 1), unique_per_from=true (field 4 = 1),
+	// data_policy=AUDIT (field 5 = 3), on_subject_exit=TO (field 6 = 2),
+	// description=... (field 9), deprecated=true (field 10 = 1).
+	richEdgeOptsInner := encodeVarintField(1, 501)
+	richEdgeOptsInner = append(richEdgeOptsInner, encodeVarintField(4, 1)...)
+	richEdgeOptsInner = append(richEdgeOptsInner, encodeVarintField(5, 3)...)
+	richEdgeOptsInner = append(richEdgeOptsInner, encodeVarintField(6, 2)...)
+	richEdgeOptsInner = append(richEdgeOptsInner, encodeStringField(9, "Rich edge; all EdgeOpts attributes")...)
+	richEdgeOptsInner = append(richEdgeOptsInner, encodeVarintField(10, 1)...)
+	richEdgeOptsRaw := encodeLengthDelimitedField(50101, richEdgeOptsInner)
+	richEdgeOpts := &descriptorpb.MessageOptions{}
+	richEdgeOpts.ProtoReflect().SetUnknown(protoreflect.RawFields(richEdgeOptsRaw))
+
+	richEdgeMsg := &descriptorpb.DescriptorProto{
+		Name:    proto.String("RichEdge"),
+		Options: richEdgeOpts,
+	}
+
 	fdp := &descriptorpb.FileDescriptorProto{
 		Name:        proto.String(name),
 		Package:     proto.String(pkg),
 		Syntax:      proto.String(syntax),
-		MessageType: []*descriptorpb.DescriptorProto{productMsg, edgeMsg, oauthMsg, notEntityMsg},
+		MessageType: []*descriptorpb.DescriptorProto{productMsg, edgeMsg, oauthMsg, notEntityMsg, richDocMsg, richEdgeMsg},
 	}
 
 	fd, err := protodesc.NewFile(fdp, nil)

--- a/sdk/go/entdb/schema_extract.go
+++ b/sdk/go/entdb/schema_extract.go
@@ -23,8 +23,12 @@ const (
 	fieldOptsRequiredField     = 1
 	fieldOptsSearchableField   = 2
 	fieldOptsIndexedField      = 3
+	fieldOptsPIIField          = 4  // bool pii = 4
 	fieldOptsEnumValuesField   = 6
 	fieldOptsKindOverrideField = 7
+	fieldOptsRefTypeIDField    = 8  // int32 ref_type_id = 8 (REQUIRED when kind == "ref")
+	fieldOptsDescriptionField  = 10 // string description = 10
+	fieldOptsDeprecatedField   = 11 // bool deprecated = 11
 	fieldOptsUniqueField       = 13
 )
 
@@ -32,12 +36,26 @@ const (
 // sdk/entdb_sdk/proto/entdb_options.proto). composite_unique is the
 // repeated UniqueConstraint message (ADR-030 / issue #566).
 const (
+	nodeOptsDataPolicyField   = 6  // DataPolicy data_policy = 6 (enum varint)
+	nodeOptsSubjectFieldField = 7  // string subject_field = 7 (proto field NAME; resolved to field_id)
+	nodeOptsLegalBasisField   = 9  // string legal_basis = 9
+	nodeOptsDescriptionField  = 10 // string description = 10
+	nodeOptsDeprecatedField   = 11 // bool deprecated = 11
 	nodeOptsCompositeUniqueField = 24 // repeated UniqueConstraint composite_unique = 24
 
 	// UniqueConstraint.fields submessage field number. NAME-FREE (ADR-031):
 	// the constraint name (field 2) is no longer read — a composite
 	// constraint is identified solely by its field_ids tuple.
 	uniqueConstraintFieldsField = 1 // repeated string fields = 1
+)
+
+// EdgeOpts extension field numbers consumed by the extractor.
+const (
+	edgeOptsUniquePerFromField = 4  // bool unique_per_from = 4
+	edgeOptsDataPolicyField    = 5  // DataPolicy data_policy = 5 (enum varint)
+	edgeOptsOnSubjectExitField = 6  // SubjectExitPolicy on_subject_exit = 6 (enum varint)
+	edgeOptsDescriptionField   = 9  // string description = 9
+	edgeOptsDeprecatedField    = 10 // bool deprecated = 10
 )
 
 // ExtractSchemaJSON reads an EntDB schema out of a compiled
@@ -319,8 +337,13 @@ type fieldOptsRaw struct {
 	searchable   bool
 	indexed      bool
 	unique       bool
+	pii          bool
+	deprecated   bool
 	enumValues   string
 	kindOverride string
+	description  string
+	refTypeID    int32 // 0 means unset (proto3 default)
+	hasRefType   bool  // explicit presence (any non-default decode counts)
 }
 
 func readFieldOpts(fd protoreflect.FieldDescriptor) fieldOptsRaw {
@@ -346,8 +369,18 @@ func readFieldOpts(fd protoreflect.FieldDescriptor) fieldOptsRaw {
 	if v, ok := findVarint(inner, uint64(fieldOptsIndexedField)); ok {
 		out.indexed = v != 0
 	}
+	if v, ok := findVarint(inner, uint64(fieldOptsPIIField)); ok {
+		out.pii = v != 0
+	}
+	if v, ok := findVarint(inner, uint64(fieldOptsDeprecatedField)); ok {
+		out.deprecated = v != 0
+	}
 	if v, ok := findVarint(inner, uint64(fieldOptsUniqueField)); ok {
 		out.unique = v != 0
+	}
+	if v, ok := findVarint(inner, uint64(fieldOptsRefTypeIDField)); ok {
+		out.refTypeID = int32(v)
+		out.hasRefType = v != 0
 	}
 	if s, ok := findString(inner, uint64(fieldOptsEnumValuesField)); ok {
 		out.enumValues = s
@@ -355,7 +388,140 @@ func readFieldOpts(fd protoreflect.FieldDescriptor) fieldOptsRaw {
 	if s, ok := findString(inner, uint64(fieldOptsKindOverrideField)); ok {
 		out.kindOverride = s
 	}
+	if s, ok := findString(inner, uint64(fieldOptsDescriptionField)); ok {
+		out.description = s
+	}
 	return out
+}
+
+// nodeOptsRaw mirrors the NodeOpts attributes the SchemaNodeTypeDef
+// descriptor needs to carry on the wire. ADR-031: name-free; the
+// subject_field name from the proto is RESOLVED to its numeric field_id
+// in nodeDescriptorFor (this struct only holds the unresolved name).
+type nodeOptsRaw struct {
+	deprecated   bool
+	dataPolicy   int32  // enum varint (0 = PERSONAL = unset on the wire)
+	hasDataPol   bool
+	subjectField string // proto field NAME, resolved to field_id by the caller
+	legalBasis   string
+	description  string
+}
+
+func readNodeOpts(md protoreflect.MessageDescriptor) nodeOptsRaw {
+	out := nodeOptsRaw{}
+	opts := md.Options()
+	if opts == nil {
+		return out
+	}
+	raw, err := proto.Marshal(opts)
+	if err != nil {
+		return out
+	}
+	inner, ok := findLengthDelimited(raw, uint64(extNodeOpts))
+	if !ok {
+		return out
+	}
+	if v, ok := findVarint(inner, uint64(nodeOptsDeprecatedField)); ok {
+		out.deprecated = v != 0
+	}
+	if v, ok := findVarint(inner, uint64(nodeOptsDataPolicyField)); ok {
+		out.dataPolicy = int32(v)
+		out.hasDataPol = v != 0 // PERSONAL (0) is the default and is omitted on the wire
+	}
+	if s, ok := findString(inner, uint64(nodeOptsSubjectFieldField)); ok {
+		out.subjectField = s
+	}
+	if s, ok := findString(inner, uint64(nodeOptsLegalBasisField)); ok {
+		out.legalBasis = s
+	}
+	if s, ok := findString(inner, uint64(nodeOptsDescriptionField)); ok {
+		out.description = s
+	}
+	return out
+}
+
+// edgeOptsRaw mirrors EdgeOpts attributes the SchemaEdgeTypeDef
+// descriptor needs to carry on the wire. NB: from_type_id / to_type_id
+// are NOT in EdgeOpts — they are derived from the proto's `from` / `to`
+// fields' message types; that derivation is tracked separately.
+type edgeOptsRaw struct {
+	uniquePerFrom bool
+	dataPolicy    int32 // enum varint (0 = PERSONAL = unset on the wire)
+	hasDataPol    bool
+	onSubjectExit int32 // enum varint (0 = BOTH default)
+	hasExit       bool  // any non-default decode emits the wire string
+	description   string
+	deprecated    bool
+}
+
+func readEdgeOpts(md protoreflect.MessageDescriptor) edgeOptsRaw {
+	out := edgeOptsRaw{}
+	opts := md.Options()
+	if opts == nil {
+		return out
+	}
+	raw, err := proto.Marshal(opts)
+	if err != nil {
+		return out
+	}
+	inner, ok := findLengthDelimited(raw, uint64(extEdgeOpts))
+	if !ok {
+		return out
+	}
+	if v, ok := findVarint(inner, uint64(edgeOptsUniquePerFromField)); ok {
+		out.uniquePerFrom = v != 0
+	}
+	if v, ok := findVarint(inner, uint64(edgeOptsDataPolicyField)); ok {
+		out.dataPolicy = int32(v)
+		out.hasDataPol = v != 0
+	}
+	if v, ok := findVarint(inner, uint64(edgeOptsOnSubjectExitField)); ok {
+		out.onSubjectExit = int32(v)
+		out.hasExit = true // BOTH (0) is the default but on_subject_exit is always emitted on the wire
+	}
+	if v, ok := findVarint(inner, uint64(edgeOptsDeprecatedField)); ok {
+		out.deprecated = v != 0
+	}
+	if s, ok := findString(inner, uint64(edgeOptsDescriptionField)); ok {
+		out.description = s
+	}
+	return out
+}
+
+// dataPolicyName maps a DataPolicy enum varint to its lowercase wire
+// string. Returns "" for PERSONAL (0, the default — omitted on the wire,
+// matching Python's _node_type_to_proto / _edge_type_to_proto).
+func dataPolicyName(v int32) string {
+	switch v {
+	case 0:
+		return "" // PERSONAL — default; omitted
+	case 1:
+		return "business"
+	case 2:
+		return "financial"
+	case 3:
+		return "audit"
+	case 4:
+		return "ephemeral"
+	case 5:
+		return "healthcare"
+	default:
+		return ""
+	}
+}
+
+// subjectExitName maps a SubjectExitPolicy enum varint to its lowercase
+// wire string. on_subject_exit is ALWAYS emitted (the schema JSON
+// contract requires the key), defaulting to "both".
+func subjectExitName(v int32) string {
+	switch v {
+	case 1:
+		return "from"
+	case 2:
+		return "to"
+	default:
+		return "both"
+	}
 }
 
 // fieldKindFor maps a proto field type to the EntDB “kind“ string

--- a/sdk/go/entdb/schema_extract_test.go
+++ b/sdk/go/entdb/schema_extract_test.go
@@ -65,9 +65,9 @@ func TestExtractSchemaJSON_ExtractsNodesAndEdgesFromTestPB(t *testing.T) {
 	schema := env["schema"].(map[string]any)
 
 	nodes := schema["node_types"].([]any)
-	// Product (201) + OAuthIdentity (202).
-	if len(nodes) != 2 {
-		t.Fatalf("want 2 nodes, got %d", len(nodes))
+	// Product (201) + OAuthIdentity (202) + RichDoc (401).
+	if len(nodes) != 3 {
+		t.Fatalf("want 3 nodes, got %d", len(nodes))
 	}
 	prod := nodes[0].(map[string]any) // sorted by type_id, Product (201) first
 	// NAME-FREE (ADR-031): no type name is emitted — identity is type_id.
@@ -83,20 +83,21 @@ func TestExtractSchemaJSON_ExtractsNodesAndEdgesFromTestPB(t *testing.T) {
 	for _, n := range nodes {
 		ids[int(n.(map[string]any)["type_id"].(float64))] = true
 	}
-	if !ids[201] || !ids[202] {
-		t.Errorf("want type_ids {201,202}, got %v", ids)
+	if !ids[201] || !ids[202] || !ids[401] {
+		t.Errorf("want type_ids {201,202,401}, got %v", ids)
 	}
 
 	edges := schema["edge_types"].([]any)
-	if len(edges) != 1 {
-		t.Fatalf("want 1 edge, got %d", len(edges))
+	// PurchaseEdge (301) + RichEdge (501).
+	if len(edges) != 2 {
+		t.Fatalf("want 2 edges, got %d", len(edges))
 	}
 	edge := edges[0].(map[string]any)
 	if _, ok := edge["name"]; ok {
 		t.Errorf("edge carried a name key; ADR-031 schema JSON is name-free")
 	}
 	if int(edge["edge_id"].(float64)) != 301 {
-		t.Errorf("edge_id = %v, want 301", edge["edge_id"])
+		t.Errorf("edge_id = %v, want 301 (first sorted by edge_id)", edge["edge_id"])
 	}
 }
 
@@ -248,14 +249,15 @@ func TestExtractSchemaJSON_HandlesMultipleFilesInSet(t *testing.T) {
 	// output (the SDK doesn't deduplicate; that's the customer's
 	// problem if their proto packages collide). What we verify here is
 	// that walking ranges over BOTH files rather than stopping at the
-	// first. Each file carries two node types (Product + OAuthIdentity)
-	// and one edge type (PurchaseEdge).
+	// first. Each file carries three node types (Product +
+	// OAuthIdentity + RichDoc) and two edge types (PurchaseEdge +
+	// RichEdge).
 	nodes := env["schema"].(map[string]any)["node_types"].([]any)
 	edges := env["schema"].(map[string]any)["edge_types"].([]any)
-	if len(nodes) != 4 {
-		t.Errorf("want 4 nodes (two per file), got %d", len(nodes))
+	if len(nodes) != 6 {
+		t.Errorf("want 6 nodes (three per file), got %d", len(nodes))
 	}
-	if len(edges) != 2 {
-		t.Errorf("want 2 edges (one per file), got %d", len(edges))
+	if len(edges) != 4 {
+		t.Errorf("want 4 edges (two per file), got %d", len(edges))
 	}
 }

--- a/sdk/go/entdb/schema_selfdescribe.go
+++ b/sdk/go/entdb/schema_selfdescribe.go
@@ -98,10 +98,30 @@ func newSchemaRegistry(msgs []proto.Message) *schemaRegistry {
 
 // nodeDescriptorFor builds a name-free pb.SchemaNodeTypeDef from a message
 // descriptor. composite_unique is identified by its field_ids tuple only
-// (ADR-031); names are never carried.
+// (ADR-031); names are never carried. All NodeOpts attributes the server's
+// canonical FieldDef/NodeTypeDef structs serialise are emitted here so
+// the client-computed fingerprint matches the server's.
 func nodeDescriptorFor(md protoreflect.MessageDescriptor, typeID int32) *pb.SchemaNodeTypeDef {
 	out := &pb.SchemaNodeTypeDef{TypeId: typeID}
 	out.Fields = fieldDescriptorsFor(md)
+	nopts := readNodeOpts(md)
+	if nopts.deprecated {
+		out.Deprecated = true
+	}
+	if nopts.description != "" {
+		out.Description = nopts.description
+	}
+	if dp := dataPolicyName(nopts.dataPolicy); dp != "" {
+		out.DataPolicy = dp
+	}
+	if nopts.subjectField != "" {
+		if fid, ok := protoFieldNameToID(md, nopts.subjectField); ok {
+			out.SubjectField = &fid
+		}
+	}
+	if nopts.legalBasis != "" {
+		out.LegalBasis = &nopts.legalBasis
+	}
 	if cu, err := extractCompositeUnique(md); err == nil {
 		for _, c := range cu {
 			ids := c["field_ids"].([]int64)
@@ -115,12 +135,45 @@ func nodeDescriptorFor(md protoreflect.MessageDescriptor, typeID int32) *pb.Sche
 	return out
 }
 
+// edgeDescriptorFor builds a name-free pb.SchemaEdgeTypeDef from a message
+// descriptor. EdgeOpts attributes (deprecated, description, data_policy,
+// unique_per_from, on_subject_exit) are carried; from_type_id/to_type_id
+// are NOT in EdgeOpts and must be resolved separately from the edge
+// message's `from`/`to` field types (tracked as a follow-up).
 func edgeDescriptorFor(md protoreflect.MessageDescriptor, edgeID int32) *pb.SchemaEdgeTypeDef {
-	return &pb.SchemaEdgeTypeDef{
+	eopts := readEdgeOpts(md)
+	out := &pb.SchemaEdgeTypeDef{
 		EdgeId:        edgeID,
 		Props:         fieldDescriptorsFor(md),
-		OnSubjectExit: "both",
+		OnSubjectExit: subjectExitName(eopts.onSubjectExit),
 	}
+	if eopts.uniquePerFrom {
+		out.UniquePerFrom = true
+	}
+	if eopts.deprecated {
+		out.Deprecated = true
+	}
+	if eopts.description != "" {
+		out.Description = eopts.description
+	}
+	if dp := dataPolicyName(eopts.dataPolicy); dp != "" {
+		out.DataPolicy = dp
+	}
+	return out
+}
+
+// protoFieldNameToID resolves a proto field NAME to its numeric field_id
+// within md. Used to lower NodeOpts.subject_field (a string name in the
+// proto option) to a name-free wire field_id (ADR-031).
+func protoFieldNameToID(md protoreflect.MessageDescriptor, name string) (uint32, bool) {
+	fds := md.Fields()
+	for i := 0; i < fds.Len(); i++ {
+		fd := fds.Get(i)
+		if string(fd.Name()) == name {
+			return uint32(fd.Number()), true
+		}
+	}
+	return 0, false
 }
 
 func fieldDescriptorsFor(md protoreflect.MessageDescriptor) []*pb.SchemaFieldDef {
@@ -145,6 +198,19 @@ func fieldDescriptorsFor(md protoreflect.MessageDescriptor) []*pb.SchemaFieldDef
 		if fopts.unique {
 			f.Unique = true
 		}
+		if fopts.pii {
+			f.Pii = true
+		}
+		if fopts.deprecated {
+			f.Deprecated = true
+		}
+		if fopts.description != "" {
+			f.Description = fopts.description
+		}
+		if fopts.hasRefType {
+			rt := fopts.refTypeID
+			f.RefTypeId = &rt
+		}
 		if fopts.enumValues != "" {
 			for _, ev := range splitEnumValues(fopts.enumValues) {
 				f.EnumValues = append(f.EnumValues, ev)
@@ -164,6 +230,24 @@ func canonNodeFor(md protoreflect.MessageDescriptor, typeID int32) map[string]an
 		"type_id": int64(typeID),
 		"fields":  canonFieldsFor(md),
 	}
+	nopts := readNodeOpts(md)
+	if nopts.deprecated {
+		out["deprecated"] = true
+	}
+	if nopts.description != "" {
+		out["description"] = nopts.description
+	}
+	if dp := dataPolicyName(nopts.dataPolicy); dp != "" {
+		out["data_policy"] = dp
+	}
+	if nopts.subjectField != "" {
+		if fid, ok := protoFieldNameToID(md, nopts.subjectField); ok {
+			out["subject_field"] = int64(fid)
+		}
+	}
+	if nopts.legalBasis != "" {
+		out["legal_basis"] = nopts.legalBasis
+	}
 	if cu, err := extractCompositeUnique(md); err == nil && len(cu) > 0 {
 		out["composite_unique"] = cu
 	}
@@ -171,13 +255,27 @@ func canonNodeFor(md protoreflect.MessageDescriptor, typeID int32) map[string]an
 }
 
 func canonEdgeFor(md protoreflect.MessageDescriptor, edgeID int32) map[string]any {
-	return map[string]any{
+	eopts := readEdgeOpts(md)
+	out := map[string]any{
 		"edge_id":         int64(edgeID),
 		"from_type_id":    int64(0),
 		"to_type_id":      int64(0),
 		"props":           canonFieldsFor(md),
-		"on_subject_exit": "both",
+		"on_subject_exit": subjectExitName(eopts.onSubjectExit),
 	}
+	if eopts.uniquePerFrom {
+		out["unique_per_from"] = true
+	}
+	if eopts.deprecated {
+		out["deprecated"] = true
+	}
+	if eopts.description != "" {
+		out["description"] = eopts.description
+	}
+	if dp := dataPolicyName(eopts.dataPolicy); dp != "" {
+		out["data_policy"] = dp
+	}
+	return out
 }
 
 func canonFieldsFor(md protoreflect.MessageDescriptor) []map[string]any {
@@ -196,11 +294,23 @@ func canonFieldsFor(md protoreflect.MessageDescriptor) []map[string]any {
 		if fopts.enumValues != "" {
 			entry["enum_values"] = splitEnumValues(fopts.enumValues)
 		}
+		if fopts.hasRefType {
+			entry["ref_type_id"] = int64(fopts.refTypeID)
+		}
 		if fopts.indexed {
 			entry["indexed"] = true
 		}
 		if fopts.searchable {
 			entry["searchable"] = true
+		}
+		if fopts.deprecated {
+			entry["deprecated"] = true
+		}
+		if fopts.description != "" {
+			entry["description"] = fopts.description
+		}
+		if fopts.pii {
+			entry["pii"] = true
 		}
 		if fopts.unique {
 			entry["unique"] = true

--- a/sdk/go/entdb/schema_selfdescribe_test.go
+++ b/sdk/go/entdb/schema_selfdescribe_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	pb "github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2/internal/pb"
 	"github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2/internal/testpb"
 )
 
@@ -74,6 +75,182 @@ func TestSelfDescribe_EmptyRegistryIsNil(t *testing.T) {
 	// nothing — the registry stays nil.
 	if newSchemaRegistry([]proto.Message{&testpb.NotAnEntity{}}) != nil {
 		t.Error("a non-entity message should yield a nil registry")
+	}
+}
+
+// findField returns the SchemaFieldDef with the given field_id, or nil.
+func findField(fields []*pb.SchemaFieldDef, id uint32) *pb.SchemaFieldDef {
+	for _, f := range fields {
+		if f.GetFieldId() == id {
+			return f
+		}
+	}
+	return nil
+}
+
+// TestSelfDescribe_RefTypeIDIsExtracted is the direct regression test for
+// issue #604: every kind:"ref" field MUST carry its ref_type_id on the wire
+// or the server rejects the whole register_schema with VALIDATION_ERROR.
+// The Go SDK previously dropped this attribute entirely; this test pins it.
+func TestSelfDescribe_RefTypeIDIsExtracted(t *testing.T) {
+	reg := newSchemaRegistry([]proto.Message{&testpb.RichDoc{}})
+	if reg == nil || reg.descriptor == nil {
+		t.Fatal("nil registry")
+	}
+	if len(reg.descriptor.GetNodeTypes()) != 1 {
+		t.Fatalf("want 1 node type, got %d", len(reg.descriptor.GetNodeTypes()))
+	}
+	node := reg.descriptor.GetNodeTypes()[0]
+
+	ownerID := findField(node.GetFields(), 3) // owner_id
+	if ownerID == nil {
+		t.Fatal("owner_id (field 3) missing from descriptor")
+	}
+	if ownerID.GetKind() != "ref" {
+		t.Errorf("owner_id.kind = %q, want \"ref\"", ownerID.GetKind())
+	}
+	if ownerID.RefTypeId == nil {
+		t.Fatal("owner_id.ref_type_id is nil — issue #604 regression: Go SDK dropped ref_type_id")
+	}
+	if *ownerID.RefTypeId != 201 {
+		t.Errorf("owner_id.ref_type_id = %d, want 201", *ownerID.RefTypeId)
+	}
+}
+
+// TestSelfDescribe_FieldAttributesRoundTrip verifies that every wire field on
+// SchemaFieldDef the Go SDK previously dropped (pii, deprecated, description,
+// ref_type_id) is now extracted from FieldOpts and emitted onto the descriptor.
+func TestSelfDescribe_FieldAttributesRoundTrip(t *testing.T) {
+	reg := newSchemaRegistry([]proto.Message{&testpb.RichDoc{}})
+	if reg == nil {
+		t.Fatal("nil registry")
+	}
+	node := reg.descriptor.GetNodeTypes()[0]
+
+	// title field: only description="the title"
+	title := findField(node.GetFields(), 1)
+	if title == nil {
+		t.Fatal("title (field 1) missing")
+	}
+	if title.GetDescription() != "the title" {
+		t.Errorf("title.description = %q, want \"the title\"", title.GetDescription())
+	}
+	if title.GetPii() || title.GetDeprecated() || title.RefTypeId != nil {
+		t.Errorf("title should only carry description; got pii=%v deprecated=%v ref=%v",
+			title.GetPii(), title.GetDeprecated(), title.RefTypeId)
+	}
+
+	// body field: nothing set (every attribute should be the zero value)
+	body := findField(node.GetFields(), 2)
+	if body == nil {
+		t.Fatal("body (field 2) missing")
+	}
+	if body.GetDescription() != "" || body.GetPii() || body.GetDeprecated() || body.RefTypeId != nil {
+		t.Errorf("body should have no attributes set; got %+v", body)
+	}
+
+	// author_email field: pii=true, deprecated=true, description=...
+	author := findField(node.GetFields(), 4)
+	if author == nil {
+		t.Fatal("author_email (field 4) missing")
+	}
+	if !author.GetPii() {
+		t.Error("author_email.pii = false; want true — Go SDK was dropping pii (GDPR-critical)")
+	}
+	if !author.GetDeprecated() {
+		t.Error("author_email.deprecated = false; want true")
+	}
+	if author.GetDescription() != "scrub on anonymise" {
+		t.Errorf("author_email.description = %q, want \"scrub on anonymise\"", author.GetDescription())
+	}
+}
+
+// TestSelfDescribe_NodeAttributesRoundTrip pins every NodeOpts attribute
+// the Go SDK previously dropped (deprecated, description, data_policy,
+// subject_field, legal_basis).
+func TestSelfDescribe_NodeAttributesRoundTrip(t *testing.T) {
+	reg := newSchemaRegistry([]proto.Message{&testpb.RichDoc{}})
+	if reg == nil {
+		t.Fatal("nil registry")
+	}
+	node := reg.descriptor.GetNodeTypes()[0]
+
+	if node.GetTypeId() != 401 {
+		t.Errorf("type_id = %d, want 401", node.GetTypeId())
+	}
+	if !node.GetDeprecated() {
+		t.Error("node.deprecated = false; want true")
+	}
+	if node.GetDescription() != "Rich doc; all NodeOpts attributes" {
+		t.Errorf("node.description = %q", node.GetDescription())
+	}
+	if node.GetDataPolicy() != "business" {
+		t.Errorf("node.data_policy = %q, want \"business\"", node.GetDataPolicy())
+	}
+	if node.SubjectField == nil {
+		t.Fatal("node.subject_field nil; want field_id of owner_id (3) — Go SDK was dropping it")
+	}
+	if *node.SubjectField != 3 {
+		t.Errorf("node.subject_field = %d, want 3 (owner_id's field_id)", *node.SubjectField)
+	}
+	if node.LegalBasis == nil || *node.LegalBasis != "user-consent" {
+		t.Errorf("node.legal_basis = %v, want \"user-consent\"", node.LegalBasis)
+	}
+}
+
+// TestSelfDescribe_EdgeAttributesRoundTrip pins every EdgeOpts attribute
+// the Go SDK previously dropped (unique_per_from, deprecated, description,
+// data_policy, on_subject_exit — which was hardcoded "both").
+func TestSelfDescribe_EdgeAttributesRoundTrip(t *testing.T) {
+	reg := newSchemaRegistry([]proto.Message{&testpb.RichEdge{}})
+	if reg == nil {
+		t.Fatal("nil registry")
+	}
+	if len(reg.descriptor.GetEdgeTypes()) != 1 {
+		t.Fatalf("want 1 edge type, got %d", len(reg.descriptor.GetEdgeTypes()))
+	}
+	edge := reg.descriptor.GetEdgeTypes()[0]
+
+	if edge.GetEdgeId() != 501 {
+		t.Errorf("edge_id = %d, want 501", edge.GetEdgeId())
+	}
+	if !edge.GetUniquePerFrom() {
+		t.Error("edge.unique_per_from = false; want true — Go SDK was dropping it")
+	}
+	if !edge.GetDeprecated() {
+		t.Error("edge.deprecated = false; want true")
+	}
+	if edge.GetDescription() != "Rich edge; all EdgeOpts attributes" {
+		t.Errorf("edge.description = %q", edge.GetDescription())
+	}
+	if edge.GetDataPolicy() != "audit" {
+		t.Errorf("edge.data_policy = %q, want \"audit\"", edge.GetDataPolicy())
+	}
+	if edge.GetOnSubjectExit() != "to" {
+		t.Errorf("edge.on_subject_exit = %q, want \"to\" — Go SDK was hardcoding \"both\"", edge.GetOnSubjectExit())
+	}
+}
+
+// TestSelfDescribe_FingerprintIncludesAllAttributes confirms the canonical
+// fingerprint changes when an attribute the SDK previously dropped becomes
+// set — i.e. the client-side fingerprint now reflects the full schema and
+// will MATCH the server's (server canonicalises FieldDef/NodeTypeDef with
+// the same omitempty rules). If the SDK drops an attribute the canonical
+// form omits it; the server's would include it; fingerprints diverge and
+// the client re-attaches schema on every write. This test pins parity.
+func TestSelfDescribe_FingerprintIncludesAllAttributes(t *testing.T) {
+	rich := newSchemaRegistry([]proto.Message{&testpb.RichDoc{}})
+	plain := newSchemaRegistry([]proto.Message{&testpb.Product{}})
+	if rich == nil || plain == nil {
+		t.Fatal("nil registry")
+	}
+	if rich.fingerprint == "" || plain.fingerprint == "" {
+		t.Fatal("empty fingerprint")
+	}
+	if rich.fingerprint == plain.fingerprint {
+		t.Error("RichDoc and Product produced the SAME fingerprint — additional " +
+			"attributes (pii, ref_type_id, data_policy, subject_field, ...) are " +
+			"not affecting the canonical form, which means they're still dropped")
 	}
 }
 


### PR DESCRIPTION
## Why

Issue #604 reported that every `kind:"ref"` field in a v2-era Go-SDK consumer's schema fails server validation with `VALIDATION_ERROR: ref_type_id required for REFERENCE field_id N`. Investigating the gap turned up **12 more wire attributes** that the Go SDK's self-describing path was silently dropping — the Python SDK populates them all; the Go SDK never read or emitted any of them.

## What was broken

**Server-rejected (hard failure):**
- `SchemaFieldDef.ref_type_id` — required when `kind == "ref"` (#604)

**Silent data loss** (info dropped, GDPR / docs / evolution behaviour wrong):

| Field-level | Node-level | Edge-level |
|---|---|---|
| `pii` (GDPR scrub) | `deprecated` | `unique_per_from` |
| `deprecated` | `description` | `deprecated` |
| `description` | `data_policy` (GDPR) | `description` |
| | `subject_field` (GDPR) | `data_policy` (GDPR) |
| | `legal_basis` (GDPR) | `on_subject_exit` (hardcoded `"both"`) |

Why it surfaced in v2 only: in v1 the server's schema was hardcoded by `--seed-profile` and the SDK didn't *send* a schema, so any extractor gap was invisible. ADR-031 made the SDK responsible for building and sending the `SchemaDescriptor`, exposing every omission.

## How

`readFieldOpts` (`schema_extract.go`) now also extracts `pii`, `ref_type_id`, `description`, `deprecated`. Added `readNodeOpts` (deprecated, description, data_policy, subject_field, legal_basis) and `readEdgeOpts` (unique_per_from, data_policy, on_subject_exit, description, deprecated). `nodeDescriptorFor` / `edgeDescriptorFor` / `fieldDescriptorsFor` (`schema_selfdescribe.go`) now emit every newly-extracted attribute onto the wire `Schema*Def`. `protoFieldNameToID` resolves NodeOpts.subject_field's proto name to its field_id (ADR-031: server is id-only).

`canonFieldsFor` / `canonNodeFor` / `canonEdgeFor` include every newly-extracted attribute under the SAME omitempty rules the server's `FieldDef`/`NodeTypeDef`/`EdgeTypeDef` JSON marshalling uses, so the **client-side fingerprint matches the server's**. Without that, a client that newly populates (say) `pii=true` would hash a different canonical form than the server materialised, breaking the fingerprint-omit steady state.

## Out of scope (follow-up)

Edge `from_type_id` / `to_type_id` derivation. EdgeOpts does not carry these — they must be resolved from the proto's `from`/`to` field message types via a cross-message walker. Currently still zero; tracked as a separate issue (any v2-era consumer with non-trivial edges hits this independent of #604).

## Tests

Five new regression tests pinning each gap, plus `RichDoc` + `RichEdge` test fixtures in `internal/testpb` that exercise every `FieldOpts`/`NodeOpts`/`EdgeOpts` attribute. Pre-existing extractor / snapshot tests had hardcoded counts that grew with the fixture additions (2→3 nodes, 1→2 edges); updated.

```
=== RUN   TestSelfDescribe_RefTypeIDIsExtracted
--- PASS  (#604 regression)
=== RUN   TestSelfDescribe_FieldAttributesRoundTrip
--- PASS  (pii / deprecated / description)
=== RUN   TestSelfDescribe_NodeAttributesRoundTrip
--- PASS  (data_policy / subject_field / legal_basis / deprecated / description)
=== RUN   TestSelfDescribe_EdgeAttributesRoundTrip
--- PASS  (unique_per_from / on_subject_exit / data_policy / deprecated / description)
=== RUN   TestSelfDescribe_FingerprintIncludesAllAttributes
--- PASS  (client/server fingerprint parity)
```

## Verification

`make ci` green end-to-end: 4 Go modules + Python integration **115** + unit **449** + e2e **25** + ruff. Fingerprint parity is implicit in the Python integration suite — any client/server canonical drift would break its pinned fingerprint, and the suite stayed green.

Patch release: this is **v2.0.2**.

Closes #604.