### PR TITLE
fix(store): invalidate index cache on rollback to prevent applier FTS crash (#629)

### DIFF
--- a/server/go/internal/apply/fts_rollback_test.go
+++ b/server/go/internal/apply/fts_rollback_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// mkRegisterSchemaSearchable builds a register_schema op for a type whose
+// single string field is searchable, so create_node triggers FTS5 index
+// creation (EnsureFTSIndexConn) inside the apply batch.
+func mkRegisterSchemaSearchable() map[string]any {
+	return map[string]any{
+		"op": string(apply.OpRegisterSchema),
+		"node_types": []any{
+			map[string]any{
+				"type_id": 1,
+				"name":    "Doc",
+				"fields": []any{
+					map[string]any{"field_id": 1, "name": "body", "kind": "str", "searchable": true},
+				},
+			},
+		},
+	}
+}
+
+// TestApplier_FTSWriteAfterRolledBackBatch is the end-to-end (#629)
+// regression: it drives the REAL applier crash sequence rather than the
+// store internals.
+//
+// Batch A registers a searchable type and creates a node (creating the
+// fts_t1 virtual table) but its in-batch CAS update misses, so the whole
+// batch fails its precondition and rolls back — SQLite reverts the CREATE
+// VIRTUAL TABLE. Before the fix, the process-local index cache still
+// recorded fts_t1 as present, so Batch B (a valid write of the same type)
+// cache-hit, skipped re-creating the table, and the applier crashed with
+// "no such table: fts_t1". After the fix, Rollback invalidated the cache
+// and Batch B re-creates the table and applies cleanly.
+func TestApplier_FTSWriteAfterRolledBackBatch(t *testing.T) {
+	t.Parallel()
+	reg := schema.NewRegistry()
+	f := newFixtureWithRegistry(t, reg)
+
+	batchA := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "rb-a", TsMs: 1700000000000,
+		Ops: []map[string]any{
+			mkRegisterSchemaSearchable(),
+			mkCreateNode("n1", 1, map[string]any{"1": "the quick brown fox"}),
+			// CAS update of the just-created n1 expecting the wrong value ->
+			// precondition miss -> the batch aborts and rolls back.
+			preconditionOp("n1", 1, map[string]any{"1": "changed"}, "1", "body", "WRONG-VALUE"),
+		},
+	}
+	batchB := apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "rb-b", TsMs: 1700000000001,
+		Ops: []map[string]any{
+			mkCreateNode("n2", 1, map[string]any{"1": "the quick brown fox"}),
+		},
+	}
+	f.appendEvent(t, batchA)
+	f.appendEvent(t, batchB)
+
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "rb-b")
+
+	ctx := context.Background()
+
+	// Batch A rolled back: n1 must NOT exist; memoized as a precondition failure.
+	if _, err := f.store.GetNode(ctx, testTenant, "n1"); err == nil {
+		t.Fatalf("n1 was written despite the rolled-back batch")
+	}
+	rec, err := f.store.CheckIdempotencyStatus(ctx, testTenant, "rb-a")
+	if err != nil {
+		t.Fatalf("CheckIdempotencyStatus rb-a: %v", err)
+	}
+	if !rec.Present || rec.Status != store.IdempotencyStatusFailedPrecondition {
+		t.Fatalf("batch A status = %+v, want FAILED_PRECONDITION", rec)
+	}
+
+	// Batch B applied without crashing the applier, and n2 is searchable —
+	// proving fts_t1 was RE-CREATED after the rollback, not skipped (#629).
+	if _, err := f.store.GetNode(ctx, testTenant, "n2"); err != nil {
+		t.Fatalf("n2 missing after a valid write following a rolled-back FTS batch (issue #629): %v", err)
+	}
+	hits, err := f.store.SearchNodes(ctx, testTenant, 1, "fox", []uint32{1}, 10, 0)
+	if err != nil {
+		t.Fatalf("SearchNodes (must succeed — proves fts_t1 exists): %v", err)
+	}
+	if len(hits) != 1 || hits[0].NodeID != "n2" {
+		t.Fatalf("FTS search after recovery returned %+v, want [n2]", hits)
+	}
+}

--- a/server/go/internal/store/index_cache_rollback_test.go
+++ b/server/go/internal/store/index_cache_rollback_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// TestFTSIndexCacheInvalidatedOnRollback reproduces issue #629.
+//
+// The applier creates a type's FTS5 virtual table lazily on first write
+// (EnsureFTSIndexConn), inside the same BEGIN IMMEDIATE batch, and records
+// it in a process-local "done" cache. SQLite's DDL is transactional: if
+// that batch ROLLs BACK (e.g. a later op fails a precondition), the
+// CREATE VIRTUAL TABLE is reverted — but the cache still reports the table
+// as present. A subsequent batch then cache-hits, skips re-creating the
+// table, and FTSInsert hits "no such table: fts_tXXXX", fatally crashing
+// the applier.
+//
+// Pre-fix this test fails on the second batch's FTSInsert. Post-fix
+// BatchTxn.Rollback invalidates the tenant's index cache, so the next
+// batch re-creates the reverted table (CREATE ... IF NOT EXISTS is safe).
+func TestFTSIndexCacheInvalidatedOnRollback(t *testing.T) {
+	cs := newStore(t)
+	ctx := context.Background()
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	const typeID int32 = 8001
+	fields := []uint32{1}
+	payload := map[string]any{"1": "the quick brown fox"}
+
+	// Batch A: create the FTS table, then roll back (mirrors a multi-op
+	// batch whose later op trips a precondition). SQLite reverts the DDL.
+	btA, err := cs.BeginBatch(ctx, "t1")
+	if err != nil {
+		t.Fatalf("BeginBatch A: %v", err)
+	}
+	if err := cs.EnsureFTSIndexConn(ctx, btA.Conn(), "t1", typeID, fields); err != nil {
+		t.Fatalf("EnsureFTSIndexConn A: %v", err)
+	}
+	if err := btA.Rollback(); err != nil {
+		t.Fatalf("Rollback A: %v", err)
+	}
+
+	// Batch B: a fresh write of the SAME type must succeed. Ensure must
+	// re-create the reverted table before FTSInsert runs.
+	btB, err := cs.BeginBatch(ctx, "t1")
+	if err != nil {
+		t.Fatalf("BeginBatch B: %v", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = btB.Rollback()
+		}
+	}()
+
+	if err := cs.EnsureFTSIndexConn(ctx, btB.Conn(), "t1", typeID, fields); err != nil {
+		t.Fatalf("EnsureFTSIndexConn B: %v", err)
+	}
+	if err := store.FTSInsertConn(ctx, btB.Conn(), typeID, "n1", payload, fields); err != nil {
+		if strings.Contains(err.Error(), "no such table") {
+			t.Fatalf("issue #629: FTSInsert hit a reverted table — the index cache was not invalidated on rollback: %v", err)
+		}
+		t.Fatalf("FTSInsertConn B: %v", err)
+	}
+	if err := btB.Commit(); err != nil {
+		t.Fatalf("Commit B: %v", err)
+	}
+	committed = true
+}

--- a/server/go/internal/store/indexes.go
+++ b/server/go/internal/store/indexes.go
@@ -34,6 +34,36 @@ func newIndexCache() *indexCache {
 	}
 }
 
+// ClearCacheForTenant drops every process-local index-cache entry for
+// tenantID's database file (unique, composite, query, and FTS).
+//
+// It MUST be called whenever a write transaction that may have created
+// index DDL rolls back: SQLite's DDL is transactional, so a ROLLBACK
+// reverts any CREATE INDEX / CREATE VIRTUAL TABLE executed in that
+// transaction, but the eager "done" cache would otherwise still report
+// the index as present — causing a later write to skip re-creating a
+// now-missing table and hit "no such table" (issue #629). Re-creation on
+// the next write is safe because all index DDL is CREATE ... IF NOT
+// EXISTS, so entries for indexes that survived in earlier committed
+// transactions are simply re-established as a no-op.
+func (s *CanonicalStore) ClearCacheForTenant(tenantID string) {
+	dbPath := s.pool.dbPath(tenantID)
+	s.indexCache.mu.Lock()
+	defer s.indexCache.mu.Unlock()
+	for _, done := range []map[indexKey]struct{}{
+		s.indexCache.uniqueDone,
+		s.indexCache.compositeDone,
+		s.indexCache.queryDone,
+		s.indexCache.ftsDone,
+	} {
+		for k := range done {
+			if k.dbPath == dbPath {
+				delete(done, k)
+			}
+		}
+	}
+}
+
 // EnsureUniqueIndex creates a partial unique expression index for each
 // (type_id, field_id) pair on demand. Idempotent at both the SQL level
 // (IF NOT EXISTS) and the in-memory cache level.
@@ -288,7 +318,10 @@ func queryIndexDDL(typeID int32, fid uint32) string {
 // the constraint unenforced. CREATE ... IF NOT EXISTS against an
 // already-committed index is a cheap metadata-only check, so re-running
 // the DDL per first-touch is correct and inexpensive. FTS tables are
-// NOT created here — the applier maintains those via fts.go.
+// NOT created here — the applier maintains those via fts.go, where
+// EnsureFTSIndexConn DOES cache; that cached in-txn path is kept
+// rollback-safe by ClearCacheForTenant, which BatchTxn.Rollback invokes
+// for exactly this reason (issue #629).
 //
 // No-ops when no schema.Registry is configured (raw-CRUD test paths).
 func (s *CanonicalStore) EnsureFieldIndexesTx(ctx context.Context, tx *BatchTxn, typeID int32) error {

--- a/server/go/internal/store/txn.go
+++ b/server/go/internal/store/txn.go
@@ -116,6 +116,17 @@ func (b *BatchTxn) Rollback() error {
 	}
 	b.done = true
 	defer b.cleanup()
+	// SQLite's DDL is transactional: this ROLLBACK reverts any index DDL
+	// (CREATE VIRTUAL TABLE / CREATE INDEX) executed in this batch. The
+	// process-local index cache must therefore be invalidated for this
+	// tenant, or a later write would cache-hit, skip re-creating the
+	// now-missing table, and crash the applier with "no such table"
+	// (issue #629). All index DDL is IF NOT EXISTS, so re-creation on the
+	// next write is a safe no-op for indexes that survived earlier
+	// committed transactions.
+	if b.store != nil {
+		b.store.ClearCacheForTenant(b.tenantID)
+	}
 	if _, err := b.conn.ExecContext(context.Background(), "ROLLBACK"); err != nil {
 		return fmt.Errorf("store: rollback batch: %w", err)
 	}


### PR DESCRIPTION
## Bug (#629)
The WAL applier crashed fatally with `no such table: fts_tXXXX` when writing a node of an FTS-searchable type, **if a prior batch that created that type's FTS table had rolled back** (e.g. a precondition/constraint failure later in the batch).

## Root cause
SQLite's DDL is transactional — a `ROLLBACK` reverts the `CREATE VIRTUAL TABLE`. But the process-local index "done" cache (`EnsureFTSIndexConn`, `internal/store/indexes.go`) eagerly recorded the table as present and was never invalidated on rollback. So the next batch cache-hit, skipped re-creating the reverted table, and `FTSInsert` hit a missing table → fatal applier exit.

(Unique/composite/query index DDL was already safe — `EnsureFieldIndexesTx` deliberately does **not** cache. FTS was the sole cached in-txn path.)

## Fix
`BatchTxn.Rollback()` now calls `CanonicalStore.ClearCacheForTenant(tenantID)`, dropping all index-cache entries for that tenant. All index DDL is `CREATE ... IF NOT EXISTS`, so re-creation on the next write is a safe no-op for indexes that survived earlier committed transactions.

## Tests (fail pre-fix, pass post-fix)
- `internal/store/index_cache_rollback_test.go` — store-level: create FTS table in batch A, rollback; batch B ensure+insert must succeed.
- `internal/apply/fts_rollback_test.go` — end-to-end applier: a precondition-failing batch (create FTS type → rollback) followed by a valid write of the same type must apply + be searchable, not crash.

Full `store`+`apply` suites green under `-race`. **Principal-engineer reviewed (APPROVE).** Verified: every applier rollback path goes through `BatchTxn.Rollback()`.

Closes #629.