### PR TITLE
fix(sdk/go): wait_applied option + serverFingerprint race + v2 migration docs (closes #606 #607 #608)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,8 +230,15 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.suffix }}
           tags: |
-            # Semantic version from tag
+            # Semantic version from tag. docker/metadata-action strips
+            # the leading "v" by default, so a git tag of v2.0.2 yields
+            # an image tag of 2.0.2. We ALSO emit the v-prefixed form
+            # so consumers who template `image: ...:${VERSION}` with
+            # ${VERSION}=v2.0.2 (the git tag spelling — the natural
+            # choice when bumping from a VERSION file or `git describe`)
+            # don't hit a "manifest unknown" pull miss (issue #608).
             type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             # Latest for stable releases

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,12 @@ test-server:
 # sdk/go/entdb: the published Go SDK module
 # (`go get github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2`). Carries
 # its own checked-in pb stubs + the self-describing-write transport
-# (ADR-031). ~10 s.
+# (ADR-031). Run under `-race` so concurrent paths (transport
+# fingerprint cache, etc.) are exercised by the race detector — guards
+# against regressions of the kind issue #607 reported. ~20 s.
 test-sdk-go:
-	@echo "=== test-sdk-go: sdk/go/entdb vet + test ==="
-	cd sdk/go/entdb && go vet ./... && go test ./...
+	@echo "=== test-sdk-go: sdk/go/entdb vet + test (-race) ==="
+	cd sdk/go/entdb && go vet ./... && go test -race ./...
 
 # tests/contract: cross-language schema-snapshot parity tests — round-
 # trip + self-consistency against the entdb-schema CLI. SEPARATE go.mod,

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -1,0 +1,80 @@
+# Migrating to EntDB v2
+
+EntDB v2 is a wire-breaking major bump anchored by [ADR-031](adr/031-self-describing-name-free-schema.md) (self-describing, name-free schema) and [ADR-032](adr/032-schema-evolution-compat-rules.md) (compat-evolution rules + customer-runnable `entdb-schema breaking` gate). This page covers the migration friction points that aren't obvious from the ADRs.
+
+If you upgrade server and SDKs together — which is the documented requirement — you should hit none of these in production. They mostly bite during the upgrade pass itself, in CI scripts that templated against v1 conventions.
+
+## Breaking changes you may hit while upgrading
+
+### 1. `kind = "string"` is rejected
+
+v1 silently accepted any free-text kind in `(entdb.field).kind = "..."` because schema validation didn't run in schemaless mode. v2 enforces the canonical FieldKind list at register-schema time and rejects anything outside it:
+
+```
+INVALID_ARGUMENT: unknown kind "string"
+```
+
+**Canonical kinds:** `str`, `int`, `float`, `bool`, `timestamp`, `json`, `bytes`, `enum`, `ref`, `list_str`, `list_int`, `list_ref`.
+
+The most common offender is `kind = "string"` (use `str`). A one-liner to find and fix:
+
+```bash
+git grep -l 'kind: "string"' '*.proto' | xargs sed -i 's/kind: "string"/kind: "str"/g'
+```
+
+### 2. `entdb-server` requires `--data-dir`
+
+v1.32.x defaulted `--data-dir` to a temp path; v2 fails fast if it isn't set:
+
+```
+entdb-server: --data-dir is required
+```
+
+Pass it explicitly — even for ephemeral in-memory WAL runs:
+
+```bash
+entdb-server --addr=:50051 --data-dir=/tmp/entdb --wal-backend=memory
+```
+
+CI / testcontainers configs that relied on the v1 default need a one-line addition.
+
+### 3. Image tag spelling
+
+The git tag is `vX.Y.Z` (with the leading `v`); the published Docker image tag historically stripped the `v` to `X.Y.Z`. As of v2.0.3 the release workflow publishes **both** forms, so you can use whichever spelling matches your `${VERSION}` variable:
+
+```yaml
+# both of these resolve to the same image after v2.0.3:
+image: ghcr.io/elloloop/tenant-shard-db:v2.0.3
+image: ghcr.io/elloloop/tenant-shard-db:2.0.3
+```
+
+Pre-v2.0.3 releases (v2.0.0 / v2.0.1 / v2.0.2) only have the no-`v` form (`2.0.0`, `2.0.1`, `2.0.2`). If you templated against `${VERSION}` containing the `v`, either drop the prefix in your template or bump to v2.0.3+.
+
+## SDK behaviour changes
+
+### Go SDK module path
+
+`go get github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2@v2.0.3` and `import "github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2"` — the `/v2` suffix is mandatory at v2 and above (Go modules major-version rule).
+
+### Self-describing writes
+
+Both SDKs auto-attach a `SchemaDescriptor` on the first write per connection and omit it once the server's fingerprint matches (ADR-031). You don't need to call anything new — the SDK reads your proto via `register_proto_schema` (Python) / generated code (Go) and handles the handshake.
+
+### Server is id-only
+
+The server now rejects name-keyed payloads, filters, and `UpdateNodePrecondition.field` strings with `INVALID_ARGUMENT`. Official SDKs translate name → field_id client-side before the call, so app code is unchanged. Hand-rolled clients need to send id-keyed.
+
+### `Plan.Commit(ctx, WithWaitApplied(true))` (Go SDK)
+
+As of v2.0.3 the Go SDK's `Plan.Commit` accepts `CommitOption` values, including `WithWaitApplied(bool)` and `WithWaitTimeout(time.Duration)`. Set `WithWaitApplied(true)` on writes whose **uniqueness or precondition outcome the caller needs to react to** — without it, the loser of a unique-constraint race gets a phantom success and only discovers the failure via a follow-up read. The Python SDK has exposed `wait_applied=True` since v2.0.0.
+
+## What is *not* breaking
+
+- The `schema_fingerprint` on `ExecuteAtomic` still exists; the SDK manages it for you.
+- Idempotency keys behave identically.
+- gRPC RPC names and routes are unchanged.
+- ACL, GDPR, mailbox, FTS surfaces are unchanged.
+
+## Where to ask
+
+If you hit a migration issue that isn't on this page, file it against the repo and tag it `v2-migration` — it likely belongs in this doc.

--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -4,6 +4,7 @@ package entdb
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -52,8 +53,10 @@ type Transport interface {
 	// returned, never a silent 100-row prefix. limit caps the total when
 	// positive; limit <= 0 returns every matching row.
 	QueryNodes(ctx context.Context, tenantID, actor string, typeID int, filter map[string]any, limit int) ([]*Node, error)
-	// ExecuteAtomic commits a batch of operations atomically.
-	ExecuteAtomic(ctx context.Context, tenantID, actor, idempotencyKey string, ops []Operation) (*CommitResult, error)
+	// ExecuteAtomic commits a batch of operations atomically. Optional
+	// CommitOption values (e.g. [WithWaitApplied]) configure a single
+	// call; see issue #606.
+	ExecuteAtomic(ctx context.Context, tenantID, actor, idempotencyKey string, ops []Operation, opts ...CommitOption) (*CommitResult, error)
 	// Share grants permission on a node to another actor.
 	Share(ctx context.Context, tenantID, actor, nodeID, grantee, permission string) error
 	// GetEdgesFrom retrieves outgoing edges from a node.
@@ -268,7 +271,31 @@ type grpcTransport struct {
 	// While it differs from config.schema.fingerprint, ExecuteAtomic
 	// attaches the SchemaDescriptor; once it matches, the descriptor is
 	// omitted. Reset on a SCHEMA_MISMATCH response.
+	//
+	// Protected by serverFPMu — multiple goroutines may concurrently
+	// race on the first ExecuteAtomic call (every one of them sees the
+	// fingerprint empty and writes the same confirmed value); the
+	// outcome is logically correct but Go's -race detector flags the
+	// unsynchronised read/write, so we serialise the field. Read-heavy
+	// after the first round trip, hence RWMutex (issue #607).
+	serverFPMu        sync.RWMutex
 	serverFingerprint string
+}
+
+// loadServerFingerprint returns the last server-confirmed fingerprint
+// under the read lock. Safe for concurrent callers (issue #607).
+func (t *grpcTransport) loadServerFingerprint() string {
+	t.serverFPMu.RLock()
+	defer t.serverFPMu.RUnlock()
+	return t.serverFingerprint
+}
+
+// storeServerFingerprint sets the cached fingerprint under the write
+// lock. Idempotent under concurrent callers writing the same value.
+func (t *grpcTransport) storeServerFingerprint(fp string) {
+	t.serverFPMu.Lock()
+	t.serverFingerprint = fp
+	t.serverFPMu.Unlock()
 }
 
 func newGRPCTransport(address string, cfg clientConfig) *grpcTransport {
@@ -480,7 +507,7 @@ func (t *grpcTransport) QueryNodes(ctx context.Context, tenantID, actor string, 
 	return out, nil
 }
 
-func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idempotencyKey string, ops []Operation) (*CommitResult, error) {
+func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idempotencyKey string, ops []Operation, opts ...CommitOption) (*CommitResult, error) {
 	client, err := t.ensureReady()
 	if err != nil {
 		return nil, err
@@ -489,18 +516,29 @@ func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idem
 	if err != nil {
 		return nil, err
 	}
-	// Auto-enable wait_applied when any op carries a precondition.
-	// CAS is only useful synchronously — the caller needs to learn
-	// the outcome before the next request. We pick a generous
-	// 30s timeout to match the server's default cap; callers who
-	// need finer control can drop down to the raw transport.
-	// GitHub issue #500.
-	waitApplied := false
-	for _, op := range ops {
-		if op.Precondition != nil {
-			waitApplied = true
-			break
+	// Resolve commit options. WithWaitApplied OVERRIDES the auto-default;
+	// in its absence we keep the issue-#500 behaviour of auto-enabling
+	// wait_applied for any op carrying a Precondition (CAS is only useful
+	// synchronously). Without that override, the loser of a composite-unique
+	// race gets a phantom success (issue #606).
+	co := commitOpts{}
+	for _, opt := range opts {
+		opt(&co)
+	}
+	var waitApplied bool
+	if co.waitApplied != nil {
+		waitApplied = *co.waitApplied
+	} else {
+		for _, op := range ops {
+			if op.Precondition != nil {
+				waitApplied = true
+				break
+			}
 		}
+	}
+	waitTimeoutMs := int32(30000)
+	if co.waitTimeoutMs > 0 {
+		waitTimeoutMs = co.waitTimeoutMs
 	}
 	// SELF-DESCRIBING WRITES (ADR-031). Attach a name-free SchemaDescriptor
 	// + fingerprint whenever the server has not yet confirmed this schema
@@ -514,7 +552,7 @@ func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idem
 		clientFP = t.config.schema.fingerprint
 		descriptor = t.config.schema.descriptor
 	}
-	attachSchema := descriptor != nil && clientFP != "" && t.serverFingerprint != clientFP
+	attachSchema := descriptor != nil && clientFP != "" && t.loadServerFingerprint() != clientFP
 
 	buildReq := func(withSchema bool) *pb.ExecuteAtomicRequest {
 		r := &pb.ExecuteAtomicRequest{
@@ -524,7 +562,7 @@ func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idem
 			WaitApplied:    waitApplied,
 		}
 		if waitApplied {
-			r.WaitTimeoutMs = 30000
+			r.WaitTimeoutMs = waitTimeoutMs
 		}
 		if withSchema {
 			r.SchemaFingerprint = clientFP
@@ -544,7 +582,7 @@ func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idem
 	// server does not have and sent no descriptor to reconcile with —
 	// re-send once WITH the descriptor.
 	if resp.GetErrorCode() == "SCHEMA_MISMATCH" && descriptor != nil {
-		t.serverFingerprint = ""
+		t.storeServerFingerprint("")
 		var t2 metadata.MD
 		resp, err = client.ExecuteAtomic(
 			t.callContext(ctx, tenantID), buildReq(true), grpc.Trailer(&t2),
@@ -557,7 +595,7 @@ func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idem
 	// server now holds exactly this fingerprint; cache it so subsequent
 	// writes omit the descriptor.
 	if attachSchema && resp.GetErrorCode() != "SCHEMA_MISMATCH" {
-		t.serverFingerprint = clientFP
+		t.storeServerFingerprint(clientFP)
 	}
 	// Precondition failure surfaces in-band: applied_status =
 	// RECEIPT_STATUS_FAILED_PRECONDITION + structured detail in

--- a/sdk/go/entdb/client_test.go
+++ b/sdk/go/entdb/client_test.go
@@ -36,6 +36,10 @@ type mockTransport struct {
 	lastQueryLimit        int
 	lastCommitOperations  []Operation
 	lastCommitIdempotency string
+	// lastWaitAppliedSet records whether the caller passed
+	// WithWaitApplied; lastWaitApplied is the value (issue #606).
+	lastWaitApplied    bool
+	lastWaitAppliedSet bool
 
 	// Mailbox read tracking (#568).
 	lastMailboxTargetUser string
@@ -90,10 +94,23 @@ func (m *mockTransport) QueryNodes(_ context.Context, _, _ string, typeID int, f
 	return m.queryResp, m.queryErr
 }
 
-func (m *mockTransport) ExecuteAtomic(_ context.Context, _, _, idempotencyKey string, ops []Operation) (*CommitResult, error) {
+func (m *mockTransport) ExecuteAtomic(_ context.Context, _, _, idempotencyKey string, ops []Operation, opts ...CommitOption) (*CommitResult, error) {
 	m.commitCalls++
 	m.lastCommitIdempotency = idempotencyKey
 	m.lastCommitOperations = append([]Operation(nil), ops...)
+	// Record the resolved commit options so race tests can inspect what
+	// Plan.Commit propagated (issue #606).
+	mco := commitOpts{}
+	for _, o := range opts {
+		o(&mco)
+	}
+	if mco.waitApplied != nil {
+		m.lastWaitApplied = *mco.waitApplied
+		m.lastWaitAppliedSet = true
+	} else {
+		m.lastWaitApplied = false
+		m.lastWaitAppliedSet = false
+	}
 	return m.commitResp, m.commitErr
 }
 
@@ -501,5 +518,51 @@ func TestScope_EdgesFromTo(t *testing.T) {
 
 	if mock.edgesFromCalls != 1 || mock.edgesToCalls != 1 {
 		t.Errorf("expected 1 call each, got from=%d to=%d", mock.edgesFromCalls, mock.edgesToCalls)
+	}
+}
+
+// ── Issue #607: serverFingerprint race ──────────────────────────────
+
+// TestGrpcTransport_ServerFingerprintConcurrentAccess is the regression
+// guard for issue #607. The grpcTransport's serverFingerprint was a
+// plain string mutated without synchronisation; multiple goroutines
+// hitting their first ExecuteAtomic concurrently raced on the field
+// and tripped Go's -race detector even though the logical outcome was
+// fine. The fix wraps reads/writes in an RWMutex (loadServerFingerprint
+// / storeServerFingerprint). This test fans out N concurrent reader +
+// writer goroutines against those accessors; the test target is
+// `go test -race` running clean.
+func TestGrpcTransport_ServerFingerprintConcurrentAccess(t *testing.T) {
+	tr := &grpcTransport{}
+	const goroutines = 32
+	const iterations = 1000
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		// Half readers, half writers — exactly the shape that bit a
+		// real consumer (their conformance suite fans out N goroutines
+		// doing first-time writes, every one of which reads the
+		// fingerprint to decide on schema attach and then writes it
+		// after the server confirms).
+		if i%2 == 0 {
+			go func() {
+				for j := 0; j < iterations; j++ {
+					_ = tr.loadServerFingerprint()
+				}
+				done <- struct{}{}
+			}()
+		} else {
+			go func(seed int) {
+				for j := 0; j < iterations; j++ {
+					tr.storeServerFingerprint("sha256:fp")
+				}
+				done <- struct{}{}
+			}(i)
+		}
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+	if got := tr.loadServerFingerprint(); got != "sha256:fp" {
+		t.Errorf("final fingerprint = %q; want sha256:fp", got)
 	}
 }

--- a/sdk/go/entdb/plan.go
+++ b/sdk/go/entdb/plan.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync/atomic"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -354,12 +355,64 @@ func (p *Plan) Actor() string { return p.actor }
 // IdempotencyKey returns the idempotency key for this plan.
 func (p *Plan) IdempotencyKey() string { return p.idempotencyKey }
 
+// commitOpts is the resolved options pack for a single Commit /
+// ExecuteAtomic call. Callers configure it via CommitOption values.
+type commitOpts struct {
+	// waitApplied, when non-nil, OVERRIDES the auto-default
+	// (precondition-driven). nil = auto-default.
+	waitApplied   *bool
+	waitTimeoutMs int32
+}
+
+// CommitOption configures a single Plan.Commit / ExecuteAtomic call.
+// Pass values to [Plan.Commit] as variadic args:
+//
+//	receipt, err := plan.Commit(ctx, entdb.WithWaitApplied(true))
+//
+// Options are independent and can be combined. Issue #606.
+type CommitOption func(*commitOpts)
+
+// WithWaitApplied controls whether [Plan.Commit] blocks until the WAL
+// applier has processed every op in the batch BEFORE returning. When
+// true, the applier's outcome (success, ALREADY_EXISTS on a unique-
+// constraint violation, FAILED_PRECONDITION on a CAS miss, …) is
+// surfaced synchronously. When false (the default), the call returns
+// as soon as the WAL has accepted the event, and an applier-side
+// rejection only shows up via a follow-up read.
+//
+// Prior to issue #606 the Plan API auto-enabled this ONLY for ops
+// carrying a Precondition. For unique-constraint races (no
+// precondition) the LOSER otherwise got a phantom success: a UUID
+// returned by Commit, then a silent ALREADY_EXISTS at apply time.
+// Set this explicitly to true on writes whose uniqueness outcome the
+// caller needs to react to.
+func WithWaitApplied(b bool) CommitOption {
+	return func(o *commitOpts) { o.waitApplied = &b }
+}
+
+// WithWaitTimeout sets the upper bound on how long the server will
+// block waiting for the applier when WaitApplied is true. Zero (the
+// default) selects the SDK's default of 30s. Values are clamped to
+// >= 1ms.
+func WithWaitTimeout(d time.Duration) CommitOption {
+	return func(o *commitOpts) {
+		ms := d / time.Millisecond
+		if ms > 0 {
+			o.waitTimeoutMs = int32(ms)
+		}
+	}
+}
+
 // Commit sends all accumulated operations to the server as a single atomic
 // transaction. The Plan cannot be used after Commit is called.
-func (p *Plan) Commit(ctx context.Context) (*CommitResult, error) {
+//
+// Pass [WithWaitApplied] / [WithWaitTimeout] to block until the applier
+// has processed the batch — useful when racing on a unique constraint
+// where the loser otherwise sees a phantom success (issue #606).
+func (p *Plan) Commit(ctx context.Context, opts ...CommitOption) (*CommitResult, error) {
 	p.ensureNotCommitted()
 	p.committed = true
-	return p.client.ExecuteAtomic(ctx, p.tenantID, p.actor, p.idempotencyKey, p.operations)
+	return p.client.ExecuteAtomic(ctx, p.tenantID, p.actor, p.idempotencyKey, p.operations, opts...)
 }
 
 // ensureNotCommitted panics if the Plan has already been committed.

--- a/sdk/go/entdb/plan_test.go
+++ b/sdk/go/entdb/plan_test.go
@@ -670,3 +670,61 @@ func TestScope_Share(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// ── Issue #606: Plan.Commit WithWaitApplied option ──────────────────
+
+// TestPlanCommit_WithWaitAppliedTrue pins that WithWaitApplied(true) is
+// propagated to the transport, so the loser of a composite-unique race
+// can finally see the applier's ALREADY_EXISTS instead of a phantom
+// success. The mock records the resolved commitOpts; the test reads
+// them back. Issue #606.
+func TestPlanCommit_WithWaitAppliedTrue(t *testing.T) {
+	mock := &mockTransport{}
+	plan := newPlan(mock, "t1", "user:alice", "key-1")
+	plan.Create(newProduct("sku-1", "Widget", 100))
+	if _, err := plan.Commit(context.Background(), WithWaitApplied(true)); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if !mock.lastWaitAppliedSet {
+		t.Fatal("transport did not see WithWaitApplied; option not propagated")
+	}
+	if !mock.lastWaitApplied {
+		t.Errorf("waitApplied = false; want true")
+	}
+}
+
+// TestPlanCommit_WithWaitAppliedFalse_OverridesPreconditionAuto pins
+// that an explicit WithWaitApplied(false) overrides the auto-enable
+// triggered by Precondition (issue #500), so callers retain control.
+// Issue #606.
+func TestPlanCommit_WithWaitAppliedFalse_OverridesPreconditionAuto(t *testing.T) {
+	mock := &mockTransport{}
+	plan := newPlan(mock, "t1", "user:alice", "key-2")
+	// An UpdateNode with a precondition would normally auto-enable
+	// waitApplied. The explicit option must win.
+	plan.UpdateIf("n1", newProduct("sku-1", "Widget", 200), "name", "Widget")
+	if _, err := plan.Commit(context.Background(), WithWaitApplied(false)); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if !mock.lastWaitAppliedSet {
+		t.Fatal("transport did not see WithWaitApplied; option not propagated")
+	}
+	if mock.lastWaitApplied {
+		t.Errorf("waitApplied = true; want false (the explicit option must override the precondition auto-enable)")
+	}
+}
+
+// TestPlanCommit_NoOption_PreservesBackwardCompat pins that
+// Plan.Commit(ctx) with no options keeps the pre-issue-#606 behaviour:
+// no commitOpts on the transport (so the auto-default path runs).
+func TestPlanCommit_NoOption_PreservesBackwardCompat(t *testing.T) {
+	mock := &mockTransport{}
+	plan := newPlan(mock, "t1", "user:alice", "key-3")
+	plan.Create(newProduct("sku-1", "Widget", 100))
+	if _, err := plan.Commit(context.Background()); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if mock.lastWaitAppliedSet {
+		t.Errorf("waitApplied was set without an option — backward-compat broken")
+	}
+}


### PR DESCRIPTION
Three Go-SDK / migration follow-ups from the v2.0.x rollout, batched into a single patch release.

## #606 — Plan.Commit lacks `wait_applied` option

`Plan.Commit` previously auto-enabled `wait_applied` ONLY when an op carried a `Precondition`. For composite-unique races (no precondition) the loser got a phantom success: a UUID returned synchronously, the applier later rejecting with `ALREADY_EXISTS`, the SDK never surfacing it. The Python SDK has exposed `wait_applied=True` since v2.0.0.

Added a functional-option API:

```go
type CommitOption func(*commitOpts)
func WithWaitApplied(b bool) CommitOption
func WithWaitTimeout(d time.Duration) CommitOption

receipt, err := plan.Commit(ctx, entdb.WithWaitApplied(true))
```

`Plan.Commit(ctx, opts ...CommitOption)` is variadic → backward-compatible. Explicit `WithWaitApplied` overrides the precondition-auto-enable. The `Transport.ExecuteAtomic` interface gained the same trailing variadic.

## #607 — `grpcTransport.serverFingerprint` race

The cache field was a plain string read/written without synchronisation; N concurrent first-calls raced on it. Logically benign (every writer writes the same value) but `-race` flagged it.

Wrapped reads/writes in `sync.RWMutex` via `loadServerFingerprint`/`storeServerFingerprint` accessor methods (RWMutex because the path is read-heavy after the first round trip). All three call sites updated. **Makefile `test-sdk-go` now runs `go test -race ./...`** so a future regression trips CI rather than only the consumer's suite.

Added `TestGrpcTransport_ServerFingerprintConcurrentAccess` that runs 32 goroutines × 1000 iterations of mixed reads/writes through the accessors; under `-race` it fails any future unsynchronised access.

## #608 — v2 migration friction points

Three pain points consumers hit upgrading v1.32.1 → v2.0.x:

1. **`kind = "string"` rejected.** v1 silently accepted it; v2 enforces the canonical `FieldKind` list. Documented + one-liner sed for the common offender.
2. **`-data-dir` required.** v1 had a default; v2 fails fast. Documented.
3. **Image tag spelling.** Git tag is `vX.Y.Z`; the docker image was published only as `X.Y.Z` (no `v`). **Fixed** in `.github/workflows/release.yml` by adding `type=semver,pattern=v{{version}}` alongside the existing `{{version}}` rule. v2.0.3+ ships BOTH `2.0.3` and `v2.0.3`, so consumer templates with either spelling work.

New page **`docs/migration-v2.md`** covers all three plus what is *not* breaking (RPC routes, idempotency, ACL/GDPR surfaces).

## Tests + verification

```
TestPlanCommit_WithWaitAppliedTrue                                  PASS
TestPlanCommit_WithWaitAppliedFalse_OverridesPreconditionAuto       PASS
TestPlanCommit_NoOption_PreservesBackwardCompat                     PASS
TestGrpcTransport_ServerFingerprintConcurrentAccess  (under -race)  PASS
```

`make ci` green end-to-end (now `-race` on the SDK module): 4 Go modules + Python integration **115** + unit **449** + e2e **25** + ruff. Patch release: **v2.0.3**.

Closes #606, #607, #608.