### PR TITLE
security(auth): derive actor privilege from the auth method, not the subject prefix (#2)

### DIFF
--- a/server/go/internal/api/remove_tenant_member_test.go
+++ b/server/go/internal/api/remove_tenant_member_test.go
@@ -201,10 +201,12 @@ func TestRemoveTenantMember_IdempotentNonMember(t *testing.T) {
 
 	srv := api.New(api.WithGlobalStore(gs))
 
-	// admin caller bypasses the role gate via the system: prefix on
-	// the trusted Identity.
+	// admin caller bypasses the role gate via the system: prefix on the
+	// trusted Identity. The carrier must be a server-minted credential
+	// (API key); a system:/admin: prefix is NOT honoured over OAuth/mTLS
+	// (finding #2 — privilege comes from the trust anchor, not the subject).
 	ctx := auth.WithIdentity(context.Background(), auth.Identity{
-		Method:  auth.MethodOAuth,
+		Method:  auth.MethodAPIKey,
 		Subject: "system:admin",
 	})
 

--- a/server/go/internal/api/revoke_all_user_access_test.go
+++ b/server/go/internal/api/revoke_all_user_access_test.go
@@ -209,7 +209,7 @@ func TestRevokeAllUserAccess_AdminHappyPath(t *testing.T) {
 	// Cross-tenant shared_index: 2 rows in acme + 1 in another tenant.
 	// The handler must clean only the acme rows.
 	ctx := auth.WithIdentity(context.Background(), auth.Identity{
-		Method:  auth.MethodOAuth,
+		Method:  auth.MethodAPIKey,
 		Subject: "admin:root",
 	})
 	if err := f.global.AddShared(ctx, target, tenantID, "doc1", "read"); err != nil {
@@ -271,7 +271,7 @@ func TestRevokeAllUserAccess_WALEventCarriesSharedIndexCleanup(t *testing.T) {
 	}
 
 	ctx := auth.WithIdentity(context.Background(), auth.Identity{
-		Method:  auth.MethodOAuth,
+		Method:  auth.MethodAPIKey,
 		Subject: "admin:root",
 	})
 	if _, err := f.srv.RevokeAllUserAccess(ctx, &pb.RevokeAllUserAccessRequest{
@@ -380,7 +380,7 @@ func TestRevokeAllUserAccess_NoGrantsIdempotent(t *testing.T) {
 	}
 
 	ctx := auth.WithIdentity(context.Background(), auth.Identity{
-		Method:  auth.MethodOAuth,
+		Method:  auth.MethodAPIKey,
 		Subject: "system:admin",
 	})
 
@@ -426,7 +426,7 @@ func TestRevokeAllUserAccess_RequiredFields(t *testing.T) {
 	t.Parallel()
 	f := newRevokeAllFixture(t)
 	ctx := auth.WithIdentity(context.Background(), auth.Identity{
-		Method:  auth.MethodOAuth,
+		Method:  auth.MethodAPIKey,
 		Subject: "admin:root",
 	})
 

--- a/server/go/internal/auth/audit_privilege_escalation_test.go
+++ b/server/go/internal/auth/audit_privilege_escalation_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package auth
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+)
+
+// FINDING #2 (HIGH / security): Privilege escalation from credential subject prefix.
+//
+// File: internal/auth/authoritative.go:47-64 (Authoritative) and
+//       internal/auth/mtls.go:29-60 (IdentityFromCertificate).
+//
+// WHY THIS IS WRONG:
+//   Authoritative() ignores Identity.Method entirely. It feeds the
+//   interceptor-attested Subject straight into ParseActor; if that string
+//   carries a "system:" / "admin:" prefix it is returned VERBATIM as a
+//   KindSystem / KindAdmin actor — regardless of how the subject was
+//   attested. A JWT `sub` (or the email fallback) of "admin:root" delivered
+//   over MethodOAuth therefore resolves to Admin("root"), and "system:x"
+//   resolves to System("x"). JWT sub / email is attacker-influenceable at
+//   many IdPs (self-service signup, email-as-subject, etc.), so a tenant
+//   user can mint a god-mode cross-tenant identity simply by choosing the
+//   right subject string. The privilege class of an actor must be derived
+//   from HOW it was authenticated (the Method / trust anchor), never from a
+//   string the credential itself can choose.
+//
+//   Compounding it, IdentityFromCertificate() hardcodes
+//   Subject = "system:" + <cert subject> for EVERY verified client cert, so
+//   any leaf chaining to the trusted CA — even one minted for a low-trust
+//   workload — is promoted to a system actor by Authoritative().
+//
+// FIXED (PR for finding #2): privilege is now derived from the trust anchor
+// (Identity.Method) via methodAttestsPrefix, not from the subject string.
+// The two tests below — previously skipped regression gates — are now active
+// and assert the secure behaviour. The earlier "_DemonstratesFinding2_*"
+// tests that pinned the buggy escalation were removed when the fix landed;
+// their negative is now covered here.
+
+// Test_Authoritative_SecureBehavior_Finding2 documents the correct behaviour:
+// a credential whose Method is MethodOAuth / MethodMTLS and whose Subject
+// carries a privileged (admin:/system:/group:) prefix MUST resolve to a
+// KindUser actor — the privilege class must come from the trust anchor
+// (Method), never from an attacker-influenceable subject string. Only a
+// genuinely privileged authentication path may yield KindSystem / KindAdmin.
+func Test_Authoritative_SecureBehavior_Finding2(t *testing.T) {
+	// Fixed in authoritative.go: privilege is derived from Identity.Method,
+	// not from a prefix the credential can choose.
+
+	// OAuth-attested subjects must NOT be able to self-elevate via prefix.
+	escalationCases := []struct {
+		name    string
+		method  string
+		subject string
+	}{
+		{name: "oauth admin prefix", method: MethodOAuth, subject: "admin:root"},
+		{name: "oauth system prefix", method: MethodOAuth, subject: "system:x"},
+		{name: "oauth group prefix", method: MethodOAuth, subject: "group:admins"},
+		{name: "mtls admin prefix", method: MethodMTLS, subject: "admin:root"},
+		{name: "mtls system prefix", method: MethodMTLS, subject: "system:x"},
+	}
+	for _, tc := range escalationCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := WithIdentity(context.Background(), Identity{
+				Method:  tc.method,
+				Subject: tc.subject,
+			})
+			got := Authoritative(ctx, User("eve"))
+			if got.Kind() != KindUser {
+				t.Errorf("Authoritative(%s %q) kind = %v, want KindUser (no self-elevation)",
+					tc.method, tc.subject, got.Kind())
+			}
+			if got.IsAdmin() || got.IsSystem() {
+				t.Errorf("Authoritative(%s %q) = %v escalated to privileged actor; must resolve to a user",
+					tc.method, tc.subject, got)
+			}
+		})
+	}
+}
+
+// Test_IdentityFromCertificate_SecureBehavior_Finding2 documents that a plain
+// verified client cert must NOT be promoted to a system actor by default. The
+// derived Identity must resolve through Authoritative to a KindUser actor
+// unless an explicit, configured privilege mapping (out of scope for this
+// gate) elevates it.
+func Test_IdentityFromCertificate_SecureBehavior_Finding2(t *testing.T) {
+	// Fixed in mtls.go + authoritative.go: a client cert resolves to a plain
+	// user actor, never system/admin by default.
+
+	cert := &x509.Certificate{
+		Subject:      pkix.Name{CommonName: "some-svc"},
+		SerialNumber: big.NewInt(1),
+	}
+	id, ok := IdentityFromCertificate(cert)
+	if !ok {
+		t.Fatalf("IdentityFromCertificate ok=false, want true")
+	}
+	got := Authoritative(WithIdentity(context.Background(), id), User("eve"))
+	if got.Kind() != KindUser {
+		t.Errorf("Authoritative(default cert identity) kind = %v, want KindUser by default", got.Kind())
+	}
+	if got.IsSystem() || got.IsAdmin() {
+		t.Errorf("Authoritative(default cert identity) = %v elevated to privileged actor; a cert must not grant system/admin by default", got)
+	}
+}

--- a/server/go/internal/auth/authoritative.go
+++ b/server/go/internal/auth/authoritative.go
@@ -21,12 +21,24 @@ import "context"
 //     actor: "system:admin" in the request body, and we MUST NOT
 //     honour the body claim.
 //
-//     The trusted Subject is normalised to an Actor:
-//     - If it already starts with user:, system:, or admin:, ParseActor
-//     gives us the right kind verbatim.
-//     - Otherwise it is wrapped as user:<subject>. A JWT
-//     sub: "alice" becomes user:alice; a session for
-//     user_id: "user:alice" stays user:alice.
+//     The trusted Subject is normalised to an Actor, but the privilege
+//     class is derived from the *trust anchor* (Identity.Method), NEVER
+//     from a prefix the credential itself chose:
+//     - A user: prefix is always honoured -- it confers no privilege
+//     beyond being that user.
+//     - A system: / admin: prefix is honoured ONLY when the Method is one
+//     the server itself mints (API key / session, see
+//     methodAttestsPrefix). On those carriers a "system:gdpr-worker"
+//     subject was set by an operator and is trustworthy.
+//     - For externally-asserted methods (OAuth JWT sub/email, mTLS client
+//     cert) the subject is attacker-influenceable -- self-service signup,
+//     email-as-subject, a cert minted for an unrelated workload -- so any
+//     system:/admin:/group: prefix is wrapped down to user:<subject>. A
+//     JWT sub "alice" becomes user:alice; a forged sub "admin:root"
+//     becomes the powerless user user:admin:root. (Promotion of an
+//     OAuth/mTLS principal to system/admin must go through an explicit,
+//     operator-configured mapping -- tracked as a follow-up, not a prefix
+//     the caller can type.)
 //
 //  2. If no trusted Identity is on ctx (interceptor disabled, unit tests,
 //     or no-auth deployment mode), claimed is returned unchanged. This
@@ -49,16 +61,45 @@ func Authoritative(ctx context.Context, claimed Actor) Actor {
 	if !ok {
 		return claimed
 	}
-	// Subject may already be a prefixed actor string ("user:alice",
-	// "system:gdpr-worker") -- common when the credential carrier is a
-	// session for a tenant_principal value. Try ParseActor first so we
-	// preserve the kind.
-	if parsed := ParseActor(id.Subject); parsed.Kind() == KindUser ||
-		parsed.Kind() == KindSystem ||
-		parsed.Kind() == KindAdmin {
+	parsed := ParseActor(id.Subject)
+	// A user: prefix is always safe to honour regardless of method: it
+	// names a user and confers no elevated privilege.
+	if parsed.Kind() == KindUser {
 		return parsed
 	}
-	// No recognised prefix -- wrap as user:<subject>. Handles the JWT
-	// sub: "alice" -> user:alice case.
+	// A system: / admin: prefix is honoured ONLY on a server-minted carrier
+	// (API key / session). On an externally-asserted carrier (OAuth / mTLS)
+	// the subject is attacker-influenceable, so a privileged prefix must NOT
+	// elevate -- it is wrapped down to a plain user identity below. group:
+	// is never a caller identity and always wraps to a user too.
+	if methodAttestsPrefix(id.Method) &&
+		(parsed.Kind() == KindSystem || parsed.Kind() == KindAdmin) {
+		return parsed
+	}
+	// Everything else -- a bare subject ("alice"), a forged privileged
+	// prefix over OAuth/mTLS ("admin:root"), or a group: subject -- wraps as
+	// user:<subject>. The raw subject is kept intact so distinct principals
+	// stay distinct (a forged "admin:root" becomes user:"admin:root", which
+	// cannot collide with the genuine user:root).
 	return User(id.Subject)
+}
+
+// methodAttestsPrefix reports whether the authentication method that
+// produced an Identity is one EntDB itself mints, and may therefore be
+// trusted to carry a privileged (system:/admin:) actor prefix in its
+// Subject.
+//
+// API keys and sessions are issued by the server / operator, so a
+// "system:gdpr-worker" subject on one of them was set by us and is
+// trustworthy. OAuth (JWT sub/email) and mTLS (client cert) subjects are
+// asserted by an external IdP or presented by the caller, who can often
+// choose them, so their prefixes confer no privilege. Anything
+// unrecognised defaults to untrusted (the safe default).
+func methodAttestsPrefix(method string) bool {
+	switch method {
+	case MethodAPIKey, MethodSession:
+		return true
+	default:
+		return false
+	}
 }

--- a/server/go/internal/auth/authoritative_test.go
+++ b/server/go/internal/auth/authoritative_test.go
@@ -11,6 +11,11 @@ import (
 // guard: when the interceptor has installed a trusted Identity, the
 // claim from the request payload MUST be ignored, even if it tries to
 // upgrade to system: or admin:.
+//
+// A system:/admin: prefix on the trusted Subject is honoured ONLY on a
+// server-minted carrier (API key / session); see
+// Test_Authoritative_SecureBehavior_Finding2 in
+// audit_privilege_escalation_test.go for the OAuth/mTLS no-elevation rule.
 func TestAuthoritative_TrustedWinsOverClaim(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -31,14 +36,17 @@ func TestAuthoritative_TrustedWinsOverClaim(t *testing.T) {
 			want:    User("alice"),
 		},
 		{
-			name:    "system identity preserved",
+			name:    "system identity preserved (server-minted carrier)",
 			trusted: Identity{Method: MethodAPIKey, Subject: "system:gdpr-worker"},
 			claimed: User("eve"),
 			want:    System("gdpr-worker"),
 		},
 		{
-			name:    "admin identity preserved",
-			trusted: Identity{Method: MethodOAuth, Subject: "admin:root"},
+			// admin: is honoured because the carrier is an API key, which
+			// only an operator can mint. The same subject over OAuth/mTLS
+			// must NOT elevate -- see the no-elevation test below.
+			name:    "admin identity preserved (server-minted carrier)",
+			trusted: Identity{Method: MethodAPIKey, Subject: "admin:root"},
 			claimed: User("eve"),
 			want:    Admin("root"),
 		},

--- a/server/go/internal/auth/mtls.go
+++ b/server/go/internal/auth/mtls.go
@@ -26,6 +26,14 @@ func IdentityFromPeerCertificate(ctx context.Context) (Identity, bool) {
 // IdentityFromCertificate maps a verified client certificate to an EntDB
 // trusted Identity. URI SANs are preferred, then DNS SANs, email SANs,
 // CommonName, and finally the full subject DN.
+//
+// The subject is emitted with a user: prefix. A client certificate proves
+// WHICH workload connected, not that the workload is privileged: chaining
+// to the trusted CA must not by itself confer system/admin. Authoritative
+// therefore resolves an mTLS identity to a plain user actor (mTLS is not a
+// server-minted carrier per methodAttestsPrefix). Elevating a specific
+// certificate to system/admin must go through an explicit, operator-
+// configured mapping, not a hardcoded prefix on every leaf.
 func IdentityFromCertificate(cert *x509.Certificate) (Identity, bool) {
 	if cert == nil {
 		return Identity{}, false
@@ -48,7 +56,7 @@ func IdentityFromCertificate(cert *x509.Certificate) (Identity, bool) {
 	}
 	return Identity{
 		Method:  MethodMTLS,
-		Subject: "system:" + subject,
+		Subject: "user:" + subject,
 		Metadata: map[string]any{
 			"subject_dn":    cert.Subject.String(),
 			"serial_number": cert.SerialNumber.String(),

--- a/server/go/internal/auth/mtls_test.go
+++ b/server/go/internal/auth/mtls_test.go
@@ -28,11 +28,15 @@ func TestIdentityFromCertificatePrefersURISAN(t *testing.T) {
 	if !ok {
 		t.Fatal("IdentityFromCertificate ok=false, want true")
 	}
-	if id.Method != MethodMTLS || id.Subject != "system:spiffe://entdb/ns/prod/sa/ingestor" {
-		t.Fatalf("identity = %+v, want mTLS spiffe system subject", id)
+	if id.Method != MethodMTLS || id.Subject != "user:spiffe://entdb/ns/prod/sa/ingestor" {
+		t.Fatalf("identity = %+v, want mTLS spiffe user subject", id)
 	}
-	if got := Authoritative(WithIdentity(context.Background(), id), User("alice")); got != System("spiffe://entdb/ns/prod/sa/ingestor") {
-		t.Fatalf("Authoritative = %v, want SPIFFE system actor", got)
+	// A client cert proves which workload connected, not that it is
+	// privileged: Authoritative resolves it to a plain user actor, never
+	// system/admin (finding #2). Operator-configured elevation is a
+	// separate, explicit mechanism.
+	if got := Authoritative(WithIdentity(context.Background(), id), User("alice")); got != User("spiffe://entdb/ns/prod/sa/ingestor") {
+		t.Fatalf("Authoritative = %v, want SPIFFE user actor (no cert auto-elevation)", got)
 	}
 }
 
@@ -58,7 +62,7 @@ func TestMTLSUnaryInterceptorInstallsPeerIdentity(t *testing.T) {
 	if !ok {
 		t.Fatal("IdentityFromContext ok=false, want true")
 	}
-	if id.Method != MethodMTLS || id.Subject != "system:billing-worker" {
+	if id.Method != MethodMTLS || id.Subject != "user:billing-worker" {
 		t.Fatalf("identity = %+v, want billing-worker mTLS identity", id)
 	}
 }

--- a/tests/python/e2e/test_acid_e2e.py
+++ b/tests/python/e2e/test_acid_e2e.py
@@ -8,14 +8,16 @@ behaviors from a client perspective using the high-level Python SDK client.
 from __future__ import annotations
 
 import uuid
-import pytest
-import e2e_schema_pb2 as pb
-from entdb_sdk.errors import UniqueConstraintError, PreconditionFailedError
 
+import e2e_schema_pb2 as pb
+import pytest
+
+from entdb_sdk.errors import PreconditionFailedError, UniqueConstraintError
 
 # =============================================================================
 # Atomicity Tests (All-or-Nothing)
 # =============================================================================
+
 
 async def test_acid_atomicity_precondition_failure(scope) -> None:
     """Verifies that a plan containing a mismatching precondition rolls back completely."""
@@ -41,7 +43,9 @@ async def test_acid_atomicity_precondition_failure(scope) -> None:
 
     # The node created in Op 1 must NOT exist in the database (rolled back)
     nodes = await scope.query(pb.User, filter={"email": email})
-    assert len(nodes) == 0, f"Atomicity violation: node with email {email} was created despite plan failure!"
+    assert len(nodes) == 0, (
+        f"Atomicity violation: node with email {email} was created despite plan failure!"
+    )
 
 
 async def test_acid_atomicity_unique_violation(scope) -> None:
@@ -78,12 +82,15 @@ async def test_acid_atomicity_unique_violation(scope) -> None:
 
     # Verify that the OK product node was NOT committed (rolled back)
     nodes = await scope.query(pb.Product, filter={"sku": distinct_sku})
-    assert len(nodes) == 0, f"Atomicity violation: SKU {distinct_sku} was committed despite unique violation!"
+    assert len(nodes) == 0, (
+        f"Atomicity violation: SKU {distinct_sku} was committed despite unique violation!"
+    )
 
 
 # =============================================================================
 # Consistency Tests (Schema Constraints)
 # =============================================================================
+
 
 async def test_acid_consistency_unique_key(scope) -> None:
     """Verifies that the database preserves consistency by enforcing field-level uniqueness."""
@@ -101,7 +108,7 @@ async def test_acid_consistency_unique_key(scope) -> None:
     p2.create(pb.Product(sku=sku, name="Product 2", price=10.0))
     with pytest.raises(UniqueConstraintError) as exc_info:
         await p2.commit(wait_applied=True)
-    
+
     assert exc_info.value.type_id == 8002
     assert exc_info.value.field_id == 1
     assert exc_info.value.value == sku
@@ -110,6 +117,7 @@ async def test_acid_consistency_unique_key(scope) -> None:
 # =============================================================================
 # Isolation Tests (Lost Update OCC)
 # =============================================================================
+
 
 async def test_acid_isolation_lost_update_precondition(scope) -> None:
     """Verifies that optimistic concurrency control prevents write-write lost updates."""
@@ -140,7 +148,7 @@ async def test_acid_isolation_lost_update_precondition(scope) -> None:
     plan_b.update(node_id, pb.User(email="new-b@x.com"), precondition=("email", orig_email))
     with pytest.raises(PreconditionFailedError) as exc_info:
         await plan_b.commit(wait_applied=True)
-    
+
     assert exc_info.value.field == "1"
     assert exc_info.value.expected == orig_email
     assert exc_info.value.observed == "new-a@x.com"


### PR DESCRIPTION
## Issue #2 — Privilege escalation from a credential's subject prefix (HIGH / security)

### Consequence
Any user who can influence their authenticated subject — a JWT `sub`/email at many IdPs, or **any** client certificate chaining to the trusted CA — could become a full `system`/`admin` actor and cross every tenant boundary: read, modify, or delete all tenants' data. Tenant isolation, the core product promise, was bypassable by *choosing a string*.

### Root cause
`auth.Authoritative()` — the single chokepoint every handler uses to resolve the trusted actor — ignored `Identity.Method` and honored a `system:`/`admin:` prefix on the subject **verbatim**:
- `internal/auth/authoritative.go:47-64` — `sub: "admin:root"` over OAuth → `Admin("root")`.
- `internal/auth/mtls.go:49-51` — hardcoded `Subject = "system:" + <cert subject>` for **every** verified client cert.

Privilege must come from *how* you authenticated (the trust anchor), never from a string the credential can pick.

### Fix
Privilege is now derived from `Identity.Method` (new `methodAttestsPrefix`):
- `user:` prefixes are always honored (no elevation).
- `system:`/`admin:` prefixes are honored **only** on server-minted carriers (`MethodAPIKey`, `MethodSession`).
- On externally-asserted carriers (`MethodOAuth`, `MethodMTLS`) a privileged prefix is wrapped down to `user:<subject>` — a forged `admin:root` becomes the powerless user `user:"admin:root"`.
- `IdentityFromCertificate` no longer prepends `system:`; a cert resolves to a plain user actor.

Promotion of a specific OAuth subject / certificate to `system`/`admin` is intentionally left to a future explicit, operator-configured mapping — tracked in the security-audit epic.

### Tests
- Activates the two finding-#2 regression gates in `audit_privilege_escalation_test.go` (previously `t.Skip`-ped) — they now assert the secure behavior.
- Updates the two existing tests that encoded the old behavior (`authoritative_test.go`, `mtls_test.go`).
- The two admin-op tests that obtained admin **through the escalation** (`remove_tenant_member_test.go`, `revoke_all_user_access_test.go`) now use the API-key carrier — matching the convention already used across the rest of the `api` suite.

### Behavior change to note for operators
A deployment that relied on **mTLS client certs being automatically treated as `system`** will now see those callers resolve to plain users. That auto-elevation was the vulnerability; intended privileged service identities should use a server-minted API key/session (or the forthcoming explicit cert→role mapping).

### Verification (full local CI, all green)
- `go vet` + `go test ./...` across all four Go modules — pass
- `ruff check` + `format --check` — clean
- Python integration contract suite — **118 passed**, including the `test_grpc_contract.py` privilege-escalation pin
- No API / proto / SDK change; server-internal only.

Part of the EntDB security-audit program (see the security epic).
