### PR TITLE
fix(sdk/go): typed coordinates on single-field UniqueConstraintError + v2.1.0 integration regression pins (#599 → v2.1.1)

### DIFF
--- a/sdk/go/entdb/errors.go
+++ b/sdk/go/entdb/errors.go
@@ -363,8 +363,108 @@ func parseUniqueConstraintFromStatus(err error, tenantID string) *UniqueConstrai
 			uce.TypeID = tid
 			uce.Details["type_id"] = tid
 		}
+		return uce
+	}
+	// Single-field violation: the server-side store/unique_violation.go
+	// emits the form
+	//
+	//   Unique constraint violation: tenant=<t> type_id=<T> field_id=<F>
+	//                                value=<pyRepr> already exists
+	//
+	// Without this branch the typed UCE is returned with TypeID/FieldID/
+	// Value all zero, which silently breaks any caller that needs to act
+	// on the colliding coordinates — InsertIfNotExists (#599) is the
+	// canonical example, since its post-conflict GetNodeByKey lookup uses
+	// exactly these three fields.
+	if tid, fid, val, ok := parseSingleFieldUniqueDetail(msg); ok {
+		uce.TypeID = tid
+		uce.FieldID = fid
+		uce.Value = val
+		uce.Details["type_id"] = tid
+		uce.Details["field_id"] = fid
+		uce.Details["value"] = val
 	}
 	return uce
+}
+
+// singleFieldUniqueDetailRE matches the server's single-field
+// ALREADY_EXISTS detail (store/unique_violation.go::BuildUniqueViolationDetail).
+// The message form is:
+//
+//	Unique constraint violation: tenant=<t> type_id=<T> field_id=<F> value=<pyRepr> already exists
+//
+// where <pyRepr> is a Python-style scalar literal (single-quoted
+// strings, bare numbers, None / True / False).
+var singleFieldUniqueDetailRE = regexp.MustCompile(
+	`tenant=(\S+)\s+type_id=(\d+)\s+field_id=(\d+)\s+value=(.+?)\s+already exists`,
+)
+
+// parseSingleFieldUniqueDetail extracts (type_id, field_id, value)
+// from a server-emitted single-field UNIQUE detail. Returns ok=false
+// when the message is not in that shape (e.g. composite, or a future
+// version's encoding). The value is best-effort-decoded from the
+// pyRepr form the server's store helper produces.
+func parseSingleFieldUniqueDetail(detail string) (int32, int32, any, bool) {
+	if detail == "" {
+		return 0, 0, nil, false
+	}
+	m := singleFieldUniqueDetailRE.FindStringSubmatch(detail)
+	if m == nil {
+		return 0, 0, nil, false
+	}
+	tid, err1 := strconv.Atoi(m[2])
+	fid, err2 := strconv.Atoi(m[3])
+	if err1 != nil || err2 != nil {
+		return 0, 0, nil, false
+	}
+	val := decodePyRepr(strings.TrimSpace(m[4]))
+	return int32(tid), int32(fid), val, true
+}
+
+// decodePyRepr undoes the server's pyRepr() rendering for the common
+// scalar shapes the typed UCE needs:
+//
+//	'foo'  -> "foo"   (single-quoted, with \\ + \' escapes)
+//	123    -> int64(123)
+//	1.5    -> float64(1.5)
+//	True   -> true
+//	False  -> false
+//	None   -> nil
+//
+// Unrecognised forms fall through to the raw string so callers can
+// still log / fingerprint them; the SDK never round-trips arbitrary
+// repr() shapes back through GetNodeByKey, only the scalars a
+// declared unique field can actually carry.
+func decodePyRepr(s string) any {
+	switch s {
+	case "None":
+		return nil
+	case "True":
+		return true
+	case "False":
+		return false
+	}
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		inner := s[1 : len(s)-1]
+		var b strings.Builder
+		b.Grow(len(inner))
+		for i := 0; i < len(inner); i++ {
+			if inner[i] == '\\' && i+1 < len(inner) {
+				b.WriteByte(inner[i+1])
+				i++
+				continue
+			}
+			b.WriteByte(inner[i])
+		}
+		return b.String()
+	}
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+	return s
 }
 
 // compositeUniqueDetailRE matches the server's composite-unique

--- a/sdk/go/entdb/errors_test.go
+++ b/sdk/go/entdb/errors_test.go
@@ -216,3 +216,65 @@ func TestUniqueConstraintError_ImplementsErrorInterface(t *testing.T) {
 		t.Errorf("FieldID=%d, want 3", uce.FieldID)
 	}
 }
+
+// TestParseUniqueConstraintFromStatus_SingleFieldExtractsCoordinates
+// pins the single-field branch of the ALREADY_EXISTS parser. Before
+// this branch was added, a single-field violation surfaced as a typed
+// UCE with TypeID/FieldID/Value all zero, which silently broke
+// InsertIfNotExists's post-conflict GetNodeByKey lookup (#599 v2.1.0
+// integration regression: the conflict path returned the raw error
+// instead of resolving to the existing id).
+func TestParseUniqueConstraintFromStatus_SingleFieldExtractsCoordinates(t *testing.T) {
+	// Exact wire form emitted by server/go/internal/store/unique_violation.go.
+	detail := "Unique constraint violation: tenant=acme type_id=201 field_id=1 value='SKU-1' already exists"
+	st := status.New(codes.AlreadyExists, detail)
+	uce := parseUniqueConstraintFromStatus(st.Err(), "acme")
+	if uce == nil {
+		t.Fatal("expected *UniqueConstraintError, got nil")
+	}
+	if uce.TypeID != 201 {
+		t.Errorf("TypeID = %d, want 201", uce.TypeID)
+	}
+	if uce.FieldID != 1 {
+		t.Errorf("FieldID = %d, want 1", uce.FieldID)
+	}
+	if uce.Value != "SKU-1" {
+		t.Errorf("Value = %v (%T), want \"SKU-1\"", uce.Value, uce.Value)
+	}
+	if uce.IsComposite() {
+		t.Error("IsComposite() = true for a single-field violation")
+	}
+}
+
+// TestParseUniqueConstraintFromStatus_SingleFieldScalarTypes pins
+// that pyRepr-style values round-trip back into Go scalars so the
+// follow-up GetNodeByKey gets the right typed value (int vs str vs
+// bool collisions matter to the server's typed-value path, #572).
+func TestParseUniqueConstraintFromStatus_SingleFieldScalarTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		detail string
+		want   any
+	}{
+		{"string", "Unique constraint violation: tenant=t type_id=1 field_id=1 value='hello' already exists", "hello"},
+		{"string with escaped quote", `Unique constraint violation: tenant=t type_id=1 field_id=1 value='it\'s' already exists`, "it's"},
+		{"int", "Unique constraint violation: tenant=t type_id=1 field_id=1 value=42 already exists", int64(42)},
+		{"big int", "Unique constraint violation: tenant=t type_id=1 field_id=1 value=9007199254740993 already exists", int64(9007199254740993)},
+		{"float", "Unique constraint violation: tenant=t type_id=1 field_id=1 value=1.5 already exists", 1.5},
+		{"bool true", "Unique constraint violation: tenant=t type_id=1 field_id=1 value=True already exists", true},
+		{"bool false", "Unique constraint violation: tenant=t type_id=1 field_id=1 value=False already exists", false},
+		{"none", "Unique constraint violation: tenant=t type_id=1 field_id=1 value=None already exists", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st := status.New(codes.AlreadyExists, tc.detail)
+			uce := parseUniqueConstraintFromStatus(st.Err(), "t")
+			if uce == nil {
+				t.Fatal("expected *UniqueConstraintError")
+			}
+			if uce.Value != tc.want {
+				t.Errorf("Value = %v (%T), want %v (%T)", uce.Value, uce.Value, tc.want, tc.want)
+			}
+		})
+	}
+}

--- a/sdk/go/entdb/integration_test.go
+++ b/sdk/go/entdb/integration_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	pb "github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2/internal/pb"
+	"github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2/internal/testpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -490,4 +491,120 @@ func TestIntegration_ZeroValueUpdateRealServer(t *testing.T) {
 	if got := node.Payload["4"]; got != false {
 		t.Fatalf("active after zero-update = %v (%T), want false — explicit zero dropped over the real wire", got, got)
 	}
+}
+
+// TestIntegration_InsertIfNotExists_Created proves the happy path
+// against a real server: a unique-keyed write with no prior collider
+// returns (created, "", nil) and the created node is queryable by id.
+// Regression pin for the v2.1.0 InsertIfNotExists helper (#599).
+//
+// A FRESH client carrying testpb.Product (type_id 201, sku=1 unique)
+// drives the test; that schema is disjoint from the integration
+// bootstrap's 8001/8002 so the SDK's auto-attached register_schema op
+// lands cleanly on the first ExecuteAtomic.
+func TestIntegration_InsertIfNotExists_Created(t *testing.T) {
+	ctx := context.Background()
+	c := newSchemaClientForIINE(t, ctx)
+
+	scope := c.Tenant(itTenant).Actor(UserActor("e2e-runner"))
+	p := testpb.NewProductMsg()
+	p.SetFields("IINE-created-1", "Widget", 100)
+
+	created, existed, err := scope.InsertIfNotExists(ctx, "iine-create-1", p)
+	if err != nil {
+		t.Fatalf("InsertIfNotExists: %v", err)
+	}
+	if created == "" {
+		t.Fatalf("created id is empty; got existed=%q", existed)
+	}
+	if existed != "" {
+		t.Fatalf("existed id is non-empty on a fresh write: %q", existed)
+	}
+
+	node, gerr := c.transport.GetNode(ctx, itTenant, "user:e2e-runner", 201, created)
+	if gerr != nil {
+		t.Fatalf("GetNode(%s): %v", created, gerr)
+	}
+	if node == nil {
+		t.Fatalf("created node %q not visible after wait_applied write", created)
+	}
+	if node.Payload["1"] != "IINE-created-1" {
+		t.Fatalf("payload sku = %v, want IINE-created-1", node.Payload["1"])
+	}
+}
+
+// TestIntegration_InsertIfNotExists_ResolvesConflict proves the
+// conflict path against a real server: a second write of the same
+// unique-keyed payload returns ("", existingID, nil) and the existing
+// id matches the prior winner. This is the racy idiom (#599) the
+// helper closes — without it the loser would race with its own
+// GetByKey and either see a phantom success (no wait_applied) or have
+// to hand-roll the catch+lookup.
+func TestIntegration_InsertIfNotExists_ResolvesConflict(t *testing.T) {
+	ctx := context.Background()
+	c := newSchemaClientForIINE(t, ctx)
+
+	scope := c.Tenant(itTenant).Actor(UserActor("e2e-runner"))
+
+	p1 := testpb.NewProductMsg()
+	p1.SetFields("IINE-race-1", "Widget", 100)
+	firstID, existed, err := scope.InsertIfNotExists(ctx, "iine-race-1a", p1)
+	if err != nil {
+		t.Fatalf("first InsertIfNotExists: %v", err)
+	}
+	if firstID == "" || existed != "" {
+		t.Fatalf("first call should be a CREATE; got created=%q existed=%q", firstID, existed)
+	}
+
+	// Same sku, different node payload — the unique-constraint trip
+	// must reroute to the first node, NOT mint a second id and NOT
+	// silently swallow the conflict.
+	p2 := testpb.NewProductMsg()
+	p2.SetFields("IINE-race-1", "Different Name", 999)
+	created2, resolved, err := scope.InsertIfNotExists(ctx, "iine-race-1b", p2)
+	if err != nil {
+		t.Fatalf("second InsertIfNotExists: %v", err)
+	}
+	if created2 != "" {
+		t.Fatalf("second call should NOT be a create; got created=%q", created2)
+	}
+	if resolved != firstID {
+		t.Fatalf("resolved existing id = %q, want %q (the first winner's id)", resolved, firstID)
+	}
+
+	// And the canonical node still carries the FIRST writer's payload —
+	// InsertIfNotExists does not overwrite; that's an upsert primitive
+	// we have deliberately not shipped (see v2.1.0 ADR notes).
+	node, gerr := c.transport.GetNode(ctx, itTenant, "user:e2e-runner", 201, firstID)
+	if gerr != nil {
+		t.Fatalf("GetNode(%s): %v", firstID, gerr)
+	}
+	if node == nil {
+		t.Fatalf("first node %q not visible", firstID)
+	}
+	if got := node.Payload["1"]; got != "IINE-race-1" {
+		t.Fatalf("sku = %v, want IINE-race-1 (first writer wins)", got)
+	}
+	if got := node.Payload["2"]; got != "Widget" {
+		t.Fatalf("name = %v, want Widget (first writer wins); the helper must NOT overwrite", got)
+	}
+}
+
+// newSchemaClientForIINE constructs a fresh DbClient with WithSchema
+// (testpb.Product) so the high-level Scope API can drive InsertIfNotExists.
+// The integration harness's `itClient` is schema-less by design (the
+// other cases hit the raw transport with op maps); InsertIfNotExists
+// lives on Scope and needs the SDK's self-describing-write path.
+func newSchemaClientForIINE(t *testing.T, ctx context.Context) *DbClient {
+	t.Helper()
+	addr := itClient.transport.(*grpcTransport).address
+	c, err := NewClient(addr, WithSchema(testpb.NewProductMsg()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if err := c.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
 }

--- a/tests/python/integration/test_insert_if_not_exists.py
+++ b/tests/python/integration/test_insert_if_not_exists.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Integration tests for ``ActorScope.insert_if_not_exists`` (issue #599).
+
+Drives the helper end-to-end against a live entdb-server. The mock-based
+unit tests (``tests/python/unit/test_insert_if_not_exists.py``) pin the
+SDK's branching logic; this suite proves the round-trip wire path
+through a real applier (the gap that surfaced the v2.1.0 single-field
+UCE parser bug — typed coordinates were dropped on the way back).
+
+Two cases per the v2.1.0 boundary:
+
+  * created path  — fresh unique key → returns ``(created_id, None)``;
+    node is queryable.
+  * conflict path — same key again → returns ``(None, existing_id)``;
+    the resolved id matches the first writer's and the original
+    payload is preserved (no upsert overwrite).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from entdb_sdk import DbClient, register_proto_schema
+from entdb_sdk.registry import reset_registry
+from tests.python._test_schemas import test_schema_pb2 as ts
+
+TENANT = "acme"
+ALICE = "user:alice"
+
+
+@pytest.fixture(autouse=True)
+def _registered_schema():
+    reset_registry()
+    register_proto_schema(ts)
+    yield
+    reset_registry()
+
+
+async def test_insert_if_not_exists_created(grpc_endpoint) -> None:
+    """Happy path: fresh unique key returns the new id, existing is None."""
+    sku = f"iine-created-{uuid.uuid4().hex[:8]}"
+    client = DbClient(address=grpc_endpoint)
+    await client.connect()
+    try:
+        scope = client.tenant(TENANT).actor(ALICE)
+        created, existed = await scope.insert_if_not_exists(
+            ts.Product(sku=sku, name="Widget", price_cents=100),
+            idempotency_key=f"iine-c-{uuid.uuid4().hex[:8]}",
+        )
+        assert created is not None and created != "", f"expected a created id, got {created!r}"
+        assert existed is None, f"existed should be None on a fresh write, got {existed!r}"
+
+        node = await scope.get(ts.Product, created)
+        assert node is not None, "created node not visible after wait_applied write"
+        assert node.payload["sku"] == sku
+    finally:
+        await client.close()
+
+
+async def test_insert_if_not_exists_resolves_conflict(grpc_endpoint) -> None:
+    """Second write of the same unique key returns the FIRST writer's id.
+
+    Regression pin for the v2.1.0 typed-coordinate bug: without the
+    single-field UCE parser branch in the SDK, the second call would
+    re-raise the UCE instead of resolving to the existing id.
+    """
+    sku = f"iine-race-{uuid.uuid4().hex[:8]}"
+    client = DbClient(address=grpc_endpoint)
+    await client.connect()
+    try:
+        scope = client.tenant(TENANT).actor(ALICE)
+
+        first_id, existed = await scope.insert_if_not_exists(
+            ts.Product(sku=sku, name="First", price_cents=100),
+            idempotency_key=f"iine-r1-{uuid.uuid4().hex[:8]}",
+        )
+        assert first_id is not None and existed is None
+
+        # Different payload, same unique sku — the helper must
+        # resolve to the first id, NOT create a second and NOT
+        # overwrite.
+        created2, resolved = await scope.insert_if_not_exists(
+            ts.Product(sku=sku, name="Second", price_cents=999),
+            idempotency_key=f"iine-r2-{uuid.uuid4().hex[:8]}",
+        )
+        assert created2 is None, f"second call should not create; got created={created2!r}"
+        assert resolved == first_id, f"resolved id {resolved!r} != first writer's id {first_id!r}"
+
+        # First writer's payload preserved (no upsert overwrite).
+        node = await scope.get(ts.Product, first_id)
+        assert node is not None
+        assert node.payload["sku"] == sku
+        assert node.payload["name"] == "First", (
+            "InsertIfNotExists must not overwrite — that's a v2.2 upsert primitive"
+        )
+        assert node.payload["price_cents"] == 100
+    finally:
+        await client.close()


### PR DESCRIPTION
v2.1.1 — bug fix surfaced by adding the live-server integration tests
the user asked for after v2.1.0 shipped.

## The bug

Mock-based unit tests on PR #613 pinned `InsertIfNotExists`'s SDK
branching (UCE caught → `GetNodeByKey` lookup → return existing id).
They could not catch this because the mocks hand-built the UCE with
`TypeID=201, FieldID=1, Value="SKU-1"` populated.

The real wire path goes through `parseUniqueConstraintFromStatus`,
which only decoded the COMPOSITE detail form into typed coordinates.
For single-field violations the comment in code said it best:

> Single-field violations use a different format (`field_id=<int>`)
> and are intentionally left for future structured-error work.

So `*UniqueConstraintError.{TypeID, FieldID, Value}` were all zero on
a single-field collision. `InsertIfNotExists` then issued
`GetNodeByKey(0, 0, nil)`, got nothing back, and surfaced the raw
UCE — meaning `InsertIfNotExists` was **broken** in v2.1.0 for the
exact case it was built for.

## Fix (sdk/go/entdb/errors.go)

Added `parseSingleFieldUniqueDetail` + `decodePyRepr`. The parser
now decodes both forms:

```
composite  -> ConstraintName + FieldIDs + Values + TypeID
single     -> TypeID + FieldID + Value   (NEW)
fallback   -> Message only
```

`decodePyRepr` round-trips the server's `pyRepr()` rendering:

| pyRepr | Go |
|---|---|
| `'foo'` (single-quoted; `\\` and `\'` escapes) | `"foo"` |
| `42` | `int64(42)` |
| `9007199254740993` | `int64(...)` lossless past 2^53 (matches ADR-028) |
| `1.5` | `float64(1.5)` |
| `True` / `False` | `bool` |
| `None` | `nil` |

## Tests

### Unit (`sdk/go/entdb/errors_test.go`)

1. `TestParseUniqueConstraintFromStatus_SingleFieldExtractsCoordinates`
   pins the wire-form parse.
2. `TestParseUniqueConstraintFromStatus_SingleFieldScalarTypes` — 8
   sub-tests: string, string with escaped quote, int, big int,
   float, True, False, None.

### Integration (`sdk/go/entdb/integration_test.go`, `-tags=integration`)

Real entdb-server boot, real applier, `testpb.Product` (type_id 201,
sku=1 unique):

1. `TestIntegration_InsertIfNotExists_Created` — happy path; created
   node queryable.
2. `TestIntegration_InsertIfNotExists_ResolvesConflict` — second
   write with the same sku returns the FIRST writer's id; first
   writer's payload preserved (no upsert overwrite — v2.2 primitive).

### Python integration (`tests/python/integration/test_insert_if_not_exists.py`)

The Python parser already handled single-field details, but the
helper had no end-to-end coverage. Mirror suite (created + conflict).

## CI

All four Go modules + python unit + python integration green locally.
Lands as v2.1.1 patch.