### PR TITLE
fix(sdk/go): offset-based read-after-write + tools tag + v2 enforcement docs (closes #600 #601 #602)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,12 +295,33 @@ jobs:
             git push origin "$GO_TAG"
           fi
 
+      - name: Tag protoc-gen-entdb-keys submodule
+        # The plugin is its own Go module (tools/protoc-gen-entdb-keys/go.mod);
+        # Go's sub-module versioning requires `<path>/vX.Y.Z` tags, so we
+        # mint one alongside the SDK tag. Without this, consumers
+        # cannot `go install
+        # github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys@vX.Y.Z`
+        # — they have to build from a clone. Issue #602.
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          TOOL_TAG="tools/protoc-gen-entdb-keys/v${VER}"
+          if git rev-parse "$TOOL_TAG" >/dev/null 2>&1; then
+            echo "tools tag $TOOL_TAG already exists, skipping"
+          else
+            git tag -a "$TOOL_TAG" -m "protoc-gen-entdb-keys $TOOL_TAG"
+            git push origin "$TOOL_TAG"
+          fi
+
       - name: Trigger Go module proxy
         run: |
           VER="${GITHUB_REF_NAME#v}"
           MODULE="github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2"
           curl -fsSL "https://proxy.golang.org/${MODULE}/@v/v${VER}.info" || \
             echo "Module proxy will index within ~30 minutes"
+          # Warm the plugin module too so `go install` resolves promptly.
+          TOOLS_MODULE="github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys"
+          curl -fsSL "https://proxy.golang.org/${TOOLS_MODULE}/@v/v${VER}.info" || \
+            echo "Tools module proxy will index within ~30 minutes"
 
   publish-pypi:
     name: Publish SDK to PyPI

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -68,6 +68,34 @@ The server now rejects name-keyed payloads, filters, and `UpdateNodePrecondition
 
 As of v2.0.3 the Go SDK's `Plan.Commit` accepts `CommitOption` values, including `WithWaitApplied(bool)` and `WithWaitTimeout(time.Duration)`. Set `WithWaitApplied(true)` on writes whose **uniqueness or precondition outcome the caller needs to react to** — without it, the loser of a unique-constraint race gets a phantom success and only discovers the failure via a follow-up read. The Python SDK has exposed `wait_applied=True` since v2.0.0.
 
+## Unique-constraint enforcement: when it actually fires (issue #601)
+
+`(entdb.field).unique = true` and `(entdb.node).composite_unique` are enforced **only after** the server's registry knows about the type. Under v2's ADR-031 model the server **boots empty** and learns each type from a `SchemaDescriptor` the SDK auto-attaches on the first write for that connection. So in v2.x with the official SDKs:
+
+1. App boots, opens a `DbClient` (the SDK builds a name-free `SchemaDescriptor` from its proto registry).
+2. First write of a uniquely-keyed type → SDK attaches the descriptor → server prepends a `register_schema` op → applier registers the type **and creates the per-tenant unique expression index** before the data op lands.
+3. From that moment on, duplicate writes for that key surface as `*UniqueConstraintError` (gRPC `ALREADY_EXISTS`).
+
+The annotation is **not silently ignored** in v2.x. If you observe duplicates landing on a uniquely-annotated field, check one of:
+
+- **Old SDK.** Pre-v2.0.2 the Go SDK dropped `(entdb.field).ref_type_id` from the descriptor, so `register_schema` was rejected for any node with a `kind:"ref"` field — schema never landed → unique never enforced. Upgrade to **v2.0.2+** (or **v2.0.4+** for the wider attribute coverage and the `Plan.Commit(ctx, WithWaitApplied(true))` option from #606 that surfaces the loser's `ALREADY_EXISTS` synchronously).
+- **Hand-rolled client / schema not attached.** Anything that talks to the server without sending a `SchemaDescriptor` keeps the registry empty for that type, and unique stays metadata-only (the proto option ships but no SQLite expression index is ever created). Use an official SDK or call `register_schema` explicitly.
+- **`Plan.Commit` without `WithWaitApplied(true)`.** Without it, the *loser* of a concurrent unique-race gets a phantom success: a UUID returned synchronously, the applier rejecting the write seconds later, no error surfaced to the caller. Use `WithWaitApplied(true)` (issue #606) on writes whose uniqueness outcome you need to react to.
+
+If you genuinely want to run the server schemaless and rely on the annotation, you can't — the annotation is a *client-side* declaration that flows to the server via the SDK's `SchemaDescriptor`. There is no server-side path that consults proto options without the descriptor.
+
+## Recommended Go codegen toolchain (issue #602)
+
+Wire **`protoc-gen-entdb-keys`** into your `buf generate` pipeline so the SDK's typed `UniqueKey[T]` tokens are generated from your proto rather than hand-constructed. Hand-construction couples your code to an internal wire format the SDK explicitly disclaims as unstable.
+
+Install the plugin once (each release tags the tools submodule too):
+
+```bash
+go install github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys@v2.0.4
+```
+
+Then drop [`docs/recipes/buf.gen.yaml.template`](recipes/buf.gen.yaml.template) into your repo as `buf.gen.yaml`. It generates `protoc-gen-go` + `protoc-gen-go-grpc` + `protoc-gen-entdb-keys` sidecars in one `buf generate` pass. The generated tokens are then the only way to call `sdk.GetByKey`, and any future change to the token shape only ripples through codegen rather than every consumer.
+
 ## What is *not* breaking
 
 - The `schema_fingerprint` on `ExecuteAtomic` still exists; the SDK manages it for you.

--- a/docs/recipes/buf.gen.yaml.template
+++ b/docs/recipes/buf.gen.yaml.template
@@ -1,0 +1,46 @@
+# buf.gen.yaml — codegen template for an EntDB app team.
+#
+# Drop this next to your buf.yaml and run `buf generate`. It produces:
+#   * Standard protoc-gen-go stubs (your .pb.go files)
+#   * protoc-gen-go-grpc service stubs
+#   * The EntDB sidecars from `protoc-gen-entdb-keys`: typed
+#     `UniqueKey[T]` tokens for every `(entdb.field).unique = true`
+#     field on your node types, plus a name-free schema descriptor for
+#     the SDKs' self-describing writes (ADR-031 / ADR-025).
+#
+# Wiring the EntDB plugin into your codegen is the recommended path
+# for v2+ consumers — hand-constructing UniqueKey values couples your
+# code to an internal wire format the SDK explicitly disclaims as
+# unstable. See issue #602 + ADR-025.
+#
+# Install the plugin once:
+#   go install github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys@v2.0.4
+# Then `buf generate` will pick it up via $PATH.
+
+version: v2
+
+plugins:
+  # ── Standard Go stubs ──────────────────────────────────────────────
+  - remote: buf.build/protocolbuffers/go:v1.36.11
+    out: gen/go
+    opt:
+      - paths=source_relative
+
+  - remote: buf.build/grpc/go:v1.5.1
+    out: gen/go
+    opt:
+      - paths=source_relative
+
+  # ── EntDB SDK sidecars ─────────────────────────────────────────────
+  # Reads (entdb.field).unique annotations from your .proto and emits a
+  # typed UniqueKey[T] for every unique field. Use the generated token
+  # as the only way to call sdk.GetByKey — never hand-construct one
+  # (issue #602; the struct's exported fields are an internal contract
+  # the SDK reserves the right to change).
+  - local: protoc-gen-entdb-keys
+    out: gen/go
+    opt:
+      - paths=source_relative
+
+inputs:
+  - directory: proto # <-- point at your own proto tree

--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -616,12 +616,17 @@ func (t *grpcTransport) ExecuteAtomic(ctx context.Context, tenantID, actor, idem
 		// after_offset (mirrors the Python SDK).
 		t.offsets.record(tenantID, r.GetStreamPosition())
 	}
+	committedOffset := ""
+	if receipt != nil {
+		committedOffset = receipt.StreamPosition
+	}
 	return &CommitResult{
-		Success:        resp.GetSuccess(),
-		Receipt:        receipt,
-		CreatedNodeIDs: resp.GetCreatedNodeIds(),
-		Applied:        resp.GetAppliedStatus() == pb.ReceiptStatus_RECEIPT_STATUS_APPLIED,
-		Error:          resp.GetError(),
+		Success:         resp.GetSuccess(),
+		Receipt:         receipt,
+		CreatedNodeIDs:  resp.GetCreatedNodeIds(),
+		Applied:         resp.GetAppliedStatus() == pb.ReceiptStatus_RECEIPT_STATUS_APPLIED,
+		Error:           resp.GetError(),
+		CommittedOffset: committedOffset,
 	}, nil
 }
 
@@ -1542,6 +1547,33 @@ func (c *DbClient) GetTenantQuota(ctx context.Context, actor, tenantID string) (
 // commit chain.
 func (c *DbClient) WaitForOffset(ctx context.Context, tenantID, actor, streamPosition string, timeoutMs int32) (bool, string, error) {
 	return c.transport.WaitForOffset(ctx, tenantID, actor, streamPosition, timeoutMs)
+}
+
+// WaitForCommit is a convenience wrapper around [DbClient.WaitForOffset]
+// that takes the result of a prior [Plan.Commit] and blocks until that
+// specific write has been applied. Use it instead of polling the field
+// value when multiple goroutines may write to the same node — a
+// value-based "wait until x == V_a" poll DEADLOCKS if a concurrent
+// writer overwrites the field with V_b, but an offset-based wait only
+// observes monotonic progress. Issue #600.
+//
+//	receipt, err := plan.Commit(ctx)
+//	if err != nil { return err }
+//	if ok, _, err := client.WaitForCommit(ctx, tenantID, actor, receipt, 30000); !ok {
+//	    return fmt.Errorf("applier did not catch up: %v", err)
+//	}
+//
+// Returns (false, "", nil) immediately when receipt is nil or carries
+// no offset (e.g. an idempotent-replay response). timeoutMs <= 0 falls
+// back to the server's default cap (30s).
+func (c *DbClient) WaitForCommit(ctx context.Context, tenantID, actor string, receipt *CommitResult, timeoutMs int32) (bool, string, error) {
+	if receipt == nil || receipt.CommittedOffset == "" {
+		return false, "", nil
+	}
+	if timeoutMs <= 0 {
+		timeoutMs = 30000
+	}
+	return c.transport.WaitForOffset(ctx, tenantID, actor, receipt.CommittedOffset, timeoutMs)
 }
 
 // offsetClearer is the optional capability a Transport exposes when

--- a/sdk/go/entdb/client_test.go
+++ b/sdk/go/entdb/client_test.go
@@ -41,6 +41,12 @@ type mockTransport struct {
 	lastWaitApplied    bool
 	lastWaitAppliedSet bool
 
+	// WaitForOffset capture for the issue #600 WaitForCommit helper.
+	waitOffsetCalls         int
+	lastWaitOffsetStreamPos string
+	lastWaitOffsetTimeoutMs int32
+	waitOffsetReached       bool
+
 	// Mailbox read tracking (#568).
 	lastMailboxTargetUser string
 	mailboxGetResp        *Node
@@ -164,8 +170,11 @@ func (m *mockTransport) GetReceiptStatus(_ context.Context, _, _, _ string) (Rec
 	return ReceiptStatusUnknown, "", nil
 }
 
-func (m *mockTransport) WaitForOffset(_ context.Context, _, _, _ string, _ int32) (bool, string, error) {
-	return false, "", nil
+func (m *mockTransport) WaitForOffset(_ context.Context, _, _, streamPosition string, timeoutMs int32) (bool, string, error) {
+	m.lastWaitOffsetStreamPos = streamPosition
+	m.lastWaitOffsetTimeoutMs = timeoutMs
+	m.waitOffsetCalls++
+	return m.waitOffsetReached, streamPosition, nil
 }
 
 func (m *mockTransport) GetConnectedNodes(_ context.Context, _, _, _ string, _ int) ([]*Node, error) {
@@ -564,5 +573,75 @@ func TestGrpcTransport_ServerFingerprintConcurrentAccess(t *testing.T) {
 	}
 	if got := tr.loadServerFingerprint(); got != "sha256:fp" {
 		t.Errorf("final fingerprint = %q; want sha256:fp", got)
+	}
+}
+
+// ── Issue #600: offset-based read-after-write primitive ─────────────
+
+// TestDbClient_WaitForCommit_PassesCommittedOffsetThroughToTransport
+// pins the wiring so a future refactor cannot silently regress the
+// offset-based wait into a no-op. Issue #600.
+func TestDbClient_WaitForCommit_PassesCommittedOffsetThroughToTransport(t *testing.T) {
+	mock := &mockTransport{waitOffsetReached: true}
+	client := newTestClient(t, mock)
+	result := &CommitResult{
+		Success:         true,
+		CommittedOffset: "wal:0:42",
+	}
+	ok, pos, err := client.WaitForCommit(context.Background(), "acme", "user:alice", result, 5000)
+	if err != nil {
+		t.Fatalf("WaitForCommit: %v", err)
+	}
+	if !ok {
+		t.Errorf("ok = false; want true (mock said reached)")
+	}
+	if pos != "wal:0:42" {
+		t.Errorf("returned position = %q, want wal:0:42 (the echoed offset)", pos)
+	}
+	if mock.waitOffsetCalls != 1 {
+		t.Errorf("WaitForOffset calls = %d, want 1", mock.waitOffsetCalls)
+	}
+	if mock.lastWaitOffsetStreamPos != "wal:0:42" {
+		t.Errorf("transport saw streamPosition = %q, want wal:0:42 — the CommittedOffset shortcut didn't propagate", mock.lastWaitOffsetStreamPos)
+	}
+	if mock.lastWaitOffsetTimeoutMs != 5000 {
+		t.Errorf("transport saw timeoutMs = %d, want 5000", mock.lastWaitOffsetTimeoutMs)
+	}
+}
+
+// TestDbClient_WaitForCommit_NilReceiptIsNoOp pins the safety guard:
+// passing a nil / empty-offset CommitResult must not call the server.
+func TestDbClient_WaitForCommit_NilReceiptIsNoOp(t *testing.T) {
+	mock := &mockTransport{}
+	client := newTestClient(t, mock)
+	ok, _, err := client.WaitForCommit(context.Background(), "acme", "user:alice", nil, 5000)
+	if err != nil || ok {
+		t.Errorf("nil CommitResult: ok=%v err=%v; want (false, nil)", ok, err)
+	}
+	if mock.waitOffsetCalls != 0 {
+		t.Errorf("server should not have been called; got %d calls", mock.waitOffsetCalls)
+	}
+	// Empty CommittedOffset must also short-circuit.
+	ok, _, err = client.WaitForCommit(context.Background(), "acme", "user:alice", &CommitResult{Success: true}, 5000)
+	if err != nil || ok {
+		t.Errorf("empty CommittedOffset: ok=%v err=%v; want (false, nil)", ok, err)
+	}
+	if mock.waitOffsetCalls != 0 {
+		t.Errorf("server still should not have been called; got %d calls", mock.waitOffsetCalls)
+	}
+}
+
+// TestDbClient_WaitForCommit_DefaultTimeout pins that timeoutMs <= 0
+// falls back to the 30s server default.
+func TestDbClient_WaitForCommit_DefaultTimeout(t *testing.T) {
+	mock := &mockTransport{waitOffsetReached: true}
+	client := newTestClient(t, mock)
+	_, _, err := client.WaitForCommit(context.Background(), "acme", "user:alice",
+		&CommitResult{CommittedOffset: "wal:0:1"}, 0)
+	if err != nil {
+		t.Fatalf("WaitForCommit: %v", err)
+	}
+	if mock.lastWaitOffsetTimeoutMs != 30000 {
+		t.Errorf("timeoutMs = %d, want 30000 (default fallback)", mock.lastWaitOffsetTimeoutMs)
 	}
 }

--- a/sdk/go/entdb/types.go
+++ b/sdk/go/entdb/types.go
@@ -100,6 +100,15 @@ type CommitResult struct {
 	CreatedNodeIDs []string `json:"created_node_ids,omitempty"`
 	Applied        bool     `json:"applied"`
 	Error          string   `json:"error,omitempty"`
+	// CommittedOffset is the WAL stream position at which this write
+	// was recorded (shortcut for Receipt.StreamPosition; empty when no
+	// receipt was returned). Pass it to [DbClient.WaitForCommit] /
+	// [DbClient.WaitForOffset] to block from any goroutine until the
+	// applier has caught up — the offset-based primitive for
+	// read-after-write under concurrency, where a value-based "poll
+	// until field equals X" wait deadlocks if a concurrent writer
+	// overwrites the field. Issue #600.
+	CommittedOffset string `json:"committed_offset,omitempty"`
 }
 
 // ── Operations ──────────────────────────────────────────────────────


### PR DESCRIPTION
Three follow-ups from the v2-era backlog, batched.

## #600 — Post-commit visibility deadlocks under concurrent writes

The "wait for field == V" poll pattern consumers reach for has a real deadlock: if a concurrent writer overwrites the field with V' before the original writer's poll reads, the poll spins forever. The offset-based primitive is the correct fix.

The primitives already existed (server's `WaitForOffset` RPC, transport's `WaitForOffset` method, `Receipt.StreamPosition`). They were just buried two levels deep. Surfaced them:

- **`CommitResult.CommittedOffset`** — top-level shortcut for `Receipt.StreamPosition`; populated at the `ExecuteAtomic` return.
- **`DbClient.WaitForCommit(ctx, tenantID, actor, *CommitResult, timeoutMs)`** — convenience wrapper that takes a `CommitResult` and blocks until its offset has been applied. 30 s default timeout (`timeoutMs <= 0`).

Now consumers do:

```go
receipt, err := plan.Commit(ctx)
if err != nil { return err }
ok, _, _ := client.WaitForCommit(ctx, tenantID, actor, receipt, 30000)
```

…instead of a value-poll. Independent of what other writers do.

Three regression tests: offset propagation, nil/empty short-circuit, default-timeout fallback.

## #602 — `protoc-gen-entdb-keys` not in the recommended toolchain

Consumers without the plugin wired into their codegen reach for inline hand-construction of `sdk.UniqueKey[T]`, coupling them to an internal wire format the SDK explicitly disclaims as unstable.

Two changes:

- **`docs/recipes/buf.gen.yaml.template`** — companion to the existing `buf.yaml.template`; wires `protoc-gen-go` + `protoc-gen-go-grpc` + `protoc-gen-entdb-keys` in one `buf generate` pass.
- **`.github/workflows/release.yml`** — now tags the `tools/protoc-gen-entdb-keys` submodule on every release (Go's sub-module versioning rule), and warms the Go proxy for it. From v2.0.4 onward consumers can `go install github.com/.../tools/protoc-gen-entdb-keys@v2.0.4` without a clone.

## #601 — `(entdb.field).unique` enforcement model under v2

Documented in `docs/migration-v2.md`: the annotation IS enforced under v2.x's ADR-031 self-describing writes once the SDK has attached the `SchemaDescriptor`; it stays metadata-only on a registry that hasn't seen the type. Listed the three reasons consumers might observe unique-not-firing (old SDK pre-v2.0.2 with the `ref_type_id` gap from #604; hand-rolled client without descriptor; missing `WithWaitApplied(true)` in the racy path).

## Verification

`make ci` green (with `-race` on the SDK): 4 Go modules + Python integration **115** + unit **449** + e2e **25** + ruff. Patch release: **v2.0.4**.

Closes #600, #601, #602.