### PR TITLE
ci: authenticate buf-setup-action to fix Proto Drift Guard rate-limit flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,11 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           version: '1.66.0'
+          # Authenticate buf's install-time GitHub API calls. Without a token
+          # the action uses the runner's shared unauthenticated IP quota and
+          # intermittently fails the Proto Drift Guard with "API rate limit
+          # exceeded" (seen on PR #636).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate server proto stubs
         run: |


### PR DESCRIPTION
## Problem
`Go Server Proto Drift Guard` intermittently fails at the `bufbuild/buf-setup-action@v1` step with:

```
##[warning]No github_token supplied, API requests will be subject to stricter rate limiting
##[error]API rate limit exceeded for <runner-ip>.
```

The action makes GitHub API calls to resolve/download buf; unauthenticated, it shares the runner's IP-based quota and flakes (observed on PR #636).

## Fix
Pass `github_token: ${{ secrets.GITHUB_TOKEN }}` to the action so install-time API calls use the per-repo authenticated quota. One-line workflow change; no behavioral effect on the drift check itself.

Surfaced during the security-audit work (epic #637).