### PR TITLE
security(api): enforce the USER_MAILBOX privacy boundary across all read paths (#639)

### DIFF
--- a/sdk/go/entdb/integration_test.go
+++ b/sdk/go/entdb/integration_test.go
@@ -399,11 +399,15 @@ func TestIntegration_GetEdgesFromAutoFollowsRealCursor(t *testing.T) {
 }
 
 // TestIntegration_MailboxReadAndPrivacy proves USER_MAILBOX writes are
-// readable via the mailbox scope and excluded from an ordinary tenant
-// read (#568), end-to-end through the real server via the Go SDK.
+// readable via the mailbox scope by the OWNING user, excluded from an
+// ordinary tenant read (#568), and NOT readable by a different non-owner
+// caller (#639) — end-to-end through the real server via the Go SDK.
 func TestIntegration_MailboxReadAndPrivacy(t *testing.T) {
 	ctx := context.Background()
-	const mailUser = "mailbox-user-1"
+	// #639: a USER_MAILBOX node is readable only by its owning user (or an
+	// admin/system actor). itActor is "user:e2e-runner", so the mailbox owner
+	// is "e2e-runner" and itActor reads its OWN mailbox.
+	const mailUser = "e2e-runner"
 
 	res, err := itClient.transport.ExecuteAtomic(ctx, itTenant, itActor, "it-mailbox",
 		[]Operation{{
@@ -434,6 +438,12 @@ func TestIntegration_MailboxReadAndPrivacy(t *testing.T) {
 	}
 	if n != nil {
 		t.Fatalf("mailbox-private node leaked into a tenant read: %+v", n)
+	}
+
+	// Privacy (#639): a DIFFERENT non-owner caller must NOT read the mailbox
+	// node. eve names e2e-runner's mailbox scope and must be denied.
+	if _, derr := itClient.transport.GetMailboxNode(ctx, itTenant, "user:eve", mailUser, itUserType, "mbox-1"); derr == nil {
+		t.Fatal("cross-user mailbox read must be denied (#639): user:eve read e2e-runner's mailbox node")
 	}
 }
 

--- a/server/go/internal/api/audit_authz_test.go
+++ b/server/go/internal/api/audit_authz_test.go
@@ -1,0 +1,565 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Security-audit tests for the read-surface authorization gaps.
+//
+// Two findings are pinned here:
+//
+//   #639 (synthesis rank #3, HIGH) USER_MAILBOX privacy bypass — FIXED.
+//      GetNode / GetNodes / QueryNodes / SearchNodes took target_user off the
+//      wire and confined the read to that user's mailbox with NO check that
+//      the trusted caller is that user, so any tenant member could read
+//      another user's private mailbox. Fixed by authorizeMailboxScope
+//      (mailbox_authz.go), called in all four handlers before the store read.
+//      The gates below are now active.
+//
+//   #640 (synthesis rank #4, HIGH) registry-read RPCs resolve then DISCARD the
+//      trusted actor (get_tenant_members.go:80 does `_ = auth.Authoritative(
+//      ...)`) with no authz gate. Any authenticated low-privilege caller dumps
+//      any tenant's roster / any user's PII / the whole user registry. NOT yet
+//      fixed — the demonstration tests pass and the gates stay skipped.
+//
+// These tests stand up their own server wiring (newAuthzTestServer) so we own
+// the globalstore handle and can register tenant members — the shared
+// newSearchTestServer does not expose the globalstore it builds.
+//
+// Tests are package api_test; they reuse seedMailboxNode / searchTypeID from
+// the sibling _test.go files.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/globalstore"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+// newAuthzTestServer mirrors newSearchTestServer but RETURNS the globalstore
+// so the test can register tenant members (the membership row is what
+// classifies an actor as roleMember in checkCrossTenantRead). The schema is
+// identical to the search fixture (typeID=searchTypeID, two searchable string
+// fields) so seedMailboxNode works unchanged.
+//
+// Note: with no auth interceptor on ctx, auth.Authoritative returns the
+// wire-claimed actor verbatim, so the wire `actor` field drives role
+// classification directly in these tests — exactly the production path when a
+// caller authenticates as a real low-privilege user.
+func newAuthzTestServer(t *testing.T) (*api.Server, *store.CanonicalStore, *globalstore.GlobalStore, string) {
+	t.Helper()
+	gs := newGlobalStore(t)
+	ctx := context.Background()
+	const tenantID = "acme"
+	if _, err := gs.CreateTenant(ctx, tenantID, "Acme", ""); err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+
+	reg := schema.NewRegistry()
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID: searchTypeID,
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Kind: schema.KindString, Searchable: true},
+			{FieldID: 2, Kind: schema.KindString, Searchable: true},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+
+	cs, err := store.New(store.Options{
+		RootDir:  t.TempDir(),
+		WALMode:  true,
+		Registry: reg,
+	})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	// A WAL producer so write RPCs (ShareNode) reach their handler body
+	// rather than the optional-deps guard; read RPCs ignore it.
+	producer := wal.NewInMemory(0)
+	if err := producer.Connect(ctx); err != nil {
+		t.Fatalf("producer.Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = producer.Close(ctx) })
+
+	srv := api.New(
+		api.WithGlobalStore(gs),
+		api.WithStore(cs),
+		api.WithSchemaRegistry(reg),
+		api.WithWALProducer(producer),
+	)
+	return srv, cs, gs, tenantID
+}
+
+// addMember registers userID as a plain "member" of tenantID. A member is
+// classified roleMember by checkCrossTenantRead, which is the privilege level
+// the #639 bypass required (a non-member with no grant is rejected at the
+// cross-tenant gate before the mailbox read even runs).
+func addMember(t *testing.T, gs *globalstore.GlobalStore, tenantID, userID string) {
+	t.Helper()
+	if err := gs.AddTenantMember(context.Background(), tenantID, userID, "member"); err != nil {
+		t.Fatalf("AddTenantMember(%q): %v", userID, err)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Finding #639 — USER_MAILBOX privacy bypass (FIXED). authorizeMailboxScope
+// gates every mailbox-scoped read: only the target user or an admin/system
+// actor may use target_user; an ordinary member naming another user is denied.
+// -----------------------------------------------------------------------
+
+// TestGetNode_MailboxBypass_SecureBehavior_Finding3 verifies the single-node
+// read path: a non-owner member is denied, the owner and admin still read it.
+func TestGetNode_MailboxBypass_SecureBehavior_Finding3(t *testing.T) {
+	srv, cs, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "alice")
+	addMember(t, gs, tenantID, "bob")
+	seedMailboxNode(t, cs, tenantID, "bob", "mb", "secret", "bob private body")
+
+	// A non-owner member MUST NOT read another user's mailbox node.
+	resp, err := srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		NodeId:     "mb",
+		TargetUser: "bob",
+	})
+	if err != nil {
+		if status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("alice -> bob mailbox: want PermissionDenied or Found=false, got err %v", err)
+		}
+	} else if resp.GetFound() {
+		t.Fatal("alice -> bob mailbox: privacy bypass still open (Found=true)")
+	}
+
+	// The owner still reads their own mailbox node.
+	own, err := srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:bob"},
+		NodeId:     "mb",
+		TargetUser: "bob",
+	})
+	if err != nil || !own.GetFound() {
+		t.Fatalf("owner bob must still read his mailbox node: found=%v err=%v", own.GetFound(), err)
+	}
+
+	// An admin still can (system/admin bypass is intentional).
+	adm, err := srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "system:test"},
+		NodeId:     "mb",
+		TargetUser: "bob",
+	})
+	if err != nil || !adm.GetFound() {
+		t.Fatalf("admin must still read the mailbox node: found=%v err=%v", adm.GetFound(), err)
+	}
+}
+
+// TestGetNodes_MailboxBypass_SecureBehavior_Finding3 verifies the batch path.
+func TestGetNodes_MailboxBypass_SecureBehavior_Finding3(t *testing.T) {
+	srv, cs, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "alice")
+	addMember(t, gs, tenantID, "bob")
+	seedMailboxNode(t, cs, tenantID, "bob", "mb", "secret", "bob private body")
+
+	// Non-owner member: bob's node must NOT appear. Either reported missing
+	// or the call is denied outright.
+	resp, err := srv.GetNodes(ctx, &pb.GetNodesRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		NodeIds:    []string{"mb"},
+		TargetUser: "bob",
+	})
+	if err != nil {
+		if status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("alice -> bob mailbox batch: want PermissionDenied or missing, got err %v", err)
+		}
+	} else {
+		for _, n := range resp.GetNodes() {
+			if n.GetNodeId() == "mb" {
+				t.Fatal("alice -> bob mailbox batch: privacy bypass still open (leaked mb)")
+			}
+		}
+	}
+
+	// Owner still gets it.
+	own, err := srv.GetNodes(ctx, &pb.GetNodesRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:bob"},
+		NodeIds:    []string{"mb"},
+		TargetUser: "bob",
+	})
+	if err != nil || len(own.GetNodes()) != 1 {
+		t.Fatalf("owner bob must still read his mailbox node in batch: nodes=%d err=%v", len(own.GetNodes()), err)
+	}
+}
+
+// TestSearchNodes_MailboxBypass_SecureBehavior_Finding3 verifies the FTS path.
+func TestSearchNodes_MailboxBypass_SecureBehavior_Finding3(t *testing.T) {
+	srv, cs, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "alice")
+	addMember(t, gs, tenantID, "bob")
+	seedMailboxNode(t, cs, tenantID, "bob", "mb", "subject", "keyword bobsecret")
+
+	// Non-owner member: must see nothing from bob's mailbox.
+	resp, err := srv.SearchNodes(ctx, &pb.SearchNodesRequest{
+		TenantId:   tenantID,
+		Actor:      "user:alice",
+		TypeId:     searchTypeID,
+		Query:      "keyword",
+		TargetUser: "bob",
+	})
+	if err != nil {
+		if status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("alice -> bob mailbox search: want PermissionDenied or empty, got err %v", err)
+		}
+	} else if len(resp.GetNodes()) != 0 {
+		t.Fatalf("alice -> bob mailbox search: privacy bypass still open (%d nodes)", len(resp.GetNodes()))
+	}
+
+	// Owner still finds their own node.
+	own, err := srv.SearchNodes(ctx, &pb.SearchNodesRequest{
+		TenantId:   tenantID,
+		Actor:      "user:bob",
+		TypeId:     searchTypeID,
+		Query:      "keyword",
+		TargetUser: "bob",
+	})
+	if err != nil || len(own.GetNodes()) != 1 {
+		t.Fatalf("owner bob must still find his mailbox node: nodes=%d err=%v", len(own.GetNodes()), err)
+	}
+}
+
+// TestQueryNodes_MailboxBypass_SecureBehavior_Finding3 verifies the query path.
+// QueryNodes also ran a per-row ACL post-filter, but the explicit
+// authorizeMailboxScope gate now denies a cross-user mailbox query outright so
+// the boundary does not depend on that filter.
+func TestQueryNodes_MailboxBypass_SecureBehavior_Finding3(t *testing.T) {
+	srv, cs, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "alice")
+	addMember(t, gs, tenantID, "bob")
+	seedMailboxNode(t, cs, tenantID, "bob", "mb", "subject", "bob body")
+
+	// Non-owner member: denied or empty, never bob's node.
+	resp, err := srv.QueryNodes(ctx, &pb.QueryNodesRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:alice"},
+		TypeId:     searchTypeID,
+		TargetUser: "bob",
+		Limit:      100,
+	})
+	if err != nil {
+		if status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("alice -> bob mailbox query: want PermissionDenied or empty, got err %v", err)
+		}
+	} else {
+		for _, n := range resp.GetNodes() {
+			if n.GetNodeId() == "mb" {
+				t.Fatal("alice -> bob mailbox query: privacy bypass still open (leaked mb)")
+			}
+		}
+	}
+
+	// Owner still queries their own mailbox.
+	own, err := srv.QueryNodes(ctx, &pb.QueryNodesRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:bob"},
+		TypeId:     searchTypeID,
+		TargetUser: "bob",
+		Limit:      100,
+	})
+	if err != nil {
+		t.Fatalf("owner bob mailbox query: unexpected err: %v", err)
+	}
+	found := false
+	for _, n := range own.GetNodes() {
+		if n.GetNodeId() == "mb" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("owner bob must still see his mailbox node via QueryNodes")
+	}
+}
+
+// TestGetNodeByKey_MailboxBypass_SecureBehavior_Finding3 closes the 5th
+// mailbox-read path surfaced by adversarial review of the #639 fix:
+// GetNodeByKey resolves a node by unique-key value (e.g. an email) with NO
+// target_user scope and no storage_mode filter, and its only gate
+// (checkNodeACL) passes on the empty ACL a mailbox node carries. The fix makes
+// USER_MAILBOX nodes invisible to this RPC entirely, mirroring the plain by-id
+// read. A non-owner member naming a mailbox node's key must NOT get the
+// payload; a non-mailbox node by key is still resolvable.
+func TestGetNodeByKey_MailboxBypass_SecureBehavior_Finding3(t *testing.T) {
+	srv, cs, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "alice")
+	addMember(t, gs, tenantID, "bob")
+	// bob's private mailbox node; field 1 holds the (guessable) key value.
+	seedMailboxNode(t, cs, tenantID, "bob", "mb", "bob-private-key", "bob private body")
+
+	// alice (member, not bob, not admin) tries to resolve bob's mailbox node
+	// by its key value — must NOT get it.
+	resp, err := srv.GetNodeByKey(ctx, &pb.GetNodeByKeyRequest{
+		TenantId: tenantID,
+		Actor:    "user:alice",
+		TypeId:   searchTypeID,
+		FieldId:  1,
+		Value:    structpb.NewStringValue("bob-private-key"),
+	})
+	if err != nil {
+		if status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("alice GetNodeByKey -> bob mailbox: want Found=false or PermissionDenied, got err %v", err)
+		}
+	} else if resp.GetFound() {
+		t.Fatalf("GetNodeByKey leaked bob's mailbox node to alice (node_id=%q)", resp.GetNode().GetNodeId())
+	}
+
+	// Mailbox nodes are invisible to by-key for everyone (no target_user scope
+	// on this RPC) — even the owner reaches their mailbox via the scoped reads.
+	bobResp, err := srv.GetNodeByKey(ctx, &pb.GetNodeByKeyRequest{
+		TenantId: tenantID, Actor: "user:bob", TypeId: searchTypeID, FieldId: 1,
+		Value: structpb.NewStringValue("bob-private-key"),
+	})
+	if err == nil && bobResp.GetFound() {
+		t.Fatal("GetNodeByKey must not expose USER_MAILBOX nodes even to the owner; use the target_user-scoped reads")
+	}
+
+	// Regression guard: a non-mailbox (tenant) node IS still resolvable by key.
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID: "tn", TypeID: searchTypeID, OwnerActor: "user:alice",
+		Payload: map[string]any{"1": "tenant-key", "2": "body"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw(tenant node): %v", err)
+	}
+	tnResp, err := srv.GetNodeByKey(ctx, &pb.GetNodeByKeyRequest{
+		TenantId: tenantID, Actor: "user:alice", TypeId: searchTypeID, FieldId: 1,
+		Value: structpb.NewStringValue("tenant-key"),
+	})
+	if err != nil || !tnResp.GetFound() || tnResp.GetNode().GetNodeId() != "tn" {
+		t.Fatalf("non-mailbox node must still be resolvable by key: found=%v err=%v", tnResp.GetFound(), err)
+	}
+}
+
+// TestShareNode_RejectsMailboxNode_Finding3 is the root-cause prevention: a
+// USER_MAILBOX node must not enter the ACL/sharing system at all, so even its
+// owner cannot share it. This stops a mailbox node from ever acquiring a
+// node_access / shared_index row (which would egress its metadata via
+// ListSharedWithMe, incl. cross-tenant).
+func TestShareNode_RejectsMailboxNode_Finding3(t *testing.T) {
+	srv, cs, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "bob")
+	// bob OWNS the mailbox node (so the ACL owner short-circuit passes); the
+	// share must still be refused because it is a USER_MAILBOX node.
+	seedMailboxNode(t, cs, tenantID, "bob", "mb", "subj", "body")
+
+	resp, err := srv.ShareNode(ctx, &pb.ShareNodeRequest{
+		Context:    &pb.RequestContext{TenantId: tenantID, Actor: "user:bob"},
+		NodeId:     "mb",
+		ActorId:    "user:carol",
+		Permission: "read",
+	})
+	if err != nil {
+		t.Fatalf("ShareNode(mailbox): unexpected gRPC error: %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatal("ShareNode must refuse to share a USER_MAILBOX node (#639 root cause)")
+	}
+}
+
+// TestListSharedWithMe_ExcludesMailbox_Finding3 closes the cross-tenant
+// shared-with-me path: even if a mailbox node already has a cross-tenant
+// shared_index row (e.g. from before the ShareNode rejection above), the
+// recipient must not see it. The per-tenant SQL already excludes mailbox
+// nodes; this pins the cross-tenant resolution path (store.GetNode) too.
+func TestListSharedWithMe_ExcludesMailbox_Finding3(t *testing.T) {
+	srv, cs, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	// bob's private mailbox node in the source tenant.
+	seedMailboxNode(t, cs, tenantID, "bob", "ma", "subj", "body")
+	// Simulate a pre-existing cross-tenant shared_index row pointing eve at
+	// bob's mailbox node (the now-prevented share).
+	if err := gs.AddShared(ctx, "user:eve", tenantID, "ma", "read"); err != nil {
+		t.Fatalf("AddShared: %v", err)
+	}
+
+	resp, err := srv.ListSharedWithMe(ctx, &pb.ListSharedWithMeRequest{
+		Context: &pb.RequestContext{TenantId: tenantID, Actor: "user:eve"},
+		Limit:   100,
+	})
+	if err != nil {
+		t.Fatalf("ListSharedWithMe(eve): %v", err)
+	}
+	for _, n := range resp.GetNodes() {
+		if n.GetNodeId() == "ma" {
+			t.Fatal("ListSharedWithMe leaked bob's USER_MAILBOX node to eve via the cross-tenant shared_index (#639)")
+		}
+	}
+}
+
+// -----------------------------------------------------------------------
+// Finding #640 — registry-read RPCs have no authz gate (NOT yet fixed).
+// -----------------------------------------------------------------------
+
+// TestGetTenantMembers_NoAuthzGate_DemonstratesFinding4 proves a non-member,
+// non-admin caller can dump a tenant's full roster.
+//
+// FINDING #4 (HIGH/security): registry-read RPCs resolve then DISCARD the
+// actor with no authz gate.
+// File: internal/api/get_tenant_members.go:80 — `_ = auth.Authoritative(
+//
+//	ctx, auth.ParseActor(req.GetActor()))`. The rebound actor is thrown
+//	away; there is no membership/admin check before the
+//	globalstore.GetTenantMembers read.
+//
+// WHY WRONG: user:mallory is neither a member of "acme" nor an admin, yet she
+//
+//	retrieves the complete member roster (every user_id + role) — a direct
+//	PII / org-structure disclosure.
+//
+// REGRESSION: when finding #4 is fixed this assertion must flip — see the
+//
+//	_SecureBehavior gate.
+func TestGetTenantMembers_NoAuthzGate_DemonstratesFinding4(t *testing.T) {
+	srv, _, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "alice")
+	addMember(t, gs, tenantID, "bob")
+	// mallory is deliberately NOT added as a member.
+
+	resp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
+		TenantId: tenantID,
+		Actor:    "user:mallory",
+	})
+	if err != nil {
+		t.Fatalf("GetTenantMembers(mallory): unexpected err: %v", err)
+	}
+	// CURRENT (buggy) behaviour: a stranger reads the whole roster.
+	if len(resp.GetMembers()) != 2 {
+		t.Fatalf("expected the CURRENT leak: non-member mallory reads the full 2-member roster; got %d members", len(resp.GetMembers()))
+	}
+}
+
+// TestGetTenantMembers_NoAuthzGate_SecureBehavior_Finding4 is the gate.
+func TestGetTenantMembers_NoAuthzGate_SecureBehavior_Finding4(t *testing.T) {
+	t.Skip("finding #4 (registry-read RPCs have no authz gate) not yet fixed — unblock this gate when the fix lands")
+
+	srv, _, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "alice")
+	addMember(t, gs, tenantID, "bob")
+
+	// Stranger must be denied.
+	_, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
+		TenantId: tenantID,
+		Actor:    "user:mallory",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-member mallory: want PermissionDenied, got %v", err)
+	}
+
+	// A member of the tenant can still read the roster.
+	memResp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
+		TenantId: tenantID,
+		Actor:    "user:alice",
+	})
+	if err != nil || len(memResp.GetMembers()) != 2 {
+		t.Fatalf("member alice must still read the roster: members=%d err=%v", len(memResp.GetMembers()), err)
+	}
+
+	// An admin can still read the roster.
+	admResp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
+		TenantId: tenantID,
+		Actor:    "system:test",
+	})
+	if err != nil || len(admResp.GetMembers()) != 2 {
+		t.Fatalf("admin must still read the roster: members=%d err=%v", len(admResp.GetMembers()), err)
+	}
+}
+
+// TestGetUser_NoAuthzGate_DemonstratesFinding4 proves any authenticated caller
+// can read any user's profile PII.
+//
+// FINDING #4 (HIGH/security): registry-read RPCs have no authz gate.
+// File: internal/api/get_user.go:84 — `_ = auth.Authoritative(...)`; the
+//
+//	handler header itself documents "Any authenticated actor may read any
+//	user's profile. NO self/admin gate."
+//
+// WHY WRONG: user:mallory reads bob's email + name with no relationship to bob
+//
+//	— a PII disclosure to any authenticated stranger.
+//
+// REGRESSION: when finding #4 is fixed this assertion must flip — see the
+//
+//	_SecureBehavior gate.
+func TestGetUser_NoAuthzGate_DemonstratesFinding4(t *testing.T) {
+	srv, _, gs, _ := newAuthzTestServer(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob Secret"); err != nil {
+		t.Fatalf("CreateUser(bob): %v", err)
+	}
+
+	resp, err := srv.GetUser(ctx, &pb.GetUserRequest{
+		Actor:  "user:mallory", // unrelated stranger
+		UserId: "bob",
+	})
+	if err != nil {
+		t.Fatalf("GetUser(mallory -> bob): unexpected err: %v", err)
+	}
+	// CURRENT (buggy) behaviour: stranger reads bob's PII.
+	if !resp.GetFound() || resp.GetUser().GetEmail() != "bob@example.com" {
+		t.Fatalf("expected the CURRENT leak: stranger reads bob's email; found=%v email=%q",
+			resp.GetFound(), resp.GetUser().GetEmail())
+	}
+}
+
+// TestGetUser_NoAuthzGate_SecureBehavior_Finding4 is the gate.
+func TestGetUser_NoAuthzGate_SecureBehavior_Finding4(t *testing.T) {
+	t.Skip("finding #4 (registry-read RPCs have no authz gate) not yet fixed — unblock this gate when the fix lands")
+
+	srv, _, gs, _ := newAuthzTestServer(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob Secret"); err != nil {
+		t.Fatalf("CreateUser(bob): %v", err)
+	}
+
+	// Unrelated stranger must be denied another user's PII.
+	_, err := srv.GetUser(ctx, &pb.GetUserRequest{
+		Actor:  "user:mallory",
+		UserId: "bob",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("stranger mallory reading bob: want PermissionDenied, got %v", err)
+	}
+
+	// Self-read still works.
+	self, err := srv.GetUser(ctx, &pb.GetUserRequest{
+		Actor:  "user:bob",
+		UserId: "bob",
+	})
+	if err != nil || !self.GetFound() {
+		t.Fatalf("bob must still read his own profile: found=%v err=%v", self.GetFound(), err)
+	}
+
+	// Admin still works.
+	adm, err := srv.GetUser(ctx, &pb.GetUserRequest{
+		Actor:  "system:test",
+		UserId: "bob",
+	})
+	if err != nil || !adm.GetFound() {
+		t.Fatalf("admin must still read bob's profile: found=%v err=%v", adm.GetFound(), err)
+	}
+}

--- a/server/go/internal/api/get_node.go
+++ b/server/go/internal/api/get_node.go
@@ -105,6 +105,14 @@ func (s *Server) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNo
 	//    (privilege-escalation guard, commit fece3fb).
 	actor := auth.Authoritative(ctx, auth.ParseActor(req.GetContext().GetActor()))
 
+	// 2a. Mailbox privacy boundary (#639): a target_user-scoped read is
+	//     allowed only for that user or an admin/system actor. An ordinary
+	//     member naming another user is denied here, before any read.
+	if err := authorizeMailboxScope(actor, req.GetTargetUser()); err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
 	// 3. Make sure the per-tenant DB exists. CheckTenant has already
 	//    vetted the tenant id; this just lazy-creates the
 	//    tenant_<id>.db file and is a precondition for both the

--- a/server/go/internal/api/get_node_by_key.go
+++ b/server/go/internal/api/get_node_by_key.go
@@ -56,6 +56,7 @@ import (
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/payload"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -135,6 +136,20 @@ func (s *Server) GetNodeByKey(ctx context.Context, req *pb.GetNodeByKeyRequest) 
 	}
 	if node == nil {
 		// In-band miss. status=ok.
+		return &pb.GetNodeByKeyResponse{Found: false}, nil
+	}
+
+	// Mailbox privacy boundary (#639 / #568): a USER_MAILBOX node is private
+	// to its owning user and reachable ONLY through the explicit target_user
+	// mailbox scope (GetNode/GetNodes/QueryNodes/SearchNodes, gated by
+	// authorizeMailboxScope). GetNodeByKey has no target_user to authorize
+	// against, and the unique-key value (e.g. an email address) is exactly the
+	// kind of guessable identifier a mailbox unique field holds — so a mailbox
+	// node must be INVISIBLE here, the same Found=false a plain by-id read
+	// returns for a mailbox node (get_node.go). Note the per-node ACL check
+	// below would NOT catch this: mailbox nodes derive privacy from
+	// storage-mode scoping, not ACL entries, so they carry an empty ACL.
+	if node.StorageMode == int32(store.StorageModeUserMailbox) {
 		return &pb.GetNodeByKeyResponse{Found: false}, nil
 	}
 

--- a/server/go/internal/api/get_nodes.go
+++ b/server/go/internal/api/get_nodes.go
@@ -99,6 +99,14 @@ func (s *Server) GetNodes(ctx context.Context, req *pb.GetNodesRequest) (*pb.Get
 	// (documented unit-test / no-auth fallback).
 	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetContext().GetActor()))
 
+	// Mailbox privacy boundary (#639): a target_user-scoped batch is allowed
+	// only for that user or an admin/system actor. Deny here, before any I/O,
+	// so an ordinary member cannot read another user's mailbox in bulk.
+	if err := authorizeMailboxScope(trusted, req.GetTargetUser()); err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
 	// Batch-size cap. Reject BEFORE any I/O so a hostile / buggy
 	// caller cannot cause work to start.
 	if len(req.GetNodeIds()) > maxBatchNodeIDs {

--- a/server/go/internal/api/list_shared_with_me.go
+++ b/server/go/internal/api/list_shared_with_me.go
@@ -277,6 +277,13 @@ func (s *Server) mergeSharedWithMe(ctx context.Context, tenantID, actorStr strin
 					}
 					continue
 				}
+				// #639: a USER_MAILBOX node is private to its owner and must
+				// never egress via shared-with-me. The per-tenant SQL already
+				// excludes it, but the cross-tenant source resolves through the
+				// unfiltered GetNode — skip mailbox nodes here too.
+				if n.StorageMode == int32(store.StorageModeUserMailbox) {
+					continue
+				}
 				candidates = append(candidates, sharedMergeRow{node: n, ts: e.SharedAt})
 			}
 		}
@@ -348,6 +355,11 @@ func (s *Server) listSharedWithMeLegacy(ctx context.Context, tenantID, actorStr 
 						log.Printf("ListSharedWithMe: skip stale shared_index (%s/%s): %v",
 							e.SourceTenant, e.NodeID, err)
 					}
+					continue
+				}
+				// #639: never egress a USER_MAILBOX node via shared-with-me
+				// (see the keyset path above).
+				if n.StorageMode == int32(store.StorageModeUserMailbox) {
 					continue
 				}
 				nodes = append(nodes, n)

--- a/server/go/internal/api/mailbox_authz.go
+++ b/server/go/internal/api/mailbox_authz.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package api
+
+import (
+	"google.golang.org/grpc/codes"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/auth"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
+)
+
+// authorizeMailboxScope enforces the USER_MAILBOX privacy boundary (#639).
+//
+// A USER_MAILBOX node is private to exactly one user. The mailbox-scoped read
+// RPCs — GetNode / GetNodes / QueryNodes / SearchNodes — take target_user off
+// the wire and confine the read to that user's mailbox. But target_user is
+// caller-supplied, so without this gate any tenant member could read another
+// user's private mailbox simply by naming them. Membership in the tenant is
+// NOT sufficient: the caller must BE that user, or be an admin/system actor.
+//
+// Rules:
+//   - empty target_user — no mailbox scope; the ordinary tenant/ACL gates apply.
+//   - admin / system actor — allowed (operator / service access).
+//   - a user reading their OWN mailbox (trusted.ID() == target_user) — allowed.
+//   - anyone else (incl. an ordinary member naming a different user) — denied.
+//
+// The denial depends only on the caller-vs-target relationship, never on
+// whether the target's node exists, so it is not an existence oracle.
+func authorizeMailboxScope(trusted auth.Actor, targetUser string) error {
+	if targetUser == "" {
+		return nil
+	}
+	if trusted.IsAdmin() || trusted.IsSystem() {
+		return nil
+	}
+	if trusted.IsUser() && trusted.ID() == targetUser {
+		return nil
+	}
+	return errs.Errorf(codes.PermissionDenied,
+		"mailbox scope: caller may only read their own mailbox")
+}

--- a/server/go/internal/api/query_nodes.go
+++ b/server/go/internal/api/query_nodes.go
@@ -80,6 +80,15 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	claimedActor := auth.ParseActor(req.GetContext().GetActor())
 	trustedAuthActor := auth.Authoritative(ctx, claimedActor)
 
+	// Mailbox privacy boundary (#639): a target_user-scoped query is allowed
+	// only for that user or an admin/system actor. Enforce it explicitly here
+	// rather than relying solely on the per-row ACL post-filter below, so the
+	// boundary is robust even if that filter changes.
+	if err := authorizeMailboxScope(trustedAuthActor, req.GetTargetUser()); err != nil {
+		resultStatus = "error"
+		return nil, err
+	}
+
 	if s.store == nil {
 		resultStatus = "error"
 		return nil, errs.Errorf(codes.Unimplemented, "canonical store not configured")
@@ -218,10 +227,20 @@ func (s *Server) QueryNodes(ctx context.Context, req *pb.QueryNodesRequest) (*pb
 	// flows through the same code path: VisibleNodeIDs honours owner_actor
 	// matches, tenant:* grants, and direct user/group node_visibility
 	// rows.
-	nodes, err = s.applyQueryACLFilter(ctx, tenantID, trustedAuthActor, nodes)
-	if err != nil {
-		resultStatus = "error"
-		return nil, err
+	//
+	// #639: skip this generic post-filter for a mailbox-scoped read. The
+	// authorizeMailboxScope gate above already proved the caller owns this
+	// mailbox (or is admin/system) and the store restricted the result to that
+	// user's USER_MAILBOX nodes. The generic visibility path now EXCLUDES
+	// USER_MAILBOX (GetVisibleNodeIDs, #639), so running it here would wrongly
+	// drop the owner's own mailbox rows. Mailbox authorization is the scope
+	// gate, not the ACL/visibility table.
+	if req.GetTargetUser() == "" {
+		nodes, err = s.applyQueryACLFilter(ctx, tenantID, trustedAuthActor, nodes)
+		if err != nil {
+			resultStatus = "error"
+			return nil, err
+		}
 	}
 
 	// Convert store.Node -> pb.Node. Payload stays id-keyed on the wire;

--- a/server/go/internal/api/search_nodes.go
+++ b/server/go/internal/api/search_nodes.go
@@ -133,6 +133,16 @@ func (s *Server) SearchNodes(
 		return nil, errs.Errorf(errs.Code(err), "SearchNodes: open tenant: %v", err)
 	}
 
+	// Mailbox privacy boundary (#639): resolve the trusted actor up front and
+	// gate the target_user scope BEFORE the FTS search runs, so an ordinary
+	// member cannot search another user's private mailbox. Reused by the ACL
+	// post-filter below.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	if err := authorizeMailboxScope(trusted, req.GetTargetUser()); err != nil {
+		outcome = "error"
+		return nil, err
+	}
+
 	// Page size: prefer the AIP-158 page_size, fall back to the legacy
 	// limit, then the default. ADR-029 carve-out: SearchNodes keeps
 	// OFFSET paging because FTS5 `rank` is computed by the MATCH and is
@@ -194,8 +204,8 @@ func (s *Server) SearchNodes(
 
 	// 5. ACL post-filter — only when the actor is classified
 	//    "cross_tenant". In-tenant members and system actors see the
-	//    unfiltered set (see spec line 42).
-	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	//    unfiltered set (see spec line 42). `trusted` was resolved above
+	//    (mailbox-scope gate).
 	if s.isCrossTenantReader(ctx, tenantID, trusted) {
 		rows = filterNodesByActor(rows, trusted)
 	}

--- a/server/go/internal/api/share_node.go
+++ b/server/go/internal/api/share_node.go
@@ -73,6 +73,7 @@ import (
 	"github.com/elloloop/tenant-shard-db/server/go/internal/errs"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
 	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
 	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
 )
 
@@ -177,6 +178,24 @@ func (s *Server) ShareNode(
 		// via the soft-fail shape; the metric label is "error".
 		status = "error"
 		return &pb.ShareNodeResponse{Success: false, Error: err.Error()}, nil
+	}
+
+	// 4a. #639: refuse to share a USER_MAILBOX node. Mailbox nodes are private
+	//     to one user and must not enter the ACL/sharing system at all —
+	//     sharing one would let it egress to other principals/tenants via
+	//     node_access / shared_index (and ListSharedWithMe). This is the root
+	//     prevention; the read paths also defensively exclude mailbox nodes.
+	//     The owner reaches their mailbox via the target_user-scoped reads, not
+	//     by sharing. Soft-fail parity (OK + success=false).
+	if s.store != nil {
+		if n, gerr := s.store.GetNode(ctx, tenantID, nodeID); gerr == nil && n != nil &&
+			n.StorageMode == int32(store.StorageModeUserMailbox) {
+			status = "denied"
+			return &pb.ShareNodeResponse{
+				Success: false,
+				Error:   "cannot share a USER_MAILBOX node; mailbox nodes are private to their owner",
+			}, nil
+		}
 	}
 
 	// 5. Build the WAL op envelope. Field defaults:

--- a/server/go/internal/store/mailbox_visibility_test.go
+++ b/server/go/internal/store/mailbox_visibility_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// TestGetVisibleNodeIDs_ExcludesMailbox_Finding639 pins the store-layer
+// chokepoint for the USER_MAILBOX privacy boundary (#639). GetVisibleNodeIDs
+// backs every generic ACL read (GetConnectedNodes, ListSharedWithMe, the
+// QueryNodes cross-tenant post-filter). A USER_MAILBOX node owned by a user
+// would otherwise match owner_actor and leak through those paths; it must be
+// excluded here, reachable only via the explicit target_user mailbox scope.
+func TestGetVisibleNodeIDs_ExcludesMailbox_Finding639(t *testing.T) {
+	cs := newStore(t)
+	ctx := context.Background()
+	const tenantID = "t1"
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	// A regular node owned by alice — must remain visible.
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:     "reg",
+		TypeID:     1,
+		OwnerActor: "user:alice",
+		Payload:    map[string]any{"1": "x"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw(reg): %v", err)
+	}
+	// A USER_MAILBOX node owned by alice (owner_actor would match) — must be
+	// excluded from generic visibility.
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:       "mb",
+		TypeID:       1,
+		OwnerActor:   "user:alice",
+		StorageMode:  int32(store.StorageModeUserMailbox),
+		TargetUserID: "alice",
+		Payload:      map[string]any{"1": "y"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw(mb): %v", err)
+	}
+
+	vis, err := cs.GetVisibleNodeIDs(ctx, tenantID, []string{"user:alice"}, []string{"reg", "mb"})
+	if err != nil {
+		t.Fatalf("GetVisibleNodeIDs: %v", err)
+	}
+	if _, ok := vis["reg"]; !ok {
+		t.Fatal("regular owned node must be visible via GetVisibleNodeIDs")
+	}
+	if _, ok := vis["mb"]; ok {
+		t.Fatal("USER_MAILBOX node must NOT surface through generic visibility (#639) — it would leak via GetConnectedNodes / ListSharedWithMe / the QueryNodes post-filter")
+	}
+}
+
+// TestExportUserData_ExcludesOtherUsersMailbox_Finding639 pins the GDPR-export
+// arm of the mailbox-privacy invariant: a USER_MAILBOX node owned by another
+// user must NOT be pulled into a subject's export via the subject field, while
+// the subject's OWN mailbox node (and ordinary subject-matched nodes) remain
+// exportable.
+func TestExportUserData_ExcludesOtherUsersMailbox_Finding639(t *testing.T) {
+	subjectField := uint32(2)
+	reg := schema.NewRegistry()
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID:       7,
+		SubjectField: &subjectField,
+		Fields: []schema.FieldDef{
+			{FieldID: 1, Kind: schema.KindString},
+			{FieldID: 2, Kind: schema.KindString},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+
+	cs := newStoreWithRegistry(t, reg)
+	ctx := context.Background()
+	const tenantID = "t1"
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	// bob's PRIVATE mailbox node that names alice as its data subject (field 2).
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID: "bob-mb", TypeID: 7, OwnerActor: "user:bob",
+		StorageMode: int32(store.StorageModeUserMailbox), TargetUserID: "bob",
+		Payload: map[string]any{"2": "alice"},
+	}); err != nil {
+		t.Fatalf("create bob mailbox: %v", err)
+	}
+	// alice's OWN mailbox node — her data, must stay exportable to her.
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID: "alice-mb", TypeID: 7, OwnerActor: "user:alice",
+		StorageMode: int32(store.StorageModeUserMailbox), TargetUserID: "alice",
+		Payload: map[string]any{"1": "x", "2": "alice"},
+	}); err != nil {
+		t.Fatalf("create alice mailbox: %v", err)
+	}
+	// an ordinary (non-mailbox) node about alice, owned by bob — subject access OK.
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID: "reg-about-alice", TypeID: 7, OwnerActor: "user:bob",
+		Payload: map[string]any{"2": "alice"},
+	}); err != nil {
+		t.Fatalf("create regular subject node: %v", err)
+	}
+
+	exp, err := cs.ExportUserData(ctx, tenantID, "user:alice", reg)
+	if err != nil {
+		t.Fatalf("ExportUserData: %v", err)
+	}
+	got := map[string]bool{}
+	for _, n := range exp.Nodes {
+		got[n.NodeID] = true
+	}
+	if got["bob-mb"] {
+		t.Fatal("ExportUserData leaked bob's USER_MAILBOX node (subject=alice) into alice's export (#639)")
+	}
+	if !got["alice-mb"] {
+		t.Fatal("alice's OWN mailbox node must remain in her export (GDPR portability of her own data)")
+	}
+	if !got["reg-about-alice"] {
+		t.Fatal("an ordinary node naming alice as subject must still be exported (subject access)")
+	}
+}

--- a/server/go/internal/store/nodes.go
+++ b/server/go/internal/store/nodes.go
@@ -837,7 +837,7 @@ func (s *CanonicalStore) ExportUserData(
 	}
 	rows, err := db.QueryContext(ctx, `
 		SELECT node_id, type_id, payload_json,
-		       created_at, updated_at, owner_actor
+		       created_at, updated_at, owner_actor, storage_mode
 		FROM nodes WHERE tenant_id = ?`,
 		tenantID,
 	)
@@ -848,10 +848,10 @@ func (s *CanonicalStore) ExportUserData(
 	for rows.Next() {
 		var (
 			nodeID, payloadJSON, owner string
-			typeID                     int32
+			typeID, storageMode        int32
 			createdAt, updatedAt       int64
 		)
-		if err := rows.Scan(&nodeID, &typeID, &payloadJSON, &createdAt, &updatedAt, &owner); err != nil {
+		if err := rows.Scan(&nodeID, &typeID, &payloadJSON, &createdAt, &updatedAt, &owner, &storageMode); err != nil {
 			return out, fmt.Errorf("store: ExportUserData scan: %w", err)
 		}
 
@@ -882,7 +882,15 @@ func (s *CanonicalStore) ExportUserData(
 
 		isOwner := owner == principal
 		isSubject := false
-		if hasSubjectField {
+		// #639: a USER_MAILBOX node is private to its owning user and must not
+		// be pulled into another user's export via the subject field. It is
+		// included ONLY when the export principal OWNS it (isOwner — their own
+		// mailbox, i.e. GDPR portability of their own data); it is NEVER matched
+		// by subject. Otherwise bob's private mailbox node that names alice as
+		// its data subject would egress to alice (or an admin running alice's
+		// export). Subject-access to mailbox content about a user, if ever
+		// wanted, needs a deliberate owner-aware mechanism, not this scan.
+		if hasSubjectField && storageMode != int32(StorageModeUserMailbox) {
 			// Strip the `user:` prefix from `principal` before
 			// comparing to the subject field value (which stores the
 			// bare user_id, e.g. "alice", not the principal form).

--- a/server/go/internal/store/visibility.go
+++ b/server/go/internal/store/visibility.go
@@ -90,16 +90,25 @@ func (s *CanonicalStore) GetVisibleNodeIDs(ctx context.Context, tenantID string,
 	visPh := strings.Repeat("?,", len(visIDs))
 	visPh = visPh[:len(visPh)-1]
 
+	// #639: USER_MAILBOX nodes are private to their owning user and reachable
+	// ONLY through the explicit target_user mailbox scope. They must never
+	// surface through generic ACL visibility — owner_actor / node_visibility /
+	// tenant:* — which backs GetConnectedNodes, ListSharedWithMe, and the
+	// QueryNodes cross-tenant post-filter. Excluding storage_mode==USER_MAILBOX
+	// here is the single store-layer chokepoint for that invariant (the
+	// mailbox-scoped reads use GetMailboxNode / SearchMailboxNodes, which do
+	// not go through this method).
 	q := fmt.Sprintf(`
 		SELECT DISTINCT n.node_id FROM nodes n
 		LEFT JOIN node_visibility v
 		    ON v.tenant_id = n.tenant_id AND v.node_id = n.node_id
 		WHERE n.tenant_id = ? AND n.node_id IN (%s)
 		  AND ( n.owner_actor IN (%s)
-		     OR v.principal IN (%s) )`,
+		     OR v.principal IN (%s) )
+		  AND n.storage_mode <> ?`,
 		nodePh, actorPh, visPh,
 	)
-	args := make([]any, 0, 1+len(nodeIDs)+len(actorIDs)+len(visIDs))
+	args := make([]any, 0, 2+len(nodeIDs)+len(actorIDs)+len(visIDs))
 	args = append(args, tenantID)
 	for _, id := range nodeIDs {
 		args = append(args, id)
@@ -110,6 +119,7 @@ func (s *CanonicalStore) GetVisibleNodeIDs(ctx context.Context, tenantID string,
 	for _, v := range visIDs {
 		args = append(args, v)
 	}
+	args = append(args, int32(StorageModeUserMailbox))
 	rows, err := db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("store: GetVisibleNodeIDs: %w", err)
@@ -179,14 +189,18 @@ func (s *CanonicalStore) ListSharedWithMePaged(ctx context.Context, tenantID str
 		  AND na.actor_id IN (%s)
 		  AND na.permission != 'deny'
 		  AND (na.expires_at IS NULL OR na.expires_at > ?)
+		  AND n.storage_mode <> ?
 		GROUP BY n.node_id`, ph,
 	)
-	args := make([]any, 0, 6+len(actorIDs))
+	args := make([]any, 0, 7+len(actorIDs))
 	args = append(args, tenantID)
 	for _, a := range actorIDs {
 		args = append(args, a)
 	}
-	args = append(args, s.now())
+	// #639: a USER_MAILBOX node must never egress through shared-with-me, even
+	// if it somehow acquired a node_access grant — mailbox privacy is not ACL-
+	// based.
+	args = append(args, s.now(), int32(StorageModeUserMailbox))
 	// Keyset seek (ADR-029): resume strictly after the cursor tuple in the
 	// effective DESC order (granted_at, source_tenant, node_id). The
 	// source_tenant for every per-tenant row is tenantID itself, so the
@@ -253,15 +267,17 @@ func (s *CanonicalStore) ListSharedWithMe(ctx context.Context, tenantID string, 
 		  AND na.actor_id IN (%s)
 		  AND na.permission != 'deny'
 		  AND (na.expires_at IS NULL OR na.expires_at > ?)
+		  AND n.storage_mode <> ?
 		ORDER BY na.granted_at DESC, n.node_id DESC
 		LIMIT ? OFFSET ?`, ph,
 	)
-	args := make([]any, 0, 4+len(actorIDs))
+	args := make([]any, 0, 5+len(actorIDs))
 	args = append(args, tenantID)
 	for _, a := range actorIDs {
 		args = append(args, a)
 	}
-	args = append(args, s.now(), limit, offset)
+	// #639: exclude USER_MAILBOX (mailbox privacy is not ACL/grant based).
+	args = append(args, s.now(), int32(StorageModeUserMailbox), limit, offset)
 	rows, err := db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("store: ListSharedWithMe: %w", err)

--- a/tests/python/e2e/test_pagination_mailbox.py
+++ b/tests/python/e2e/test_pagination_mailbox.py
@@ -63,10 +63,15 @@ async def test_edges_out_auto_follows_complete_set(db_client, fresh_tenant, acto
 
 
 async def test_mailbox_read_and_tenant_privacy(db_client, fresh_tenant, actor) -> None:
-    """A USER_MAILBOX node is visible via the mailbox scope and EXCLUDED
-    from an ordinary tenant read (#568 privacy boundary)."""
+    """A USER_MAILBOX node is visible to its OWNING user via the mailbox
+    scope and EXCLUDED from an ordinary tenant read (#568 privacy boundary).
+
+    #639: the mailbox scope is authorized only for the owning user (or an
+    admin/system actor), so the owner reads their OWN mailbox here — the
+    mailbox user is the caller's own id, not an arbitrary third user.
+    """
     scope = db_client.tenant(fresh_tenant).actor(actor)
-    mailbox_user = "mail-user-1"
+    mailbox_user = actor.removeprefix("user:")  # owner reads their own mailbox
 
     plan = scope.plan()
     plan.create(pb.User(email="tenant@x", name="Tenant Node"), as_="tenant_node")


### PR DESCRIPTION
Closes #639. Part of the security-audit epic #637.

## Consequence (why this matters)
A USER_MAILBOX node is a user's private inbox. The mailbox-scoped read RPCs took a caller-supplied `target_user` and confined the read to that user's mailbox — **with no check that the caller is that user** — so any tenant member could read anyone else's private mailbox by naming them. Adversarial review then found the leak was a *class*: there was no store-layer chokepoint, so several other read paths egressed mailbox content too.

## The invariant
A USER_MAILBOX node is reachable **only** through the explicit `target_user` scope, authorized to the owning user (`trusted.ID() == target_user`) or an admin/system actor. It must never egress to anyone else through any read, edge, share, or export path.

## What's closed (every surface)
| Surface | Fix |
|---|---|
| `GetNode` / `GetNodes` / `QueryNodes` / `SearchNodes` | `authorizeMailboxScope` gate before the store read (oracle-safe denial) |
| `GetNodeByKey` | mailbox nodes invisible to by-key lookups |
| `GetConnectedNodes` (incl. multi-hop) + QueryNodes cross-tenant post-filter | **store chokepoint**: `GetVisibleNodeIDs` excludes `USER_MAILBOX` |
| `ListSharedWithMe` (per-tenant **and** cross-tenant) | SQL exclusion + cross-tenant resolution filter |
| `ShareNode` | **root cause**: refuses to share a `USER_MAILBOX` node |
| `ExportUserData` | mailbox node exported only if the principal **owns** it; never via the subject field |

Owner + admin/system keep full mailbox access; a user's **own** mailbox stays in their GDPR export.

## How it was verified
Three rounds of independent adversarial review, each found and closed a residual the prior round missed:
1. `GetNodeByKey` (5th read path)
2. `GetConnectedNodes` + `ListSharedWithMe` (no store chokepoint → added `GetVisibleNodeIDs` exclusion)
3. cross-tenant `ListSharedWithMe` share path + `ExportUserData` subject arm

The final sweep confirmed all other paths sound (GetEdges = pre-existing metadata-only gap; mailbox RPCs are stubs; `GetNodeByCompositeKey` isn't exposed; the gate is robust against actor-kind edge cases).

## Tests
9 regression tests: 7 RPC gates (the 4 scoped reads + `GetNodeByKey` + `ShareNode` rejection + `ListSharedWithMe` cross-tenant exclusion) and 2 store-level chokepoint tests (`GetVisibleNodeIDs` + `ExportUserData`).

## Behavior changes for operators
- `ShareNode` on a `USER_MAILBOX` node now soft-fails (mailbox nodes are not shareable — by design).
- A mailbox node that names another user as its data subject is no longer pulled into that user's `ExportUserData` bundle.

## Verification (full local CI, green)
- `go vet` + `go test ./...` across all 4 Go modules · `gofmt` clean · `ruff` clean
- Python integration contract suite — **118 passed**
- No proto/SDK change; server-internal only.
