### PR TITLE
fix(tools): protoc-gen-entdb-keys module path /v2 (same Go v2+ rule that bit the SDK on v2.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
         # Go's sub-module versioning requires `<path>/vX.Y.Z` tags, so we
         # mint one alongside the SDK tag. Without this, consumers
         # cannot `go install
-        # github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys@vX.Y.Z`
+        # github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2@vX.Y.Z`
         # — they have to build from a clone. Issue #602.
         run: |
           VER="${GITHUB_REF_NAME#v}"
@@ -319,7 +319,7 @@ jobs:
           curl -fsSL "https://proxy.golang.org/${MODULE}/@v/v${VER}.info" || \
             echo "Module proxy will index within ~30 minutes"
           # Warm the plugin module too so `go install` resolves promptly.
-          TOOLS_MODULE="github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys"
+          TOOLS_MODULE="github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2"
           curl -fsSL "https://proxy.golang.org/${TOOLS_MODULE}/@v/v${VER}.info" || \
             echo "Tools module proxy will index within ~30 minutes"
 

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -91,7 +91,7 @@ Wire **`protoc-gen-entdb-keys`** into your `buf generate` pipeline so the SDK's 
 Install the plugin once (each release tags the tools submodule too):
 
 ```bash
-go install github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys@v2.0.4
+go install github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2@v2.0.5
 ```
 
 Then drop [`docs/recipes/buf.gen.yaml.template`](recipes/buf.gen.yaml.template) into your repo as `buf.gen.yaml`. It generates `protoc-gen-go` + `protoc-gen-go-grpc` + `protoc-gen-entdb-keys` sidecars in one `buf generate` pass. The generated tokens are then the only way to call `sdk.GetByKey`, and any future change to the token shape only ripples through codegen rather than every consumer.

--- a/docs/recipes/buf.gen.yaml.template
+++ b/docs/recipes/buf.gen.yaml.template
@@ -14,7 +14,7 @@
 # unstable. See issue #602 + ADR-025.
 #
 # Install the plugin once:
-#   go install github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys@v2.0.4
+#   go install github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2@v2.0.5
 # Then `buf generate` will pick it up via $PATH.
 
 version: v2

--- a/tools/protoc-gen-entdb-keys/go.mod
+++ b/tools/protoc-gen-entdb-keys/go.mod
@@ -1,4 +1,4 @@
-module github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys
+module github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2
 
 go 1.22
 

--- a/tools/protoc-gen-entdb-keys/testdata/bad_nonscalar.proto
+++ b/tools/protoc-gen-entdb-keys/testdata/bad_nonscalar.proto
@@ -4,7 +4,7 @@ package badnonscalar;
 
 import "entdb_options.proto";
 
-option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/testdata/badnonscalar";
+option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2/testdata/badnonscalar";
 
 message Inner {
   string v = 1;

--- a/tools/protoc-gen-entdb-keys/testdata/entdb_options.proto
+++ b/tools/protoc-gen-entdb-keys/testdata/entdb_options.proto
@@ -9,7 +9,7 @@ package entdb;
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/testdata/entdbopts";
+option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2/testdata/entdbopts";
 
 message NodeOpts {
   int32 type_id = 1;

--- a/tools/protoc-gen-entdb-keys/testdata/initialisms.proto
+++ b/tools/protoc-gen-entdb-keys/testdata/initialisms.proto
@@ -4,7 +4,7 @@ package initialisms;
 
 import "entdb_options.proto";
 
-option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/testdata/initialisms";
+option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2/testdata/initialisms";
 
 message Customer {
   option (entdb.node) = { type_id: 400 };

--- a/tools/protoc-gen-entdb-keys/testdata/sample.proto
+++ b/tools/protoc-gen-entdb-keys/testdata/sample.proto
@@ -4,7 +4,7 @@ package shop;
 
 import "entdb_options.proto";
 
-option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/testdata/shop";
+option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2/testdata/shop";
 
 message Product {
   option (entdb.node) = { type_id: 201 };

--- a/tools/protoc-gen-entdb-keys/testdata/types.proto
+++ b/tools/protoc-gen-entdb-keys/testdata/types.proto
@@ -4,7 +4,7 @@ package types_fixture;
 
 import "entdb_options.proto";
 
-option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/testdata/typesfixture";
+option go_package = "github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2/testdata/typesfixture";
 
 message AllScalars {
   option (entdb.node) = { type_id: 300 };


### PR DESCRIPTION
v2.0.4 added release-time tagging for `protoc-gen-entdb-keys` so consumers could `go install …@v2.0.4` without a clone (issue #602). The tag was created, the proxy was warmed — but the plugin's `go.mod` still declared

```
module github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys
```

without `/v2`. The Go proxy rejected:

> *invalid version: module contains a go.mod file, so module path must match major version (`.../tools/protoc-gen-entdb-keys/v2`)*

Same failure mode as the Go SDK on v2.0.0 (issues #597/#598, fixed in v2.0.1). My regression.

## Fix

- `tools/protoc-gen-entdb-keys/go.mod` — module path bumped to `/v2`.
- `tools/protoc-gen-entdb-keys/testdata/*.proto` — `go_package` options for the test fixtures bumped to the `/v2` subpath so generated test `pb.go` files resolve under the new module.
- `docs/recipes/buf.gen.yaml.template` + `docs/migration-v2.md` — install command bumped to `@v2.0.5`.
- `.github/workflows/release.yml` — proxy warm-up curl now targets the `/v2` path.

The plugin has **zero external Go importers** (it's a standalone protoc plugin binary), so no consumer rewrite is needed. The path change is invisible to anyone running `go install` against `@v2.0.5+`.

## Verification

`make ci` green (with `-race` on the SDK): 4 Go modules + Python integration **115** + unit **449** + e2e **25** + ruff. The tools module builds + tests under the new path.

Patch release: **v2.0.5**.