### PR TITLE
fix(release): gh release upload needs --repo when actions/checkout is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -672,9 +672,16 @@ jobs:
       - name: Upload SBOMs to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # --repo is REQUIRED — this job intentionally skips
+        # actions/checkout (the SBOMs come in via download-artifact),
+        # so the runner has no .git directory for `gh release upload`
+        # to infer the repo from. v2.1.3 failed exactly here ('fatal:
+        # not a git repository'); v2.1.4 is the first release where
+        # this lands without a manual retrofit.
         run: |
           set -euo pipefail
           gh release upload "$GITHUB_REF_NAME" \
             /tmp/sbom-assets/sbom-server-"$GITHUB_REF_NAME".spdx.json \
             /tmp/sbom-assets/sbom-schema-"$GITHUB_REF_NAME".spdx.json \
-            --clobber
+            --clobber \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
v2.1.3 surfaced a second SBOM-attach bug right after #620 fixed the first one:

```
failed to run git: fatal: not a git repository (or any of the
parent directories): .git
##[error]Process completed with exit code 1.
```

`gh release upload` infers the repo from the local git remote when run inside a checkout. The `attach-sboms-to-release` job intentionally skips `actions/checkout` (the SBOMs arrive via `download-artifact`, no source needed), so the runner has no `.git` for gh to read.

**Fix:** pass `--repo ${{ github.repository }}` explicitly.

v2.1.3 was patched manually post-hoc (downloaded the SBOM workflow artifacts → `gh release upload` from local). v2.1.4 is the first release where this lands without a retrofit.