### PR TITLE
security(api): gate registry-read RPCs (GetUser/GetUserTenants/GetTenantMembers/ListUsers) (#640)

### DIFF
--- a/server/go/internal/api/audit_authz_test.go
+++ b/server/go/internal/api/audit_authz_test.go
@@ -15,8 +15,8 @@
 //   #640 (synthesis rank #4, HIGH) registry-read RPCs resolve then DISCARD the
 //      trusted actor (get_tenant_members.go:80 does `_ = auth.Authoritative(
 //      ...)`) with no authz gate. Any authenticated low-privilege caller dumps
-//      any tenant's roster / any user's PII / the whole user registry. NOT yet
-//      fixed — the demonstration tests pass and the gates stay skipped.
+//      any tenant's roster / any user's PII / the whole user registry. now
+//      gated (this change) — the gates below are active.
 //
 // These tests stand up their own server wiring (newAuthzTestServer) so we own
 // the globalstore handle and can register tenant members — the shared
@@ -410,70 +410,30 @@ func TestListSharedWithMe_ExcludesMailbox_Finding3(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------
-// Finding #640 — registry-read RPCs have no authz gate (NOT yet fixed).
+// Finding #640 (FIXED): registry-read RPCs are now gated. GetUser /
+// GetUserTenants require self-or-admin; GetTenantMembers requires
+// membership-or-admin; ListUsers requires an admin/system actor.
 // -----------------------------------------------------------------------
 
-// TestGetTenantMembers_NoAuthzGate_DemonstratesFinding4 proves a non-member,
-// non-admin caller can dump a tenant's full roster.
-//
-// FINDING #4 (HIGH/security): registry-read RPCs resolve then DISCARD the
-// actor with no authz gate.
-// File: internal/api/get_tenant_members.go:80 — `_ = auth.Authoritative(
-//
-//	ctx, auth.ParseActor(req.GetActor()))`. The rebound actor is thrown
-//	away; there is no membership/admin check before the
-//	globalstore.GetTenantMembers read.
-//
-// WHY WRONG: user:mallory is neither a member of "acme" nor an admin, yet she
-//
-//	retrieves the complete member roster (every user_id + role) — a direct
-//	PII / org-structure disclosure.
-//
-// REGRESSION: when finding #4 is fixed this assertion must flip — see the
-//
-//	_SecureBehavior gate.
-func TestGetTenantMembers_NoAuthzGate_DemonstratesFinding4(t *testing.T) {
-	srv, _, gs, tenantID := newAuthzTestServer(t)
-	ctx := context.Background()
-	addMember(t, gs, tenantID, "alice")
-	addMember(t, gs, tenantID, "bob")
-	// mallory is deliberately NOT added as a member.
-
-	resp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
-		TenantId: tenantID,
-		Actor:    "user:mallory",
-	})
-	if err != nil {
-		t.Fatalf("GetTenantMembers(mallory): unexpected err: %v", err)
-	}
-	// CURRENT (buggy) behaviour: a stranger reads the whole roster.
-	if len(resp.GetMembers()) != 2 {
-		t.Fatalf("expected the CURRENT leak: non-member mallory reads the full 2-member roster; got %d members", len(resp.GetMembers()))
-	}
-}
-
-// TestGetTenantMembers_NoAuthzGate_SecureBehavior_Finding4 is the gate.
+// TestGetTenantMembers_NoAuthzGate_SecureBehavior_Finding4 verifies a
+// non-member, non-admin caller is denied while a member and an admin still
+// read the roster.
 func TestGetTenantMembers_NoAuthzGate_SecureBehavior_Finding4(t *testing.T) {
-	t.Skip("finding #4 (registry-read RPCs have no authz gate) not yet fixed — unblock this gate when the fix lands")
-
 	srv, _, gs, tenantID := newAuthzTestServer(t)
 	ctx := context.Background()
 	addMember(t, gs, tenantID, "alice")
 	addMember(t, gs, tenantID, "bob")
 
 	// Stranger must be denied.
-	_, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
-		TenantId: tenantID,
-		Actor:    "user:mallory",
-	})
-	if status.Code(err) != codes.PermissionDenied {
+	if _, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
+		TenantId: tenantID, Actor: "user:mallory",
+	}); status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("non-member mallory: want PermissionDenied, got %v", err)
 	}
 
-	// A member of the tenant can still read the roster.
+	// A member can still read the roster.
 	memResp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
-		TenantId: tenantID,
-		Actor:    "user:alice",
+		TenantId: tenantID, Actor: "user:alice",
 	})
 	if err != nil || len(memResp.GetMembers()) != 2 {
 		t.Fatalf("member alice must still read the roster: members=%d err=%v", len(memResp.GetMembers()), err)
@@ -481,85 +441,78 @@ func TestGetTenantMembers_NoAuthzGate_SecureBehavior_Finding4(t *testing.T) {
 
 	// An admin can still read the roster.
 	admResp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
-		TenantId: tenantID,
-		Actor:    "system:test",
+		TenantId: tenantID, Actor: "system:test",
 	})
 	if err != nil || len(admResp.GetMembers()) != 2 {
 		t.Fatalf("admin must still read the roster: members=%d err=%v", len(admResp.GetMembers()), err)
 	}
 }
 
-// TestGetUser_NoAuthzGate_DemonstratesFinding4 proves any authenticated caller
-// can read any user's profile PII.
-//
-// FINDING #4 (HIGH/security): registry-read RPCs have no authz gate.
-// File: internal/api/get_user.go:84 — `_ = auth.Authoritative(...)`; the
-//
-//	handler header itself documents "Any authenticated actor may read any
-//	user's profile. NO self/admin gate."
-//
-// WHY WRONG: user:mallory reads bob's email + name with no relationship to bob
-//
-//	— a PII disclosure to any authenticated stranger.
-//
-// REGRESSION: when finding #4 is fixed this assertion must flip — see the
-//
-//	_SecureBehavior gate.
-func TestGetUser_NoAuthzGate_DemonstratesFinding4(t *testing.T) {
-	srv, _, gs, _ := newAuthzTestServer(t)
-	ctx := context.Background()
-	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob Secret"); err != nil {
-		t.Fatalf("CreateUser(bob): %v", err)
-	}
-
-	resp, err := srv.GetUser(ctx, &pb.GetUserRequest{
-		Actor:  "user:mallory", // unrelated stranger
-		UserId: "bob",
-	})
-	if err != nil {
-		t.Fatalf("GetUser(mallory -> bob): unexpected err: %v", err)
-	}
-	// CURRENT (buggy) behaviour: stranger reads bob's PII.
-	if !resp.GetFound() || resp.GetUser().GetEmail() != "bob@example.com" {
-		t.Fatalf("expected the CURRENT leak: stranger reads bob's email; found=%v email=%q",
-			resp.GetFound(), resp.GetUser().GetEmail())
-	}
-}
-
-// TestGetUser_NoAuthzGate_SecureBehavior_Finding4 is the gate.
+// TestGetUser_NoAuthzGate_SecureBehavior_Finding4 verifies a stranger cannot
+// read another user's profile PII; self and admin still can.
 func TestGetUser_NoAuthzGate_SecureBehavior_Finding4(t *testing.T) {
-	t.Skip("finding #4 (registry-read RPCs have no authz gate) not yet fixed — unblock this gate when the fix lands")
-
 	srv, _, gs, _ := newAuthzTestServer(t)
 	ctx := context.Background()
 	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob Secret"); err != nil {
 		t.Fatalf("CreateUser(bob): %v", err)
 	}
 
-	// Unrelated stranger must be denied another user's PII.
-	_, err := srv.GetUser(ctx, &pb.GetUserRequest{
-		Actor:  "user:mallory",
-		UserId: "bob",
-	})
-	if status.Code(err) != codes.PermissionDenied {
+	if _, err := srv.GetUser(ctx, &pb.GetUserRequest{
+		Actor: "user:mallory", UserId: "bob",
+	}); status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("stranger mallory reading bob: want PermissionDenied, got %v", err)
 	}
 
-	// Self-read still works.
-	self, err := srv.GetUser(ctx, &pb.GetUserRequest{
-		Actor:  "user:bob",
-		UserId: "bob",
-	})
+	self, err := srv.GetUser(ctx, &pb.GetUserRequest{Actor: "user:bob", UserId: "bob"})
 	if err != nil || !self.GetFound() {
 		t.Fatalf("bob must still read his own profile: found=%v err=%v", self.GetFound(), err)
 	}
 
-	// Admin still works.
-	adm, err := srv.GetUser(ctx, &pb.GetUserRequest{
-		Actor:  "system:test",
-		UserId: "bob",
-	})
+	adm, err := srv.GetUser(ctx, &pb.GetUserRequest{Actor: "system:test", UserId: "bob"})
 	if err != nil || !adm.GetFound() {
 		t.Fatalf("admin must still read bob's profile: found=%v err=%v", adm.GetFound(), err)
+	}
+}
+
+// TestGetUserTenants_NoAuthzGate_SecureBehavior_Finding4 verifies a stranger
+// cannot enumerate another user's tenant graph; self and admin can.
+func TestGetUserTenants_NoAuthzGate_SecureBehavior_Finding4(t *testing.T) {
+	srv, _, gs, tenantID := newAuthzTestServer(t)
+	ctx := context.Background()
+	addMember(t, gs, tenantID, "bob")
+
+	if _, err := srv.GetUserTenants(ctx, &pb.GetUserTenantsRequest{
+		Actor: "user:mallory", UserId: "bob",
+	}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("stranger mallory reading bob's tenants: want PermissionDenied, got %v", err)
+	}
+
+	if _, err := srv.GetUserTenants(ctx, &pb.GetUserTenantsRequest{
+		Actor: "user:bob", UserId: "bob",
+	}); err != nil {
+		t.Fatalf("bob must still read his own tenant memberships: %v", err)
+	}
+
+	if _, err := srv.GetUserTenants(ctx, &pb.GetUserTenantsRequest{
+		Actor: "system:test", UserId: "bob",
+	}); err != nil {
+		t.Fatalf("admin must still read bob's tenant memberships: %v", err)
+	}
+}
+
+// TestListUsers_NoAuthzGate_SecureBehavior_Finding4 verifies ListUsers is
+// admin/system only — a non-privileged caller cannot enumerate the registry.
+func TestListUsers_NoAuthzGate_SecureBehavior_Finding4(t *testing.T) {
+	srv, _, gs, _ := newAuthzTestServer(t)
+	ctx := context.Background()
+	if _, err := gs.CreateUser(ctx, "bob", "bob@example.com", "Bob"); err != nil {
+		t.Fatalf("CreateUser(bob): %v", err)
+	}
+
+	if _, err := srv.ListUsers(ctx, &pb.ListUsersRequest{Actor: "user:mallory", Limit: 10}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin ListUsers: want PermissionDenied, got %v", err)
+	}
+	if _, err := srv.ListUsers(ctx, &pb.ListUsersRequest{Actor: "system:test", Limit: 10}); err != nil {
+		t.Fatalf("admin ListUsers must succeed: %v", err)
 	}
 }

--- a/server/go/internal/api/get_tenant_members.go
+++ b/server/go/internal/api/get_tenant_members.go
@@ -72,12 +72,23 @@ func (s *Server) GetTenantMembers(
 		return nil, errs.Errorf(codes.InvalidArgument, "tenant_id is required")
 	}
 
-	// Trusted-actor rebinding. No-op on the response today (no
-	// membership gate), but consistent with the rest of the
-	// surface and the privilege-escalation fix in #168. The rebound
-	// actor is intentionally unused; we keep the call as documentation
-	// and to match the canonical handler shape.
-	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	// #640: a tenant's roster (every member's user_id + role) is readable only
+	// by a member of that tenant or an admin/system actor — not by an
+	// authenticated stranger from another tenant. A non-member is denied
+	// before the read; lookupMemberRole("") naturally covers an unknown tenant
+	// (no membership row) too.
+	trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	if !(trusted.IsAdmin() || trusted.IsSystem()) {
+		role, rerr := s.lookupMemberRole(ctx, req.GetTenantId(), trusted.ID())
+		if rerr != nil {
+			metrics.RecordGRPCRequest(ctx, getTenantMembersMethod, "error", time.Since(start))
+			return nil, errs.Errorf(codes.Internal, "GetTenantMembers: membership check failed")
+		}
+		if role == "" {
+			metrics.RecordGRPCRequest(ctx, getTenantMembersMethod, "error", time.Since(start))
+			return nil, errs.Errorf(codes.PermissionDenied, "actor is not a member of this tenant")
+		}
+	}
 
 	rows, err := s.global.GetTenantMembers(ctx, req.GetTenantId())
 	if err != nil {

--- a/server/go/internal/api/get_tenant_members_test.go
+++ b/server/go/internal/api/get_tenant_members_test.go
@@ -39,7 +39,7 @@ func TestGetTenantMembers_EmptyTenant(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	resp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
-		Actor:    "user:alice",
+		Actor:    "system:admin", // #640: roster read requires member-or-admin
 		TenantId: "acme",
 	})
 	if err != nil {
@@ -73,7 +73,7 @@ func TestGetTenantMembers_SingleMember(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	resp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
-		Actor:    "user:alice",
+		Actor:    "system:admin", // #640: roster read requires member-or-admin
 		TenantId: "acme",
 	})
 	if err != nil {
@@ -121,7 +121,7 @@ func TestGetTenantMembers_MultipleMembers(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	resp, err := srv.GetTenantMembers(ctx, &pb.GetTenantMembersRequest{
-		Actor:    "user:alice",
+		Actor:    "system:admin", // #640: roster read requires member-or-admin
 		TenantId: "acme",
 	})
 	if err != nil {
@@ -158,7 +158,7 @@ func TestGetTenantMembers_UnknownTenant(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	resp, err := srv.GetTenantMembers(context.Background(), &pb.GetTenantMembersRequest{
-		Actor:    "user:alice",
+		Actor:    "system:admin", // #640: roster read requires member-or-admin
 		TenantId: "ghost",
 	})
 	if err != nil {

--- a/server/go/internal/api/get_user.go
+++ b/server/go/internal/api/get_user.go
@@ -76,12 +76,14 @@ func (s *Server) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.GetUs
 		return nil, errs.Errorf(codes.InvalidArgument, "user_id is required")
 	}
 
-	// Resolve trusted identity from ctx. The result is intentionally
-	// unused for any authorization decision (this RPC has none) -- the
-	// call exists so a future tightening to self-or-admin has a single
-	// chokepoint to bind against, and so we explicitly honour the
-	// trusted-actor pattern documented in CLAUDE.md / commit fece3fb.
-	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	// #640: a user's profile (email + name) is readable only by that user or
+	// an admin/system actor — not by any authenticated stranger. The denial
+	// is independent of whether user_id exists, so it is not an existence
+	// oracle.
+	if trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor())); !isSelfOrAdmin(trusted, req.GetUserId()) {
+		resultStatus = "error"
+		return nil, errs.Errorf(codes.PermissionDenied, "actor may only read their own profile")
+	}
 
 	// Read globalstore.user_registry. (nil, nil) on miss.
 	user, err := s.global.GetUser(ctx, req.GetUserId())

--- a/server/go/internal/api/get_user_tenants.go
+++ b/server/go/internal/api/get_user_tenants.go
@@ -77,12 +77,13 @@ func (s *Server) GetUserTenants(
 		metrics.RecordGRPCRequest(ctx, grpcMethodGetUserTenants, outcome, time.Since(start))
 	}()
 
-	// Trusted-actor resolution. The result is intentionally not used
-	// for an authz decision; the call exists so the interceptor's
-	// identity always wins over any payload-claimed actor (defence in
-	// depth — see the spec's "privilege-boundary gap" note and the
-	// comment block above).
-	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	// #640: a user's tenant graph (which tenants they belong to) is readable
+	// only by that user or an admin/system actor, not by any authenticated
+	// stranger.
+	if trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor())); !isSelfOrAdmin(trusted, req.GetUserId()) {
+		outcome = "error"
+		return nil, status.Error(codes.PermissionDenied, "actor may only read their own tenant memberships")
+	}
 
 	rows, qerr := s.global.GetUserTenants(ctx, req.GetUserId())
 	if qerr != nil {

--- a/server/go/internal/api/get_user_test.go
+++ b/server/go/internal/api/get_user_test.go
@@ -93,7 +93,7 @@ func TestGetUser_MissingUser(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	resp, err := srv.GetUser(context.Background(), &pb.GetUserRequest{
-		Actor:  "user:alice",
+		Actor:  "system:admin", // #640: registry read requires self-or-admin
 		UserId: "ghost",
 	})
 	if err != nil {

--- a/server/go/internal/api/list_users.go
+++ b/server/go/internal/api/list_users.go
@@ -65,10 +65,14 @@ func (s *Server) ListUsers(
 		return nil, errs.Errorf(codes.InvalidArgument, "actor is required")
 	}
 
-	// Trusted-actor invariant: rebind from ctx even though no privilege
-	// check consumes it today. Keeps the privilege-escalation guard wired
-	// for a future capability gate (see commit fece3fb / CLAUDE.md).
-	_ = auth.Authoritative(ctx, auth.ParseActor(req.GetActor()))
+	// #640: ListUsers paginates the deployment-wide user_registry (no tenant
+	// scope — the registry has no tenant column), so it is restricted to
+	// admin/system actors, the same class as ListTenants. A non-privileged
+	// caller cannot enumerate every user / email in the deployment.
+	if trusted := auth.Authoritative(ctx, auth.ParseActor(req.GetActor())); !(trusted.IsAdmin() || trusted.IsSystem()) {
+		statusLabel = "error"
+		return nil, errs.Errorf(codes.PermissionDenied, "ListUsers requires an admin or system actor")
+	}
 
 	statusFilter := req.GetStatus()
 	if statusFilter == "" {

--- a/server/go/internal/api/list_users_test.go
+++ b/server/go/internal/api/list_users_test.go
@@ -40,7 +40,7 @@ func TestListUsers_EmptyRegistry(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	resp, err := srv.ListUsers(context.Background(), &pb.ListUsersRequest{
-		Actor: "user:u1",
+		Actor: "system:admin",
 	})
 	if err != nil {
 		t.Fatalf("ListUsers: unexpected error: %v", err)
@@ -140,7 +140,7 @@ func TestListUsers_DefaultStatusApplied(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	// No status -> default: status="active".
-	resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{Actor: "user:u1"})
+	resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{Actor: "system:admin"})
 	if err != nil {
 		t.Fatalf("ListUsers: unexpected error: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestListUsers_DefaultStatusApplied(t *testing.T) {
 
 	// Explicit status="deleted" should now surface ghost.
 	resp, err = srv.ListUsers(ctx, &pb.ListUsersRequest{
-		Actor:  "user:u1",
+		Actor:  "system:admin",
 		Status: "deleted",
 	})
 	if err != nil {
@@ -187,7 +187,7 @@ func TestListUsers_DefaultLimitApplied(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	// limit unset (zero) -> default 100.
-	resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{Actor: "user:u1"})
+	resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{Actor: "system:admin"})
 	if err != nil {
 		t.Fatalf("ListUsers: unexpected error: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestListUsers_DefaultLimitApplied(t *testing.T) {
 	// Explicit larger limit returns all rows — proves no hidden cap and
 	// that the previous result was bounded by the default, not the data.
 	resp, err = srv.ListUsers(ctx, &pb.ListUsersRequest{
-		Actor: "user:u1",
+		Actor: "system:admin",
 		Limit: 200,
 	})
 	if err != nil {
@@ -249,7 +249,7 @@ func TestListUsers_GlobalStoreUnconfigured(t *testing.T) {
 	srv := api.New() // no WithGlobalStore — global == nil.
 
 	_, err := srv.ListUsers(context.Background(), &pb.ListUsersRequest{
-		Actor: "user:u1",
+		Actor: "system:admin",
 	})
 	if err == nil {
 		t.Fatalf("ListUsers: expected UNIMPLEMENTED, got nil")
@@ -276,7 +276,7 @@ func TestListUsers_InternalErrorSurfaced(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	_, err := srv.ListUsers(context.Background(), &pb.ListUsersRequest{
-		Actor: "user:u1",
+		Actor: "system:admin",
 	})
 	if status.Code(err) != codes.Internal {
 		t.Fatalf("ListUsers on broken store: code = %s, want Internal (%v)", status.Code(err), err)
@@ -306,7 +306,7 @@ func TestListUsers_KeysetPagesAllUsers(t *testing.T) {
 			t.Fatal("pagination did not terminate")
 		}
 		resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{
-			Actor: "user:admin", PageSize: 10, PageToken: token,
+			Actor: "system:admin", PageSize: 10, PageToken: token,
 		})
 		if err != nil {
 			t.Fatalf("ListUsers: %v", err)
@@ -340,7 +340,7 @@ func TestListUsers_KeysetRejectsCrossFilterToken(t *testing.T) {
 		}
 	}
 	srv := api.New(api.WithGlobalStore(gs))
-	first, err := srv.ListUsers(ctx, &pb.ListUsersRequest{Actor: "user:admin", Status: "active", PageSize: 5})
+	first, err := srv.ListUsers(ctx, &pb.ListUsersRequest{Actor: "system:admin", Status: "active", PageSize: 5})
 	if err != nil {
 		t.Fatalf("ListUsers: %v", err)
 	}
@@ -348,7 +348,7 @@ func TestListUsers_KeysetRejectsCrossFilterToken(t *testing.T) {
 		t.Fatal("expected a next_page_token")
 	}
 	_, err = srv.ListUsers(ctx, &pb.ListUsersRequest{
-		Actor: "user:admin", Status: "deleted", PageSize: 5, PageToken: first.GetNextPageToken(),
+		Actor: "system:admin", Status: "deleted", PageSize: 5, PageToken: first.GetNextPageToken(),
 	})
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("cross-filter token: code = %s, want InvalidArgument (%v)", status.Code(err), err)

--- a/server/go/internal/api/pagination_clamp_test.go
+++ b/server/go/internal/api/pagination_clamp_test.go
@@ -103,7 +103,7 @@ func TestListUsers_OversizedLimitClampedToMax(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{
-		Actor: "user:admin",
+		Actor: "system:admin", // #640: ListUsers is admin/system only
 		Limit: 10_000_000,
 	})
 	if err != nil {
@@ -135,8 +135,8 @@ func TestListUsers_NegativeLimitCoercedToDefault(t *testing.T) {
 	srv := api.New(api.WithGlobalStore(gs))
 
 	resp, err := srv.ListUsers(ctx, &pb.ListUsersRequest{
-		Actor: "user:admin",
-		Limit: -1, // pre-fix: flowed through as SQLite "unlimited"
+		Actor: "system:admin", // #640: ListUsers is admin/system only
+		Limit: -1,             // pre-fix: flowed through as SQLite "unlimited"
 	})
 	if err != nil {
 		t.Fatalf("ListUsers(limit=-1): %v", err)

--- a/tests/python/integration/test_grpc_contract.py
+++ b/tests/python/integration/test_grpc_contract.py
@@ -273,8 +273,10 @@ CONTRACT_CASES: list[dict] = [
         "check": lambda r: r.found is True and r.user.user_id == "alice",
     },
     {
+        # #640: GetUser is self-or-admin gated, so a missing-user read uses an
+        # admin caller (a stranger now gets PERMISSION_DENIED, not found=False).
         "rpc": "GetUser",
-        "build": lambda: pb.GetUserRequest(actor=ALICE, user_id="ghost"),
+        "build": lambda: pb.GetUserRequest(actor=ADMIN, user_id="ghost"),
         "mode": "not_found",
         "check": lambda r: r.found is False,
     },


### PR DESCRIPTION
Closes #640. Part of the security-audit epic #637.

## Consequence (why this matters)
Any authenticated caller could read the whole directory:
- `GetTenantMembers{any tenant}` → that tenant's **full roster** (user_ids + roles)
- `GetUser{any user}` → that user's **email + name** (PII)
- `GetUserTenants{any user}` → that user's **tenant graph**
- `ListUsers` → the **entire deployment-wide user registry** (email enumeration)

These four read RPCs resolved the trusted actor with `auth.Authoritative(...)` and then **threw it away** — no self / membership / admin check before the read. `ListTenants` already gated correctly; these never did.

## Fix
Gate each on the already-resolved actor:
| RPC | Gate |
|---|---|
| `GetUser`, `GetUserTenants` | `isSelfOrAdmin` — admin/system, or the user themselves |
| `GetTenantMembers` | member of the tenant, or admin/system (`lookupMemberRole`; unknown tenant has no row → denied) |
| `ListUsers` | admin/system only (no tenant scope — same class as `ListTenants`) |

Denials depend only on the caller-vs-target relationship, never on whether the target exists — so they are **not existence oracles**.

## Tests
- Activates the four `_SecureBehavior_Finding4` gates (incl. **new** gates for `GetUserTenants` and `ListUsers`); removes the demonstrations.
- Updated every existing test that drove these RPCs with a non-privileged actor (relying on the old ungated reads) to use an admin actor — server-side (`get_user_test`, `get_tenant_members_test`, `list_users_test`, `pagination_clamp_test`) **and** the Python contract `GetUser-not_found` case (now an admin caller; a stranger correctly gets `PERMISSION_DENIED`).

## Behavior change for operators
A non-self / non-member / non-admin caller now gets `PERMISSION_DENIED` from these RPCs (previously they returned the data). Admin/system, self-reads, and same-tenant member reads are unchanged.

## Verification (full local CI, green)
- `go vet` + `go test ./...` (4 Go modules) · `gofmt` · `ruff` — clean
- **Go SDK `-tags=integration`** (real server) — pass
- **Python contract + integration** (118) — pass
- **e2e Docker stack** — pass

No proto/SDK change; server-internal authorization only.
