### PR TITLE
security(crypto): random per-tenant DEKs + crash-safe re-key migration so crypto-shred is irreversible (#638)

### DIFF
--- a/docs/adr/011-security-and-compliance.md
+++ b/docs/adr/011-security-and-compliance.md
@@ -3,7 +3,8 @@
 **Status:** Accepted
 **Decided:** original ADR date predates current convention; revised
 2026-05-16 to match shipped reality (v1.13.0 closed the major
-encryption + TLS gaps)
+encryption + TLS gaps); amended 2026-06-01 (finding #638: per-tenant
+keys are now random, not master-derived — see the crypto-shred section)
 **Tags:** security, compliance, encryption, gdpr, hipaa, soc2
 **Implementation:** `server/go/internal/{crypto,gdpr,auth}/` + the
 CLI flags on `cmd/entdb-server/`
@@ -39,8 +40,9 @@ Key hierarchy (`server/go/internal/crypto/{key_manager,master_key,tenant_key_vau
 
 ```
 Master Key  — provisioned out-of-band (KMS / Vault / file)
-  └── Tenant Key (derived per tenant, wrapped under master,
-                  persisted in the tenant_key_vault table in global.db)
+  └── Tenant Key (RANDOM 256-bit DEK per tenant, wrapped under master,
+                  persisted in the tenant_key_vault table in global.db;
+                  see the #638 amendment — keys were formerly DERIVED)
         └── SQLite file encrypted at PRAGMA-key open time
 ```
 
@@ -90,6 +92,43 @@ Worker that processes the deletion queue at the configured cadence
 -gdpr-worker-interval=1m
 -crypto-shred-delete-files=false
 ```
+
+#### Amendment (2026-06-01, finding #638): per-tenant keys are RANDOM, not derived
+
+The original implementation derived each tenant DEK deterministically as
+`HKDF-SHA256(masterKey, "entdb-tenant-key:"+tenantID)` with no salt and no
+random material, and crypto-shred only nulled the master-wrapped copy in
+`tenant_key_vault`. Because the DEK was a pure function of two values the
+server always holds (the master key and the tenant id), a "shredded"
+tenant's key was trivially re-derivable offline, and the at-rest data was
+**not actually destroyed** — the Article-17 guarantee above did not hold.
+
+**Fix.** Provision a **random 256-bit DEK** with `crypto/rand` at first
+touch and persist ONLY the master-key-wrapped copy (AES-256-GCM, AAD =
+tenant id). Nulling that copy on shred now destroys the sole copy of the
+key, so the shred is irreversible.
+
+**Migration.** Tenants minted before this change still wrap a derived key.
+They are migrated by an idempotent, crash-safe operator command —
+`entdb-server --migrate-tenant-keys` (preview with
+`--migrate-tenant-keys-dry-run`) — which, per tenant: generates a random
+DEK, stages it in the vault (preserving the old key as `prev_wrapped_key`,
+`key_origin='rekeying'`), re-encrypts the tenant database in place via
+SQLCipher `PRAGMA rekey`, then finalizes (`key_origin='random'`, previous
+key dropped). A crash at any point is resumable — a `'rekeying'` row is
+detected on the next run and the re-key re-driven idempotently. Run it
+offline (server stopped) so no pooled handle holds a tenant DB open.
+`key_origin` (`derived`|`random`|`rekeying`) on `tenant_key_vault`
+distinguishes migrated tenants; pre-#638 rows default to `derived`.
+
+**Caveats (tracked).** Vault-less mode (`KeyManager` with no vault — a
+dev/test convenience) cannot persist a random key, so it necessarily keeps
+the derived key and its crypto-shred is non-durable (in-memory only; not a
+production posture). Separately, the WAL / S3 audit archive still holds
+plaintext payloads encrypted only by the operator KMS key, not the
+per-tenant key, so shredding the tenant key does not yet render the
+archived copy unreadable — that is finding #644 and must ship before the
+"unrecoverable on the S3 archive" claim above is fully true.
 
 ### Encryption in transit — **Shipped (v1.13.0)**
 

--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -64,6 +64,8 @@ func main() {
 	legalHoldLiftWorkerEnabled := flag.Bool("legal-hold-lift-worker-enabled", true, "run the durable legal_hold_lift_queue worker that lifts S3 Object Lock legal hold on a released tenant's already-archived objects (EPIC #511 Gap 1); only does work when -archive-enabled")
 	legalHoldLiftWorkerInterval := flag.Duration("legal-hold-lift-worker-interval", time.Minute, "how often the legal-hold-lift worker drains the pending-lift queue")
 	cryptoShredDeleteFiles := flag.Bool("crypto-shred-delete-files", false, "delete tenant .db/-wal/-shm files after key shred")
+	migrateTenantKeys := flag.Bool("migrate-tenant-keys", false, "re-key all legacy derived-key tenants to fresh random keys (crypto-shred remediation, #638) then exit; requires encryption-at-rest. Run as an offline step with the server stopped.")
+	migrateTenantKeysDryRun := flag.Bool("migrate-tenant-keys-dry-run", false, "list the tenants --migrate-tenant-keys would re-key, then exit; makes no changes")
 	walBackend := flag.String("wal-backend", "memory", "WAL backend: memory | kafka | kinesis | pubsub | sqs | servicebus | eventhubs")
 	walTopic := flag.String("wal-topic", "entdb-wal", "WAL topic name")
 	walGroup := flag.String("wal-group", "entdb-applier", "WAL consumer group id")
@@ -244,6 +246,31 @@ func main() {
 	}
 	defer func() { _ = canonical.Close() }()
 	srvOpts = append(srvOpts, api.WithStore(canonical))
+
+	// #638 crypto-shred remediation: optional offline re-key of legacy
+	// derived-key tenants to fresh random keys. Runs to completion and exits;
+	// never part of normal startup. Idempotent + crash-safe (resumes an
+	// interrupted run), so it is safe to re-invoke.
+	if *migrateTenantKeys || *migrateTenantKeysDryRun {
+		if keyManager == nil {
+			log.Fatalf("entdb-server: --migrate-tenant-keys requires encryption-at-rest (set --kms-provider/--kms-key-id or --encryption-required)")
+		}
+		if *migrateTenantKeysDryRun {
+			ids, err := keyManager.DerivedTenantIDs(ctx)
+			if err != nil {
+				log.Fatalf("entdb-server: migrate-tenant-keys dry-run: %v", err)
+			}
+			log.Printf("entdb-server: migrate-tenant-keys dry-run: %d tenant(s) on a legacy derived key need re-keying: %v", len(ids), ids)
+			return
+		}
+		report, err := keyManager.MigrateDerivedTenants(ctx, canonical.RekeyTenantDB)
+		if err != nil {
+			log.Fatalf("entdb-server: migrate-tenant-keys failed (safe to re-run; it resumes): %v", err)
+		}
+		log.Printf("entdb-server: migrate-tenant-keys complete: re-keyed %d, recovered %d (rekeyed=%v recovered=%v)",
+			len(report.Rekeyed), len(report.Recovered), report.Rekeyed, report.Recovered)
+		return
+	}
 
 	// WAL backend wiring. memory: in-process, lost on restart (dev /
 	// short-running tests). kafka: Kafka/Redpanda; production-grade,

--- a/server/go/internal/crypto/audit_shred_reversibility_test.go
+++ b/server/go/internal/crypto/audit_shred_reversibility_test.go
@@ -1,0 +1,121 @@
+package crypto
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"io"
+	"testing"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// FINDING #638 (CRITICAL/security): Crypto-shred is reversible — FIXED.
+//
+//   file: server/go/internal/crypto/key_manager.go (fetchOrProvisionVault)
+//         server/go/internal/crypto/tenant_key_vault.go (Provision, rekey)
+//
+// Before the fix, the per-tenant SQLCipher DEK was
+// HKDF-SHA256(masterKey, tenantID) with no salt/random, so a "shredded"
+// tenant's key was re-derivable offline from masterKey+tenantID and the at-
+// rest data was never actually destroyed. The fix provisions a random 256-bit
+// DEK and stores only the master-wrapped copy, so nulling that copy on shred
+// is irreversible. Legacy derived-key tenants are migrated by
+// MigrateDerivedTenants (see rekey_migration_test.go).
+//
+// The test below — previously a skipped regression gate — is now active and
+// asserts the secure behaviour. The earlier "_DemonstratesFinding1" test that
+// pinned the reversible behaviour was removed when the fix landed.
+
+// TestCryptoShred_SecureBehavior_Finding1 asserts the fixed behaviour: a
+// tenant DEK is backed by per-tenant random material, so it is NOT
+// reproducible from masterKey+tenantID. Two independent provisions of the same
+// tenant under the same master key yield DIFFERENT keys, and a pure offline
+// HKDF over masterKey+tenantID does not reproduce the working key.
+func TestCryptoShred_SecureBehavior_Finding1(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0xc1)
+	const tenantID = "acme"
+
+	provision := func() []byte {
+		t.Helper()
+		db := testVaultDB(t)
+		vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
+		if err != nil {
+			t.Fatalf("NewTenantKeyVault: %v", err)
+		}
+		mgr, err := NewKeyManager(master, vault)
+		if err != nil {
+			t.Fatalf("NewKeyManager: %v", err)
+		}
+		key, err := mgr.TenantKey(ctx, tenantID)
+		if err != nil {
+			t.Fatalf("TenantKey: %v", err)
+		}
+		return key
+	}
+
+	// Two independent provisions of the same tenant under the same master key
+	// must NOT produce the same key bytes — the DEK is random now.
+	first := provision()
+	second := provision()
+	if bytes.Equal(first, second) {
+		t.Fatalf("two independent provisions of %q under the same master key produced "+
+			"identical DEKs (%x); the per-tenant key has no random component, so "+
+			"crypto-shred would remain reversible", tenantID, first)
+	}
+
+	// A pure offline HKDF over masterKey+tenantID must NOT reproduce the live
+	// working key.
+	reader := hkdf.New(sha256.New, master, nil, []byte(hkdfInfoPrefix+tenantID))
+	offline := make([]byte, KeyLength)
+	if _, err := io.ReadFull(reader, offline); err != nil {
+		t.Fatalf("offline HKDF: %v", err)
+	}
+	if bytes.Equal(offline, first) {
+		t.Fatalf("offline HKDF over masterKey+tenantID reproduced the working DEK (%x); "+
+			"the key is still re-derivable offline and crypto-shred is reversible", offline)
+	}
+}
+
+// TestProvisionedKeyIsNotMasterDerived pins the core property directly: the
+// key the vault hands out for a freshly provisioned tenant is not the HKDF
+// derivation of masterKey+tenantID.
+func TestProvisionedKeyIsNotMasterDerived(t *testing.T) {
+	ctx := context.Background()
+	master := testMaster(0x7e)
+	const tenantID = "tenant-x"
+
+	db := testVaultDB(t)
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault: %v", err)
+	}
+	mgr, err := NewKeyManager(master, vault)
+	if err != nil {
+		t.Fatalf("NewKeyManager: %v", err)
+	}
+
+	provisioned, err := mgr.TenantKey(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("TenantKey: %v", err)
+	}
+	derived, err := mgr.deriveTenantKey(tenantID)
+	if err != nil {
+		t.Fatalf("deriveTenantKey: %v", err)
+	}
+	if bytes.Equal(provisioned, derived) {
+		t.Fatalf("provisioned key equals the master-derived key; provisioning is not random")
+	}
+
+	// The freshly provisioned tenant is NOT a re-key candidate (origin random).
+	cands, err := mgr.DerivedTenantIDs(ctx)
+	if err != nil {
+		t.Fatalf("DerivedTenantIDs: %v", err)
+	}
+	for _, id := range cands {
+		if id == tenantID {
+			t.Fatalf("freshly provisioned tenant %q reported as a derived-key candidate", tenantID)
+		}
+	}
+}

--- a/server/go/internal/crypto/key_manager.go
+++ b/server/go/internal/crypto/key_manager.go
@@ -117,7 +117,7 @@ func (m *KeyManager) ShredTenant(ctx context.Context, tenantID string) error {
 		return err
 	}
 	if row == nil {
-		seed, err := m.deriveTenantKey(tenantID)
+		seed, err := newRandomKey()
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,11 @@ func (m *KeyManager) fetchOrProvisionVault(ctx context.Context, tenantID string)
 	if !errors.Is(err, ErrTenantKeyNotFound) {
 		return nil, err
 	}
-	seed, err := m.deriveTenantKey(tenantID)
+	// #638: provision a fresh RANDOM DEK, not a master-derived one. Only the
+	// master-wrapped copy is persisted (vault.Provision), so nulling it on
+	// shred is irreversible. Legacy rows that still wrap a derived key are
+	// migrated by MigrateDerivedTenants.
+	seed, err := newRandomKey()
 	if err != nil {
 		return nil, err
 	}
@@ -186,6 +190,16 @@ func (m *KeyManager) fetchOrProvisionVault(ctx context.Context, tenantID string)
 	return seed, nil
 }
 
+// deriveTenantKey is the legacy deterministic key derivation. As of #638 it
+// is used ONLY in vault-less mode (KeyManager built with a nil vault — a
+// dev/test convenience): with no vault there is nowhere to persist a random
+// key, so the DEK must be reproducible, and crypto-shred is necessarily
+// non-durable (it survives only as the in-memory `shredded` flag and does not
+// outlast the process). Vault-backed deployments provision random keys
+// (fetchOrProvisionVault) and never call this. The function is retained both
+// for that vault-less path and so existing vault rows minted before #638 —
+// which wrap a derived key — remain openable until MigrateDerivedTenants
+// re-keys them.
 func (m *KeyManager) deriveTenantKey(tenantID string) ([]byte, error) {
 	reader := hkdf.New(sha256.New, m.masterKey, nil, []byte(hkdfInfoPrefix+tenantID))
 	key := make([]byte, KeyLength)
@@ -193,4 +207,110 @@ func (m *KeyManager) deriveTenantKey(tenantID string) ([]byte, error) {
 		return nil, fmt.Errorf("crypto: derive tenant key: %w", err)
 	}
 	return key, nil
+}
+
+// RekeyDBFunc re-encrypts tenantID's database so it ends encrypted under
+// newKey. It is called knowing the DB is currently under oldKey, but MUST be
+// idempotent: a crash can leave the DB on either key, so the implementation
+// should succeed whether the file is already on newKey, still on oldKey, or
+// absent (a never-written tenant — a no-op). Implemented by the store package
+// via SQLCipher PRAGMA rekey.
+type RekeyDBFunc func(ctx context.Context, tenantID string, oldKey, newKey []byte) error
+
+// RekeyReport summarizes a MigrateDerivedTenants run.
+type RekeyReport struct {
+	// Rekeyed lists tenants migrated from a derived key to a fresh random key.
+	Rekeyed []string
+	// Recovered lists tenants whose interrupted ('rekeying') migration was
+	// detected and completed on this run.
+	Recovered []string
+}
+
+// DerivedTenantIDs returns the tenants still on a legacy derived key (or with
+// an interrupted migration) — the set MigrateDerivedTenants would act on.
+// Intended for a dry-run / status check. Empty when there is no vault.
+func (m *KeyManager) DerivedTenantIDs(ctx context.Context) ([]string, error) {
+	if m.vault == nil {
+		return nil, nil
+	}
+	return m.vault.rekeyCandidates(ctx)
+}
+
+// MigrateDerivedTenants re-keys every tenant whose DEK is still the legacy
+// deterministic derived key (finding #638) to a fresh random key, so a later
+// crypto-shred is irreversible. Idempotent and crash-safe:
+//
+//   - derived tenant: generate a random DEK, stage it in the vault (the old
+//     key is preserved as prev_wrapped_key), re-key the DB, then finalize.
+//   - 'rekeying' tenant (a prior run crashed mid-flight): the new key is
+//     already the vault's wrapped_key and the old key is prev_wrapped_key;
+//     re-run the (idempotent) DB re-key and finalize.
+//
+// Already-random tenants are skipped. Requires a vault. Run as an operator
+// step with the server stopped, so no pooled handle holds a tenant DB open
+// while it is re-keyed.
+func (m *KeyManager) MigrateDerivedTenants(ctx context.Context, rekeyDB RekeyDBFunc) (*RekeyReport, error) {
+	if m.vault == nil {
+		return nil, errors.New("crypto: tenant key migration requires a key vault")
+	}
+	if rekeyDB == nil {
+		return nil, errors.New("crypto: rekeyDB callback is required")
+	}
+	candidates, err := m.vault.rekeyCandidates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	report := &RekeyReport{}
+	for _, tenantID := range candidates {
+		origin, err := m.vault.keyOriginOf(ctx, tenantID)
+		if err != nil {
+			return report, err
+		}
+		switch origin {
+		case keyOriginRekeying:
+			// Resume an interrupted migration: wrapped_key is already the new
+			// key, prev_wrapped_key the old one.
+			oldKey, err := m.vault.prevKey(ctx, tenantID)
+			if err != nil {
+				return report, err
+			}
+			newKey, err := m.vault.Get(ctx, tenantID)
+			if err != nil {
+				return report, err
+			}
+			if err := rekeyDB(ctx, tenantID, oldKey, newKey); err != nil {
+				return report, fmt.Errorf("crypto: resume rekey %q: %w", tenantID, err)
+			}
+			if err := m.vault.completeRekey(ctx, tenantID); err != nil {
+				return report, err
+			}
+			report.Recovered = append(report.Recovered, tenantID)
+		case keyOriginDerived:
+			oldKey, err := m.vault.Get(ctx, tenantID)
+			if err != nil {
+				return report, err
+			}
+			newKey, err := newRandomKey()
+			if err != nil {
+				return report, err
+			}
+			if err := m.vault.stageRekey(ctx, tenantID, newKey); err != nil {
+				return report, err
+			}
+			if err := rekeyDB(ctx, tenantID, oldKey, newKey); err != nil {
+				return report, fmt.Errorf("crypto: rekey %q: %w", tenantID, err)
+			}
+			if err := m.vault.completeRekey(ctx, tenantID); err != nil {
+				return report, err
+			}
+			report.Rekeyed = append(report.Rekeyed, tenantID)
+		default:
+			// 'random' (or unknown) — already safe, nothing to do.
+		}
+		// Drop any cached copy so a long-lived manager re-reads the new key.
+		m.mu.Lock()
+		delete(m.cache, tenantID)
+		m.mu.Unlock()
+	}
+	return report, nil
 }

--- a/server/go/internal/crypto/rekey_migration_test.go
+++ b/server/go/internal/crypto/rekey_migration_test.go
@@ -1,0 +1,210 @@
+package crypto
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// seedDerivedVaultRow inserts a legacy derived-key vault row (key_origin
+// 'derived') wrapping derivedKey, modelling a tenant provisioned before #638.
+func seedDerivedVaultRow(t *testing.T, v *TenantKeyVault, tenantID string, derivedKey []byte) {
+	t.Helper()
+	wrapped, err := v.wrap(derivedKey, tenantID)
+	if err != nil {
+		t.Fatalf("wrap derived key: %v", err)
+	}
+	if _, err := v.db.ExecContext(context.Background(),
+		`INSERT INTO tenant_key_vault (tenant_id, wrapped_key, created_at_ms, key_origin) VALUES (?, ?, ?, ?)`,
+		tenantID, wrapped, v.nowFn().UnixMilli(), keyOriginDerived,
+	); err != nil {
+		t.Fatalf("seed derived vault row: %v", err)
+	}
+}
+
+func newVaultMgr(t *testing.T, fill byte) (context.Context, []byte, *TenantKeyVault, *KeyManager) {
+	t.Helper()
+	ctx := context.Background()
+	master := testMaster(fill)
+	db := testVaultDB(t)
+	vault, err := NewTenantKeyVault(ctx, TenantKeyVaultOptions{DB: db, MasterKey: master})
+	if err != nil {
+		t.Fatalf("NewTenantKeyVault: %v", err)
+	}
+	mgr, err := NewKeyManager(master, vault)
+	if err != nil {
+		t.Fatalf("NewKeyManager: %v", err)
+	}
+	return ctx, master, vault, mgr
+}
+
+// TestMigrateDerivedTenants_RekeysToRandom is the core migration test: a
+// legacy derived-key tenant is re-keyed to a fresh random key that is no
+// longer re-derivable from masterKey+tenantID, and the DB re-key is driven
+// with the correct (old, new) key pair.
+func TestMigrateDerivedTenants_RekeysToRandom(t *testing.T) {
+	ctx, _, vault, mgr := newVaultMgr(t, 0xa1)
+	const tenantID = "legacy"
+
+	derivedKey, err := mgr.deriveTenantKey(tenantID)
+	if err != nil {
+		t.Fatalf("deriveTenantKey: %v", err)
+	}
+	seedDerivedVaultRow(t, vault, tenantID, derivedKey)
+
+	cands, err := mgr.DerivedTenantIDs(ctx)
+	if err != nil {
+		t.Fatalf("DerivedTenantIDs: %v", err)
+	}
+	if len(cands) != 1 || cands[0] != tenantID {
+		t.Fatalf("candidates = %v, want [%q]", cands, tenantID)
+	}
+
+	var gotOld, gotNew []byte
+	calls := 0
+	rekeyDB := func(_ context.Context, id string, oldKey, newKey []byte) error {
+		calls++
+		if id != tenantID {
+			t.Errorf("rekeyDB tenant = %q, want %q", id, tenantID)
+		}
+		gotOld = append([]byte(nil), oldKey...)
+		gotNew = append([]byte(nil), newKey...)
+		return nil
+	}
+
+	report, err := mgr.MigrateDerivedTenants(ctx, rekeyDB)
+	if err != nil {
+		t.Fatalf("MigrateDerivedTenants: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("rekeyDB called %d times, want 1", calls)
+	}
+	if len(report.Rekeyed) != 1 || report.Rekeyed[0] != tenantID {
+		t.Fatalf("report.Rekeyed = %v, want [%q]", report.Rekeyed, tenantID)
+	}
+	if len(report.Recovered) != 0 {
+		t.Fatalf("report.Recovered = %v, want empty", report.Recovered)
+	}
+	if !bytes.Equal(gotOld, derivedKey) {
+		t.Fatalf("rekeyDB old key = %x, want the derived key %x", gotOld, derivedKey)
+	}
+	if bytes.Equal(gotNew, derivedKey) {
+		t.Fatalf("rekeyDB new key equals the derived key; not random")
+	}
+
+	// The vault now hands out the new random key, marked 'random'.
+	cur, err := vault.Get(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("vault.Get after migrate: %v", err)
+	}
+	if !bytes.Equal(cur, gotNew) {
+		t.Fatalf("vault current key %x != rekeyDB new key %x", cur, gotNew)
+	}
+	if org, _ := vault.keyOriginOf(ctx, tenantID); org != keyOriginRandom {
+		t.Fatalf("key_origin = %q, want %q", org, keyOriginRandom)
+	}
+	// Irreversibility: master+tenantID no longer derives the live key.
+	rederived, _ := mgr.deriveTenantKey(tenantID)
+	if bytes.Equal(rederived, cur) {
+		t.Fatalf("post-migration key is still re-derivable from masterKey+tenantID")
+	}
+	// No longer a candidate.
+	if cands2, _ := mgr.DerivedTenantIDs(ctx); len(cands2) != 0 {
+		t.Fatalf("tenant still a candidate after migration: %v", cands2)
+	}
+}
+
+// TestMigrateDerivedTenants_Idempotent: a second run is a no-op (the tenant is
+// already 'random').
+func TestMigrateDerivedTenants_Idempotent(t *testing.T) {
+	ctx, _, vault, mgr := newVaultMgr(t, 0xb2)
+	const tenantID = "legacy"
+	dk, _ := mgr.deriveTenantKey(tenantID)
+	seedDerivedVaultRow(t, vault, tenantID, dk)
+
+	noop := func(_ context.Context, _ string, _, _ []byte) error { return nil }
+	if _, err := mgr.MigrateDerivedTenants(ctx, noop); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	calls := 0
+	report, err := mgr.MigrateDerivedTenants(ctx, func(_ context.Context, _ string, _, _ []byte) error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	if calls != 0 || len(report.Rekeyed) != 0 || len(report.Recovered) != 0 {
+		t.Fatalf("second migrate not a no-op: calls=%d report=%+v", calls, report)
+	}
+}
+
+// TestMigrateDerivedTenants_ResumesInterrupted: a tenant left in 'rekeying'
+// state (a prior run crashed after staging) is completed on re-run using the
+// staged previous/new key pair, and the DB re-key is driven idempotently.
+func TestMigrateDerivedTenants_ResumesInterrupted(t *testing.T) {
+	ctx, _, vault, mgr := newVaultMgr(t, 0xc3)
+	const tenantID = "interrupted"
+	oldKey, _ := mgr.deriveTenantKey(tenantID)
+	seedDerivedVaultRow(t, vault, tenantID, oldKey)
+
+	// Simulate a crash mid-migration: stage a new key (origin -> 'rekeying',
+	// prev_wrapped_key = old) but never complete.
+	stagedNew, err := newRandomKey()
+	if err != nil {
+		t.Fatalf("newRandomKey: %v", err)
+	}
+	if err := vault.stageRekey(ctx, tenantID, stagedNew); err != nil {
+		t.Fatalf("stageRekey: %v", err)
+	}
+	if org, _ := vault.keyOriginOf(ctx, tenantID); org != keyOriginRekeying {
+		t.Fatalf("post-stage origin = %q, want %q", org, keyOriginRekeying)
+	}
+
+	var gotOld, gotNew []byte
+	report, err := mgr.MigrateDerivedTenants(ctx, func(_ context.Context, _ string, o, n []byte) error {
+		gotOld = append([]byte(nil), o...)
+		gotNew = append([]byte(nil), n...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("resume migrate: %v", err)
+	}
+	if len(report.Recovered) != 1 || report.Recovered[0] != tenantID {
+		t.Fatalf("report.Recovered = %v, want [%q]", report.Recovered, tenantID)
+	}
+	if len(report.Rekeyed) != 0 {
+		t.Fatalf("report.Rekeyed = %v, want empty (this was a resume)", report.Rekeyed)
+	}
+	// Resume must re-key from the staged OLD key to the staged NEW key.
+	if !bytes.Equal(gotOld, oldKey) {
+		t.Fatalf("resume old key = %x, want staged previous %x", gotOld, oldKey)
+	}
+	if !bytes.Equal(gotNew, stagedNew) {
+		t.Fatalf("resume new key = %x, want staged new %x", gotNew, stagedNew)
+	}
+	// Finalized: origin 'random', prev cleared, current == staged new.
+	if org, _ := vault.keyOriginOf(ctx, tenantID); org != keyOriginRandom {
+		t.Fatalf("post-resume origin = %q, want %q", org, keyOriginRandom)
+	}
+	cur, err := vault.Get(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("vault.Get after resume: %v", err)
+	}
+	if !bytes.Equal(cur, stagedNew) {
+		t.Fatalf("post-resume current key %x != staged new %x", cur, stagedNew)
+	}
+}
+
+// TestMigrateDerivedTenants_RequiresVault: a vault-less KeyManager cannot
+// durably re-key, so migration is refused rather than silently no-op.
+func TestMigrateDerivedTenants_RequiresVault(t *testing.T) {
+	mgr, err := NewKeyManager(testMaster(0xd4), nil)
+	if err != nil {
+		t.Fatalf("NewKeyManager: %v", err)
+	}
+	if _, err := mgr.MigrateDerivedTenants(context.Background(),
+		func(_ context.Context, _ string, _, _ []byte) error { return nil }); err == nil {
+		t.Fatal("MigrateDerivedTenants with no vault: expected an error, got nil")
+	}
+}

--- a/server/go/internal/crypto/tenant_key_vault.go
+++ b/server/go/internal/crypto/tenant_key_vault.go
@@ -16,10 +16,12 @@ import (
 const (
 	vaultTableDDL = `
 CREATE TABLE IF NOT EXISTS tenant_key_vault (
-    tenant_id       TEXT PRIMARY KEY NOT NULL,
-    wrapped_key     BLOB,
-    created_at_ms   INTEGER NOT NULL,
-    shredded_at_ms  INTEGER,
+    tenant_id        TEXT PRIMARY KEY NOT NULL,
+    wrapped_key      BLOB,
+    created_at_ms    INTEGER NOT NULL,
+    shredded_at_ms   INTEGER,
+    key_origin       TEXT NOT NULL DEFAULT 'derived',
+    prev_wrapped_key BLOB,
     CHECK (
         (wrapped_key IS NOT NULL AND shredded_at_ms IS NULL) OR
         (wrapped_key IS NULL AND shredded_at_ms IS NOT NULL)
@@ -27,6 +29,16 @@ CREATE TABLE IF NOT EXISTS tenant_key_vault (
 );
 `
 	nonceLength = 12
+
+	// key_origin values. A tenant DEK is either deterministically derived
+	// from the master key (legacy, re-derivable — finding #638) or a random
+	// 256-bit key that exists only as the master-wrapped blob (so a shred is
+	// irreversible). 'rekeying' marks a tenant mid-migration: wrapped_key
+	// holds the NEW random key, prev_wrapped_key the OLD one, and the DB may
+	// be encrypted under either until the migration completes.
+	keyOriginDerived  = "derived"
+	keyOriginRandom   = "random"
+	keyOriginRekeying = "rekeying"
 )
 
 var (
@@ -89,6 +101,53 @@ func (v *TenantKeyVault) initSchema(ctx context.Context) error {
 	if _, err := v.db.ExecContext(ctx, vaultTableDDL); err != nil {
 		return fmt.Errorf("crypto: create tenant key vault schema: %w", err)
 	}
+	// Migrate vault DBs created before #638: add the key_origin and
+	// prev_wrapped_key columns if absent. Pre-#638 rows hold derived keys,
+	// so key_origin defaults to 'derived' — exactly what the re-key
+	// migration (MigrateDerivedTenants) looks for.
+	return v.ensureColumns(ctx)
+}
+
+// ensureColumns adds columns introduced after the table's original shape,
+// idempotently. SQLite lacks ADD COLUMN IF NOT EXISTS, so we probe
+// table_info first. New columns use constant defaults (allowed by ALTER).
+func (v *TenantKeyVault) ensureColumns(ctx context.Context) error {
+	rows, err := v.db.QueryContext(ctx, `PRAGMA table_info(tenant_key_vault)`)
+	if err != nil {
+		return fmt.Errorf("crypto: inspect vault columns: %w", err)
+	}
+	have := map[string]struct{}{}
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("crypto: scan vault column: %w", err)
+		}
+		have[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("crypto: iterate vault columns: %w", err)
+	}
+	_ = rows.Close()
+
+	adds := []struct {
+		col, ddl string
+	}{
+		{"key_origin", `ALTER TABLE tenant_key_vault ADD COLUMN key_origin TEXT NOT NULL DEFAULT 'derived'`},
+		{"prev_wrapped_key", `ALTER TABLE tenant_key_vault ADD COLUMN prev_wrapped_key BLOB`},
+	}
+	for _, a := range adds {
+		if _, ok := have[a.col]; ok {
+			continue
+		}
+		if _, err := v.db.ExecContext(ctx, a.ddl); err != nil {
+			return fmt.Errorf("crypto: add vault column %s: %w", a.col, err)
+		}
+	}
 	return nil
 }
 
@@ -149,8 +208,8 @@ func (v *TenantKeyVault) Provision(ctx context.Context, tenantID string, dek []b
 		return err
 	}
 	if _, err := v.db.ExecContext(ctx,
-		`INSERT INTO tenant_key_vault (tenant_id, wrapped_key, created_at_ms) VALUES (?, ?, ?)`,
-		tenantID, wrapped, v.nowFn().UnixMilli(),
+		`INSERT INTO tenant_key_vault (tenant_id, wrapped_key, created_at_ms, key_origin) VALUES (?, ?, ?, ?)`,
+		tenantID, wrapped, v.nowFn().UnixMilli(), keyOriginRandom,
 	); err != nil {
 		return fmt.Errorf("crypto: provision tenant key %q: %w", tenantID, err)
 	}
@@ -256,6 +315,126 @@ func (v *TenantKeyVault) RewrapWithNewMaster(ctx context.Context, newMasterKey [
 	}
 	v.aead = newAEAD
 	return len(updates), nil
+}
+
+// --- #638 re-key migration primitives (package-internal) ---
+
+// rekeyCandidates returns the tenant_ids still needing migration to a random
+// key: non-shredded rows whose origin is 'derived' (never migrated) or
+// 'rekeying' (a prior migration was interrupted). Ordered for deterministic,
+// resumable runs.
+func (v *TenantKeyVault) rekeyCandidates(ctx context.Context) ([]string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	rows, err := v.db.QueryContext(ctx,
+		`SELECT tenant_id FROM tenant_key_vault
+		 WHERE shredded_at_ms IS NULL AND key_origin IN (?, ?)
+		 ORDER BY tenant_id`, keyOriginDerived, keyOriginRekeying)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: list rekey candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("crypto: scan rekey candidate: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("crypto: iterate rekey candidates: %w", err)
+	}
+	return out, nil
+}
+
+// keyOriginOf returns the key_origin for tenantID, or "" if the row is absent.
+func (v *TenantKeyVault) keyOriginOf(ctx context.Context, tenantID string) (string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	var origin string
+	err := v.db.QueryRowContext(ctx,
+		`SELECT key_origin FROM tenant_key_vault WHERE tenant_id = ?`, tenantID,
+	).Scan(&origin)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("crypto: read key_origin %q: %w", tenantID, err)
+	}
+	return origin, nil
+}
+
+// prevKey unwraps the previous (pre-rekey) DEK staged for a tenant that is
+// mid-migration. Used by recovery to re-key a DB still on its old key.
+func (v *TenantKeyVault) prevKey(ctx context.Context, tenantID string) ([]byte, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	var prev []byte
+	if err := v.db.QueryRowContext(ctx,
+		`SELECT prev_wrapped_key FROM tenant_key_vault WHERE tenant_id = ?`, tenantID,
+	).Scan(&prev); err != nil {
+		return nil, fmt.Errorf("crypto: read prev_wrapped_key %q: %w", tenantID, err)
+	}
+	if len(prev) == 0 {
+		return nil, fmt.Errorf("crypto: tenant %q has no staged previous key", tenantID)
+	}
+	return v.unwrap(prev, tenantID)
+}
+
+// stageRekey atomically moves a 'derived' row into 'rekeying': the current
+// wrapped_key is preserved as prev_wrapped_key and the master-wrapped newDEK
+// becomes the new wrapped_key. The WHERE clause pins the source state to
+// 'derived', so a re-run after a crash (row already 'rekeying') is a no-op
+// that cannot clobber the staged previous key.
+func (v *TenantKeyVault) stageRekey(ctx context.Context, tenantID string, newDEK []byte) error {
+	if len(newDEK) != KeyLength {
+		return fmt.Errorf("crypto: rekey DEK must be %d bytes, got %d", KeyLength, len(newDEK))
+	}
+	wrapped, err := v.wrap(newDEK, tenantID)
+	if err != nil {
+		return err
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	res, err := v.db.ExecContext(ctx,
+		`UPDATE tenant_key_vault
+		    SET prev_wrapped_key = wrapped_key, wrapped_key = ?, key_origin = ?
+		  WHERE tenant_id = ? AND key_origin = ?`,
+		wrapped, keyOriginRekeying, tenantID, keyOriginDerived,
+	)
+	if err != nil {
+		return fmt.Errorf("crypto: stage rekey %q: %w", tenantID, err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("crypto: stage rekey %q: row not in %q state", tenantID, keyOriginDerived)
+	}
+	return nil
+}
+
+// completeRekey finalizes a migrated tenant: it drops the staged previous key
+// and marks the origin 'random'. After this the old derived key is gone from
+// the vault, so a subsequent shred is genuinely irreversible.
+func (v *TenantKeyVault) completeRekey(ctx context.Context, tenantID string) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if _, err := v.db.ExecContext(ctx,
+		`UPDATE tenant_key_vault SET prev_wrapped_key = NULL, key_origin = ?
+		  WHERE tenant_id = ?`,
+		keyOriginRandom, tenantID,
+	); err != nil {
+		return fmt.Errorf("crypto: complete rekey %q: %w", tenantID, err)
+	}
+	return nil
+}
+
+// newRandomKey returns a fresh cryptographically-random 256-bit DEK.
+func newRandomKey() ([]byte, error) {
+	key := make([]byte, KeyLength)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("crypto: generate random tenant key: %w", err)
+	}
+	return key, nil
 }
 
 func (v *TenantKeyVault) getRowLocked(ctx context.Context, tenantID string) (*VaultRow, error) {

--- a/server/go/internal/store/rekey.go
+++ b/server/go/internal/store/rekey.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
+)
+
+// RekeyTenantDB re-encrypts tenantID's SQLite database so it ends encrypted
+// under newKey. It implements crypto.RekeyDBFunc for the #638 derived-key
+// migration and is idempotent + crash-safe:
+//
+//   - if the DB is already readable with newKey it is a no-op (a previous run
+//     re-keyed the file but may have crashed before the vault was finalized);
+//   - otherwise it opens with oldKey and runs SQLCipher PRAGMA rekey;
+//   - a missing/empty database file is a no-op (a tenant provisioned in the
+//     vault but never written — the file will be created under newKey on the
+//     first write).
+//
+// It first drops any pooled handle for the tenant so the re-key runs on a
+// fresh, exclusive connection. Run this as an offline migration step with the
+// server stopped: the store must otherwise be idle for the tenant while its
+// database file is rewritten.
+func (s *CanonicalStore) RekeyTenantDB(ctx context.Context, tenantID string, oldKey, newKey []byte) error {
+	if s.pool.keyManager == nil {
+		return fmt.Errorf("store: RekeyTenantDB requires encryption-at-rest (no key manager configured)")
+	}
+	if len(oldKey) != entcrypto.KeyLength || len(newKey) != entcrypto.KeyLength {
+		return fmt.Errorf("store: RekeyTenantDB keys must be %d bytes", entcrypto.KeyLength)
+	}
+	if err := s.CloseTenant(tenantID); err != nil {
+		return fmt.Errorf("store: close tenant %q before rekey: %w", tenantID, err)
+	}
+	path := s.pool.dbPath(tenantID)
+	_, hasDatabase, err := entcrypto.SQLiteFileEncryptionStatus(path)
+	if err != nil {
+		return err
+	}
+	if !hasDatabase {
+		// Nothing on disk yet; the first write will create the file under the
+		// new key, so there is nothing to re-encrypt.
+		return nil
+	}
+	// Idempotency: if newKey already opens the DB, a previous run re-keyed it
+	// (and only the vault finalize was lost) — treat as done.
+	if ok, err := s.dbOpensWith(ctx, path, newKey); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+	return s.rekeyFile(ctx, path, oldKey, newKey)
+}
+
+// dbOpensWith reports whether the SQLCipher database at path is readable with
+// key (i.e. key is its current encryption key). A read is forced so SQLCipher
+// actually applies and verifies the key.
+func (s *CanonicalStore) dbOpensWith(ctx context.Context, path string, key []byte) (bool, error) {
+	dsn, err := entcrypto.SQLCipherDSN(path, key, s.pool.busyTimeout)
+	if err != nil {
+		return false, err
+	}
+	db, err := sql.Open(entcrypto.SQLCipherDriverName, dsn)
+	if err != nil {
+		return false, fmt.Errorf("store: open %q for probe: %w", path, err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	var n int
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master`).Scan(&n); err != nil {
+		// Wrong key (or otherwise unreadable) — not openable with this key.
+		return false, nil
+	}
+	return true, nil
+}
+
+// rekeyFile opens path with oldKey and runs SQLCipher PRAGMA rekey to newKey
+// on a single dedicated connection.
+func (s *CanonicalStore) rekeyFile(ctx context.Context, path string, oldKey, newKey []byte) error {
+	dsn, err := entcrypto.SQLCipherDSN(path, oldKey, s.pool.busyTimeout)
+	if err != nil {
+		return err
+	}
+	db, err := sql.Open(entcrypto.SQLCipherDriverName, dsn)
+	if err != nil {
+		return fmt.Errorf("store: open %q for rekey: %w", path, err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("store: rekey conn %q: %w", path, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Confirm oldKey actually opens the DB before mutating it.
+	var n int
+	if err := conn.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master`).Scan(&n); err != nil {
+		return fmt.Errorf("store: rekey %q: database not readable with the supplied current key: %w", path, err)
+	}
+	// Flush WAL frames into the main database so the rekey covers every page.
+	if _, err := conn.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+		return fmt.Errorf("store: rekey %q: checkpoint: %w", path, err)
+	}
+	// SQLCipher PRAGMA rekey re-encrypts the whole database in place; it is
+	// atomic (journalled), so a crash leaves the file fully on the old or fully
+	// on the new key, never partially — which is what makes the migration
+	// safe to resume.
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf(`PRAGMA rekey = "x'%s'"`, hex.EncodeToString(newKey))); err != nil {
+		return fmt.Errorf("store: rekey %q: %w", path, err)
+	}
+	return nil
+}

--- a/server/go/internal/store/rekey_test.go
+++ b/server/go/internal/store/rekey_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store_test
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	entcrypto "github.com/elloloop/tenant-shard-db/server/go/internal/crypto"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+func randKey(t *testing.T) []byte {
+	t.Helper()
+	k := make([]byte, entcrypto.KeyLength)
+	if _, err := rand.Read(k); err != nil {
+		t.Fatalf("rand key: %v", err)
+	}
+	return k
+}
+
+// newEncryptedStore builds a CanonicalStore backed by a vault-backed
+// KeyManager (real SQLCipher tenant DBs).
+func newEncryptedStore(t *testing.T) (*store.CanonicalStore, *entcrypto.KeyManager) {
+	t.Helper()
+	ctx := context.Background()
+	master := make([]byte, entcrypto.KeyLength)
+	for i := range master {
+		master[i] = 0x5a
+	}
+	vdb, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "vault.db"))
+	if err != nil {
+		t.Fatalf("open vault db: %v", err)
+	}
+	t.Cleanup(func() { _ = vdb.Close() })
+	vault, err := entcrypto.NewTenantKeyVault(ctx, entcrypto.TenantKeyVaultOptions{DB: vdb, MasterKey: master})
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	km, err := entcrypto.NewKeyManager(master, vault)
+	if err != nil {
+		t.Fatalf("key manager: %v", err)
+	}
+	cs, err := store.New(store.Options{
+		RootDir:            t.TempDir(),
+		WALMode:            true,
+		KeyManager:         km,
+		EncryptionRequired: true,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs, km
+}
+
+// dbReadableWith reports whether the SQLCipher DB at path opens with key and
+// whether node nodeID is present (data-integrity probe).
+func dbReadableWith(t *testing.T, path string, key []byte, nodeID string) (opens bool, hasNode bool) {
+	t.Helper()
+	dsn, err := entcrypto.SQLCipherDSN(path, key, 0)
+	if err != nil {
+		t.Fatalf("dsn: %v", err)
+	}
+	db, err := sql.Open(entcrypto.SQLCipherDriverName, dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM sqlite_master`).Scan(&n); err != nil {
+		return false, false // wrong key
+	}
+	var c int
+	if err := db.QueryRow(`SELECT count(*) FROM nodes WHERE node_id = ?`, nodeID).Scan(&c); err != nil {
+		return true, false
+	}
+	return true, c == 1
+}
+
+// TestRekeyTenantDB_ReEncryptsAndRevokesOldKey is the crux of finding #638:
+// after a re-key the database opens with the NEW key (data intact) and no
+// longer opens with the OLD key — so an attacker who recomputes the old
+// (derived) key can no longer read the data.
+func TestRekeyTenantDB_ReEncryptsAndRevokesOldKey(t *testing.T) {
+	ctx := context.Background()
+	cs, km := newEncryptedStore(t)
+	const tenantID = "acme"
+
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	// Write a row so we can prove data survives the re-key.
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:     "n1",
+		TypeID:     1,
+		OwnerActor: "user:alice",
+		Payload:    map[string]any{"1": "secret-value"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+
+	oldKey, err := km.TenantKey(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("TenantKey: %v", err)
+	}
+	oldKey = append([]byte(nil), oldKey...)
+	newKey := randKey(t)
+
+	path, err := cs.TenantDBPath(tenantID)
+	if err != nil {
+		t.Fatalf("TenantDBPath: %v", err)
+	}
+
+	// Precondition: old key opens it (and has the node); new key does not.
+	if opens, hasNode := dbReadableWith(t, path, oldKey, "n1"); !opens || !hasNode {
+		t.Fatalf("precondition: oldKey opens=%v hasNode=%v, want true,true", opens, hasNode)
+	}
+	if opens, _ := dbReadableWith(t, path, newKey, "n1"); opens {
+		t.Fatal("precondition: newKey already opens the DB before rekey")
+	}
+
+	if err := cs.RekeyTenantDB(ctx, tenantID, oldKey, newKey); err != nil {
+		t.Fatalf("RekeyTenantDB: %v", err)
+	}
+
+	// After: new key opens it AND the row is intact; old key no longer opens.
+	if opens, hasNode := dbReadableWith(t, path, newKey, "n1"); !opens || !hasNode {
+		t.Fatalf("after rekey: newKey opens=%v hasNode=%v, want true,true (data must survive)", opens, hasNode)
+	}
+	if opens, _ := dbReadableWith(t, path, oldKey, "n1"); opens {
+		t.Fatal("after rekey: the OLD key still opens the DB — re-key did not revoke it (finding #638 not closed)")
+	}
+}
+
+// TestRekeyTenantDB_Idempotent: re-running with the same (old,new) pair after
+// the DB is already on newKey is a safe no-op (models a crash after the file
+// re-key but before the vault finalize).
+func TestRekeyTenantDB_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	cs, km := newEncryptedStore(t)
+	const tenantID = "acme"
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID: "n1", TypeID: 1, OwnerActor: "user:alice", Payload: map[string]any{"1": "v"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+	oldKey, _ := km.TenantKey(ctx, tenantID)
+	oldKey = append([]byte(nil), oldKey...)
+	newKey := randKey(t)
+
+	if err := cs.RekeyTenantDB(ctx, tenantID, oldKey, newKey); err != nil {
+		t.Fatalf("first rekey: %v", err)
+	}
+	// Second call: file is already on newKey -> no-op success.
+	if err := cs.RekeyTenantDB(ctx, tenantID, oldKey, newKey); err != nil {
+		t.Fatalf("idempotent rekey: %v", err)
+	}
+	path, _ := cs.TenantDBPath(tenantID)
+	if opens, hasNode := dbReadableWith(t, path, newKey, "n1"); !opens || !hasNode {
+		t.Fatalf("after idempotent rekey: newKey opens=%v hasNode=%v, want true,true", opens, hasNode)
+	}
+}
+
+// TestRekeyTenantDB_MissingFileIsNoOp: a tenant provisioned in the vault but
+// never written has no DB file, so re-key is a no-op success.
+func TestRekeyTenantDB_MissingFileIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	cs, _ := newEncryptedStore(t)
+	if err := cs.RekeyTenantDB(ctx, "never-written", randKey(t), randKey(t)); err != nil {
+		t.Fatalf("rekey of absent DB should be a no-op, got: %v", err)
+	}
+}
+
+// TestRekeyTenantDB_WrongOldKeyFails: if neither the new nor the supplied old
+// key opens the DB, re-key fails loudly rather than corrupting anything.
+func TestRekeyTenantDB_WrongOldKeyFails(t *testing.T) {
+	ctx := context.Background()
+	cs, _ := newEncryptedStore(t)
+	const tenantID = "acme"
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if err := cs.RekeyTenantDB(ctx, tenantID, randKey(t), randKey(t)); err == nil {
+		t.Fatal("RekeyTenantDB with a wrong current key: expected an error, got nil")
+	}
+}


### PR DESCRIPTION
Closes #638. Part of the security-audit epic #637.

## Consequence (why this matters)
GDPR "right to erasure" was an illusion. The per-tenant SQLCipher key was a pure function of the server-wide master key + tenant id (`HKDF-SHA256(masterKey, tenantID)`, no salt/random), and crypto-shred only nulled the master-wrapped copy. Anyone holding a retained/S3-archived `tenant_<id>.db` plus the master key could recompute the key offline and read every "erased" record. Article-17 (ADR-011) did not hold.

## Fix
Provision a **random 256-bit DEK** with `crypto/rand` at first touch; persist **only** the master-wrapped copy (AES-256-GCM, AAD = tenant id). Nulling that copy on shred destroys the sole copy → the shred is genuinely irreversible. New tenants are safe immediately.

**Crux test** (`store/rekey_test.go`): after a re-key the DB opens with the new key with data intact, and **no longer opens with the old key**.

## Migration for existing (derived-key) tenants
Idempotent, crash-safe, **operator-triggered** — never runs on boot, so merging this PR rewrites nothing:

```
entdb-server --migrate-tenant-keys-dry-run   # preview: lists derived-key tenants
entdb-server --migrate-tenant-keys           # re-key, offline (server stopped)
```

Per tenant: stage a random DEK in the vault (old key kept as `prev_wrapped_key`, `key_origin='rekeying'`) → re-encrypt the DB via SQLCipher `PRAGMA rekey` → finalize (`key_origin='random'`). A crash at any point is resumable: a `'rekeying'` row is detected on the next run and re-driven idempotently (`RekeyTenantDB` no-ops if the DB is already on the new key). No crash window can orphan a DB from its key.

## Changes
- `tenant_key_vault`: `+key_origin (derived|random|rekeying)`, `+prev_wrapped_key`, with an in-place column migration for existing vault DBs.
- `crypto.KeyManager.MigrateDerivedTenants` — the crash-safe state machine; `store.RekeyTenantDB` — the SQLCipher re-key.
- Activates the finding-#638 regression gate; adds orchestrator tests (re-key, idempotent, resume-after-crash, requires-vault) + real-SQLCipher integration tests (re-encrypt + old-key-revoked, idempotent, missing-file, wrong-key-fails).
- **ADR-011 amended** (key hierarchy + crypto-shred section).

## Behavior notes for operators
- New tenants get random keys automatically. **Existing tenants stay re-derivable until you run `--migrate-tenant-keys`.**
- Vault-less mode (`KeyManager` with no vault — dev/test) cannot durably shred and keeps a derived key; not a production posture.
- The WAL/S3 audit archive still holds plaintext under the operator KMS key, not the per-tenant key — tracked as #644; must ship before the "unrecoverable on S3 archive" claim is fully true.

## Verification (full local CI, green)
- `go vet` + `go test ./...` across all four Go modules — pass (incl. new crypto + store SQLCipher rekey tests)
- `gofmt` clean · `ruff check`/`format` clean
- Python integration contract suite — **118 passed**
