### PR TITLE
feat(store): persist schema catalog in SQLite — registry survives a no-replay restart (#624, #626)

### DIFF
--- a/docs/adr/035-persist-schema-catalog-in-sqlite.md
+++ b/docs/adr/035-persist-schema-catalog-in-sqlite.md
@@ -1,8 +1,36 @@
 # ADR-035: Persist the schema catalog in SQLite (registry as a cache, not a WAL rebuild)
 
-**Status:** Proposed
-**Decided:** —
+**Status:** Accepted
+**Decided:** 2026-05-30
 **Tags:** schema, storage, recovery, registry, durability
+
+**Implementation:** per-tenant `schema_catalog` table
+(`server/go/internal/store/schema.go`); `UpsertCatalogTx` +
+`LoadCatalogInto` + `MarshalCatalogDef`
+(`server/go/internal/store/catalog.go`); atomic write in the apply txn
+(`server/go/internal/apply/ops_register_schema.go`); load-once-per-tenant
+on `OpenTenant`/`dbAuto` (`server/go/internal/store/canonical.go`);
+GetSchema reduced to a pure registry serializer
+(`server/go/internal/api/get_schema.go`). Fixes #624; closes #626.
+
+**Decided refinements vs the original proposal:**
+- **Catalog home = per-tenant SQLite** (resolves the open question
+  below). `register_schema` is always tenant-scoped and runs inside the
+  per-tenant `BatchTxn`, so a per-tenant `schema_catalog` row is atomic
+  with the indexes it describes and the `applied_events`/`applied_offsets`
+  rows — atomicity a globalstore catalog could not give. The process-wide
+  registry is keyed by `type_id`, so it is reconstructed identically by
+  replaying each tenant's catalog.
+- **Load strategy = lazy, load-once-per-tenant on open.** The catalog is
+  replayed into the registry the first time a tenant is opened (apply path
+  via `OpenTenant`, read/write paths via `dbAuto`), so the registry warms
+  as the server processes traffic post-restart — fixing the #624 read
+  failures with **zero boot-time change**. The eager all-tenant boot-scan
+  the proposal floated (to warm GetSchema before any traffic) is
+  **deliberately deferred**: opening every tenant DB at boot risks
+  startup latency + file-descriptor pressure at scale. It is a future
+  opt-in flag; the lazy load already makes GetSchema correct as soon as
+  any tenant is touched.
 
 **Supersedes/refines:** the boot mechanics of
 [ADR-031](031-self-describing-name-free-schema.md) (self-describing,
@@ -84,6 +112,28 @@ for schema.
   Rejected: a side file is a second source of truth that can drift from
   SQLite; the catalog belongs in the same transactional store as the
   indexes it describes.
+
+## Known asymmetry (accepted)
+
+`applyRegisterSchema` mutates the **process-global in-memory registry**
+(`RegisterOrVerifyNode/Edge` publish a new snapshot) *before* the
+`BatchTxn` commits. If a single multi-type `register_schema` op
+establishes an earlier type and then a later type **conflicts**, the
+batch rolls back — reverting the earlier type's catalog row and indexes —
+but the in-memory registry keeps the earlier type. So the live process
+registry can briefly hold a type whose durable state (catalog + indexes)
+was rolled back.
+
+This non-transactional registry mutation is **pre-existing** (it predates
+this ADR). Promoting the catalog to the durable source of truth makes the
+**durable** side the more-correct one: on the next restart the registry is
+reloaded from the committed catalog and the phantom type is dropped, and
+every write is self-describing so the next write of that type
+re-establishes it consistently. The asymmetry is therefore self-healing
+and is accepted rather than fixed here; making the in-memory mutation
+all-or-nothing (validate every type before any publish) is a separate,
+optional hardening. The catalog and the physical indexes never diverge —
+only registry-vs-durable, transiently.
 
 ## Open questions
 

--- a/server/go/internal/api/get_schema.go
+++ b/server/go/internal/api/get_schema.go
@@ -13,18 +13,13 @@
 //     (tests/python/integration/test_grpc_contract.py:208) only
 //     asserts `fingerprint != "" || HasField("schema")`, so the
 //     empty-but-OK response is the documented degraded path.
-//   - Optional req.TenantId drives a data-driven fallback when the
-//     registry is empty: we synthesise placeholder type entries from
-//     distinct type_ids observed in that tenant's SQLite. The
-//     canonicalstore doesn't expose GetDistinctTypeIDs yet, so the
-//     fallback is a no-op here and surfaces as an empty-Struct response.
-//     This matches the contract pin and is flagged for the canonicalstore
-//     follow-up.
-//
-// Known latent bug (not fixed here): req.TenantId is read without
-// cross-checking the caller's authenticated tenant binding, leaking
-// distinct type_ids across tenants. See spec "Open questions / risks"
-// — flagged as follow-up.
+//   - Pure serializer of the process-wide schema registry. As of
+//     ADR-035 that registry is catalog-backed (loaded from each
+//     tenant's SQLite schema_catalog on tenant open), so it is durably
+//     correct after a restart instead of booting empty. The old
+//     empty-registry SQLite fallback (which never had a backing store
+//     method) has been removed. The optional req.type_id filter still
+//     applies. req.TenantId is currently unused.
 
 package api
 
@@ -83,18 +78,11 @@ func (s *Server) GetSchema(ctx context.Context, req *pb.GetSchemaRequest) (resp 
 		return &pb.GetSchemaResponse{Fingerprint: ""}, nil
 	}
 
-	// Data-driven fallback when the registry is empty and the caller
-	// provided a tenant_id. The canonicalstore does not yet expose
-	// GetDistinctTypeIDs; until it does, this path degrades to an
-	// empty-Struct result — well within the contract pin (fingerprint
-	// or schema field present; an empty Struct still counts as "schema
-	// field present"). Flagged for the canonicalstore follow-up.
-	_ = mapHasTypes(schemaMap)
-	_ = req.GetTenantId()
-
-	// type_id filter. Applied after the fallback so the
-	// node_types/edge_types maps reflect either registry contents or
-	// the fallback synthesis (today: just registry contents).
+	// type_id filter. With ADR-035 the registry is catalog-backed (loaded
+	// from per-tenant SQLite on tenant open), so it is durably correct
+	// after a restart and GetSchema is a pure serializer of it — the old
+	// empty-registry SQLite fallback (which never had a backing store
+	// method) is gone.
 	if req.GetTypeId() != 0 {
 		schemaMap = filterByTypeID(schemaMap, req.GetTypeId())
 	}
@@ -146,19 +134,6 @@ func (s *Server) snapshotSchemaMap() (map[string]any, error) {
 		m["edge_types"] = []any{}
 	}
 	return m, nil
-}
-
-// mapHasTypes reports whether the snapshot contains any node or edge
-// type entries. Used to decide whether to fall back to the per-tenant
-// SQLite distinct-type read.
-func mapHasTypes(m map[string]any) bool {
-	if nt, ok := m["node_types"].([]any); ok && len(nt) > 0 {
-		return true
-	}
-	if et, ok := m["edge_types"].([]any); ok && len(et) > 0 {
-		return true
-	}
-	return false
 }
 
 // filterByTypeID applies the optional req.type_id filter.

--- a/server/go/internal/apply/applier_test.go
+++ b/server/go/internal/apply/applier_test.go
@@ -33,6 +33,7 @@ type fixture struct {
 	store   *store.CanonicalStore
 	global  *globalstore.GlobalStore
 	applier *apply.Applier
+	dir     string // RootDir, so a test can reopen the same data dir
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -70,7 +71,7 @@ func newFixture(t *testing.T) *fixture {
 		t.Fatalf("OpenTenant: %v", err)
 	}
 
-	return &fixture{t: t, wal: w, store: cs, global: gs, applier: a}
+	return &fixture{t: t, wal: w, store: cs, global: gs, applier: a, dir: dir}
 }
 
 // appendEvent JSON-encodes ev and appends it to the WAL under the

--- a/server/go/internal/apply/catalog_restart_test.go
+++ b/server/go/internal/apply/catalog_restart_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// TestApplier_RegistryRebuiltFromCatalogAfterRestart is the end-to-end
+// #624 proof. A register_schema applied through the full WAL→applier path
+// persists its node type into the per-tenant schema_catalog (atomic with
+// the type's indexes — ADR-035). A brand-new store opened on the SAME data
+// dir with a FRESH empty registry and NO WAL replay reloads the type from
+// the catalog on tenant-open — so the registry is rebuilt from durable
+// local state, independent of the WAL/Kafka committed offset.
+//
+// Before ADR-035 the fresh registry stayed empty (it was only ever rebuilt
+// by replaying register_schema WAL ops, which a committed-offset restart
+// skips), so reads of the type failed with "unknown type_id" (#624).
+func TestApplier_RegistryRebuiltFromCatalogAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	reg1 := schema.NewRegistry()
+	f := newFixtureWithRegistry(t, reg1)
+
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:alice", IdempotencyKey: "s1", TsMs: 1700000000000,
+		Ops: []map[string]any{
+			mkRegisterSchema(true),
+			mkCreateNode("n1", 1, map[string]any{"1": "alice@example.com"}),
+		},
+	})
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "s1")
+	if reg1.NodeTypeByID(1) == nil {
+		t.Fatal("type 1 not registered in the live registry")
+	}
+
+	// Simulate a restart that does NOT replay the WAL: a brand-new store on
+	// the SAME data dir with a FRESH registry and no applier.
+	reg2 := schema.NewRegistry()
+	cs2, err := store.New(store.Options{RootDir: f.dir, WALMode: true, Registry: reg2})
+	if err != nil {
+		t.Fatalf("store.New (restart): %v", err)
+	}
+	t.Cleanup(func() { _ = cs2.Close() })
+	if err := cs2.OpenTenant(ctx, testTenant); err != nil {
+		t.Fatalf("OpenTenant (restart): %v", err)
+	}
+
+	if reg2.NodeTypeByID(1) == nil {
+		t.Fatal("issue #624: type 1 not reloaded from schema_catalog after a no-replay restart")
+	}
+	if got := reg2.UniqueFieldIDs(1); len(got) != 1 || got[0] != 1 {
+		t.Errorf("UniqueFieldIDs(1) = %v, want [1]", got)
+	}
+	// The node written before the restart is still readable.
+	if _, err := cs2.GetNode(ctx, testTenant, "n1"); err != nil {
+		t.Fatalf("n1 not readable after restart: %v", err)
+	}
+}

--- a/server/go/internal/apply/mailbox_test.go
+++ b/server/go/internal/apply/mailbox_test.go
@@ -70,7 +70,7 @@ func newMailboxFixture(t *testing.T) *fixture {
 	if err := cs.OpenTenant(context.Background(), testTenant); err != nil {
 		t.Fatalf("OpenTenant: %v", err)
 	}
-	return &fixture{t: t, wal: w, store: cs, global: gs, applier: a}
+	return &fixture{t: t, wal: w, store: cs, global: gs, applier: a, dir: dir}
 }
 
 func mkMailboxCreate(id, targetUser, subject string) map[string]any {

--- a/server/go/internal/apply/ops_register_schema.go
+++ b/server/go/internal/apply/ops_register_schema.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 )
 
 // applyRegisterSchema materializes a "register_schema" op (SELF-DESCRIBING
@@ -77,6 +78,17 @@ func (a *Applier) applyRegisterSchema(ctx context.Context, tx *BatchTxn, ev *Eve
 		if err := a.store.EnsureFieldIndexesTx(ctx, tx, nt.TypeID); err != nil {
 			return fmt.Errorf("apply register_schema: ensure indexes t%d: %w", nt.TypeID, err)
 		}
+		// Persist the type into the per-tenant schema_catalog on the SAME
+		// txn connection, so it commits atomically with the indexes,
+		// applied_events, and applied_offsets — and survives a restart
+		// that does not replay the WAL (ADR-035 / #624).
+		defJSON, err := store.MarshalCatalogDef(nt)
+		if err != nil {
+			return fmt.Errorf("apply register_schema: marshal node type_id %d: %w", nt.TypeID, err)
+		}
+		if err := a.store.UpsertCatalogTx(ctx, tx, store.CatalogKindNode, nt.TypeID, defJSON); err != nil {
+			return fmt.Errorf("apply register_schema: persist node type_id %d: %w", nt.TypeID, err)
+		}
 	}
 	for i := range edgeDefs {
 		et := &edgeDefs[i]
@@ -85,6 +97,13 @@ func (a *Applier) applyRegisterSchema(ctx context.Context, tx *BatchTxn, ev *Eve
 				return &SchemaConflict{Detail: err.Error()}
 			}
 			return fmt.Errorf("%w: register_schema edge edge_id %d: %v", ErrPoisonEvent, et.EdgeID, err)
+		}
+		defJSON, err := store.MarshalCatalogDef(et)
+		if err != nil {
+			return fmt.Errorf("apply register_schema: marshal edge_id %d: %w", et.EdgeID, err)
+		}
+		if err := a.store.UpsertCatalogTx(ctx, tx, store.CatalogKindEdge, et.EdgeID, defJSON); err != nil {
+			return fmt.Errorf("apply register_schema: persist edge_id %d: %w", et.EdgeID, err)
 		}
 	}
 	return nil

--- a/server/go/internal/apply/unique_violation_test.go
+++ b/server/go/internal/apply/unique_violation_test.go
@@ -53,7 +53,7 @@ func newFixtureWithRegistry(t *testing.T, reg *schema.Registry) *fixture {
 	if err := cs.OpenTenant(context.Background(), testTenant); err != nil {
 		t.Fatalf("OpenTenant: %v", err)
 	}
-	return &fixture{t: t, wal: w, store: cs, global: gs, applier: a}
+	return &fixture{t: t, wal: w, store: cs, global: gs, applier: a, dir: dir}
 }
 
 func compositeRegistry(t *testing.T) *schema.Registry {

--- a/server/go/internal/store/canonical.go
+++ b/server/go/internal/store/canonical.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -83,6 +84,13 @@ type CanonicalStore struct {
 	nowFn      func() int64
 	indexCache *indexCache
 
+	// catalogMu guards catalogLoaded. catalogLoaded records tenants whose
+	// persisted schema_catalog has already been replayed into the
+	// registry (ADR-035), so the load runs once per tenant rather than on
+	// every open.
+	catalogMu     sync.Mutex
+	catalogLoaded map[string]struct{}
+
 	// offsetMu guards offsetCond / appliedOffsets. Reads and writes of
 	// the offset map both go through this mutex.
 	offsetMu        sync.Mutex
@@ -119,6 +127,7 @@ func New(opts Options) (*CanonicalStore, error) {
 		registry:       opts.Registry,
 		nowFn:          nowFn,
 		indexCache:     newIndexCache(),
+		catalogLoaded:  map[string]struct{}{},
 		appliedOffsets: map[string]int64{},
 		preCommitHook:  opts.preCommitHook,
 	}
@@ -130,8 +139,39 @@ func New(opts Options) (*CanonicalStore, error) {
 // schema DDL, and applies the production PRAGMAs. Idempotent: a second
 // call for the same tenant_id is a fast O(1) lookup.
 func (s *CanonicalStore) OpenTenant(ctx context.Context, tenantID string) error {
-	_, err := s.pool.open(ctx, tenantID)
-	return err
+	if _, err := s.pool.open(ctx, tenantID); err != nil {
+		return err
+	}
+	s.loadCatalogOnce(ctx, tenantID)
+	return nil
+}
+
+// loadCatalogOnce replays the tenant's persisted schema_catalog into the
+// process-global registry the FIRST time the tenant is opened — the fix
+// for the registry booting empty after a restart that did not replay the
+// WAL (ADR-035 / #624). A load failure is logged and retried on the next
+// open rather than failing the open: a missing or partial catalog must
+// not take the server down (it degrades to the pre-ADR-035
+// self-heal-on-first-write behaviour). Idempotent under concurrency —
+// RegisterOrVerify* makes a double load a no-op.
+func (s *CanonicalStore) loadCatalogOnce(ctx context.Context, tenantID string) {
+	if s.registry == nil {
+		return
+	}
+	s.catalogMu.Lock()
+	_, done := s.catalogLoaded[tenantID]
+	s.catalogMu.Unlock()
+	if done {
+		return
+	}
+	if err := s.LoadCatalogInto(ctx, tenantID, s.registry); err != nil {
+		slog.WarnContext(ctx, "store: schema catalog load failed; registry may be incomplete until a write re-registers",
+			"tenant_id", tenantID, "error", err.Error())
+		return
+	}
+	s.catalogMu.Lock()
+	s.catalogLoaded[tenantID] = struct{}{}
+	s.catalogMu.Unlock()
 }
 
 // CloseTenant closes the per-tenant DB handle. Idempotent.
@@ -190,6 +230,7 @@ func (s *CanonicalStore) dbAuto(ctx context.Context, tenantID string) (*sql.DB, 
 	if err != nil {
 		return nil, nil, err
 	}
+	s.loadCatalogOnce(ctx, tenantID)
 	return e.db, e, nil
 }
 

--- a/server/go/internal/store/catalog.go
+++ b/server/go/internal/store/catalog.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+)
+
+// Catalog "kind" discriminators stored in schema_catalog.kind.
+const (
+	CatalogKindNode = "node"
+	CatalogKindEdge = "edge"
+)
+
+// UpsertCatalogTx writes one node/edge type definition into the tenant's
+// schema_catalog ON the open BatchTxn's connection, so it commits (or
+// rolls back) atomically with the register_schema op, its indexes, and
+// the applied_events / applied_offsets rows. def_json is the per-type
+// canonical JSON (see ops_register_schema.go); an UPSERT against an
+// unchanged definition is a no-op (ADR-035 / #626).
+func (s *CanonicalStore) UpsertCatalogTx(ctx context.Context, tx *BatchTxn, kind string, typeID int32, defJSON []byte) error {
+	if tx == nil {
+		return fmt.Errorf("store: UpsertCatalogTx: nil tx")
+	}
+	_, err := tx.Conn().ExecContext(ctx,
+		`INSERT INTO schema_catalog (kind, type_id, def_json, updated_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(kind, type_id) DO UPDATE SET
+		     def_json   = excluded.def_json,
+		     updated_at = excluded.updated_at`,
+		kind, typeID, string(defJSON), s.now(),
+	)
+	if err != nil {
+		return fmt.Errorf("store: upsert schema_catalog %s/%d: %w", kind, typeID, err)
+	}
+	return nil
+}
+
+// LoadCatalogInto replays a tenant's persisted schema_catalog into reg
+// via RegisterOrVerifyNode/Edge (establish-or-reject, idempotent). It is
+// how the process-global registry is repopulated after a restart that
+// did not replay the WAL — the fix for the registry booting empty
+// (ADR-035 / #624). A nil reg is a no-op. Node types are loaded before
+// edge types so edge cross-references resolve.
+//
+// The tenant must already be open (callers go through OpenTenant /
+// dbAuto, which open then load).
+func (s *CanonicalStore) LoadCatalogInto(ctx context.Context, tenantID string, reg *schema.Registry) error {
+	if reg == nil {
+		return nil
+	}
+	// Pure SELECT — use the read handle so it never contends for the
+	// single write connection (read/write split, issue #137).
+	db, err := s.readDB(tenantID)
+	if err != nil {
+		return err
+	}
+	rows, err := db.QueryContext(ctx,
+		`SELECT kind, def_json FROM schema_catalog
+		 ORDER BY CASE kind WHEN 'node' THEN 0 ELSE 1 END, type_id`)
+	if err != nil {
+		return fmt.Errorf("store: query schema_catalog: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var kind, defJSON string
+		if err := rows.Scan(&kind, &defJSON); err != nil {
+			return fmt.Errorf("store: scan schema_catalog: %w", err)
+		}
+		if err := registerCatalogRow(reg, kind, []byte(defJSON)); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func registerCatalogRow(reg *schema.Registry, kind string, defJSON []byte) error {
+	switch kind {
+	case CatalogKindNode:
+		var nt schema.NodeTypeDef
+		if err := json.Unmarshal(defJSON, &nt); err != nil {
+			return fmt.Errorf("store: decode catalog node: %w", err)
+		}
+		if _, err := reg.RegisterOrVerifyNode(&nt); err != nil {
+			return fmt.Errorf("store: load catalog node type_id %d: %w", nt.TypeID, err)
+		}
+	case CatalogKindEdge:
+		var et schema.EdgeTypeDef
+		if err := json.Unmarshal(defJSON, &et); err != nil {
+			return fmt.Errorf("store: decode catalog edge: %w", err)
+		}
+		if _, err := reg.RegisterOrVerifyEdge(&et); err != nil {
+			return fmt.Errorf("store: load catalog edge_id %d: %w", et.EdgeID, err)
+		}
+	default:
+		return fmt.Errorf("store: unknown schema_catalog kind %q", kind)
+	}
+	return nil
+}
+
+// MarshalCatalogDef renders a node/edge type definition to the canonical
+// JSON stored in schema_catalog. It is exported so the applier writes
+// exactly the bytes LoadCatalogInto round-trips. v must be a
+// *schema.NodeTypeDef or *schema.EdgeTypeDef.
+func MarshalCatalogDef(v any) ([]byte, error) {
+	switch v.(type) {
+	case *schema.NodeTypeDef, *schema.EdgeTypeDef:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("store: marshal catalog def: %w", err)
+		}
+		return b, nil
+	default:
+		return nil, fmt.Errorf("store: MarshalCatalogDef: unsupported type %T", v)
+	}
+}

--- a/server/go/internal/store/catalog_test.go
+++ b/server/go/internal/store/catalog_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// catalogNodeDefJSON is the wire shape of a User type (type_id 1) with a
+// unique email field — the same snake_case contract the register_schema
+// op carries.
+const catalogNodeDefJSON = `{"type_id":1,"fields":[{"field_id":1,"name":"email","kind":"str","unique":true}]}`
+
+const catalogEdgeDefJSON = `{"edge_id":10,"from_type_id":1,"to_type_id":1,"on_subject_exit":"both"}`
+
+func catalogDefBytes(t *testing.T) []byte {
+	t.Helper()
+	var nt schema.NodeTypeDef
+	if err := json.Unmarshal([]byte(catalogNodeDefJSON), &nt); err != nil {
+		t.Fatalf("decode node def: %v", err)
+	}
+	b, err := store.MarshalCatalogDef(&nt)
+	if err != nil {
+		t.Fatalf("MarshalCatalogDef: %v", err)
+	}
+	return b
+}
+
+func openCatalogStore(t *testing.T, dir string, reg *schema.Registry) *store.CanonicalStore {
+	t.Helper()
+	cs, err := store.New(store.Options{RootDir: dir, WALMode: true, Registry: reg})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// TestCatalog_PersistsAndReloadsAcrossRestart is the core #626/ADR-035
+// proof: a type written to schema_catalog in a committed batch is reloaded
+// into a FRESH registry when a new store opens the SAME data dir, with NO
+// WAL replay. Before ADR-035 the fresh registry stayed empty (#624).
+func TestCatalog_PersistsAndReloadsAcrossRestart(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	defJSON := catalogDefBytes(t)
+
+	// Store 1: persist the catalog row inside a committed BatchTxn.
+	cs1 := openCatalogStore(t, dir, schema.NewRegistry())
+	if err := cs1.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	tx, err := cs1.BeginBatch(ctx, "t1")
+	if err != nil {
+		t.Fatalf("BeginBatch: %v", err)
+	}
+	if err := cs1.UpsertCatalogTx(ctx, tx, store.CatalogKindNode, 1, defJSON); err != nil {
+		t.Fatalf("UpsertCatalogTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	_ = cs1.Close()
+
+	// Store 2: a FRESH registry, the SAME dir, no applier / WAL replay.
+	reg2 := schema.NewRegistry()
+	cs2 := openCatalogStore(t, dir, reg2)
+	if err := cs2.OpenTenant(ctx, "t1"); err != nil { // triggers the catalog reload
+		t.Fatalf("OpenTenant 2: %v", err)
+	}
+	if reg2.NodeTypeByID(1) == nil {
+		t.Fatal("issue #624: type 1 not reloaded from schema_catalog into a fresh registry after restart")
+	}
+	if got := reg2.UniqueFieldIDs(1); len(got) != 1 || got[0] != 1 {
+		t.Errorf("UniqueFieldIDs(1) = %v, want [1]", got)
+	}
+}
+
+// TestCatalog_ReloadIsIdempotentNotConflict pins the def_json canonical
+// round-trip: a type reloaded from the catalog must be establish-or-reject
+// IDENTICAL to a fresh register of the same definition (idempotent no-op,
+// not ErrSchemaConflict). A non-canonical serialization would make a
+// post-restart self-describing write of an already-known type conflict.
+func TestCatalog_ReloadIsIdempotentNotConflict(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	defJSON := catalogDefBytes(t)
+
+	cs := openCatalogStore(t, dir, schema.NewRegistry())
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	tx, err := cs.BeginBatch(ctx, "t1")
+	if err != nil {
+		t.Fatalf("BeginBatch: %v", err)
+	}
+	if err := cs.UpsertCatalogTx(ctx, tx, store.CatalogKindNode, 1, defJSON); err != nil {
+		t.Fatalf("UpsertCatalogTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	reg2 := schema.NewRegistry()
+	if err := cs.LoadCatalogInto(ctx, "t1", reg2); err != nil {
+		t.Fatalf("LoadCatalogInto: %v", err)
+	}
+	var nt schema.NodeTypeDef
+	if err := json.Unmarshal(defJSON, &nt); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	registered, err := reg2.RegisterOrVerifyNode(&nt)
+	if err != nil {
+		t.Fatalf("identical re-register after catalog reload conflicted (def_json is not a canonical round-trip): %v", err)
+	}
+	if registered {
+		t.Error("re-register of an already-loaded type should be a no-op (registered=false), got true")
+	}
+}
+
+// TestCatalog_RollbackLeavesNoRow proves the catalog UPSERT is atomic with
+// the batch: a rolled-back BatchTxn persists nothing.
+func TestCatalog_RollbackLeavesNoRow(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cs := openCatalogStore(t, dir, schema.NewRegistry())
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	tx, err := cs.BeginBatch(ctx, "t1")
+	if err != nil {
+		t.Fatalf("BeginBatch: %v", err)
+	}
+	if err := cs.UpsertCatalogTx(ctx, tx, store.CatalogKindNode, 1, catalogDefBytes(t)); err != nil {
+		t.Fatalf("UpsertCatalogTx: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if n := countCatalogRows(t, cs, ctx); n != 0 {
+		t.Errorf("rolled-back UpsertCatalogTx left %d catalog rows, want 0", n)
+	}
+}
+
+// TestCatalog_UpsertIdempotent: a second identical upsert leaves one row.
+func TestCatalog_UpsertIdempotent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cs := openCatalogStore(t, dir, schema.NewRegistry())
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	defJSON := catalogDefBytes(t)
+	for i := 0; i < 2; i++ {
+		tx, err := cs.BeginBatch(ctx, "t1")
+		if err != nil {
+			t.Fatalf("BeginBatch #%d: %v", i, err)
+		}
+		if err := cs.UpsertCatalogTx(ctx, tx, store.CatalogKindNode, 1, defJSON); err != nil {
+			t.Fatalf("UpsertCatalogTx #%d: %v", i, err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("Commit #%d: %v", i, err)
+		}
+	}
+	if n := countCatalogRows(t, cs, ctx); n != 1 {
+		t.Errorf("idempotent upsert produced %d rows, want 1", n)
+	}
+}
+
+// TestCatalog_EdgeRoundTrip exercises the edge branch of the catalog
+// (UpsertCatalogTx kind="edge" + LoadCatalogInto + RegisterOrVerifyEdge),
+// including the canonical round-trip idempotency.
+func TestCatalog_EdgeRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	var et schema.EdgeTypeDef
+	if err := json.Unmarshal([]byte(catalogEdgeDefJSON), &et); err != nil {
+		t.Fatalf("decode edge def: %v", err)
+	}
+	defJSON, err := store.MarshalCatalogDef(&et)
+	if err != nil {
+		t.Fatalf("MarshalCatalogDef edge: %v", err)
+	}
+
+	cs := openCatalogStore(t, dir, schema.NewRegistry())
+	if err := cs.OpenTenant(ctx, "t1"); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	tx, err := cs.BeginBatch(ctx, "t1")
+	if err != nil {
+		t.Fatalf("BeginBatch: %v", err)
+	}
+	if err := cs.UpsertCatalogTx(ctx, tx, store.CatalogKindEdge, et.EdgeID, defJSON); err != nil {
+		t.Fatalf("UpsertCatalogTx edge: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	reg2 := schema.NewRegistry()
+	if err := cs.LoadCatalogInto(ctx, "t1", reg2); err != nil {
+		t.Fatalf("LoadCatalogInto: %v", err)
+	}
+	if reg2.EdgeTypeByID(10) == nil {
+		t.Fatal("edge_id 10 not reloaded from schema_catalog")
+	}
+	registered, err := reg2.RegisterOrVerifyEdge(&et)
+	if err != nil {
+		t.Fatalf("identical edge re-register conflicted after reload: %v", err)
+	}
+	if registered {
+		t.Error("edge re-register after reload should be a no-op (registered=false)")
+	}
+}
+
+func countCatalogRows(t *testing.T, cs *store.CanonicalStore, ctx context.Context) int {
+	t.Helper()
+	db, err := cs.AdminDB("t1")
+	if err != nil {
+		t.Fatalf("AdminDB: %v", err)
+	}
+	var n int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM schema_catalog").Scan(&n); err != nil {
+		t.Fatalf("count schema_catalog: %v", err)
+	}
+	return n
+}

--- a/server/go/internal/store/schema.go
+++ b/server/go/internal/store/schema.go
@@ -137,6 +137,21 @@ CREATE TABLE IF NOT EXISTS acl_inherit (
 CREATE INDEX IF NOT EXISTS idx_inherit_from
     ON acl_inherit(inherit_from);
 
+-- schema_catalog is the durable per-tenant copy of the schema registry
+-- (node/edge type definitions), written in the SAME applier transaction
+-- as the register_schema op and loaded into the process-global registry
+-- on tenant open. It makes the registry survive a restart that does not
+-- replay the WAL (e.g. a normal Kafka restart resuming from the committed
+-- offset), instead of booting empty (ADR-035 / #624 / #626). CREATE ...
+-- IF NOT EXISTS makes this a transparent in-place migration.
+CREATE TABLE IF NOT EXISTS schema_catalog (
+    kind       TEXT    NOT NULL,   -- 'node' | 'edge'
+    type_id    INTEGER NOT NULL,   -- node type_id or edge edge_id
+    def_json   TEXT    NOT NULL,   -- per-type canonical JSON definition
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (kind, type_id)
+);
+
 INSERT OR IGNORE INTO schema_version (version, applied_at)
     VALUES (1, strftime('%s', 'now') * 1000);
 `


### PR DESCRIPTION
## Bug (#624 / #626)
The process-wide schema registry was in-memory and rebuilt only by replaying `register_schema` WAL ops. A normal Kafka restart resumes from the **committed offset**, so those ops aren't re-delivered → the registry boots **empty**: reads of un-rewritten types fail `unknown type_id` (#624) and `GetSchema` returns empty (#626).

## Fix (ADR-035)
SQLite becomes the durable source of truth; the in-memory registry is a cache.
- New per-tenant **`schema_catalog`** table (CREATE TABLE IF NOT EXISTS — transparent migration).
- `applyRegisterSchema` UPSERTs each node/edge def into it on the **same `BatchTxn`** → atomic with the type's indexes, `applied_events`, `applied_offsets`.
- The catalog is replayed into the registry the **first time a tenant is opened** (`OpenTenant`/`dbAuto`), so the registry is rebuilt from durable local state independent of the WAL/Kafka offset.
- `GetSchema` reduced to a pure serializer of the now-durable registry; the dead empty-registry fallback (`mapHasTypes`, a never-existed store method) removed.
- **Eager all-tenant boot-scan deliberately deferred** (boot latency / FD cost at scale) — the lazy load warms the registry as tenants are touched. ADR documents this.

## Tests (fail pre-fix, pass post-fix)
- `internal/store/catalog_test.go` — persist→reload across a no-replay restart; canonical-JSON round-trip idempotency (no spurious `ErrSchemaConflict`); rollback-leaves-no-row (atomicity); upsert idempotency; edge round-trip.
- `internal/apply/catalog_restart_test.go` — end-to-end: apply `register_schema`, then a fresh store on the **same dir** with a **fresh registry + no WAL replay** must reload the type and serve reads.

## Review
Principal-engineer reviewed → **APPROVE** (no blocking defects). Verified atomicity, canonical round-trip, deadlock-freedom under `--apply-concurrency`, global-scope path, FTS/index post-restart, migration compat. Follow-ups addressed (ADR asymmetry note, stale header, edge coverage).

Local: all 4 Go modules + `-race` on store/apply/api, vet, ruff, docs-not-stale, **118 integration tests pass**.

Closes #624, #626.