### PR TITLE
feat(observability): W3C traceparent across logs/traces/metrics + fix applier transient-error crash-loop (#627)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,8 @@ jobs:
           uv pip install -e ./sdk/python \
             "pytest>=8.0.0" "pytest-asyncio>=0.23.0" "pytest-cov>=4.1.0" \
             "pytest-timeout>=2.2.0" "ruff>=0.15.0" "httpx>=0.26.0" \
-            "grpcio-tools>=1.60.0" pytest-xdist==3.5.0
+            "grpcio-tools>=1.60.0" pytest-xdist==3.5.0 \
+            "opentelemetry-sdk>=1.20.0"
 
       - name: Run unit tests (parallel)
         run: uv run pytest tests/python/unit -v -n auto --cov=entdb_sdk --cov-report=xml

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,11 @@ logs/
 .env
 .env.local
 .claude/worktrees/
+.antigravitycli/
 
 # Private notes / red-team review drafts. Never commit.
 /report.md
 /review_prompt.txt
+
+# Built server binary (go build ./cmd/entdb-server)
+/server/go/entdb-server

--- a/docs/adr/033-distributed-tracing-and-trace-correlated-observability.md
+++ b/docs/adr/033-distributed-tracing-and-trace-correlated-observability.md
@@ -1,0 +1,158 @@
+# ADR-033: Accept incoming W3C trace context; correlate logs, traces, and metrics
+
+**Status:** Accepted
+**Decided:** 2026-05-29
+**Tags:** observability, tracing, logging, metrics, grpc, wire-contract, sdk
+
+**Implementation:** observability bootstrap
+(`server/go/internal/observability/`); gRPC `StatsHandler` +
+trace-correlated slog default (`server/go/cmd/entdb-server/main.go`);
+WAL trace-context headers (`server/go/internal/wal/wal.go`,
+`internal/api/execute_atomic.go`, `internal/apply/applier.go`); metric
+exemplars (`server/go/internal/metrics/grpc.go`); SDK injection
+(`sdk/go/entdb`, `sdk/python/entdb_sdk`).
+
+## Context
+
+The server emitted Prometheus metrics (`entdb_grpc_*`, behind
+`--metrics-addr`) but had **no distributed tracing and no
+trace-correlated logging**. OpenTelemetry was present only as transitive
+`// indirect` deps; the auth interceptor read gRPC metadata for auth
+headers only, never `traceparent`; logging was the stdlib `log` package
+(plaintext, no trace id); and a `RequestContext.trace_id` proto field
+existed but no handler ever read it. An operator could not take a
+`traceparent` from an upstream service and follow that request through
+EntDB's logs, traces, and metrics.
+
+## Decision
+
+EntDB **accepts incoming [W3C Trace Context](https://www.w3.org/TR/trace-context/)**
+(`traceparent` / `tracestate`) on every RPC and threads the resulting
+trace id through **all three** observability signals: logs, traces, and
+metrics. The standard `traceparent` gRPC metadata header is the source of
+truth; the `RequestContext.trace_id` proto field is **superseded** (see
+"Superseded proto field" below).
+
+### 1. Extraction + propagation (the entry point)
+
+- A single global propagator is installed at boot:
+  `propagation.NewCompositeTextMapPropagator(TraceContext{}, Baggage{})`.
+- The gRPC server installs `grpc.StatsHandler(otelgrpc.NewServerHandler())`.
+  otelgrpc runs the global propagator over incoming metadata, so an
+  upstream `traceparent` becomes the **parent** of EntDB's server span;
+  when absent, EntDB starts a fresh root. Either way a valid
+  `SpanContext` lives on the request `ctx` and flows down the existing
+  ctx-first call path (handler → store → SQLite) with no extra plumbing.
+- This is wired as a `StatsHandler`, **before** the auth interceptors,
+  so the span wraps authentication and an auth rejection is still traced.
+
+### 2. Traces (export is opt-in, correlation is always on)
+
+- A real `sdktrace.TracerProvider` is **always** configured (sampler
+  `ParentBased(AlwaysSample)`), so a valid trace id is available for log
+  and metric correlation **even when nothing is exported**.
+- Span **export** is opt-in: an OTLP/gRPC exporter is attached only when
+  `--otlp-endpoint` (or the standard `OTEL_EXPORTER_OTLP_ENDPOINT` env)
+  is set. With no endpoint there is no exporter and no network egress —
+  spans are created and carry the trace id but go nowhere. This keeps the
+  default build side-effect-free (matches `--metrics-addr` defaulting
+  off) while making "turn on tracing" a one-flag change.
+- A `resource` with `service.name=entdb-server` (+ version) attributes
+  every span.
+
+### 3. Logs (structured, trace-correlated)
+
+- A structured `slog` handler is set as the process default at boot
+  (`--log-format=text|json`, default `text` to preserve dev output). The
+  handler wraps the base handler and, for every record carrying a ctx
+  with a valid span, adds `trace_id` and `span_id` attributes.
+- Because the existing request-path logging already uses the
+  `slog.*Context` variants (`internal/errs/sanitize.go`,
+  `internal/audit/*`), setting the default handler is sufficient to make
+  those lines carry the trace id — no call-site churn. Boot/lifecycle
+  `log.Printf` lines run with no request ctx and are intentionally left
+  as-is (nothing to correlate).
+
+### 4. Metrics (trace exemplars)
+
+- `metrics.RecordGRPCRequest` becomes **ctx-aware**; when the ctx carries
+  a sampled span it records a `trace_id` **exemplar** on the
+  `entdb_grpc_latency_seconds` histogram (`ObserveWithExemplar`). Per-RPC
+  status semantics stay in the handlers (e.g. ExecuteAtomic's in-band
+  `INTERNAL` outcome), so metrics recording stays per-handler rather than
+  moving to an interceptor that can only see the gRPC status.
+- `/metrics` is served with OpenMetrics enabled so exemplars are exposed
+  to scrapers that support them.
+
+### 5. Trace context survives the async WAL boundary
+
+The write path is async: a handler appends to the WAL and the applier
+writes SQLite later, on the boot ctx (not the request ctx) — so an
+in-process span chain would end at `ExecuteAtomic`. To keep the trace
+continuous through apply:
+
+- `ExecuteAtomic` injects the current `traceparent`/`tracestate` into the
+  WAL `Record.Headers` map (alongside the existing
+  `HeaderIdempotencyKey`), using the global propagator.
+- The applier extracts that context from `rec.Headers` and starts the
+  per-record apply span **linked to / as a child of** the originating
+  request's trace, so apply-side spans, logs, and metrics correlate back
+  to the request that produced the event.
+
+Headers are metadata-only; they do **not** change the WAL `Event` JSON
+body, so the cross-impl contract byte layout (ADR-006/ADR-018) and replay
+determinism are unaffected.
+
+### 6. SDK injection (both SDKs, one PR)
+
+For an end-to-end trace to exist, callers must emit `traceparent`. Both
+the Go (`sdk/go/entdb`) and Python (`sdk/python/entdb_sdk`) SDKs inject
+the active span's W3C `traceparent` into outgoing gRPC metadata via a
+client interceptor. If the host app has no active OTel span, injection is
+a no-op (no dependency forced on SDK consumers). Shipped together per the
+"both SDKs in one PR" rule, each with mock unit tests + a live-server
+integration test.
+
+### 7. Trace context is NOT persisted in SQLite (decided 2026-05-29)
+
+The trace id is intentionally **not** stored in SQLite — not on business
+rows and not in the `applied_events` bookkeeping. Tracing/observability
+is not data: the durable provenance link already lives in the WAL record
+headers (and therefore the S3 archive, ADR-015), and live debugging is
+served by spans (trace backend) + `trace_id` on logs + metric exemplars.
+SQLite stays data + indexes only. This is the standard-DB posture and
+avoids coupling observability into the data model or the replayed,
+fingerprinted event body.
+
+## Superseded proto field
+
+`RequestContext.trace_id` (proto field 3) predates this work and was
+never read by the server. W3C `traceparent` metadata is now the
+mechanism. The field is left in place (removing it is a breaking wire
+change per ADR-032) but documented as superseded; the server does not
+read it. A future cleanup may reserve the id.
+
+## Alternatives considered
+
+- **Honor `RequestContext.trace_id` instead of `traceparent`.** Rejected:
+  non-standard, no propagation format, no parent/sampling semantics,
+  doesn't interop with upstream services or collectors.
+- **otelgrpc interceptor instead of `StatsHandler`.** `StatsHandler` is
+  the maintained, lower-overhead path and is what otelgrpc documents;
+  the interceptor path is legacy.
+- **Centralize metrics in one interceptor.** Rejected: loses
+  handler-specific status (in-band `INTERNAL`, skipped, etc.) that an
+  interceptor cannot observe.
+- **Always export spans.** Rejected: forces an OTLP endpoint and network
+  egress on every deployment; export is opt-in, correlation is not.
+
+## Consequences
+
+- Operators get true request-level traceability across logs, traces, and
+  metrics from an incoming `traceparent`, with a single flag to ship
+  spans to any OTLP collector (Tempo, Jaeger, etc.).
+- OTel modules move from `// indirect` to direct requires; `otel/sdk` and
+  an OTLP exporter are added.
+- Default behavior is unchanged for anyone who sets no new flags (no
+  exporter, text logs) — except logs now carry `trace_id`/`span_id` when
+  a request is traced, which is additive.

--- a/docs/adr/034-restore-from-object-store-archive.md
+++ b/docs/adr/034-restore-from-object-store-archive.md
@@ -1,0 +1,136 @@
+# ADR-034: Opt-in restore from the object-store WAL archive (disaster recovery)
+
+**Status:** Accepted
+**Decided:** 2026-05-29
+**Tags:** recovery, durability, wal, s3, object-lock, disaster-recovery, applier
+
+**Implementation:** archive reader + restore orchestrator
+(`server/go/internal/audit/archive_reader.go`,
+`server/go/internal/restore/`); WAL `Seek` primitive
+(`server/go/internal/wal/wal.go`, `memory.go`, `kafka.go`); boot wiring
+(`server/go/cmd/entdb-server/main.go`, `--restore-from-archive`).
+
+## Context
+
+On a normal restart EntDB reads the durable on-disk per-tenant SQLite and
+resumes the live WAL consumer from its committed offset (see
+[ADR-016](016-handlers-append-applier-writes.md)). That local-disk fast
+path is sufficient for ordinary restarts and stays the default.
+
+But if a node **loses its local SQLite** — fresh node, ephemeral disk,
+region failover, disaster — there was **no way to rebuild it**. The
+object store already holds the full, immutable history: per
+[ADR-015](015-wal-and-s3-object-lock-as-audit-log.md) the archiver ships
+every WAL record to S3/Azure as gzip-JSONL under Object Lock COMPLIANCE
+retention. But that archive was **write-only** — nothing read it back —
+and `Applier.Replay`'s `fromPos` was a documented no-op (no backend
+implemented the `Seek` primitive it needs). So the durable backup existed
+but could not be used to recover.
+
+## Decision
+
+Add an **opt-in** restore path that rebuilds local SQLite from the
+object-store WAL archive, then hands off to the live queue. Local-disk
+recovery stays the default; restore is never automatic.
+
+This is the **read side of ADR-015** realized as recovery, and a concrete
+implementation of the deterministic-replay rebuild ADR-016 describes.
+
+### Trigger
+
+A boot flag `--restore-from-archive` (off by default) runs the restore
+**before** the live applier loop starts. To avoid clobbering good data it
+**refuses to run against a non-empty data-dir** unless `--restore-force`
+is also set (restore is idempotent — see below — so force is safe but
+must be deliberate). It reuses the existing `--archive-*` config (bucket,
+endpoint, credentials) as the source. An optional `--restore-tenant`
+filter restores a single tenant; default is all.
+
+### Mechanism (reuses the applier, no new write path)
+
+The archive *is* the WAL, so restore replays it through the **same
+applier** that the live path uses — honoring ADR-016 ("only the applier
+writes SQLite") and inheriting idempotency, per-tenant ordering, and
+schema establishment (the leading `register_schema` op per ADR-031, so
+the registry is rebuilt too) for free.
+
+1. **Read.** An `ArchiveReader` lists objects under `wal/{topic}/`,
+   reads the authoritative `entdb-partition` / `entdb-start-offset` /
+   `entdb-end-offset` object metadata, and orders them by
+   `(partition, start-offset)` **numerically** (not by lexical S3 list
+   order — `10-20` sorts before `9-9` lexically). It downloads, gunzips,
+   verifies the `entdb-sha256`, and decodes each gzip-JSONL line back
+   into a `wal.Record` (the `value` field is the original WAL `Event`
+   JSON; `value_base64` for non-JSON).
+2. **Replay.** The decoded records are served to an applier through an
+   in-memory, archive-backed `wal.Consumer` adapter (so all existing
+   apply machinery applies unchanged) writing into the fresh per-tenant
+   SQLite under `--data-dir`. Replay drains when the archive is
+   exhausted.
+3. **Track.** The orchestrator records the max applied `StreamPos` per
+   `(topic, partition)`.
+4. **Hand off.** For each partition it `Seek`s the **live** consumer
+   group (`--wal-group`) to `lastRestoredOffset + 1`, so when the live
+   applier starts it resumes **exactly after** the restored history — no
+   gap, no full re-replay of the topic, no dependence on broker retention
+   covering the restored range.
+
+### The `Seek` primitive
+
+`wal.Consumer` gains:
+
+```go
+// Seek sets the committed offset for (topic, groupID, partition) to
+// offset, so the next PollBatch/Subscribe for that group resumes at
+// offset. Used by restore to hand off to the live tail. Returns
+// ErrSeekUnsupported on backends that cannot reposition a group.
+Seek(ctx context.Context, topic, groupID string, partition int32, offset int64) error
+```
+
+- **In-memory:** sets the `committed` map entry.
+- **Kafka:** commits the group offset via a sarama `OffsetManager`
+  (a group offset commit, no consumption).
+- **Other cloud backends:** return `ErrSeekUnsupported` for now; restore
+  is supported on the backends that can reposition a group
+  (in-memory + Kafka), and the flag errors clearly on unsupported
+  backends. This finally implements the primitive `Applier.Replay`'s
+  comment anticipated.
+
+### Idempotent + resumable
+
+Apply is idempotent (the in-txn `applied_events` probe, ADR-016) and the
+restore commits per record, so a restore interrupted midway can simply be
+re-run: already-applied records take the SKIP path and the resume point
+advances. This is why `--restore-force` against a partially-restored
+data-dir is safe.
+
+## Alternatives considered
+
+- **Auto-restore when the data-dir is empty.** Rejected as the default:
+  surprising and risky (a misconfigured volume mount would silently pull
+  the whole history). Restore is an explicit operator action.
+- **A separate `entdb-restore` binary.** Rejected for now: the restore
+  needs the exact applier/store/registry wiring `entdb-server` already
+  builds; a flag reuses it without duplicating bootstrap. A standalone
+  verb can wrap this later if needed.
+- **Restore by copying SQLite snapshots to S3** (physical backup) instead
+  of replaying the WAL archive. Rejected: the WAL archive is already the
+  immutable source of truth (ADR-015); physical snapshots would add a
+  second backup mechanism and lose the per-record audit granularity and
+  Object Lock guarantees.
+- **Read S3 directly into the live consumer position without replay.**
+  Not possible — SQLite is a materialized view; it must be rebuilt by
+  applying the events.
+
+## Consequences
+
+- A node that lost its local SQLite can be rebuilt from the object-store
+  archive with one flag, then seamlessly resume the live queue.
+- The object-store archive gains a read side; the `Seek` primitive is now
+  real for in-memory + Kafka.
+- Restore is bounded by what the archiver has flushed to the object store
+  (archive lag); records appended to the live WAL but not yet archived
+  are recovered from the live queue tail after the `Seek` handoff,
+  provided broker retention still covers them — the archive + live-tail
+  union is the recoverable set.
+- Default behavior is unchanged: no flag, no restore.

--- a/docs/adr/035-persist-schema-catalog-in-sqlite.md
+++ b/docs/adr/035-persist-schema-catalog-in-sqlite.md
@@ -1,0 +1,99 @@
+# ADR-035: Persist the schema catalog in SQLite (registry as a cache, not a WAL rebuild)
+
+**Status:** Proposed
+**Decided:** —
+**Tags:** schema, storage, recovery, registry, durability
+
+**Supersedes/refines:** the boot mechanics of
+[ADR-031](031-self-describing-name-free-schema.md) (self-describing,
+name-free schema). ADR-031's wire/identity model is unchanged; only
+*where the registry lives across a restart* changes.
+
+## Context
+
+EntDB keeps schema in two layers today:
+
+- **Physical schema — durable in SQLite.** The actual per-tenant tables
+  and indexes (unique, composite-unique tuple, FTS5, expression/query
+  indexes) are created on disk during `register_schema` apply
+  (`EnsureFieldIndexesTx`) and survive restart. Stored data is
+  `field_id`-keyed (ADR-018), so reads need no name catalog.
+- **Logical registry — in-memory only.** `schema.NewRegistry()`
+  (`cmd/entdb-server/main.go`) holds the type/field definitions and the
+  canonical fingerprint. There is **no SQLite catalog table** for it. It
+  boots empty and is populated by replaying `register_schema` WAL ops;
+  every write is self-describing (ADR-031), so it self-heals on the next
+  write per type.
+
+The in-memory registry backs: the schema fingerprint advertised on
+writes, the read-only `GetSchema` RPC, establish-or-reject validation on
+writes, and query field translation.
+
+**The gap.** "Rebuilt deterministically from the WAL on every boot" is
+only literally true for a *full replay* (the in-memory backend, or a
+fresh Kafka consumer group reading from `earliest`). On a **normal Kafka
+restart** the applier resumes from the *committed* offset, so already
+applied `register_schema` ops are **not** re-delivered — the registry
+boots empty and stays empty until the next write re-registers a type. In
+that window `GetSchema` returns an empty/degraded response (its SQLite
+distinct-type_id fallback is a documented no-op in `api/get_schema.go`).
+Data reads are unaffected (`field_id`-keyed; `query_nodes.go` guards its
+type check on `!registry.Empty()`), but the schema surface is
+restart-fragile and depends on broker retention for correctness rather
+than on durable local state — unlike a standard DB's catalog.
+
+## Decision (proposed)
+
+Make **SQLite the durable source of truth for the schema catalog**, and
+demote the in-memory registry to a cache loaded from it at boot.
+
+- Persist node/edge type definitions (the registry's canonical,
+  `field_id`-keyed form) to a catalog table, written **in the same
+  applier transaction** as the `register_schema` op that establishes
+  them — so the catalog is atomic with the indexes it describes and
+  survives any restart.
+  - Tenant-scoped types → per-tenant SQLite; control-plane/global types →
+    globalstore. (Open question below.)
+- At boot, **load the catalog into the registry** (analogous to how the
+  physical indexes are already durable), instead of relying on WAL
+  replay to repopulate it.
+- `register_schema` apply becomes: upsert catalog row (establish-or-
+  reject) + ensure indexes, both in one txn. Replay stays idempotent and
+  deterministic (ADR-031) — re-applying an identical type is a no-op
+  against the catalog too.
+- `GetSchema` reads the registry (now always populated post-restart);
+  the dead SQLite-distinct-type_id fallback is removed.
+
+The registry stays in memory for fast, lock-free reads — it is now a
+**cache of a durable catalog**, not a structure rebuilt from the WAL.
+This keeps ADR-031's self-describing, name-free model and determinism
+while removing the restart-fragility and the broker-retention dependence
+for schema.
+
+## Alternatives considered
+
+- **Keep WAL-replay rebuild, fix only `GetSchema`** (e.g. implement the
+  distinct-type_id fallback). Rejected: it patches the symptom
+  (`GetSchema`) without making the catalog durable; establish-or-reject
+  validation and the fingerprint are still empty-until-first-write after
+  a restart.
+- **Always replay the schema prefix from `earliest` on boot.** Rejected:
+  re-reading history on every restart is slow, depends on broker
+  retention, and conflates schema bootstrap with data replay.
+- **Snapshot the registry to a file (.schema-snapshot.json) at boot.**
+  Rejected: a side file is a second source of truth that can drift from
+  SQLite; the catalog belongs in the same transactional store as the
+  indexes it describes.
+
+## Open questions
+
+- Catalog home for tenant vs global/control-plane types (per-tenant
+  SQLite vs globalstore vs both).
+- Migration: existing deployments boot empty and self-heal on first
+  write today; a one-time backfill (replay-from-earliest into the
+  catalog, or lazy population) may be needed so `GetSchema` is correct
+  immediately after upgrade without waiting for a write.
+- Interaction with the deferred restore-from-archive path
+  ([ADR-034](034-restore-from-object-store-archive.md)): archive replay
+  rebuilds the catalog for free via the same `register_schema` apply, so
+  the two are complementary.

--- a/docs/generated/sdk-go.md
+++ b/docs/generated/sdk-go.md
@@ -506,6 +506,13 @@ func WithUnaryClientInterceptors(interceptors ...grpc.UnaryClientInterceptor) Cl
     interceptors are also installed, for example node redirect handling,
     these interceptors run first and wrap the full outbound RPC.
 
+func WithoutTracePropagation() ClientOption
+    WithoutTracePropagation disables the SDK-owned interceptor that injects the
+    caller's active W3C trace context (traceparent) into outgoing gRPC metadata.
+    Propagation is ON by default and is a no-op when there is no active
+    OpenTelemetry span, so this is only needed to suppress propagation entirely.
+    See ADR-033 §6.
+
 type CommitOption func(*commitOpts)
     CommitOption configures a single Plan.Commit / ExecuteAtomic call. Pass
     values to Plan.Commit as variadic args:

--- a/sdk/go/entdb/client.go
+++ b/sdk/go/entdb/client.go
@@ -350,6 +350,13 @@ func (t *grpcTransport) Connect(_ context.Context) error {
 	if interceptor := redirectInterceptor(t.config.nodeResolver, t.redirectCache); interceptor != nil {
 		chain = append(chain, interceptor)
 	}
+	// Innermost SDK-owned interceptor: inject the caller's active W3C
+	// trace context onto the outgoing request so the server continues
+	// the same trace (ADR-033 §6). Placed last so it runs closest to the
+	// wire and re-injects on every retry attempt; no-op without a span.
+	if !t.config.disableTracePropagation {
+		chain = append(chain, traceparentUnaryInterceptor())
+	}
 	if len(chain) > 0 {
 		opts = append(opts, grpc.WithChainUnaryInterceptor(chain...))
 	}

--- a/sdk/go/entdb/go.mod
+++ b/sdk/go/entdb/go.mod
@@ -11,8 +11,15 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect

--- a/sdk/go/entdb/go.sum
+++ b/sdk/go/entdb/go.sum
@@ -3,6 +3,7 @@ connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/sdk/go/entdb/options.go
+++ b/sdk/go/entdb/options.go
@@ -40,6 +40,11 @@ type clientConfig struct {
 	unaryClientInterceptors []grpc.UnaryClientInterceptor
 	// streamClientInterceptors are caller-supplied stream interceptors.
 	streamClientInterceptors []grpc.StreamClientInterceptor
+	// disableTracePropagation turns off the SDK-owned interceptor that
+	// injects the caller's active W3C trace context (traceparent) into
+	// outgoing gRPC metadata. Propagation is ON by default and is a
+	// no-op when the caller has no active OpenTelemetry span. ADR-033 §6.
+	disableTracePropagation bool
 }
 
 // defaultConfig returns a clientConfig with sensible defaults.
@@ -155,6 +160,17 @@ func WithNodeResolver(r NodeResolver) ClientOption {
 func WithBaseDomain(baseDomain string) ClientOption {
 	return func(c *clientConfig) {
 		c.nodeResolver = &DNSTemplateResolver{BaseDomain: baseDomain}
+	}
+}
+
+// WithoutTracePropagation disables the SDK-owned interceptor that
+// injects the caller's active W3C trace context (traceparent) into
+// outgoing gRPC metadata. Propagation is ON by default and is a no-op
+// when there is no active OpenTelemetry span, so this is only needed to
+// suppress propagation entirely. See ADR-033 §6.
+func WithoutTracePropagation() ClientOption {
+	return func(c *clientConfig) {
+		c.disableTracePropagation = true
 	}
 }
 

--- a/sdk/go/entdb/trace_propagation.go
+++ b/sdk/go/entdb/trace_propagation.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+package entdb
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/propagation"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// w3cPropagator injects the caller's active span as W3C trace context.
+// The concrete TraceContext propagator is used (not the OpenTelemetry
+// global) so the SDK propagates whenever the caller has an active span,
+// regardless of whether they configured a global propagator.
+var w3cPropagator = propagation.TraceContext{}
+
+// traceparentUnaryInterceptor injects the caller's active OpenTelemetry
+// span context as a W3C traceparent (+ tracestate) into the outgoing
+// gRPC metadata so the server — and, via the WAL, the applier —
+// continue the same trace (ADR-033 §6).
+//
+// It is a no-op when the caller has no active span, so it forces no
+// tracing dependency or behavior on SDK consumers who don't use
+// OpenTelemetry.
+func traceparentUnaryInterceptor() grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if ok {
+			md = md.Copy()
+		} else {
+			md = metadata.MD{}
+		}
+		w3cPropagator.Inject(ctx, &metadataCarrier{md: md})
+		ctx = metadata.NewOutgoingContext(ctx, md)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// metadataCarrier adapts gRPC metadata.MD to propagation.TextMapCarrier
+// so the W3C propagator can write traceparent/tracestate into it.
+type metadataCarrier struct{ md metadata.MD }
+
+func (c *metadataCarrier) Get(key string) string {
+	vals := c.md.Get(key)
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
+}
+
+func (c *metadataCarrier) Set(key, value string) { c.md.Set(key, value) }
+
+func (c *metadataCarrier) Keys() []string {
+	out := make([]string, 0, len(c.md))
+	for k := range c.md {
+		out = append(out, k)
+	}
+	return out
+}

--- a/sdk/go/entdb/trace_propagation_test.go
+++ b/sdk/go/entdb/trace_propagation_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+
+package entdb
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func captureOutgoingMD(t *testing.T, ctx context.Context) metadata.MD {
+	t.Helper()
+	var got metadata.MD
+	invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		got, _ = metadata.FromOutgoingContext(ctx)
+		return nil
+	}
+	if err := traceparentUnaryInterceptor()(ctx, "/entdb.v1.EntDBService/GetNode", nil, nil, nil, invoker); err != nil {
+		t.Fatalf("interceptor returned error: %v", err)
+	}
+	return got
+}
+
+// TestTraceparentUnaryInterceptor_InjectsActiveSpan verifies the SDK
+// injects the caller's active W3C trace context as a traceparent header
+// (ADR-033 §6).
+func TestTraceparentUnaryInterceptor_InjectsActiveSpan(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("trace id: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("0123456789abcdef")
+	if err != nil {
+		t.Fatalf("span id: %v", err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	got := captureOutgoingMD(t, ctx)
+	tp := got.Get("traceparent")
+	if len(tp) == 0 {
+		t.Fatal("traceparent header not injected for an active span")
+	}
+	if !strings.Contains(tp[0], traceID.String()) {
+		t.Errorf("traceparent %q does not carry trace id %s", tp[0], traceID)
+	}
+	if !strings.Contains(tp[0], spanID.String()) {
+		t.Errorf("traceparent %q does not carry span id %s", tp[0], spanID)
+	}
+}
+
+// TestTraceparentUnaryInterceptor_NoSpanNoHeader verifies the SDK forces
+// no tracing behaviour on callers without an active span: nothing is
+// injected, so non-OpenTelemetry consumers are unaffected.
+func TestTraceparentUnaryInterceptor_NoSpanNoHeader(t *testing.T) {
+	got := captureOutgoingMD(t, context.Background())
+	if len(got.Get("traceparent")) != 0 {
+		t.Errorf("traceparent must not be injected without an active span; got %v", got.Get("traceparent"))
+	}
+}
+
+// TestTraceparentUnaryInterceptor_PreservesExistingMetadata verifies the
+// injected header is added alongside (not replacing) existing outgoing
+// metadata such as the auth header.
+func TestTraceparentUnaryInterceptor_PreservesExistingMetadata(t *testing.T) {
+	traceID, _ := trace.TraceIDFromHex("aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb")
+	spanID, _ := trace.SpanIDFromHex("cccccccccccccccc")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled})
+	ctx := metadata.NewOutgoingContext(
+		trace.ContextWithSpanContext(context.Background(), sc),
+		metadata.Pairs("authorization", "Bearer tok"),
+	)
+	got := captureOutgoingMD(t, ctx)
+	if len(got.Get("authorization")) == 0 {
+		t.Error("existing authorization header was dropped")
+	}
+	if len(got.Get("traceparent")) == 0 {
+		t.Error("traceparent was not added alongside existing metadata")
+	}
+}

--- a/sdk/python/entdb_sdk/_grpc_client.py
+++ b/sdk/python/entdb_sdk/_grpc_client.py
@@ -95,6 +95,7 @@ from ._generated import (
     UpdateUserRequest,
     WaitForOffsetRequest,
 )
+from ._tracing import inject_trace_context
 
 
 def _value_from_python(v: Any) -> Value:
@@ -957,10 +958,17 @@ class GrpcClient:
         return self._stub
 
     def _build_metadata(self) -> list[tuple[str, str]]:
-        """Build gRPC call metadata including authentication."""
+        """Build gRPC call metadata: authentication + W3C trace context.
+
+        Every RPC funnels through here, so injecting the caller's active
+        trace context (traceparent/tracestate) here propagates it on ALL
+        methods uniformly (ADR-033 §6). No-op without OpenTelemetry / an
+        active span.
+        """
         metadata: list[tuple[str, str]] = []
         if self._api_key:
             metadata.append(("authorization", f"Bearer {self._api_key}"))
+        inject_trace_context(metadata)
         return metadata
 
     def _make_context(self, tenant_id: str, actor: str, trace_id: str = "") -> RequestContext:

--- a/sdk/python/entdb_sdk/_tracing.py
+++ b/sdk/python/entdb_sdk/_tracing.py
@@ -1,0 +1,42 @@
+"""W3C trace-context propagation for the EntDB Python SDK (ADR-033 §6).
+
+Injects the caller's active OpenTelemetry span as ``traceparent`` (and
+``tracestate``) gRPC metadata so the server continues the same trace.
+
+This is a *no-op* when OpenTelemetry is not installed or when there is no
+active span, so SDK consumers are never forced to depend on
+OpenTelemetry. Install the optional extra to enable propagation::
+
+    pip install "entdb-sdk[tracing]"
+"""
+
+from __future__ import annotations
+
+try:
+    from opentelemetry.propagate import inject as _otel_inject
+
+    _OTEL_AVAILABLE = True
+except Exception:  # pragma: no cover - exercised by the no-otel path
+    _OTEL_AVAILABLE = False
+
+
+def inject_trace_context(
+    metadata: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    """Append W3C ``traceparent``/``tracestate`` for the active span.
+
+    Mutates and returns ``metadata``. No-op when OpenTelemetry is absent
+    or no span is active (the carrier comes back empty). Uses the global
+    propagator, which OpenTelemetry defaults to W3C tracecontext +
+    baggage.
+    """
+    if not _OTEL_AVAILABLE:
+        return metadata
+    carrier: dict[str, str] = {}
+    try:
+        _otel_inject(carrier)
+    except Exception:  # pragma: no cover - defensive: never break a call
+        return metadata
+    for key, value in carrier.items():
+        metadata.append((key, value))
+    return metadata

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -32,6 +32,14 @@ dependencies = [
     "protobuf>=4.25.0",
 ]
 
+# Optional W3C trace-context propagation (ADR-033 §6). Without this the
+# SDK never injects a traceparent; with an active OpenTelemetry span it
+# propagates the trace to the server. Install: pip install "entdb-sdk[tracing]".
+[project.optional-dependencies]
+tracing = [
+    "opentelemetry-api>=1.20.0",
+]
+
 [project.scripts]
 entdb = "entdb_sdk.cli:main"
 

--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -21,7 +21,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
@@ -31,6 +33,7 @@ import (
 	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/gdpr"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/observability"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
@@ -131,6 +134,14 @@ func main() {
 	archiveBatchBytes := flag.Int("archive-batch-bytes", 10<<20, "approximate maximum uncompressed bytes per archive object")
 	archivePollTimeout := flag.Duration("archive-poll-timeout", time.Second, "how long the archive sidecar polls for WAL records")
 	archiveRetryBackoff := flag.Duration("archive-retry-backoff", 5*time.Second, "retry backoff after archive poll/write failures")
+	// Observability (ADR-033). Incoming W3C traceparent is honored on
+	// every RPC regardless of these flags; they only control span EXPORT
+	// and log format. Span export is OFF unless --otlp-endpoint (or the
+	// standard OTEL_EXPORTER_OTLP_ENDPOINT env) is set, mirroring how
+	// --metrics-addr defaults the scrape endpoint off.
+	otlpEndpoint := flag.String("otlp-endpoint", "", "OTLP/gRPC endpoint for trace span export (host:port or URL); empty disables export. Incoming traceparent is honored regardless. Also honors OTEL_EXPORTER_OTLP_ENDPOINT.")
+	otlpInsecure := flag.Bool("otlp-insecure", false, "disable transport security for the OTLP exporter (local collectors only)")
+	logFormat := flag.String("log-format", "text", "structured log format: text | json")
 	flag.Parse()
 
 	if strings.TrimSpace(*dataDir) == "" {
@@ -154,6 +165,26 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Install the observability pipeline early: a structured slog default
+	// that stamps trace_id/span_id onto request-path logs, the global W3C
+	// propagator that lets the gRPC StatsHandler parse an incoming
+	// traceparent, and (opt-in) an OTLP span exporter (ADR-033).
+	obsShutdown, err := observability.Init(ctx, observability.Config{
+		OTLPEndpoint: *otlpEndpoint,
+		OTLPInsecure: *otlpInsecure,
+		LogFormat:    *logFormat,
+	})
+	if err != nil {
+		log.Fatalf("entdb-server: observability init: %v", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := obsShutdown(shutdownCtx); err != nil {
+			log.Printf("entdb-server: observability shutdown: %v", err)
+		}
+	}()
 
 	var masterKey []byte
 	encryptionConfigured := *encryptionRequired ||
@@ -463,6 +494,25 @@ func main() {
 	if err != nil {
 		log.Fatalf("entdb-server: TLS config: %v", err)
 	}
+
+	// Trace context extraction (ADR-033): the otelgrpc StatsHandler runs
+	// the global W3C propagator over incoming metadata, so an upstream
+	// traceparent becomes the parent of this server's span and a valid
+	// SpanContext rides the request ctx into handlers, the store, logs,
+	// and metric exemplars. Installed at the transport level so it wraps
+	// the auth interceptors too.
+	grpcServerOpts = append(grpcServerOpts, grpc.StatsHandler(otelgrpc.NewServerHandler()))
+
+	// Per-request access log (ADR-033): one structured line per RPC
+	// carrying method/status/latency, auto-stamped with trace_id/span_id
+	// by the trace-correlating slog handler. Registered FIRST so it is
+	// the outermost interceptor and records the final status of every
+	// request, including auth rejections.
+	grpcServerOpts = append(grpcServerOpts,
+		grpc.ChainUnaryInterceptor(observability.AccessLogUnaryInterceptor()),
+		grpc.ChainStreamInterceptor(observability.AccessLogStreamInterceptor()),
+	)
+
 	if tlsEnabled {
 		grpcServerOpts = append(grpcServerOpts,
 			grpc.ChainUnaryInterceptor(auth.MTLSPeerIdentityUnaryInterceptor()),
@@ -534,7 +584,9 @@ func main() {
 	var metricsSrv *http.Server
 	if strings.TrimSpace(*metricsAddr) != "" {
 		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.Handler())
+		// OpenMetrics exposition so trace_id exemplars on
+		// entdb_grpc_latency_seconds (ADR-033) are scrapeable.
+		mux.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{EnableOpenMetrics: true}))
 		metricsSrv = &http.Server{
 			Addr:              strings.TrimSpace(*metricsAddr),
 			Handler:           mux,

--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -61,6 +62,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
@@ -83,8 +85,12 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
@@ -93,7 +99,7 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/server/go/go.sum
+++ b/server/go/go.sum
@@ -78,6 +78,8 @@ github.com/aws/smithy-go v1.26.0 h1:9ouqbi+NyKP7fV3Te7UElCwdAb6Y8uk7LGwPE5tVe/s=
 github.com/aws/smithy-go v1.26.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
@@ -125,6 +127,8 @@ github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -207,6 +211,10 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:Oyrsyzu
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0/go.mod h1:AGmbycVGEsRx9mXMZ75CsOyhSP6MFIcj/6dnG+vhVjk=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=
@@ -215,6 +223,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
@@ -276,6 +286,8 @@ google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 h1:XzmzkmB14QhVhgn
 google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
 google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7 h1:41r6JMbpzBMen0R/4TZeeAmGXSJC7DftGINUodzTkPI=
 google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:EIQZ5bFCfRQDV4MhRle7+OgjNtZ6P1PiZBgAKuxXu/Y=
+google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 h1:VPWxll4HlMw1Vs/qXtN7BvhZqsS9cdAittCNvVENElA=
+google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9/go.mod h1:7QBABkRtR8z+TEnmXTqIqwJLlzrZKVfAUm7tY3yGv0M=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 h1:PvEgGJf9C/1u5CHkInMg7UFYYUoiaQmW2LbtH0pjB78=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=

--- a/server/go/internal/api/add_group_member.go
+++ b/server/go/internal/api/add_group_member.go
@@ -79,7 +79,7 @@ func (s *Server) AddGroupMember(
 	start := time.Now()
 	statusLabel := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest("AddGroupMember", statusLabel, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, "AddGroupMember", statusLabel, time.Since(start))
 	}()
 
 	if s.producer == nil {

--- a/server/go/internal/api/add_tenant_member.go
+++ b/server/go/internal/api/add_tenant_member.go
@@ -72,7 +72,7 @@ func (s *Server) AddTenantMember(
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest("AddTenantMember", status, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, "AddTenantMember", status, time.Since(start))
 	}()
 
 	if s.global == nil {

--- a/server/go/internal/api/archive_tenant.go
+++ b/server/go/internal/api/archive_tenant.go
@@ -53,7 +53,7 @@ func (s *Server) ArchiveTenant(
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(archiveTenantMethod, status, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, archiveTenantMethod, status, time.Since(start))
 	}()
 
 	// Optional-store guard. Aborts with UNIMPLEMENTED when the global_store

--- a/server/go/internal/api/cancel_user_deletion.go
+++ b/server/go/internal/api/cancel_user_deletion.go
@@ -51,7 +51,7 @@ func (s *Server) CancelUserDeletion(ctx context.Context, req *pb.CancelUserDelet
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(cancelUserDeletionMethod, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, cancelUserDeletionMethod, outcome, time.Since(start))
 	}()
 
 	// Configuration gate.

--- a/server/go/internal/api/change_member_role.go
+++ b/server/go/internal/api/change_member_role.go
@@ -53,23 +53,23 @@ func (s *Server) ChangeMemberRole(
 	start := time.Now()
 
 	if s.global == nil {
-		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 		return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
 	}
 	if req.GetActor() == "" {
-		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
 	}
 	if req.GetTenantId() == "" {
-		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
 	}
 	if req.GetUserId() == "" {
-		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "user_id is required")
 	}
 	if req.GetNewRole() == "" {
-		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "new_role is required")
 	}
 
@@ -83,11 +83,11 @@ func (s *Server) ChangeMemberRole(
 		// Caller must be a tenant-level admin/owner to mutate roles.
 		callerRole, err := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
 		if err != nil {
-			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+			metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 			return nil, errs.Internal(ctx, "list tenant members", err)
 		}
 		if callerRole != "owner" && callerRole != "admin" {
-			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+			metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 			return nil, errs.Errorf(codes.PermissionDenied,
 				"Only tenant admins can change member roles")
 		}
@@ -95,7 +95,7 @@ func (s *Server) ChangeMemberRole(
 
 	members, err := s.global.GetTenantMembers(ctx, req.GetTenantId())
 	if err != nil {
-		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 		return nil, errs.Internal(ctx, "list tenant members", err)
 	}
 	var targetJoinedAt int64
@@ -120,7 +120,7 @@ func (s *Server) ChangeMemberRole(
 			}
 		}
 		if targetIsOwner && ownerCount == 1 {
-			metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+			metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 			return nil, errs.Errorf(codes.FailedPrecondition,
 				"cannot demote the last owner of tenant %q", req.GetTenantId())
 		}
@@ -136,7 +136,7 @@ func (s *Server) ChangeMemberRole(
 
 	if !targetFound {
 		// Soft failure: gRPC OK, response.success=false.
-		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "ok", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "ok", time.Since(start))
 		return &pb.ChangeMemberRoleResponse{Success: false, Error: "Member not found"}, nil
 	}
 	if targetJoinedAt == 0 {
@@ -151,10 +151,10 @@ func (s *Server) ChangeMemberRole(
 		"joined_at": targetJoinedAt,
 	})
 	if err != nil {
-		metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "error", time.Since(start))
 		return nil, err
 	}
 
-	metrics.RecordGRPCRequest(grpcMethodChangeMemberRole, "ok", time.Since(start))
+	metrics.RecordGRPCRequest(ctx, grpcMethodChangeMemberRole, "ok", time.Since(start))
 	return &pb.ChangeMemberRoleResponse{Success: true}, nil
 }

--- a/server/go/internal/api/create_tenant.go
+++ b/server/go/internal/api/create_tenant.go
@@ -45,7 +45,7 @@ func (s *Server) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) 
 	start := time.Now()
 	resultStatus := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest("CreateTenant", resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, "CreateTenant", resultStatus, time.Since(start))
 	}()
 
 	// Step 1a: globalstore must be wired.

--- a/server/go/internal/api/create_user.go
+++ b/server/go/internal/api/create_user.go
@@ -54,7 +54,7 @@ func (s *Server) CreateUser(ctx context.Context, req *pb.CreateUserRequest) (*pb
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(createUserMethod, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, createUserMethod, outcome, time.Since(start))
 	}()
 
 	if s.global == nil {

--- a/server/go/internal/api/delegate_access.go
+++ b/server/go/internal/api/delegate_access.go
@@ -67,21 +67,21 @@ func (s *Server) DelegateAccess(
 
 	// 1. Tenant gate (sharding + region pinning).
 	if err := s.checkTenant(ctx, req.GetTenantId()); err != nil {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return nil, err
 	}
 
 	// 2. Required-field validation.
 	if req.GetTenantId() == "" {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
 	}
 	if req.GetFromUser() == "" {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "from_user is required")
 	}
 	if req.GetToUser() == "" {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "to_user is required")
 	}
 
@@ -95,16 +95,16 @@ func (s *Server) DelegateAccess(
 	//    hold tenant role "owner" or "admin".
 	if !(trusted.IsSystem() || trusted.IsAdmin()) {
 		if s.global == nil {
-			metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+			metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 			return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
 		}
 		role, err := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
 		if err != nil {
-			metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+			metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 			return nil, err
 		}
 		if role != "owner" && role != "admin" {
-			metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+			metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 			return nil, errs.Errorf(codes.PermissionDenied,
 				"Only tenant owner or admin can delegate access")
 		}
@@ -115,7 +115,7 @@ func (s *Server) DelegateAccess(
 	//    WAL); without them we soft-fail rather than wire-error so the
 	//    SDK shape stays parsable.
 	if s.store == nil || s.producer == nil {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return &pb.DelegateAccessResponse{
 			Success: false,
 			Error:   "DelegateAccess: store/wal not configured",
@@ -128,7 +128,7 @@ func (s *Server) DelegateAccess(
 	//    inflate the actual grant count.
 	nodeIDs, err := listNodesByOwner(ctx, s, req.GetTenantId(), req.GetFromUser())
 	if err != nil {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return &pb.DelegateAccessResponse{
 			Success: false,
 			Error:   fmt.Sprintf("DelegateAccess: list owner nodes: %v", err),
@@ -161,7 +161,7 @@ func (s *Server) DelegateAccess(
 
 	idemKey, err := newDelegateIdempotencyKey()
 	if err != nil {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return &pb.DelegateAccessResponse{
 			Success: false,
 			Error:   fmt.Sprintf("DelegateAccess: idempotency key: %v", err),
@@ -177,7 +177,7 @@ func (s *Server) DelegateAccess(
 	}
 	value, err := event.Encode()
 	if err != nil {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return &pb.DelegateAccessResponse{
 			Success: false,
 			Error:   fmt.Sprintf("DelegateAccess: encode event: %v", err),
@@ -186,7 +186,7 @@ func (s *Server) DelegateAccess(
 
 	headers := map[string][]byte{wal.HeaderIdempotencyKey: []byte(idemKey)}
 	if _, err := s.producer.Append(ctx, s.walTopic(), req.GetTenantId(), value, headers); err != nil {
-		metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "error", time.Since(start))
 		return &pb.DelegateAccessResponse{
 			Success: false,
 			Error:   fmt.Sprintf("DelegateAccess: wal append: %v", err),
@@ -201,7 +201,7 @@ func (s *Server) DelegateAccess(
 	// echoes the request. Pinned by sdk/go/entdb/admin_test.go:291-333.
 	resp.ExpiresAt = expiresAt
 
-	metrics.RecordGRPCRequest(grpcMethodDelegateAccess, "ok", time.Since(start))
+	metrics.RecordGRPCRequest(ctx, grpcMethodDelegateAccess, "ok", time.Since(start))
 	return resp, nil
 }
 

--- a/server/go/internal/api/delete_user.go
+++ b/server/go/internal/api/delete_user.go
@@ -82,7 +82,7 @@ func (s *Server) DeleteUser(ctx context.Context, req *pb.DeleteUserRequest) (*pb
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(deleteUserMethod, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, deleteUserMethod, outcome, time.Since(start))
 	}()
 
 	// Configuration gate.

--- a/server/go/internal/api/execute_atomic.go
+++ b/server/go/internal/api/execute_atomic.go
@@ -43,6 +43,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -77,7 +78,7 @@ const (
 func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest) (*pb.ExecuteAtomicResponse, error) {
 	start := time.Now()
 	outcome := "ok"
-	defer func() { metrics.RecordGRPCRequest(executeAtomicMethod, outcome, time.Since(start)) }()
+	defer func() { metrics.RecordGRPCRequest(ctx, executeAtomicMethod, outcome, time.Since(start)) }()
 
 	if s.producer == nil || s.topic == "" {
 		outcome = "error"
@@ -300,6 +301,11 @@ func (s *Server) ExecuteAtomic(ctx context.Context, req *pb.ExecuteAtomicRequest
 	headers := map[string][]byte{
 		wal.HeaderIdempotencyKey: []byte(idem),
 	}
+	// Carry the request's W3C trace context onto the WAL record so the
+	// applier can continue this trace when it materialises the event on
+	// its own goroutine/context later (ADR-033 §5). No-op when the
+	// request is untraced (no traceparent on ctx).
+	otel.GetTextMapPropagator().Inject(ctx, wal.HeaderCarrier(headers))
 	pos, err := s.producer.Append(ctx, s.topic, tenantID, payloadBytes, headers)
 	if err != nil {
 		// In-band INTERNAL channel — gRPC status stays OK, error_code

--- a/server/go/internal/api/export_user_data.go
+++ b/server/go/internal/api/export_user_data.go
@@ -70,7 +70,7 @@ func (s *Server) ExportUserData(
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(exportUserDataMethod, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, exportUserDataMethod, outcome, time.Since(start))
 	}()
 
 	// Configuration gate.

--- a/server/go/internal/api/freeze_user.go
+++ b/server/go/internal/api/freeze_user.go
@@ -58,7 +58,7 @@ func (s *Server) FreezeUser(ctx context.Context, req *pb.FreezeUserRequest) (*pb
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(freezeUserMethod, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, freezeUserMethod, outcome, time.Since(start))
 	}()
 
 	// Configuration gate.

--- a/server/go/internal/api/get_connected_nodes.go
+++ b/server/go/internal/api/get_connected_nodes.go
@@ -86,7 +86,7 @@ func (s *Server) GetConnectedNodes(ctx context.Context, req *pb.GetConnectedNode
 	start := time.Now()
 	resultStatus := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(getConnectedNodesMethod, resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getConnectedNodesMethod, resultStatus, time.Since(start))
 	}()
 
 	tenantID := req.GetContext().GetTenantId()

--- a/server/go/internal/api/get_edges_from.go
+++ b/server/go/internal/api/get_edges_from.go
@@ -63,7 +63,7 @@ func (s *Server) GetEdgesFrom(ctx context.Context, req *pb.GetEdgesRequest) (*pb
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(grpcMethodGetEdgesFrom, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodGetEdgesFrom, outcome, time.Since(start))
 	}()
 
 	tenantID := req.GetContext().GetTenantId()

--- a/server/go/internal/api/get_edges_to.go
+++ b/server/go/internal/api/get_edges_to.go
@@ -56,7 +56,7 @@ func (s *Server) GetEdgesTo(
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(grpcMethodGetEdgesTo, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodGetEdgesTo, outcome, time.Since(start))
 	}()
 
 	tenantID := req.GetContext().GetTenantId()

--- a/server/go/internal/api/get_mailbox.go
+++ b/server/go/internal/api/get_mailbox.go
@@ -44,7 +44,7 @@ func (s *Server) GetMailbox(ctx context.Context, req *pb.GetMailboxRequest) (*pb
 	)
 	defer func() {
 		if r := recover(); r != nil {
-			metrics.RecordGRPCRequest("GetMailbox", "error", time.Since(start))
+			metrics.RecordGRPCRequest(ctx, "GetMailbox", "error", time.Since(start))
 			resp = emptyMailboxResponse()
 			err = nil
 		}
@@ -52,11 +52,11 @@ func (s *Server) GetMailbox(ctx context.Context, req *pb.GetMailboxRequest) (*pb
 
 	tenantID := req.GetContext().GetTenantId()
 	if cerr := s.checkTenant(ctx, tenantID); cerr != nil {
-		metrics.RecordGRPCRequest("GetMailbox", "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, "GetMailbox", "error", time.Since(start))
 		return nil, cerr
 	}
 
-	metrics.RecordGRPCRequest("GetMailbox", "ok", time.Since(start))
+	metrics.RecordGRPCRequest(ctx, "GetMailbox", "ok", time.Since(start))
 	resp = emptyMailboxResponse()
 	return resp, err
 }

--- a/server/go/internal/api/get_node.go
+++ b/server/go/internal/api/get_node.go
@@ -80,7 +80,7 @@ func (s *Server) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNo
 	start := time.Now()
 	resultStatus := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(getNodeMethod, resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getNodeMethod, resultStatus, time.Since(start))
 	}()
 
 	if s.store == nil {

--- a/server/go/internal/api/get_node_by_key.go
+++ b/server/go/internal/api/get_node_by_key.go
@@ -72,7 +72,7 @@ func (s *Server) GetNodeByKey(ctx context.Context, req *pb.GetNodeByKeyRequest) 
 	start := time.Now()
 	resultStatus := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(getNodeByKeyMethod, resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getNodeByKeyMethod, resultStatus, time.Since(start))
 	}()
 
 	// 1. Tenant gate. UNAVAILABLE / FAILED_PRECONDITION / NOT_FOUND

--- a/server/go/internal/api/get_nodes.go
+++ b/server/go/internal/api/get_nodes.go
@@ -84,7 +84,7 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 	start := time.Now()
 	resultStatus := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(getNodesMethod, resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getNodesMethod, resultStatus, time.Since(start))
 	}()
 
 	tenantID := req.GetContext().GetTenantId()

--- a/server/go/internal/api/get_receipt_status.go
+++ b/server/go/internal/api/get_receipt_status.go
@@ -38,7 +38,7 @@ func (s *Server) GetReceiptStatus(ctx context.Context, req *pb.GetReceiptStatusR
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(grpcMethodGetReceiptStatus, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodGetReceiptStatus, outcome, time.Since(start))
 	}()
 
 	// Panic safety: collapses every runtime fault — including programmer

--- a/server/go/internal/api/get_schema.go
+++ b/server/go/internal/api/get_schema.go
@@ -44,14 +44,14 @@ const getSchemaMethod = "GetSchema"
 // GetSchema returns the in-memory schema registry as a typed
 // google.protobuf.Struct plus its post-freeze fingerprint. See file
 // header for the swallow-all-errors-as-OK contract.
-func (s *Server) GetSchema(_ context.Context, req *pb.GetSchemaRequest) (resp *pb.GetSchemaResponse, err error) {
+func (s *Server) GetSchema(ctx context.Context, req *pb.GetSchemaRequest) (resp *pb.GetSchemaResponse, err error) {
 	start := time.Now()
 	status := "ok"
 	defer func() {
 		// Single emission point: emit metric whether we exited
 		// normally or via recover. status is mutated on the
 		// degraded path below.
-		metrics.RecordGRPCRequest(getSchemaMethod, status, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getSchemaMethod, status, time.Since(start))
 	}()
 
 	defer func() {

--- a/server/go/internal/api/get_tenant.go
+++ b/server/go/internal/api/get_tenant.go
@@ -51,7 +51,7 @@ func (s *Server) GetTenant(ctx context.Context, req *pb.GetTenantRequest) (resp 
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(getTenantMethod, status, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getTenantMethod, status, time.Since(start))
 	}()
 
 	// Defensive: registry not configured. No test pins this path but it

--- a/server/go/internal/api/get_tenant_members.go
+++ b/server/go/internal/api/get_tenant_members.go
@@ -56,7 +56,7 @@ func (s *Server) GetTenantMembers(
 	start := time.Now()
 
 	if s.global == nil {
-		metrics.RecordGRPCRequest(getTenantMembersMethod, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getTenantMembersMethod, "error", time.Since(start))
 		return nil, errs.Errorf(codes.Unimplemented, "Tenant registry not configured")
 	}
 
@@ -64,11 +64,11 @@ func (s *Server) GetTenantMembers(
 	// tenant_id, and the SDK contract tests rely on the exact
 	// INVALID_ARGUMENT messages.
 	if req.GetActor() == "" {
-		metrics.RecordGRPCRequest(getTenantMembersMethod, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getTenantMembersMethod, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
 	}
 	if req.GetTenantId() == "" {
-		metrics.RecordGRPCRequest(getTenantMembersMethod, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getTenantMembersMethod, "error", time.Since(start))
 		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
 	}
 
@@ -85,7 +85,7 @@ func (s *Server) GetTenantMembers(
 		// globalstore failure; SDK callers cannot distinguish "no
 		// members" from "DB blew up". Flagged in the EPIC's
 		// open-questions for tightening.
-		metrics.RecordGRPCRequest(getTenantMembersMethod, "error", time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getTenantMembersMethod, "error", time.Since(start))
 		return &pb.GetTenantMembersResponse{Members: []*pb.TenantMemberInfo{}}, nil
 	}
 
@@ -98,6 +98,6 @@ func (s *Server) GetTenantMembers(
 			JoinedAt: m.JoinedAt,
 		})
 	}
-	metrics.RecordGRPCRequest(getTenantMembersMethod, "ok", time.Since(start))
+	metrics.RecordGRPCRequest(ctx, getTenantMembersMethod, "ok", time.Since(start))
 	return &pb.GetTenantMembersResponse{Members: out}, nil
 }

--- a/server/go/internal/api/get_tenant_quota.go
+++ b/server/go/internal/api/get_tenant_quota.go
@@ -48,7 +48,7 @@ func (s *Server) GetTenantQuota(
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(grpcMethodGetTenantQuota, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodGetTenantQuota, outcome, time.Since(start))
 	}()
 
 	tenantID := req.GetTenantId()

--- a/server/go/internal/api/get_user.go
+++ b/server/go/internal/api/get_user.go
@@ -52,7 +52,7 @@ func (s *Server) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.GetUs
 	start := time.Now()
 	resultStatus := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(getUserMethod, resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, getUserMethod, resultStatus, time.Since(start))
 	}()
 
 	// Guard the optional global_store dep. Returns

--- a/server/go/internal/api/get_user_tenants.go
+++ b/server/go/internal/api/get_user_tenants.go
@@ -74,7 +74,7 @@ func (s *Server) GetUserTenants(
 			}
 			err = nil
 		}
-		metrics.RecordGRPCRequest(grpcMethodGetUserTenants, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodGetUserTenants, outcome, time.Since(start))
 	}()
 
 	// Trusted-actor resolution. The result is intentionally not used

--- a/server/go/internal/api/health.go
+++ b/server/go/internal/api/health.go
@@ -48,10 +48,10 @@ func (s *Server) Health(ctx context.Context, _ *pb.HealthRequest) (*pb.HealthRes
 	resultStatus := "ok"
 	defer func() {
 		if r := recover(); r != nil {
-			metrics.RecordGRPCRequest("Health", "error", time.Since(start))
+			metrics.RecordGRPCRequest(ctx, "Health", "error", time.Since(start))
 			panic(r)
 		}
-		metrics.RecordGRPCRequest("Health", resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, "Health", resultStatus, time.Since(start))
 	}()
 
 	components := make(map[string]string, 4)

--- a/server/go/internal/api/list_shared_with_me.go
+++ b/server/go/internal/api/list_shared_with_me.go
@@ -105,7 +105,7 @@ func (s *Server) ListSharedWithMe(
 	start := time.Now()
 	statusLabel := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(listSharedWithMeMethod, statusLabel, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, listSharedWithMeMethod, statusLabel, time.Since(start))
 	}()
 
 	tenantID := req.GetContext().GetTenantId()

--- a/server/go/internal/api/list_tenants.go
+++ b/server/go/internal/api/list_tenants.go
@@ -67,7 +67,7 @@ func (s *Server) ListTenants(
 	start := time.Now()
 	stat := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(listTenantsMethod, stat, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, listTenantsMethod, stat, time.Since(start))
 	}()
 
 	// Swallow panics → empty + OK. PERMISSION_DENIED returns through

--- a/server/go/internal/api/list_users.go
+++ b/server/go/internal/api/list_users.go
@@ -53,7 +53,7 @@ func (s *Server) ListUsers(
 	start := time.Now()
 	statusLabel := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest("ListUsers", statusLabel, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, "ListUsers", statusLabel, time.Since(start))
 	}()
 
 	if s.global == nil {

--- a/server/go/internal/api/query_nodes.go
+++ b/server/go/internal/api/query_nodes.go
@@ -62,7 +62,7 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	start := time.Now()
 	resultStatus := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(queryNodesMethod, resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, queryNodesMethod, resultStatus, time.Since(start))
 	}()
 
 	tenantID := req.GetContext().GetTenantId()

--- a/server/go/internal/api/remove_group_member.go
+++ b/server/go/internal/api/remove_group_member.go
@@ -83,7 +83,7 @@ func (s *Server) RemoveGroupMember(
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(removeGroupMemberMethod, status, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, removeGroupMemberMethod, status, time.Since(start))
 	}()
 
 	tenantID := req.GetContext().GetTenantId()

--- a/server/go/internal/api/remove_tenant_member.go
+++ b/server/go/internal/api/remove_tenant_member.go
@@ -67,7 +67,7 @@ func (s *Server) RemoveTenantMember(
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(removeTenantMemberMethod, status, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, removeTenantMemberMethod, status, time.Since(start))
 	}()
 
 	// Registry-less deployment guard.

--- a/server/go/internal/api/revoke_access.go
+++ b/server/go/internal/api/revoke_access.go
@@ -99,7 +99,7 @@ func (s *Server) RevokeAccess(
 	start := time.Now()
 	statusLabel := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(revokeAccessMethod, statusLabel, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, revokeAccessMethod, statusLabel, time.Since(start))
 	}()
 
 	// Required-arg validation. Empty actor / tenant_id / node_id /

--- a/server/go/internal/api/revoke_all_user_access.go
+++ b/server/go/internal/api/revoke_all_user_access.go
@@ -86,7 +86,7 @@ func (s *Server) RevokeAllUserAccess(
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(revokeAllUserAccessMethod, status, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, revokeAllUserAccessMethod, status, time.Since(start))
 	}()
 
 	// Required-field validation BEFORE auth.

--- a/server/go/internal/api/search_nodes.go
+++ b/server/go/internal/api/search_nodes.go
@@ -76,7 +76,7 @@ func (s *Server) SearchNodes(
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(grpcMethodSearchNodes, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodSearchNodes, outcome, time.Since(start))
 	}()
 
 	// 1. Tenant gate (UNAVAILABLE / FAILED_PRECONDITION / NOT_FOUND /

--- a/server/go/internal/api/set_legal_hold.go
+++ b/server/go/internal/api/set_legal_hold.go
@@ -71,7 +71,7 @@ func (s *Server) SetLegalHold(
 	start := time.Now()
 	resultStatus := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(grpcMethodSetLegalHold, resultStatus, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodSetLegalHold, resultStatus, time.Since(start))
 	}()
 
 	// Optional-store guard. Returns UNIMPLEMENTED when the global_store

--- a/server/go/internal/api/share_node.go
+++ b/server/go/internal/api/share_node.go
@@ -95,7 +95,7 @@ func (s *Server) ShareNode(
 	start := time.Now()
 	status := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(shareNodeMethod, status, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, shareNodeMethod, status, time.Since(start))
 	}()
 
 	// Optional-deps guard. The WAL producer is mandatory for ShareNode

--- a/server/go/internal/api/transfer_ownership.go
+++ b/server/go/internal/api/transfer_ownership.go
@@ -93,7 +93,7 @@ func (s *Server) TransferOwnership(
 	start := time.Now()
 	statusLabel := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(grpcMethodTransferOwnership, statusLabel, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, grpcMethodTransferOwnership, statusLabel, time.Since(start))
 	}()
 
 	// 1. Validation. Required-arg checks per spec §"Wire contract".

--- a/server/go/internal/api/transfer_user_content.go
+++ b/server/go/internal/api/transfer_user_content.go
@@ -98,7 +98,7 @@ func (s *Server) TransferUserContent(
 	start := time.Now()
 	statusLabel := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(transferUserContentMethod, statusLabel, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, transferUserContentMethod, statusLabel, time.Since(start))
 	}()
 
 	//  dependency guard. A node booted without a globalstore can

--- a/server/go/internal/api/update_user.go
+++ b/server/go/internal/api/update_user.go
@@ -57,7 +57,7 @@ func (s *Server) UpdateUser(ctx context.Context, req *pb.UpdateUserRequest) (*pb
 	start := time.Now()
 	outcome := "ok"
 	defer func() {
-		metrics.RecordGRPCRequest(updateUserMethod, outcome, time.Since(start))
+		metrics.RecordGRPCRequest(ctx, updateUserMethod, outcome, time.Since(start))
 	}()
 
 	// Configuration gate.

--- a/server/go/internal/apply/applier.go
+++ b/server/go/internal/apply/applier.go
@@ -8,15 +8,25 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
+
+// applierTracerName names the tracer used for apply-side spans that
+// continue an originating request's trace across the async WAL boundary
+// (ADR-033 §5).
+const applierTracerName = "entdb-applier"
 
 // Options configures a new Applier. Required fields: Store, Consumer,
 // Topic, GroupID. Global is required for wal.ScopeGlobal records; an
@@ -64,6 +74,22 @@ type Options struct {
 	// worker pool; the cap never exceeds the number of distinct tenants
 	// in the batch.
 	MaxApplyConcurrency int
+
+	// TransientPollBackoff is the base backoff between retries of a
+	// transient WAL poll error (issue #627). Capped-exponential up to
+	// 30s. Defaults to 1s. A transient poll error (idle-connection EOF,
+	// network timeout, broker rebalance) is retried rather than crashing
+	// the process.
+	TransientPollBackoff time.Duration
+
+	// MaxTransientPollStreak caps consecutive transient poll errors
+	// before the applier gives up and exits. 0 (default) retries
+	// indefinitely — a transient error must never crash the process; a
+	// persistent broker outage is surfaced via warn logs + the
+	// entdb_applier_transient_poll_errors_total metric, not a crash
+	// loop. Set >0 to force an exit after N consecutive transient
+	// failures.
+	MaxTransientPollStreak int
 }
 
 // Applier is the WAL consumer that materialises TransactionEvents into
@@ -95,6 +121,9 @@ type Applier struct {
 	fanoutHook   func(ctx context.Context, ev *Event, res *Result)
 	haltOnPoison bool
 	maxApplyConc int
+
+	transientBackoff   time.Duration
+	maxTransientStreak int
 
 	// running is non-zero when the Run loop has started. Used by
 	// Stop to skip the wait-for-loop-exit path when Run never started.
@@ -142,20 +171,26 @@ func New(opts Options) (*Applier, error) {
 	if maxConc < 1 {
 		maxConc = 1
 	}
+	transientBackoff := opts.TransientPollBackoff
+	if transientBackoff <= 0 {
+		transientBackoff = time.Second
+	}
 	return &Applier{
-		store:        opts.Store,
-		global:       opts.Global,
-		consumer:     opts.Consumer,
-		topic:        opts.Topic,
-		groupID:      opts.GroupID,
-		batchSize:    batch,
-		pollTimeout:  pollTO,
-		nowFn:        nowFn,
-		fanoutHook:   opts.FanoutHook,
-		haltOnPoison: halt,
-		maxApplyConc: maxConc,
-		stopCh:       make(chan struct{}),
-		doneCh:       make(chan struct{}),
+		store:              opts.Store,
+		global:             opts.Global,
+		consumer:           opts.Consumer,
+		topic:              opts.Topic,
+		groupID:            opts.GroupID,
+		batchSize:          batch,
+		pollTimeout:        pollTO,
+		nowFn:              nowFn,
+		fanoutHook:         opts.FanoutHook,
+		haltOnPoison:       halt,
+		maxApplyConc:       maxConc,
+		transientBackoff:   transientBackoff,
+		maxTransientStreak: opts.MaxTransientPollStreak,
+		stopCh:             make(chan struct{}),
+		doneCh:             make(chan struct{}),
 	}, nil
 }
 
@@ -171,6 +206,10 @@ func (a *Applier) Run(ctx context.Context) error {
 	}
 	defer close(a.doneCh)
 
+	// transientStreak counts consecutive transient poll errors so the
+	// backoff grows and (optionally) the MaxTransientPollStreak cap can
+	// fire. Reset on any successful poll.
+	transientStreak := 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -187,8 +226,36 @@ func (a *Applier) Run(ctx context.Context) error {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return err
 			}
+			// Transient backend errors (idle-connection EOF, network
+			// timeouts, broker rebalances/leader elections) must NOT
+			// crash the process (issue #627): on managed Kafka surfaces
+			// such as Azure Event Hubs they recur on idle traffic and
+			// previously forced a full restart each time. Back off and
+			// retry; only hard-fatal errors stop the loop. A persistent
+			// outage is surfaced via warn logs + the
+			// entdb_applier_transient_poll_errors_total metric, and (if
+			// configured) the MaxTransientPollStreak cap.
+			if wal.IsTransient(err) {
+				transientStreak++
+				metrics.IncApplierTransientPollError()
+				if a.maxTransientStreak > 0 && transientStreak >= a.maxTransientStreak {
+					return fmt.Errorf("apply: poll batch: giving up after %d consecutive transient errors: %w", transientStreak, err)
+				}
+				wait := a.transientBackoffFor(transientStreak)
+				slog.WarnContext(ctx, "applier: transient WAL poll error; backing off and retrying",
+					"streak", transientStreak, "backoff", wait.String(), "error", err.Error())
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-a.stopCh:
+					return nil
+				case <-time.After(wait):
+				}
+				continue
+			}
 			return fmt.Errorf("apply: poll batch: %w", err)
 		}
+		transientStreak = 0
 		if len(records) == 0 {
 			continue
 		}
@@ -196,6 +263,25 @@ func (a *Applier) Run(ctx context.Context) error {
 			return err
 		}
 	}
+}
+
+// transientBackoffFor returns the capped-exponential backoff for the
+// given consecutive transient-error streak: base, 2×base, 4×base, …
+// capped at 30s. base is Options.TransientPollBackoff (default 1s).
+func (a *Applier) transientBackoffFor(streak int) time.Duration {
+	const maxBackoff = 30 * time.Second
+	base := a.transientBackoff
+	if base <= 0 {
+		base = time.Second
+	}
+	wait := base
+	for i := 1; i < streak && wait < maxBackoff; i++ {
+		wait *= 2
+	}
+	if wait > maxBackoff {
+		wait = maxBackoff
+	}
+	return wait
 }
 
 // processBatch applies one poll batch with cross-tenant parallelism
@@ -380,6 +466,20 @@ func (a *Applier) Stop() {
 // opens a BatchTxn, dispatches every op, and finalises with the
 // idempotency probe (inside-txn check).
 func (a *Applier) applyRecord(ctx context.Context, rec Record) Result {
+	// Continue the originating request's trace across the async WAL
+	// boundary (ADR-033 §5): extract the W3C context the ExecuteAtomic
+	// handler injected into the record headers. An apply span is started
+	// ONLY when the event was actually traced, so untraced events never
+	// spawn root traces on the hot apply path.
+	if len(rec.Headers) > 0 {
+		ctx = otel.GetTextMapPropagator().Extract(ctx, wal.HeaderCarrier(rec.Headers))
+		if trace.SpanContextFromContext(ctx).IsValid() {
+			var span trace.Span
+			ctx, span = otel.Tracer(applierTracerName).Start(ctx, "applier.apply")
+			defer span.End()
+		}
+	}
+
 	res := Result{Position: rec.Position}
 	ev, err := wal.DecodeEvent(rec.Value)
 	if err != nil {

--- a/server/go/internal/apply/transient_retry_test.go
+++ b/server/go/internal/apply/transient_retry_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// scriptedConsumer is a minimal wal.Consumer whose PollBatch returns a
+// scripted (records, error) per 1-based poll number and signals each
+// poll on pollCh so a test can observe whether Run retried (issue #627).
+type scriptedConsumer struct {
+	mu     sync.Mutex
+	n      int
+	pollCh chan int
+	poll   func(n int) ([]wal.Record, error)
+}
+
+func (c *scriptedConsumer) PollBatch(ctx context.Context, _ string, _ string, _ int, _ time.Duration) ([]wal.Record, error) {
+	c.mu.Lock()
+	c.n++
+	n := c.n
+	c.mu.Unlock()
+	select {
+	case c.pollCh <- n:
+	default:
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return c.poll(n)
+}
+
+func (c *scriptedConsumer) Commit(context.Context, string, wal.Record) error { return nil }
+
+func (c *scriptedConsumer) Subscribe(context.Context, string, string) (<-chan wal.Record, <-chan error, error) {
+	return nil, nil, errors.New("scriptedConsumer.Subscribe: unused")
+}
+
+func (c *scriptedConsumer) polls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+// transientPollErr mirrors what kafka.go's wrapPollErr produces for an
+// idle-connection EOF: tagged with both ErrWal and ErrTransient.
+func transientPollErr() error {
+	return fmt.Errorf("%w: %w: kafka poll: EOF", wal.ErrWal, wal.ErrTransient)
+}
+
+func newApplierWithConsumer(t *testing.T, c wal.Consumer, opts apply.Options) *apply.Applier {
+	t.Helper()
+	dir := t.TempDir()
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	gs, err := globalstore.New(globalstore.Options{DataDir: dir, WALMode: true})
+	if err != nil {
+		t.Fatalf("globalstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = gs.Close() })
+
+	opts.Store = cs
+	opts.Global = gs
+	opts.Consumer = c
+	opts.Topic = "entdb-wal-transient-test"
+	opts.GroupID = "applier-transient-test"
+	a, err := apply.New(opts)
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	return a
+}
+
+func waitForPolls(t *testing.T, ch <-chan int, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case n := <-ch:
+			if n >= want {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("applier did not reach poll #%d within %s — it exited on the transient WAL error instead of retrying (issue #627)", want, timeout)
+		}
+	}
+}
+
+// TestApplier_RetriesTransientPollError surfaces issue #627: a transient
+// WAL poll error (e.g. Azure Event Hubs idle-connection EOF) must NOT
+// crash the applier. The fake returns a transient error on the first
+// poll, then drains empty; the applier must keep polling rather than
+// return the error. Pre-fix, Run returns on poll #1 and never reaches
+// poll #2, so waitForPolls fails.
+func TestApplier_RetriesTransientPollError(t *testing.T) {
+	c := &scriptedConsumer{
+		pollCh: make(chan int, 128),
+		poll: func(n int) ([]wal.Record, error) {
+			if n == 1 {
+				return nil, transientPollErr()
+			}
+			return nil, nil // drained
+		},
+	}
+	a := newApplierWithConsumer(t, c, apply.Options{TransientPollBackoff: time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- a.Run(ctx) }()
+
+	// Must poll at least twice: transient error on #1, retry on #2.
+	waitForPolls(t, c.pollCh, 2, 3*time.Second)
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned %v; want context.Canceled (the transient error must be retried, not surfaced)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// TestApplier_FatalPollErrorExits ensures the retry path does not swallow
+// genuinely-fatal poll errors: a non-transient error still stops Run.
+func TestApplier_FatalPollErrorExits(t *testing.T) {
+	fatal := fmt.Errorf("%w: kafka poll: SASL authentication failed", wal.ErrWal)
+	c := &scriptedConsumer{
+		pollCh: make(chan int, 128),
+		poll:   func(int) ([]wal.Record, error) { return nil, fatal },
+	}
+	a := newApplierWithConsumer(t, c, apply.Options{TransientPollBackoff: time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- a.Run(ctx) }()
+	select {
+	case err := <-errCh:
+		if err == nil || errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned %v; a fatal poll error must stop the applier", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit on a fatal poll error")
+	}
+}
+
+// TestApplier_GivesUpAfterMaxTransientStreak verifies the opt-in safety
+// valve: with a cap set, persistent transient errors eventually exit
+// (after at least the cap's worth of retries, not on the first error).
+func TestApplier_GivesUpAfterMaxTransientStreak(t *testing.T) {
+	c := &scriptedConsumer{
+		pollCh: make(chan int, 128),
+		poll:   func(int) ([]wal.Record, error) { return nil, transientPollErr() },
+	}
+	a := newApplierWithConsumer(t, c, apply.Options{
+		TransientPollBackoff:   time.Millisecond,
+		MaxTransientPollStreak: 3,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- a.Run(ctx) }()
+	select {
+	case err := <-errCh:
+		if err == nil || errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned %v; want a give-up error after the transient streak cap", err)
+		}
+		if !errors.Is(err, wal.ErrTransient) {
+			t.Errorf("give-up error should wrap the transient cause: %v", err)
+		}
+		if got := c.polls(); got < 3 {
+			t.Errorf("expected >=3 retries before giving up, got %d polls (pre-fix it exits on the first error)", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not give up after MaxTransientPollStreak transient errors")
+	}
+}

--- a/server/go/internal/metrics/applier.go
+++ b/server/go/internal/metrics/applier.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// applierTransientPollErrors counts transient WAL poll errors the
+// applier retried (with backoff) instead of exiting the process. A
+// rising rate signals broker instability (e.g. idle-connection reaping
+// on Azure Event Hubs) without the old crash-loop behaviour. See
+// issue #627.
+var applierTransientPollErrors = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: "entdb_applier_transient_poll_errors_total",
+		Help: "Transient WAL poll errors the applier retried instead of exiting (issue #627).",
+	},
+)
+
+func init() {
+	prometheus.MustRegister(applierTransientPollErrors)
+}
+
+// IncApplierTransientPollError records one retried transient WAL poll
+// error.
+func IncApplierTransientPollError() {
+	applierTransientPollErrors.Inc()
+}
+
+// ApplierTransientPollErrorsCollector exposes the collector so tests can
+// register it against a fresh registry without polluting the default
+// one.
+func ApplierTransientPollErrorsCollector() prometheus.Collector {
+	return applierTransientPollErrors
+}

--- a/server/go/internal/metrics/grpc.go
+++ b/server/go/internal/metrics/grpc.go
@@ -12,9 +12,11 @@
 package metrics
 
 import (
+	"context"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // latencyBuckets is the histogram bucket layout used by gRPC latency
@@ -50,9 +52,22 @@ func init() {
 // way out. It increments the per-(method,status) counter and observes the
 // per-method latency histogram. The Prometheus client is cheap so we always
 // record; an HTTP scrape endpoint is wired separately.
-func RecordGRPCRequest(method, status string, duration time.Duration) {
+//
+// When ctx carries a sampled OpenTelemetry span (an incoming traceparent,
+// ADR-033), the latency observation is recorded with a trace_id exemplar so
+// a slow request on a dashboard links straight to its trace. Exemplars are
+// only attached for sampled spans (an unsampled/absent trace is observed
+// without one).
+func RecordGRPCRequest(ctx context.Context, method, status string, duration time.Duration) {
 	grpcRequests.WithLabelValues(method, status).Inc()
-	grpcLatency.WithLabelValues(method).Observe(duration.Seconds())
+	obs := grpcLatency.WithLabelValues(method)
+	if eo, ok := obs.(prometheus.ExemplarObserver); ok {
+		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() && sc.IsSampled() {
+			eo.ObserveWithExemplar(duration.Seconds(), prometheus.Labels{"trace_id": sc.TraceID().String()})
+			return
+		}
+	}
+	obs.Observe(duration.Seconds())
 }
 
 // Collectors returns the package's collectors. Tests use this to register

--- a/server/go/internal/metrics/grpc_test.go
+++ b/server/go/internal/metrics/grpc_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -18,7 +19,7 @@ func TestRecordGRPCRequestIncrementsCounterAndHistogram(t *testing.T) {
 	beforeCount := testutil.ToFloat64(grpcRequests.WithLabelValues(method, statusOK))
 	beforeHist := histogramSampleCount(t, grpcLatency.WithLabelValues(method))
 
-	RecordGRPCRequest(method, statusOK, 50*time.Millisecond)
+	RecordGRPCRequest(context.Background(), method, statusOK, 50*time.Millisecond)
 
 	afterCount := testutil.ToFloat64(grpcRequests.WithLabelValues(method, statusOK))
 	if afterCount-beforeCount != 1 {
@@ -37,9 +38,9 @@ func TestRecordGRPCRequestSeparatesStatusLabels(t *testing.T) {
 	beforeOK := testutil.ToFloat64(grpcRequests.WithLabelValues(method, "OK"))
 	beforeErr := testutil.ToFloat64(grpcRequests.WithLabelValues(method, "INTERNAL"))
 
-	RecordGRPCRequest(method, "OK", time.Millisecond)
-	RecordGRPCRequest(method, "OK", time.Millisecond)
-	RecordGRPCRequest(method, "INTERNAL", time.Millisecond)
+	RecordGRPCRequest(context.Background(), method, "OK", time.Millisecond)
+	RecordGRPCRequest(context.Background(), method, "OK", time.Millisecond)
+	RecordGRPCRequest(context.Background(), method, "INTERNAL", time.Millisecond)
 
 	if got := testutil.ToFloat64(grpcRequests.WithLabelValues(method, "OK")) - beforeOK; got != 2 {
 		t.Errorf("OK delta = %v, want 2", got)

--- a/server/go/internal/observability/grpc_logging.go
+++ b/server/go/internal/observability/grpc_logging.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package observability
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// accessLogSkip is the set of high-frequency methods omitted from the
+// per-request access log to avoid drowning real traffic in health-probe
+// noise (orchestrators poll Health every few seconds).
+var accessLogSkip = map[string]struct{}{
+	"/entdb.v1.EntDBService/Health": {},
+	"/grpc.health.v1.Health/Check":  {},
+}
+
+// AccessLogUnaryInterceptor emits exactly one structured log line per
+// unary RPC, carrying the method, gRPC status, and latency. Because it
+// logs with the request context, the trace-correlating slog handler
+// (see Init) stamps trace_id/span_id onto the line — so every request
+// has a log entry tagged with the same correlation id as its trace and
+// metric exemplar (ADR-033).
+//
+// Install it as the OUTERMOST interceptor so it records the final status
+// of every request, including those rejected by auth.
+func AccessLogUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if _, skip := accessLogSkip[info.FullMethod]; skip {
+			return handler(ctx, req)
+		}
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		logRequest(ctx, info.FullMethod, err, time.Since(start))
+		return resp, err
+	}
+}
+
+// AccessLogStreamInterceptor is the streaming counterpart of
+// AccessLogUnaryInterceptor.
+func AccessLogStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if _, skip := accessLogSkip[info.FullMethod]; skip {
+			return handler(srv, ss)
+		}
+		start := time.Now()
+		err := handler(srv, ss)
+		logRequest(ss.Context(), info.FullMethod, err, time.Since(start))
+		return err
+	}
+}
+
+func logRequest(ctx context.Context, method string, err error, elapsed time.Duration) {
+	code := status.Code(err)
+	level := slog.LevelInfo
+	if code != codes.OK {
+		level = slog.LevelWarn
+	}
+	attrs := []slog.Attr{
+		slog.String("method", method),
+		slog.String("grpc_code", code.String()),
+		slog.Int64("latency_ms", elapsed.Milliseconds()),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("error", err.Error()))
+	}
+	// LogAttrs with ctx so the trace handler can attach trace_id/span_id.
+	slog.Default().LogAttrs(ctx, level, "grpc request", attrs...)
+}

--- a/server/go/internal/observability/grpc_logging_test.go
+++ b/server/go/internal/observability/grpc_logging_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// withBufferedTraceLogger installs a JSON slog default wrapped in the
+// trace handler (so trace_id/span_id are stamped) and returns the buffer
+// + a restore func.
+func withBufferedTraceLogger(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(&traceHandler{Handler: slog.NewJSONHandler(&buf, nil)}))
+	return &buf, func() { slog.SetDefault(prev) }
+}
+
+func TestAccessLogUnaryInterceptor_LogsMethodStatusLatencyAndTraceID(t *testing.T) {
+	buf, restore := withBufferedTraceLogger(t)
+	defer restore()
+
+	ctx, traceID, spanID := tracedCtx(t)
+	_, err := AccessLogUnaryInterceptor()(
+		ctx, "req",
+		&grpc.UnaryServerInfo{FullMethod: "/entdb.v1.EntDBService/GetNode"},
+		func(context.Context, any) (any, error) { return "ok", nil },
+	)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("access log not JSON: %v\n%s", err, buf.String())
+	}
+	if rec["msg"] != "grpc request" {
+		t.Errorf("msg = %v", rec["msg"])
+	}
+	if rec["method"] != "/entdb.v1.EntDBService/GetNode" {
+		t.Errorf("method = %v", rec["method"])
+	}
+	if rec["grpc_code"] != "OK" {
+		t.Errorf("grpc_code = %v, want OK", rec["grpc_code"])
+	}
+	if _, ok := rec["latency_ms"]; !ok {
+		t.Error("missing latency_ms")
+	}
+	if rec["trace_id"] != traceID.String() {
+		t.Errorf("trace_id = %v, want %s", rec["trace_id"], traceID)
+	}
+	if rec["span_id"] != spanID.String() {
+		t.Errorf("span_id = %v, want %s", rec["span_id"], spanID)
+	}
+}
+
+func TestAccessLogUnaryInterceptor_ErrorStatusLogsWarn(t *testing.T) {
+	buf, restore := withBufferedTraceLogger(t)
+	defer restore()
+
+	_, _ = AccessLogUnaryInterceptor()(
+		context.Background(), "req",
+		&grpc.UnaryServerInfo{FullMethod: "/svc/M"},
+		func(context.Context, any) (any, error) { return nil, status.Error(codes.NotFound, "nope") },
+	)
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if rec["grpc_code"] != "NotFound" {
+		t.Errorf("grpc_code = %v, want NotFound", rec["grpc_code"])
+	}
+	if rec["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN for a non-OK status", rec["level"])
+	}
+}
+
+func TestAccessLogUnaryInterceptor_SkipsHealthProbes(t *testing.T) {
+	buf, restore := withBufferedTraceLogger(t)
+	defer restore()
+
+	called := false
+	_, _ = AccessLogUnaryInterceptor()(
+		context.Background(), "req",
+		&grpc.UnaryServerInfo{FullMethod: "/grpc.health.v1.Health/Check"},
+		func(context.Context, any) (any, error) { called = true; return "ok", nil },
+	)
+	if !called {
+		t.Error("handler must still run for health probes")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("health probes must not be access-logged, got: %s", buf.String())
+	}
+}

--- a/server/go/internal/observability/logging.go
+++ b/server/go/internal/observability/logging.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package observability
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// setupLogger installs a process-wide structured slog default whose
+// handler stamps trace_id/span_id onto every record carrying a traced
+// context (ADR-033). Existing slog.*Context call sites
+// (internal/errs/sanitize.go, internal/audit/*) gain trace correlation
+// with no call-site changes.
+func setupLogger(cfg Config) {
+	w := cfg.LogWriter
+	if w == nil {
+		w = os.Stderr
+	}
+	opts := &slog.HandlerOptions{Level: cfg.LogLevel}
+
+	var base slog.Handler
+	if strings.EqualFold(strings.TrimSpace(cfg.LogFormat), "json") {
+		base = slog.NewJSONHandler(w, opts)
+	} else {
+		base = slog.NewTextHandler(w, opts)
+	}
+	slog.SetDefault(slog.New(&traceHandler{Handler: base}))
+}
+
+// traceHandler decorates a base slog.Handler so every record carrying a
+// ctx with a valid OpenTelemetry span context is enriched with the
+// trace_id and span_id, tying logs to traces and (via exemplars)
+// metrics.
+type traceHandler struct {
+	slog.Handler
+}
+
+func (h *traceHandler) Handle(ctx context.Context, r slog.Record) error {
+	if ctx != nil {
+		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+			r.AddAttrs(
+				slog.String("trace_id", sc.TraceID().String()),
+				slog.String("span_id", sc.SpanID().String()),
+			)
+		}
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+func (h *traceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &traceHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+func (h *traceHandler) WithGroup(name string) slog.Handler {
+	return &traceHandler{Handler: h.Handler.WithGroup(name)}
+}

--- a/server/go/internal/observability/observability.go
+++ b/server/go/internal/observability/observability.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package observability bootstraps the EntDB server's tracing, logging,
+// and metric-correlation pipeline per ADR-033.
+//
+// The headline capability is: accept an incoming W3C `traceparent` on
+// every RPC and thread the resulting trace id through all three
+// observability signals.
+//
+//   - A global W3C TraceContext+Baggage propagator is installed so the
+//     gRPC StatsHandler (wired in cmd/entdb-server) parses an upstream
+//     traceparent into the request context.
+//   - A real TracerProvider is ALWAYS configured (so a valid trace id is
+//     available for log/metric correlation), but span EXPORT is opt-in:
+//     an OTLP/gRPC exporter is attached only when an endpoint is set.
+//   - A structured slog default is installed whose handler stamps
+//     trace_id/span_id onto every record carrying a traced context.
+//
+// Init is side-effect-free with respect to the network unless an OTLP
+// endpoint is configured — mirroring how --metrics-addr defaults off.
+package observability
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// ServiceName is the service.name resource attribute attached to every
+// span and reported to collectors.
+const ServiceName = "entdb-server"
+
+// Config configures the observability bootstrap. The zero value is
+// valid: no exporter, text logs at info level to stderr.
+type Config struct {
+	// ServiceVersion is the service.version resource attribute. Empty is
+	// fine (attribute omitted).
+	ServiceVersion string
+
+	// OTLPEndpoint, when non-empty, attaches an OTLP/gRPC span exporter
+	// pointing at this host:port (or URL). Empty disables span export;
+	// the standard OTEL_EXPORTER_OTLP_ENDPOINT env var is consulted as a
+	// fallback so the flag and the env both work.
+	OTLPEndpoint string
+
+	// OTLPInsecure disables transport security for the OTLP exporter
+	// (plaintext gRPC). For local collectors only.
+	OTLPInsecure bool
+
+	// LogFormat selects the base slog handler: "json" or "text"
+	// (default "text").
+	LogFormat string
+
+	// LogLevel is the minimum slog level (default slog.LevelInfo).
+	LogLevel slog.Level
+
+	// LogWriter is where logs are written (default os.Stderr).
+	LogWriter io.Writer
+}
+
+// Init installs the global propagator, tracer provider, and structured
+// logger, and returns a shutdown function that flushes and closes the
+// span pipeline. Init is safe to call once at process start.
+//
+// The returned shutdown function is always non-nil (a no-op when nothing
+// needs flushing), so callers can defer it unconditionally.
+func Init(ctx context.Context, cfg Config) (shutdown func(context.Context) error, err error) {
+	// Logging first so any later setup failures are structured.
+	setupLogger(cfg)
+
+	// W3C propagator: makes an incoming traceparent the parent of our
+	// server span, and lets us inject it into outgoing calls / WAL
+	// headers. Composite with Baggage for general OTel interop.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	res := resource.NewSchemaless(serviceAttrs(cfg)...)
+
+	opts := []sdktrace.TracerProviderOption{
+		sdktrace.WithResource(res),
+		// ParentBased(AlwaysSample): honor an upstream sampling decision
+		// when present, otherwise sample roots. Trace ids are available
+		// for log/metric correlation regardless of the sampling decision
+		// or whether an exporter is attached.
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())),
+	}
+
+	endpoint := strings.TrimSpace(cfg.OTLPEndpoint)
+	envEndpoint := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")) +
+		strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"))
+	var exporter sdktrace.SpanExporter
+	if endpoint != "" || envEndpoint != "" {
+		exporter, err = newOTLPExporter(ctx, endpoint, cfg.OTLPInsecure)
+		if err != nil {
+			return func(context.Context) error { return nil }, fmt.Errorf("observability: otlp exporter: %w", err)
+		}
+		opts = append(opts, sdktrace.WithBatcher(exporter))
+		slog.Info("tracing: OTLP span export enabled", "endpoint", endpointOrEnv(endpoint, envEndpoint), "insecure", cfg.OTLPInsecure)
+	} else {
+		slog.Info("tracing: incoming traceparent honored; span export OFF (no --otlp-endpoint)")
+	}
+
+	tp := sdktrace.NewTracerProvider(opts...)
+	otel.SetTracerProvider(tp)
+
+	return func(shutdownCtx context.Context) error {
+		// tp.Shutdown flushes the batch processor and closes the
+		// exporter underneath it.
+		return tp.Shutdown(shutdownCtx)
+	}, nil
+}
+
+// newOTLPExporter builds an OTLP/gRPC trace exporter. When endpoint is
+// empty the exporter falls back to the standard OTEL_EXPORTER_OTLP_*
+// environment variables.
+func newOTLPExporter(ctx context.Context, endpoint string, insecure bool) (sdktrace.SpanExporter, error) {
+	expOpts := []otlptracegrpc.Option{}
+	if endpoint != "" {
+		expOpts = append(expOpts, otlptracegrpc.WithEndpoint(endpoint))
+	}
+	if insecure {
+		expOpts = append(expOpts, otlptracegrpc.WithInsecure())
+	}
+	return otlptracegrpc.New(ctx, expOpts...)
+}
+
+func serviceAttrs(cfg Config) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{attribute.String("service.name", ServiceName)}
+	if v := strings.TrimSpace(cfg.ServiceVersion); v != "" {
+		attrs = append(attrs, attribute.String("service.version", v))
+	}
+	return attrs
+}
+
+func endpointOrEnv(flagEndpoint, envEndpoint string) string {
+	if flagEndpoint != "" {
+		return flagEndpoint
+	}
+	return "env:OTEL_EXPORTER_OTLP_ENDPOINT"
+}

--- a/server/go/internal/observability/observability_test.go
+++ b/server/go/internal/observability/observability_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func tracedCtx(t *testing.T) (context.Context, trace.TraceID, trace.SpanID) {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex("11112222333344445555666677778888")
+	if err != nil {
+		t.Fatalf("trace id: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("1111222233334444")
+	if err != nil {
+		t.Fatalf("span id: %v", err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled})
+	return trace.ContextWithSpanContext(context.Background(), sc), traceID, spanID
+}
+
+// TestTraceHandlerStampsTraceAndSpanID verifies request-path logs carry
+// trace_id/span_id when the ctx is traced (ADR-033 §3) — the property
+// that ties logs to traces with no call-site changes.
+func TestTraceHandlerStampsTraceAndSpanID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(&traceHandler{Handler: slog.NewJSONHandler(&buf, nil)})
+
+	ctx, traceID, spanID := tracedCtx(t)
+	logger.InfoContext(ctx, "internal error sanitized for client", "op", "GetNode")
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("log line is not JSON: %v\n%s", err, buf.String())
+	}
+	if got := rec["trace_id"]; got != traceID.String() {
+		t.Errorf("trace_id = %v, want %s", got, traceID)
+	}
+	if got := rec["span_id"]; got != spanID.String() {
+		t.Errorf("span_id = %v, want %s", got, spanID)
+	}
+}
+
+func TestTraceHandlerNoStampWithoutSpan(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(&traceHandler{Handler: slog.NewJSONHandler(&buf, nil)})
+	logger.InfoContext(context.Background(), "no span here")
+	if strings.Contains(buf.String(), "trace_id") {
+		t.Errorf("trace_id must not be stamped without an active span: %s", buf.String())
+	}
+}
+
+// TestInitInstallsW3CPropagator verifies Init wires the global W3C
+// propagator so an incoming traceparent is extracted into a valid span
+// context — the entry point the gRPC StatsHandler relies on (ADR-033 §1).
+func TestInitInstallsW3CPropagator(t *testing.T) {
+	shutdown, err := Init(context.Background(), Config{})
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+
+	carrier := propagation.MapCarrier{
+		"traceparent": "00-11112222333344445555666677778888-1111222233334444-01",
+	}
+	ctx := otel.GetTextMapPropagator().Extract(context.Background(), carrier)
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		t.Fatal("global propagator did not extract a valid span context from an incoming traceparent")
+	}
+	if got := sc.TraceID().String(); got != "11112222333344445555666677778888" {
+		t.Errorf("extracted trace id = %s", got)
+	}
+	if !sc.IsSampled() {
+		t.Error("extracted span context should be sampled (flags=01)")
+	}
+}

--- a/server/go/internal/wal/kafka.go
+++ b/server/go/internal/wal/kafka.go
@@ -41,6 +41,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -691,6 +693,54 @@ func (c *saramaConsumer) ConsumeClaim(
 	}
 }
 
+// isTransientConsumerErr reports whether a sarama consumer error is
+// operationally transient (retryable) rather than deployment-fatal.
+// Idle-connection reaping (io.EOF), network read/write timeouts, broker
+// rebalances, and leader elections are transient and recur against
+// managed Kafka surfaces (notably Azure Event Hubs, which reaps idle
+// consumer sockets); auth failures and a genuinely-missing topic are
+// not. See issue #627.
+func isTransientConsumerErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, sarama.ErrOutOfBrokers) ||
+		errors.Is(err, sarama.ErrUnknownTopicOrPartition) ||
+		errors.Is(err, sarama.ErrNotLeaderForPartition) ||
+		errors.Is(err, sarama.ErrLeaderNotAvailable) ||
+		errors.Is(err, sarama.ErrBrokerNotAvailable) ||
+		errors.Is(err, sarama.ErrNetworkException) ||
+		errors.Is(err, sarama.ErrRequestTimedOut) {
+		return true
+	}
+	// sarama surfaces broker/transport errors wrapped in a
+	// *ConsumerError that does not Unwrap to its cause on older versions;
+	// recurse into the cause so io.EOF / net timeouts nested inside one
+	// are still classified.
+	var ce *sarama.ConsumerError
+	if errors.As(err, &ce) && ce != nil && ce.Err != nil && ce.Err != err {
+		return isTransientConsumerErr(ce.Err)
+	}
+	return false
+}
+
+// wrapPollErr wraps a consumer poll error under ErrWal, additionally
+// tagging it ErrTransient when it is operationally transient so the
+// applier retries with backoff instead of exiting the process (#627).
+func wrapPollErr(err error) error {
+	if isTransientConsumerErr(err) {
+		return fmt.Errorf("%w: %w: kafka poll: %v", ErrWal, ErrTransient, err)
+	}
+	return fmt.Errorf("%w: kafka poll: %v", ErrWal, err)
+}
+
 // poll drains up to maxRecords from c.msgs, blocking up to timeout.
 func (c *saramaConsumer) poll(ctx context.Context, maxRecords int, timeout time.Duration) ([]Record, error) {
 	deadline := time.NewTimer(timeout)
@@ -708,7 +758,7 @@ func (c *saramaConsumer) poll(ctx context.Context, maxRecords int, timeout time.
 			if err == nil {
 				continue
 			}
-			return nil, fmt.Errorf("%w: kafka poll: %v", ErrWal, err)
+			return nil, wrapPollErr(err)
 		case msg, ok := <-c.msgs:
 			if !ok {
 				return out, nil

--- a/server/go/internal/wal/trace_headers.go
+++ b/server/go/internal/wal/trace_headers.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package wal
+
+// W3C Trace Context header keys carried on WAL records so a request's
+// trace survives the async hop from the ExecuteAtomic handler (which
+// appends) to the applier (which writes SQLite later, on a different
+// goroutine + context). See ADR-033 §5.
+//
+// They ride alongside HeaderIdempotencyKey in Record.Headers and never
+// touch the Event JSON body, so the cross-impl contract byte layout
+// (ADR-006/ADR-018) and replay determinism are unaffected.
+const (
+	HeaderTraceparent = "traceparent"
+	HeaderTracestate  = "tracestate"
+)
+
+// HeaderCarrier adapts a WAL Record.Headers map to the
+// propagation.TextMapCarrier interface (Get/Set/Keys) so the global
+// OpenTelemetry propagator can Inject into / Extract from WAL headers.
+// It is intentionally defined here (not in a tracing package) so the
+// wal package stays free of any OpenTelemetry import — the interface is
+// satisfied structurally.
+type HeaderCarrier map[string][]byte
+
+// Get returns the value for key, or "" if absent.
+func (c HeaderCarrier) Get(key string) string {
+	if v, ok := c[key]; ok {
+		return string(v)
+	}
+	return ""
+}
+
+// Set stores value under key.
+func (c HeaderCarrier) Set(key, value string) {
+	c[key] = []byte(value)
+}
+
+// Keys returns the header names currently present.
+func (c HeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/server/go/internal/wal/transient.go
+++ b/server/go/internal/wal/transient.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package wal
+
+import "errors"
+
+// ErrTransient marks a WAL error that is operationally transient — the
+// caller (the applier consumer loop) should retry with backoff rather
+// than treat it as fatal and exit the process.
+//
+// Backends wrap their transient causes with this sentinel (in addition
+// to ErrWal) so the applier can distinguish "retry" from "deployment
+// fatal" without re-classifying backend-specific error types itself.
+// Transient causes include idle-connection reaping (io.EOF), network
+// read/write timeouts, broker rebalances, and leader elections — the
+// errors that recur against managed Kafka surfaces such as Azure Event
+// Hubs and must not crash-loop the server. See issue #627.
+var ErrTransient = errors.New("wal: transient error")
+
+// IsTransient reports whether err is an operationally-transient WAL
+// error that the consumer loop should retry with backoff instead of
+// treating as fatal. It is the public classifier each backend's
+// transient tagging feeds into.
+func IsTransient(err error) bool {
+	return errors.Is(err, ErrTransient)
+}

--- a/server/go/internal/wal/transient_test.go
+++ b/server/go/internal/wal/transient_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package wal
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+// fakeTimeoutErr implements net.Error with Timeout()==true, mirroring a
+// "read tcp ...: i/o timeout" surfaced by sarama on idle-connection
+// reaping (issue #627).
+type fakeTimeoutErr struct{}
+
+func (fakeTimeoutErr) Error() string   { return "read tcp 10.0.8.4:52494->broker:9093: i/o timeout" }
+func (fakeTimeoutErr) Timeout() bool   { return true }
+func (fakeTimeoutErr) Temporary() bool { return true }
+
+func TestIsTransientConsumerErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"io.EOF (idle-connection reap)", io.EOF, true},
+		{"wrapped io.EOF", fmt.Errorf("consume: %w", io.EOF), true},
+		{"net timeout", fakeTimeoutErr{}, true},
+		{"out of brokers (leader election)", sarama.ErrOutOfBrokers, true},
+		{"unknown topic/partition (rebalance)", sarama.ErrUnknownTopicOrPartition, true},
+		{"leader not available", sarama.ErrLeaderNotAvailable, true},
+		{"ConsumerError wrapping EOF", &sarama.ConsumerError{Topic: "entdb-wal", Partition: 2, Err: io.EOF}, true},
+		{"generic error", errors.New("boom"), false},
+		{"sasl/auth-like error", errors.New("kafka: SASL authentication failed"), false},
+		{"closed consumer group (shutdown, not transient)", sarama.ErrClosedConsumerGroup, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		if got := isTransientConsumerErr(tc.err); got != tc.want {
+			t.Errorf("%s: isTransientConsumerErr(%v) = %v, want %v", tc.name, tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestWrapPollErrTagsTransient(t *testing.T) {
+	// A transient cause is tagged ErrTransient AND ErrWal.
+	transient := wrapPollErr(io.EOF)
+	if !IsTransient(transient) {
+		t.Errorf("wrapPollErr(io.EOF) should be transient: %v", transient)
+	}
+	if !errors.Is(transient, ErrWal) {
+		t.Errorf("wrapPollErr(io.EOF) should also be ErrWal: %v", transient)
+	}
+
+	// A fatal cause is ErrWal but NOT ErrTransient.
+	fatal := wrapPollErr(errors.New("kafka: SASL authentication failed"))
+	if IsTransient(fatal) {
+		t.Errorf("wrapPollErr(auth error) must NOT be transient: %v", fatal)
+	}
+	if !errors.Is(fatal, ErrWal) {
+		t.Errorf("wrapPollErr(auth error) should be ErrWal: %v", fatal)
+	}
+}

--- a/tests/python/unit/test_trace_propagation.py
+++ b/tests/python/unit/test_trace_propagation.py
@@ -1,0 +1,59 @@
+"""Unit tests for W3C trace-context propagation in the Python SDK.
+
+ADR-033 §6: the SDK injects the caller's active OpenTelemetry span as a
+``traceparent`` gRPC metadata header so the server continues the trace.
+Injection is a no-op without an active span. Because every RPC funnels
+through ``_GrpcClient._build_metadata``, injecting there covers all
+methods uniformly.
+"""
+
+from __future__ import annotations
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from entdb_sdk._tracing import inject_trace_context
+
+
+def _tracer() -> trace.Tracer:
+    # A bare provider mints valid sampled span contexts; no exporter is
+    # needed because the SDK only PROPAGATES (the server exports).
+    return TracerProvider().get_tracer("entdb-sdk-test")
+
+
+def test_inject_adds_traceparent_for_active_span() -> None:
+    with _tracer().start_as_current_span("client-call") as span:
+        md: list[tuple[str, str]] = []
+        inject_trace_context(md)
+        keys = {k for k, _ in md}
+        assert "traceparent" in keys, f"traceparent not injected: {md}"
+        trace_id_hex = format(span.get_span_context().trace_id, "032x")
+        traceparent = next(v for k, v in md if k == "traceparent")
+        assert trace_id_hex in traceparent, f"{traceparent!r} missing {trace_id_hex}"
+
+
+def test_inject_is_noop_without_active_span() -> None:
+    md: list[tuple[str, str]] = []
+    inject_trace_context(md)
+    assert md == [], f"traceparent must not be injected without an active span: {md}"
+
+
+def test_inject_preserves_existing_metadata() -> None:
+    with _tracer().start_as_current_span("client-call"):
+        md: list[tuple[str, str]] = [("authorization", "Bearer tok")]
+        inject_trace_context(md)
+        keys = {k for k, _ in md}
+        assert "authorization" in keys, "existing auth header dropped"
+        assert "traceparent" in keys, "traceparent not added alongside auth"
+
+
+def test_build_metadata_injects_traceparent() -> None:
+    """_build_metadata (the per-RPC chokepoint) wires injection so all
+    methods propagate the trace."""
+    from entdb_sdk._grpc_client import GrpcClient
+
+    client = GrpcClient.__new__(GrpcClient)
+    client._api_key = None  # type: ignore[attr-defined]
+    with _tracer().start_as_current_span("client-call"):
+        md = client._build_metadata()
+        assert any(k == "traceparent" for k, _ in md), f"_build_metadata omitted traceparent: {md}"

--- a/tests/python/unit/test_trace_propagation.py
+++ b/tests/python/unit/test_trace_propagation.py
@@ -9,10 +9,18 @@ methods uniformly.
 
 from __future__ import annotations
 
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
+import pytest
 
 from entdb_sdk._tracing import inject_trace_context
+
+# OpenTelemetry is the SDK's OPTIONAL [tracing] extra; skip these tests
+# when it isn't installed (e.g. a minimal CI unit-test env) rather than
+# failing collection. The no-otel behaviour (injection is a no-op) is the
+# SDK's contract and is covered by the SDK shipping without this extra.
+pytest.importorskip("opentelemetry.sdk.trace")
+
+from opentelemetry import trace  # noqa: E402  (after importorskip guard)
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
 
 
 def _tracer() -> trace.Tracer:


### PR DESCRIPTION
## What

Two things, shipped together:

### 1. Accept incoming W3C `traceparent` across logs, traces, and metrics (ADR-033)
- **Extraction**: otelgrpc `StatsHandler` + global W3C `TraceContext`+`Baggage` propagator — every RPC continues an upstream `traceparent` (or starts a fresh root). Always-on `TracerProvider` so a `trace_id` exists for correlation even when nothing is exported.
- **Export**: opt-in OTLP/gRPC via `--otlp-endpoint` (off by default; also honors `OTEL_EXPORTER_OTLP_ENDPOINT`).
- **Logs**: structured `slog` default stamps `trace_id`/`span_id` onto context-aware log lines; a **per-request access-log interceptor** emits one trace-tagged line per RPC (`method`/`grpc_code`/`latency_ms`).
- **Metrics**: `trace_id` exemplars on `entdb_grpc_latency_seconds`; `/metrics` served with OpenMetrics.
- **Async boundary**: trace context rides WAL record headers so the applier continues the trace across the apply hop (`applier.apply` span). Not in the event body (preserves replay determinism / wire contract).
- **SDKs (both)**: Go + Python inject the caller's active span as a `traceparent` on every RPC; no-op without an active OpenTelemetry span. `WithoutTracePropagation()` opts out (Go).

### 2. Fix #627 — applier crash-loop on transient Kafka errors
`apply.Applier.Run` treated every `PollBatch` error as fatal, crash-looping the process on transient errors (idle-connection EOF, net timeouts, rebalances) — a recurring outage on Azure Event Hubs. Adds `wal.ErrTransient`/`wal.IsTransient`, a Kafka transient classifier, and retry-with-capped-backoff in the applier (optional `MaxTransientPollStreak` cap, `entdb_applier_transient_poll_errors_total` metric). **Surfacing tests fail pre-fix, pass post-fix.**

## Tests (local, green)
- All 4 Go modules: `go vet` + `go test` ✅
- Python integration contract suite: **118 passed** ✅
- New unit tests: server observability (trace handler, propagator, access log), metric/applier, both SDK injectors, #627 surfacing tests ✅
- `ruff check` + `format --check` clean ✅
- `docs/generated/sdk-go.md` regenerated with pinned Go 1.25 ✅

## Deferred (design captured, not implemented)
- ADR-034 → #625 (S3/object-store restore)
- ADR-035 → #626 (persist schema catalog in SQLite)

Closes #627.