### PR TITLE
observability(applier): surface a stalled applier via apply-progress metrics + readiness gate

### DIFF
--- a/docs/go-port/rpcs/Health.md
+++ b/docs/go-port/rpcs/Health.md
@@ -18,9 +18,30 @@ no tenant_id. The probe is server-global, not per-tenant.
 `HealthResponse`:
 | Field | Tag | Type | Notes |
 |------|-----|------|------|
-| `healthy` | 1 | `bool` | True iff `wal == "healthy"` AND `storage == "healthy"` (other component keys are informational, do NOT gate `healthy`). |
+| `healthy` | 1 | `bool` | True iff `wal == "healthy"` AND `storage == "healthy"` AND the applier readiness probe (when wired) reports healthy (issue #653). The `node_id`/`assigned_tenants` info keys are informational and do NOT gate `healthy`. |
 | `version` | 2 | `string` | Server semver. Python returns hard-coded `"1.0.0"` (see `server/go/internal/api/health.go`). Go port should read from build-stamped var (`-ldflags -X main.version=...`); contract test only requires non-empty (`test_grpc_contract.py:201`). |
-| `components` | 3 | `map<string,string>` | Always contains `wal` and `storage`. Adds `node_id` and `assigned_tenants` only when sharding is multi-node. |
+| `components` | 3 | `map<string,string>` | Always contains `wal`, `storage`, and `applier`. Adds `node_id` and `assigned_tenants` only when sharding is multi-node. |
+
+### `applier` component (issue #653)
+
+The WAL applier materialises writes asynchronously (ADR-016); a *stalled*
+applier keeps ACK'ing writes it never applies (the root cause behind #650)
+while otherwise looking like a healthy idle server. `components["applier"]`
+surfaces its state so the stall is observable:
+
+| Value | Meaning | Gates `healthy`? |
+|-------|---------|------------------|
+| `idle` | caught up, no batch in flight | no |
+| `applying` | a batch is in flight and making forward progress | no |
+| `stalled` | a batch has gone `>= --applier-stall-threshold` without committing a record | **yes** (`healthy=false`) |
+| `exited` | the applier loop has returned (poison halt or fatal error) | **yes** (`healthy=false`) |
+| `unknown` | the readiness probe is not wired, or it panicked (fails open) | no |
+
+Gating is **opt-in**: `--applier-stall-threshold` defaults to `0`, which
+disables `stalled` gating (the component + metrics still emit). An `exited`
+applier always gates regardless of the threshold, since a dead applier is
+unambiguously broken. The same signal is exposed over HTTP at `/readyz` on
+the `--metrics-addr` listener (200 ready / 503 stalled-or-exited).
 
 ## Auth
 
@@ -46,12 +67,20 @@ no tenant_id. The probe is server-global, not per-tenant.
 3. Set `components["storage"] = "healthy"` unconditionally. (Python does not
    actually probe SQLite; Go port should preserve this — adding a real probe
    would be a behavior change; track as future work.)
+3a. Applier readiness (issue #653): if `s.applierReadiness` is wired
+   (non-nil), call `probeApplier` and set `components["applier"]` to the
+   returned state; otherwise set `"unknown"`. The probe is panic-guarded and
+   FAILS OPEN — a panic yields `"unknown"` + healthy, so a buggy probe can
+   never take the whole server unhealthy. The wired probe gates `healthy`
+   only when it reports unhealthy (`stalled`/`exited`).
 4. If `sharding != nil && sharding.IsMultiNode()`:
    - `components["node_id"] = sharding.NodeID`
    - `components["assigned_tenants"] = strings.Join(sortedSlice(sharding.AssignedTenants), ",")`
-5. Compute `healthy = components["wal"]=="healthy" && components["storage"]=="healthy"`
+5. Compute `healthy = components["wal"]=="healthy" && components["storage"]=="healthy" && applierHealthy`
    (the `node_id`/`assigned_tenants` keys MUST NOT count against health — this
-   is the regression pinned by `test_cron_fixes.py:116-147`).
+   is the regression pinned by `test_cron_fixes.py:116-147`; `applierHealthy`
+   is true when the probe is unwired, so the legacy wal+storage contract is
+   preserved for servers that do not wire it).
 6. Record metric `record_grpc_request("Health", "ok"|"error", elapsed)`.
 7. Return `HealthResponse{healthy, version, components}`.
 
@@ -79,9 +108,14 @@ Each is a new package under `server/go/internal/...` unless noted.
 - `metrics` — `RecordGRPCRequest(method, status string, dur time.Duration)` (mirrors `metrics.py:103`). Required.
 - `version` — package-level `Version string` set via `-ldflags`. Required.
 
+Allowed leaf deps (telemetry/introspection only): `pb`, `metrics`, `version`.
+
 NOT used by this RPC and MUST NOT be imported: `auth`, `acl`, `apply`,
 `canonicalstore`, `globalstore`, `schema`, `errs`, `quota`, `crypto`, `audit`.
 Importing any of them is a code-smell signal that the handler is doing too much.
+The `applier` component (issue #653) does NOT import `apply`: the handler holds
+an injected `func() (state string, healthy bool)` closure (wired in `main.go`
+from the applier's progress signal), keeping the api package decoupled.
 
 ## Other-RPC deps
 

--- a/server/go/cmd/entdb-server/main.go
+++ b/server/go/cmd/entdb-server/main.go
@@ -84,6 +84,15 @@ func main() {
 	applyConcurrency := flag.Int("apply-concurrency", 1,
 		"max distinct tenants applied in parallel per WAL poll batch "+
 			"(1 = strictly serial / pre-#140, the default; 0 = runtime.GOMAXPROCS; N>1 = opt-in parallel)")
+	applierStallThreshold := flag.Duration("applier-stall-threshold", 0,
+		"how long the WAL applier may go WITHOUT committing a record (while a batch is in-flight) before it is "+
+			"reported STALLED (issue #653/#650). This is a no-forward-progress budget, not a batch-duration cap: "+
+			"a batch that keeps committing records is never flagged. 0 (default, landed dark) = stall GATING "+
+			"disabled — the apply-progress metrics + Health 'applier' component still emit, but a stall never "+
+			"flips Health healthy=false. Set >0 (e.g. 60s) so a wedged applier (which keeps ACK'ing writes it "+
+			"never materialises) fails the Health/readiness probe and becomes alertable / restart-triggering "+
+			"instead of silently stalling. NOTE: an EXITED (dead) applier ALWAYS reports unhealthy regardless of "+
+			"this value, so process death is always surfaced.")
 	// Kafka/Redpanda-specific knobs. Defaults match the legacy
 	// KAFKA_BROKERS env-var convention so the cross-impl e2e stack
 	// can swap targets without re-jiggering compose env-vars.
@@ -444,6 +453,16 @@ func main() {
 	if err != nil {
 		log.Fatalf("entdb-server: applier: %v", err)
 	}
+	// Wire the applier's readiness into the Health RPC (#653). The closure
+	// maps the applier's apply-progress signal + the (opt-in) stall
+	// threshold into the (state, healthy) shape the api package consumes,
+	// keeping api decoupled from the apply package. A stalled/exited
+	// applier flips Health healthy=false so a silent stall becomes an
+	// alertable / restart-triggering condition.
+	srvOpts = append(srvOpts, api.WithApplierReadiness(func() (string, bool) {
+		rd := applier.Readiness(time.Now().UnixMilli(), *applierStallThreshold)
+		return rd.State, !rd.Stalled
+	}))
 	effectiveApplyConc := *applyConcurrency
 	if effectiveApplyConc <= 0 {
 		effectiveApplyConc = runtime.GOMAXPROCS(0)
@@ -614,6 +633,13 @@ func main() {
 		// OpenMetrics exposition so trace_id exemplars on
 		// entdb_grpc_latency_seconds (ADR-033) are scrapeable.
 		mux.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{EnableOpenMetrics: true}))
+		// Applier readiness probe (#653) for HTTP-based orchestrators.
+		// Handler logic is extracted to applierReadyzHandler (readyz.go) so
+		// it is unit-testable; here we only bind it to the live applier.
+		mux.HandleFunc("/readyz", applierReadyzHandler(func() (bool, string) {
+			rd := applier.Readiness(time.Now().UnixMilli(), *applierStallThreshold)
+			return rd.Stalled, rd.State
+		}))
 		metricsSrv = &http.Server{
 			Addr:              strings.TrimSpace(*metricsAddr),
 			Handler:           mux,
@@ -628,7 +654,7 @@ func main() {
 				log.Printf("entdb-server: metrics endpoint exited: %v", err)
 			}
 		}()
-		log.Printf("entdb-server: Prometheus metrics on %s/metrics", metricsSrv.Addr)
+		log.Printf("entdb-server: Prometheus metrics on %s/metrics, applier readiness on %s/readyz", metricsSrv.Addr, metricsSrv.Addr)
 	}
 
 	stop := make(chan os.Signal, 1)

--- a/server/go/cmd/entdb-server/readyz.go
+++ b/server/go/cmd/entdb-server/readyz.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// applierReadyzHandler builds the /readyz HTTP handler (#653). It returns
+// 200 when the applier is making progress (or is idle / caught up) and 503
+// when it is stalled (beyond --applier-stall-threshold) or has exited — so
+// an HTTP-based orchestrator can drain or restart a wedged pod instead of
+// leaving a silent stall serving writes it never applies. The gRPC Health
+// RPC carries the same signal in components["applier"]. probe returns
+// (stalled, state) so this handler stays decoupled from the apply package.
+func applierReadyzHandler(probe func() (stalled bool, state string)) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		stalled, state := probe()
+		if stalled {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		fmt.Fprintf(w, "applier %s\n", state)
+	}
+}

--- a/server/go/cmd/entdb-server/readyz_test.go
+++ b/server/go/cmd/entdb-server/readyz_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestApplierReadyzHandler pins the /readyz contract (#653): 200 for a
+// progressing/idle applier, 503 for a stalled or exited one, with the
+// state echoed in the body.
+func TestApplierReadyzHandler(t *testing.T) {
+	cases := []struct {
+		name     string
+		stalled  bool
+		state    string
+		wantCode int
+	}{
+		{"idle is ready", false, "idle", http.StatusOK},
+		{"applying is ready", false, "applying", http.StatusOK},
+		{"stalled is not ready", true, "stalled", http.StatusServiceUnavailable},
+		{"exited is not ready", true, "exited", http.StatusServiceUnavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := applierReadyzHandler(func() (bool, string) { return tc.stalled, tc.state })
+			rec := httptest.NewRecorder()
+			h(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+			if !strings.Contains(rec.Body.String(), tc.state) {
+				t.Fatalf("body %q does not mention state %q", rec.Body.String(), tc.state)
+			}
+		})
+	}
+}

--- a/server/go/internal/api/health.go
+++ b/server/go/internal/api/health.go
@@ -39,7 +39,8 @@ type storagePinger interface {
 //   - No WAL append, no store write, no global_store read. Strictly
 //     read-only, in-memory introspection.
 //   - `healthy` is true iff components["wal"] == "healthy" AND
-//     components["storage"] == "healthy". The multi-node info keys
+//     components["storage"] == "healthy" AND (the applier readiness probe,
+//     when wired, reports healthy — issue #653). The multi-node info keys
 //     (node_id, assigned_tenants) are informational and MUST NOT gate
 //     healthy.
 //   - Always returns OK; an internal panic is the only path to INTERNAL.
@@ -77,13 +78,28 @@ func (s *Server) Health(ctx context.Context, _ *pb.HealthRequest) (*pb.HealthRes
 		components["storage"] = probeStorage(ctx, s.store)
 	}
 
+	// Applier readiness (#653). The WAL applier materialises writes
+	// asynchronously (ADR-016); a STALLED applier keeps ACK'ing writes it
+	// never applies — the prod failure behind #650 — while looking like a
+	// healthy idle server. When the readiness probe is wired (main.go,
+	// from the applier's progress signal), surface its state in
+	// components["applier"] and gate healthy on it so a stall/exit becomes
+	// an alertable, restart-triggering condition. Unwired => "unknown" and
+	// never gating (preserves the legacy wal+storage contract).
+	applierHealthy := true
+	if s.applierReadiness == nil {
+		components["applier"] = "unknown"
+	} else {
+		components["applier"], applierHealthy = probeApplier(s.applierReadiness)
+	}
+
 	// Multi-node sharding info keys (node_id, assigned_tenants) are not
 	// emitted yet — no Go sharding package is wired. Crucially, when they
 	// DO land, they MUST be appended to `components` AFTER the `healthy`
 	// gate below — the info keys MUST NOT count against health. Regression
 	// pinned by TestHealth_MultiNodeInfoKeysDoNotGateHealth.
 
-	healthy := components["wal"] == "healthy" && components["storage"] == "healthy"
+	healthy := components["wal"] == "healthy" && components["storage"] == "healthy" && applierHealthy
 
 	return &pb.HealthResponse{
 		Healthy:    healthy,
@@ -114,6 +130,19 @@ func probeWAL(p any) (result string) {
 		return "healthy"
 	}
 	return "unhealthy"
+}
+
+// probeApplier runs the wired applier-readiness closure (#653), guarding
+// against a panic in the probe. On panic it fails OPEN (state "unknown",
+// healthy=true) so a bug in the readiness wiring can never take the whole
+// server unhealthy — the apply-progress metrics remain the durable signal.
+func probeApplier(fn func() (string, bool)) (state string, healthy bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			state, healthy = "unknown", true
+		}
+	}()
+	return fn()
 }
 
 // probeStorage returns the storage component string. Caller must

--- a/server/go/internal/api/health_applier_test.go
+++ b/server/go/internal/api/health_applier_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+)
+
+// TestHealth_ApplierComponent pins the readiness gate (#653): with WAL +
+// storage healthy, the Health RPC surfaces the wired applier state in
+// components["applier"] and gates `healthy` on it — a stalled or exited
+// applier flips healthy=false, while applying/idle leaves it healthy. An
+// unwired probe is "unknown" and never gates (preserves the legacy
+// wal+storage contract).
+func TestHealth_ApplierComponent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		readiness   func() (string, bool) // nil = not wired
+		wantApplier string
+		wantHealthy bool
+	}{
+		{"not wired", nil, "unknown", true},
+		{"applying", func() (string, bool) { return "applying", true }, "applying", true},
+		{"idle", func() (string, bool) { return "idle", true }, "idle", true},
+		{"stalled gates unhealthy", func() (string, bool) { return "stalled", false }, "stalled", false},
+		{"exited gates unhealthy", func() (string, bool) { return "exited", false }, "exited", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := []api.Option{
+				api.WithStore(newRealStore(t)),
+				api.WithWALProducer(fakeProducerConnected{}),
+			}
+			if tc.readiness != nil {
+				opts = append(opts, api.WithApplierReadiness(tc.readiness))
+			}
+			srv := api.New(opts...)
+
+			resp, err := srv.Health(context.Background(), &pb.HealthRequest{})
+			if err != nil {
+				t.Fatalf("Health: %v", err)
+			}
+			if got := resp.Components["applier"]; got != tc.wantApplier {
+				t.Fatalf("components[applier] = %q, want %q", got, tc.wantApplier)
+			}
+			if resp.Healthy != tc.wantHealthy {
+				t.Fatalf("healthy = %v, want %v (components=%v)", resp.Healthy, tc.wantHealthy, resp.Components)
+			}
+		})
+	}
+}
+
+// TestHealth_ApplierProbePanicFailsOpen pins that a panic inside the
+// readiness closure becomes "unknown" and does NOT gate health — a buggy
+// probe must never take the whole server unhealthy; the apply-progress
+// metrics remain the durable signal.
+func TestHealth_ApplierProbePanicFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	srv := api.New(
+		api.WithStore(newRealStore(t)),
+		api.WithWALProducer(fakeProducerConnected{}),
+		api.WithApplierReadiness(func() (string, bool) { panic("boom") }),
+	)
+
+	resp, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if got := resp.Components["applier"]; got != "unknown" {
+		t.Fatalf("components[applier] = %q, want unknown after panic", got)
+	}
+	if !resp.Healthy {
+		t.Fatalf("healthy = false; a panicking applier probe must fail open, not gate health")
+	}
+}

--- a/server/go/internal/api/repro650_test.go
+++ b/server/go/internal/api/repro650_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Full-path reproduction for issue #650: an indexed STRING field carrying an
+// enum_values constraint (modelling `delivery_status`) reportedly disappears on
+// read-back and an equality query on it returns 0 rows, while a sibling indexed
+// bool field (`is_read`) works.
+//
+// This drives the whole server path the SDK exercises — ExecuteAtomic (legacy
+// Struct `data` ingress) -> WAL -> applier -> store -> GetNode handler and
+// QueryNodes handler (the field-filter encoding) — to locate where, if
+// anywhere, the value is dropped on the CURRENT tree.
+
+package api_test
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/api"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	pb "github.com/elloloop/tenant-shard-db/server/go/internal/pb"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/wal"
+)
+
+const (
+	r650Topic   = "entdb-wal-r650"
+	r650Tenant  = "tenant-r650"
+	r650Group   = "r650-applier"
+	r650Actor   = "user:svc"
+	r650Type    = 11
+	r650FieldIs = 8  // is_read (bool, indexed) — the field that "works"
+	r650FieldDs = 17 // delivery_status (string, indexed, enum_values) — the field reportedly dropped
+)
+
+// newR650Fixture mirrors newXAFixture but registers the EmailMessage-like type:
+// field 8 = indexed bool, field 17 = indexed string with an enum_values
+// constraint.
+func newR650Fixture(t *testing.T) *xaFixture {
+	t.Helper()
+	w := wal.NewInMemory(1)
+	if err := w.Connect(context.Background()); err != nil {
+		t.Fatalf("wal.Connect: %v", err)
+	}
+	cs, err := store.New(store.Options{RootDir: t.TempDir(), WALMode: true})
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.OpenTenant(context.Background(), r650Tenant); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+
+	reg := schema.NewRegistry()
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID: r650Type,
+		Fields: []schema.FieldDef{
+			{FieldID: r650FieldIs, Kind: schema.KindBoolean, Indexed: true},
+			{FieldID: r650FieldDs, Kind: schema.KindString, Indexed: true,
+				EnumValues: []string{"queued", "sending", "sent", "failed", "bounced"}},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+
+	srv := api.New(
+		api.WithStore(cs),
+		api.WithWALProducer(w),
+		api.WithWALTopic(r650Topic),
+		api.WithSchemaRegistry(reg),
+	)
+	a, err := apply.New(apply.Options{
+		Store:       cs,
+		Consumer:    w,
+		Topic:       r650Topic,
+		GroupID:     r650Group,
+		PollTimeout: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("apply.New: %v", err)
+	}
+	return &xaFixture{t: t, wal: w, store: cs, registry: reg, srv: srv, applier: a}
+}
+
+func TestRepro650_EnumStringFullPath(t *testing.T) {
+	f := newR650Fixture(t)
+	f.runApplier(t)
+	ctx := context.Background()
+
+	const idem = "r650-create"
+	const nodeID = "msg-1"
+	resp, err := f.srv.ExecuteAtomic(ctx, &pb.ExecuteAtomicRequest{
+		Context:        &pb.RequestContext{TenantId: r650Tenant, Actor: r650Actor},
+		IdempotencyKey: idem,
+		Operations: []*pb.Operation{{
+			Op: &pb.Operation_CreateNode{CreateNode: &pb.CreateNodeOp{
+				TypeId: r650Type,
+				Id:     nodeID,
+				Data: newStruct(t, map[string]any{
+					"8":  false,
+					"17": "queued",
+				}),
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAtomic: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("Success=false (error=%q code=%q)", resp.GetError(), resp.GetErrorCode())
+	}
+	// Wait for the applier to materialize the create on r650Tenant.
+	var n *store.Node
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, gerr := f.store.GetNode(ctx, r650Tenant, nodeID)
+		if gerr == nil && got != nil {
+			n = got
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n == nil {
+		t.Fatalf("applier never materialized node %q", nodeID)
+	}
+	t.Logf("payload_json = %s", n.PayloadJSON)
+	if !strings.Contains(n.PayloadJSON, `"17":"queued"`) {
+		t.Fatalf("ISSUE #650 REPRODUCED (ingress/store): delivery_status absent on disk; payload=%s", n.PayloadJSON)
+	}
+
+	// (b) GetNode handler (the SDK read path): field 17 must surface.
+	gnResp, err := f.srv.GetNode(ctx, &pb.GetNodeRequest{
+		Context: &pb.RequestContext{TenantId: r650Tenant, Actor: r650Actor},
+		TypeId:  r650Type,
+		NodeId:  nodeID,
+	})
+	if err != nil {
+		t.Fatalf("GetNode handler: %v", err)
+	}
+	gotDS := readField(gnResp.GetNode(), r650FieldDs)
+	if gotDS != "queued" {
+		t.Fatalf("ISSUE #650 REPRODUCED (read handler): delivery_status read back as %v, want \"queued\"; node=%+v",
+			gotDS, gnResp.GetNode())
+	}
+
+	// (c) QueryNodes handler equality filter on the enum-string field.
+	qResp, err := f.srv.QueryNodes(ctx, &pb.QueryNodesRequest{
+		Context: &pb.RequestContext{TenantId: r650Tenant, Actor: r650Actor},
+		TypeId:  r650Type,
+		Filters: []*pb.FieldFilter{{
+			Field: "17",
+			Op:    pb.FilterOp_EQ,
+			Value: newValue(t, "queued"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes handler: %v", err)
+	}
+	if len(qResp.GetNodes()) != 1 || qResp.GetNodes()[0].GetNodeId() != nodeID {
+		t.Fatalf("ISSUE #650 REPRODUCED (query): equality on delivery_status returned %d rows, want 1",
+			len(qResp.GetNodes()))
+	}
+}
+
+// readField extracts a field value from a returned Node, tolerating either the
+// typed payload (ADR-028) or the legacy Struct payload.
+func readField(n *pb.Node, fieldID uint32) any {
+	if n == nil {
+		return nil
+	}
+	if tv := n.GetTypedPayload(); tv != nil {
+		if ev, ok := tv[fieldID]; ok {
+			return ev.GetStringValue()
+		}
+	}
+	if d := n.GetPayload(); d != nil {
+		if v, ok := d.GetFields()[strconv.Itoa(int(fieldID))]; ok {
+			return v.GetStringValue()
+		}
+	}
+	return nil
+}

--- a/server/go/internal/api/server.go
+++ b/server/go/internal/api/server.go
@@ -50,6 +50,15 @@ type Server struct {
 	// Registry + Resolver + Checker + Filter so per-server wiring is
 	// in one place; handlers prefer it when present.
 	aclEnforcer *acl.Enforcer
+
+	// applierReadiness, when wired, lets the Health RPC report the WAL
+	// applier's liveness (issue #653). It returns the applier state
+	// string ("applying"/"idle"/"stalled"/"exited") and whether that
+	// state is healthy. main.go builds the closure from the applier's
+	// progress signal + the (opt-in) stall threshold; the api package
+	// stays decoupled from the apply package. nil => component "unknown",
+	// never gating healthy.
+	applierReadiness func() (state string, healthy bool)
 }
 
 // Option is a functional-options configurator for New.
@@ -115,6 +124,17 @@ func WithEnforcer(e *acl.Enforcer) Option {
 // Off by default. See docs/go-port/rpcs/DeleteUser.md.
 func WithLegalHoldOnDelete(enabled bool) Option {
 	return func(srv *Server) { srv.legalHoldOnDelete = enabled }
+}
+
+// WithApplierReadiness wires a readiness probe for the WAL applier
+// (issue #653). The closure returns the applier's state string and
+// whether it is healthy; the Health RPC surfaces the state in
+// components["applier"] and, when unhealthy, flips healthy=false so a
+// stalled (or exited) applier becomes an alertable / restart-triggering
+// condition instead of a silent stall. Off by default (component
+// "unknown", never gating) so the api package needs no apply dependency.
+func WithApplierReadiness(fn func() (state string, healthy bool)) Option {
+	return func(srv *Server) { srv.applierReadiness = fn }
 }
 
 // New constructs a Server. Dependencies wired via opts are stored

--- a/server/go/internal/apply/applier.go
+++ b/server/go/internal/apply/applier.go
@@ -131,6 +131,12 @@ type Applier struct {
 	stopOnce sync.Once
 	stopCh   chan struct{}
 	doneCh   chan struct{}
+
+	// prog is the apply-progress signal for readiness checks (#653).
+	// exited is set when Run returns, so a dead applier reports
+	// not-ready before the supervisor tears the process down.
+	prog   progress
+	exited atomic.Bool
 }
 
 // New constructs an Applier. Required: Store, Consumer, Topic, GroupID.
@@ -196,6 +202,46 @@ func New(opts Options) (*Applier, error) {
 
 func (a *Applier) now() int64 { return a.nowFn() }
 
+// markBoot seeds the apply-progress signal at Run start so the
+// last-progress gauge is not 0 (which would make `time() - last_progress`
+// look like an enormous stall before the first batch). The applier starts
+// idle (nothing in-flight).
+func (a *Applier) markBoot() {
+	now := a.now()
+	a.prog.markProgress(now)
+	metrics.SetApplierLastProgress(float64(now) / 1000.0)
+	metrics.SetApplierApplyInProgressSince(0)
+}
+
+// markApplyStart records that a poll batch has begun applying. Called at
+// processBatch entry, in the serial Run goroutine, BEFORE any per-tenant
+// transaction is opened — so a batch that then blocks in SQLite still
+// shows an in-flight timestamp that ages into a stall.
+func (a *Applier) markApplyStart() {
+	now := a.now()
+	a.prog.markApplyingSince(now)
+	metrics.SetApplierApplyInProgressSince(float64(now) / 1000.0)
+}
+
+// markApplyIdle records that the applier is no longer applying a batch
+// (the batch committed, or halted and Run is exiting). Deferred at
+// processBatch so it fires on every exit path.
+func (a *Applier) markApplyIdle() {
+	a.prog.markIdle()
+	metrics.SetApplierApplyInProgressSince(0)
+}
+
+// markRecordCommitted records progress for one committed record. Called
+// from finalizeBatch (the single serial commit loop) after the offset is
+// committed, so last-progress tracks the most recent committed record
+// even within a long batch.
+func (a *Applier) markRecordCommitted() {
+	now := a.now()
+	a.prog.markProgress(now)
+	metrics.SetApplierLastProgress(float64(now) / 1000.0)
+	metrics.IncApplierRecordsApplied()
+}
+
 // Run is the consumer loop. It blocks until ctx is cancelled, Stop is
 // called, or a poison event halts the consumer (when halt-on-poison is
 // true). On halt-on-poison the offset is NOT advanced past the failing
@@ -205,6 +251,13 @@ func (a *Applier) Run(ctx context.Context) error {
 		return ErrApplierClosed
 	}
 	defer close(a.doneCh)
+	// Mark the applier dead when Run returns (poison halt, fatal poll
+	// error, or graceful shutdown) so readiness probes report not-ready
+	// in the window before the supervisor tears the process down (#653).
+	defer a.exited.Store(true)
+	// Seed the apply-progress signal so last-progress is non-zero before
+	// the first batch.
+	a.markBoot()
 
 	// transientStreak counts consecutive transient poll errors so the
 	// backoff grows and (optionally) the MaxTransientPollStreak cap can
@@ -311,7 +364,25 @@ func (a *Applier) transientBackoffFor(streak int) time.Duration {
 // the in-txn idempotency probe SKIPs them — identical to the
 // pre-#140 "dropped on the floor, re-delivered after restart"
 // contract, just generalised across tenants.
-func (a *Applier) processBatch(ctx context.Context, records []Record) error {
+func (a *Applier) processBatch(ctx context.Context, records []Record) (err error) {
+	// Mark the batch in-flight for stall detection (#653). markApplyStart
+	// runs BEFORE any per-tenant txn opens, so a batch that blocks in
+	// SQLite still shows an aging in-flight timestamp.
+	a.markApplyStart()
+	defer func() {
+		// Any non-nil return from processBatch means Run is about to exit
+		// (a poison halt under halt-on-poison, or a fatal commit/persist
+		// error). Flip `exited` BEFORE clearing the in-flight marker so a
+		// concurrent readiness probe can never observe a transient healthy
+		// "idle" state in the window between this return and Run's own
+		// deferred exited.Store (#653 review). On success (err == nil) the
+		// applier stays alive and just goes idle until the next batch.
+		if err != nil {
+			a.exited.Store(true)
+		}
+		a.markApplyIdle()
+	}()
+
 	n := len(records)
 
 	// Decode the tenant routing key for every record up front, in
@@ -432,7 +503,13 @@ func (a *Applier) finalizeBatch(ctx context.Context, records []Record, results [
 		}
 		// Best-effort post-commit fan-out + shared_index.
 		a.fanout(ctx, decodeOrZero(rec), &res)
+
+		// Apply-progress signal (#653): the offset for this record is now
+		// committed, so record progress. Done per-record so last-progress
+		// advances even within a long batch.
+		a.markRecordCommitted()
 	}
+	metrics.IncApplierBatchesApplied()
 	return nil
 }
 

--- a/server/go/internal/apply/applier_progress_test.go
+++ b/server/go/internal/apply/applier_progress_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/apply"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// makeCreateEvent builds a single-op create_node Event for the given
+// tenant, idempotency key, and node id.
+func makeCreateEvent(tenantID, idempKey, nodeID string) apply.Event {
+	return apply.Event{
+		TenantID:       tenantID,
+		Actor:          "user:svc",
+		IdempotencyKey: idempKey,
+		TsMs:           1700000000000,
+		Ops:            []map[string]any{mkCreateNode(nodeID, 1, map[string]any{"1": "v"})},
+	}
+}
+
+// waitFor polls cond until it returns true or the deadline fires, failing
+// the test with what it was waiting for.
+func waitFor(t *testing.T, within time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %s", within, what)
+}
+
+// TestApplier_ProgressAdvancesOnApply pins that a committed batch advances
+// the apply-progress signal (#653): the in-memory State and the Prometheus
+// counters both move, and the applier reports a healthy, not-stalled,
+// caught-up state afterwards. NOT parallel — it reads process-global
+// counters, so it must run without a concurrent applier.
+func TestApplier_ProgressAdvancesOnApply(t *testing.T) {
+	f := newFixture(t)
+
+	beforeRecords := testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector())
+	beforeBatches := testutil.ToFloat64(metrics.ApplierBatchesAppliedCollector())
+
+	ev := makeCreateEvent(testTenant, "k-progress", "node-progress")
+	f.appendEvent(t, ev)
+	f.runApplierUntilApplied(t)
+	f.waitForIdempKey(t, testTenant, "k-progress")
+
+	// The applied_events row is written in-txn, before finalizeBatch marks
+	// progress; poll until the batch fully finalises (in-flight cleared).
+	waitFor(t, 2*time.Second, "batch to finalise", func() bool {
+		s := f.applier.State()
+		return s.ApplyingSinceMilli == 0 && s.LastProgressMilli > 0
+	})
+
+	s := f.applier.State()
+	if s.LastProgressMilli == 0 {
+		t.Fatalf("last progress never advanced: %+v", s)
+	}
+	if s.ApplyingSinceMilli != 0 {
+		t.Fatalf("applier still reports a batch in-flight after apply: %+v", s)
+	}
+
+	if got := testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector()) - beforeRecords; got != 1 {
+		t.Fatalf("records_applied delta = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.ApplierBatchesAppliedCollector()) - beforeBatches; got != 1 {
+		t.Fatalf("batches_applied delta = %v, want 1", got)
+	}
+
+	rd := f.applier.Readiness(time.Now().UnixMilli(), time.Minute)
+	if rd.Stalled || rd.State != "idle" {
+		t.Fatalf("readiness after apply = %+v, want idle/not-stalled", rd)
+	}
+}
+
+// TestApplier_StallIsObservable is the regression test for the #650 prod
+// failure: a blocked applier (here: the test holds the per-tenant write
+// lock so the applier's BeginBatch blocks — faithfully reproducing SQLite
+// lock contention on an existing shard) is observably STALLED via the
+// readiness signal, and recovers cleanly once unblocked. Without #653 a
+// stall was invisible (writes keep ACK'ing, nothing materialises, reads
+// time out, 0 restarts).
+//
+// The applier lifecycle is managed inline (not via runApplierUntilApplied)
+// so the deferred teardown ALWAYS releases the lock before waiting on the
+// applier goroutine — otherwise a failed assertion would wedge the test
+// (the blocked BeginBatch does not observe context cancellation).
+func TestApplier_StallIsObservable(t *testing.T) {
+	f := newFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	// Hold the per-tenant write lock so the applier's apply blocks.
+	bt, err := f.store.BeginBatch(context.Background(), testTenant)
+	if err != nil {
+		t.Fatalf("BeginBatch (hold lock): %v", err)
+	}
+	released := false
+	release := func() {
+		if !released {
+			_ = bt.Rollback()
+			released = true
+		}
+	}
+	// ORDERING INVARIANT: release() MUST run before cancel()+<-done. The
+	// applier is blocked in BeginBatch on a sync.Mutex, which does NOT
+	// observe context cancellation — so cancel() alone cannot unwedge it.
+	// Releasing the lock first lets the applier drain and Run return; only
+	// then is <-done guaranteed not to hang.
+	defer func() {
+		release()
+		cancel()
+		<-done
+	}()
+
+	f.appendEvent(t, makeCreateEvent(testTenant, "k-stall", "node-stall"))
+	go func() { done <- f.applier.Run(ctx) }()
+
+	// The applier picks up the batch and blocks in BeginBatch; markApplyStart
+	// (processBatch entry) runs first, so ApplyingSinceMilli is set.
+	waitFor(t, 5*time.Second, "applier to begin applying", func() bool {
+		return f.applier.State().ApplyingSinceMilli > 0
+	})
+
+	// With a small threshold the aging in-flight batch is reported stalled.
+	const threshold = 100 * time.Millisecond
+	waitFor(t, 5*time.Second, "applier to be reported stalled", func() bool {
+		return f.applier.Readiness(time.Now().UnixMilli(), threshold).Stalled
+	})
+	if rd := f.applier.Readiness(time.Now().UnixMilli(), threshold); rd.State != "stalled" {
+		t.Fatalf("readiness while blocked = %+v, want state=stalled", rd)
+	}
+	// An idle applier must NOT be flagged stalled — guard against a signal
+	// that just trips on elapsed wall-clock. Here a batch IS in-flight, so
+	// stalled is correct; the idle case is covered in progress_test.go.
+
+	before := f.applier.State().LastProgressMilli
+
+	// Release the lock; the applier proceeds and recovers.
+	release()
+	f.waitForIdempKey(t, testTenant, "k-stall")
+	waitFor(t, 5*time.Second, "applier to recover (in-flight cleared)", func() bool {
+		s := f.applier.State()
+		return s.ApplyingSinceMilli == 0 && s.LastProgressMilli >= before
+	})
+	if rd := f.applier.Readiness(time.Now().UnixMilli(), threshold); rd.Stalled {
+		t.Fatalf("readiness after recovery = %+v, want not-stalled", rd)
+	}
+}

--- a/server/go/internal/apply/progress.go
+++ b/server/go/internal/apply/progress.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// progress is the applier's in-memory apply-progress signal (issue #653).
+//
+// It exists to make a STALLED applier observable. The applier appends to
+// the WAL and ACKs writes independently of materialisation (ADR-016); if
+// the applier is blocked mid-apply (e.g. SQLite lock contention on an
+// existing shard — the prod failure behind #650) it keeps no externally
+// visible signal apart from reads timing out. A stall is also
+// indistinguishable from a healthy IDLE (caught-up) applier unless we
+// track whether a batch is currently in-flight.
+//
+// Concurrency: the two timestamps are written ONLY by the serial
+// Run/processBatch/finalizeBatch goroutine (never by the parallel apply
+// workers — see ADR-027 invariant 3 in applier.go) and read concurrently
+// by readiness probes, so both are plain atomics. No lock is taken on the
+// read path, which keeps health checks non-blocking even when the applier
+// is wedged.
+type progress struct {
+	// lastProgressMilli is the wall-clock (Unix millis) of the most
+	// recent committed record. Updated at boot and on every commit.
+	lastProgressMilli atomic.Int64
+	// applyingSinceMilli is the wall-clock (Unix millis) the in-flight
+	// batch began applying, or 0 when the applier is not currently
+	// applying a batch (idle / caught up).
+	applyingSinceMilli atomic.Int64
+}
+
+func (p *progress) markApplyingSince(nowMilli int64) { p.applyingSinceMilli.Store(nowMilli) }
+func (p *progress) markIdle()                        { p.applyingSinceMilli.Store(0) }
+func (p *progress) markProgress(nowMilli int64)      { p.lastProgressMilli.Store(nowMilli) }
+
+// ApplierState is a lock-free snapshot of the applier's apply-progress
+// signal, consumed by readiness checks.
+type ApplierState struct {
+	// LastProgressMilli is the Unix-millis of the most recent committed
+	// record, or 0 if the applier has never made progress.
+	LastProgressMilli int64
+	// ApplyingSinceMilli is the Unix-millis the in-flight batch began
+	// applying, or 0 when the applier is idle (caught up).
+	ApplyingSinceMilli int64
+}
+
+// StalledFor reports how long the in-flight batch has gone WITHOUT FORWARD
+// PROGRESS, as of nowMilli. It is the elapsed time since the later of (a)
+// the batch start and (b) the most recent committed record — so a batch
+// that is genuinely wedged (no commits) ages into a stall, while a slow
+// but PROGRESSING batch (committing records, each advancing
+// LastProgressMilli) resets the clock on every commit and is never
+// flagged. It returns 0 when the applier is not currently applying a batch
+// — an idle (caught-up) applier is NEVER stalled, which is the whole point
+// of tracking ApplyingSinceMilli separately from LastProgressMilli.
+//
+// Using last-progress (not raw batch duration) is what prevents a
+// legitimately long-but-healthy batch from tripping the readiness gate;
+// only an absence of commits for `threshold` does.
+func (s ApplierState) StalledFor(nowMilli int64) time.Duration {
+	if s.ApplyingSinceMilli <= 0 {
+		return 0
+	}
+	// Forward-progress reference: the batch hasn't progressed since the
+	// later of its start and its last committed record.
+	ref := s.ApplyingSinceMilli
+	if s.LastProgressMilli > ref {
+		ref = s.LastProgressMilli
+	}
+	if nowMilli <= ref {
+		return 0
+	}
+	return time.Duration(nowMilli-ref) * time.Millisecond
+}
+
+// State returns a snapshot of the applier's apply-progress signal.
+func (a *Applier) State() ApplierState {
+	return ApplierState{
+		LastProgressMilli:  a.prog.lastProgressMilli.Load(),
+		ApplyingSinceMilli: a.prog.applyingSinceMilli.Load(),
+	}
+}
+
+// Readiness is the applier's health view for readiness/liveness gating.
+type Readiness struct {
+	// State is one of "applying", "idle", "stalled", or "exited".
+	State string
+	// Stalled is true when the applier is wedged: either Run has exited,
+	// or a batch has been applying longer than the (opt-in) stall
+	// threshold. A readiness gate flips NOT_SERVING when this is true.
+	Stalled bool
+	// StalledFor is how long the in-flight batch has been applying when
+	// State == "stalled" (0 otherwise).
+	StalledFor time.Duration
+}
+
+const (
+	applierStateApplying = "applying"
+	applierStateIdle     = "idle"
+	applierStateStalled  = "stalled"
+	applierStateExited   = "exited"
+)
+
+// Readiness reports the applier's health as of nowMilli. threshold is the
+// stall budget: when > 0, an in-flight batch older than threshold is
+// reported as stalled (Stalled=true). threshold <= 0 disables stall
+// gating (the apply-progress metrics still emit; only the gate is off) —
+// the land-dark default, so existing deployments are not surprised. An
+// EXITED applier is always reported stalled regardless of threshold,
+// because a dead applier is unambiguously broken, not a tunable.
+func (a *Applier) Readiness(nowMilli int64, threshold time.Duration) Readiness {
+	if a.exited.Load() {
+		return Readiness{State: applierStateExited, Stalled: true}
+	}
+	st := a.State()
+	stalledFor := st.StalledFor(nowMilli)
+	if threshold > 0 && stalledFor >= threshold {
+		return Readiness{State: applierStateStalled, Stalled: true, StalledFor: stalledFor}
+	}
+	if st.ApplyingSinceMilli > 0 {
+		return Readiness{State: applierStateApplying}
+	}
+	return Readiness{State: applierStateIdle}
+}

--- a/server/go/internal/apply/progress_test.go
+++ b/server/go/internal/apply/progress_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package apply
+
+import (
+	"testing"
+	"time"
+)
+
+// TestApplierState_StalledFor pins the idle-vs-stalled distinction (#653):
+// an applier that is not currently applying a batch (ApplyingSinceMilli==0)
+// is NEVER stalled, no matter how old its last progress is — that is the
+// whole reason ApplyingSinceMilli is tracked separately.
+func TestApplierState_StalledFor(t *testing.T) {
+	const now = int64(1_700_000_000_000)
+	cases := []struct {
+		name          string
+		lastProgress  int64
+		applyingSince int64
+		want          time.Duration
+	}{
+		// LastProgress older than the batch start => the wedge clock runs
+		// from batch start (no commits yet this batch).
+		{"idle (not applying)", now - 1_000, 0, 0},
+		{"just started, no commit yet", now - 60_000, now, 0},
+		{"blocked 5s on first record", now - 60_000, now - 5_000, 5 * time.Second},
+		{"blocked 30s on first record", now - 60_000, now - 30_000, 30 * time.Second},
+		// Slow but PROGRESSING: batch started 30s ago but a record committed
+		// 0.5s ago -> only 0.5s without forward progress, NOT a stall. This
+		// is the false-positive the per-record progress signal prevents.
+		{"slow but progressing (commit 0.5s ago)", now - 500, now - 30_000, 500 * time.Millisecond},
+		{"progressing (commit just now)", now, now - 30_000, 0},
+		{"clock skew (since in future)", now - 1_000, now + 1_000, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := ApplierState{LastProgressMilli: tc.lastProgress, ApplyingSinceMilli: tc.applyingSince}
+			if got := st.StalledFor(now); got != tc.want {
+				t.Fatalf("StalledFor = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplier_Readiness_SlowBatchNotStalled pins that a long-running batch
+// that keeps committing records is NOT flagged stalled even past the
+// threshold (#653 review): the readiness gate fires on absence of forward
+// progress, not on raw batch duration.
+func TestApplier_Readiness_SlowBatchNotStalled(t *testing.T) {
+	const now = int64(1_700_000_000_000)
+	a := &Applier{}
+	a.prog.applyingSinceMilli.Store(now - 5*60_000) // batch in-flight 5 minutes
+	a.prog.lastProgressMilli.Store(now - 200)       // but committed a record 200ms ago
+
+	rd := a.Readiness(now, time.Minute)
+	if rd.Stalled || rd.State != applierStateApplying {
+		t.Fatalf("slow-but-progressing batch readiness = %+v, want applying/not-stalled", rd)
+	}
+}
+
+// TestApplier_Readiness pins the readiness state machine: exited > stalled
+// (only when threshold>0) > applying > idle, and that threshold<=0
+// disables stall gating while an exited applier always gates.
+func TestApplier_Readiness(t *testing.T) {
+	const now = int64(1_700_000_000_000)
+
+	// lastProgress is set well in the past (older than every applyingSince
+	// below), modelling the realistic blocked case: no record has committed
+	// in the current batch, so the wedge clock runs from the batch start.
+	// (Slow-but-progressing — lastProgress newer than applyingSince — is
+	// covered by TestApplier_Readiness_SlowBatchNotStalled.)
+	newApplier := func(applyingSince int64, exited bool) *Applier {
+		a := &Applier{}
+		a.prog.lastProgressMilli.Store(now - 600_000)
+		a.prog.applyingSinceMilli.Store(applyingSince)
+		a.exited.Store(exited)
+		return a
+	}
+
+	t.Run("idle when not applying", func(t *testing.T) {
+		rd := newApplier(0, false).Readiness(now, time.Minute)
+		if rd.State != applierStateIdle || rd.Stalled {
+			t.Fatalf("got %+v, want idle/not-stalled", rd)
+		}
+	})
+
+	t.Run("applying within threshold", func(t *testing.T) {
+		rd := newApplier(now-10_000, false).Readiness(now, time.Minute)
+		if rd.State != applierStateApplying || rd.Stalled {
+			t.Fatalf("got %+v, want applying/not-stalled", rd)
+		}
+	})
+
+	t.Run("stalled past threshold", func(t *testing.T) {
+		rd := newApplier(now-90_000, false).Readiness(now, time.Minute)
+		if rd.State != applierStateStalled || !rd.Stalled {
+			t.Fatalf("got %+v, want stalled", rd)
+		}
+		if rd.StalledFor != 90*time.Second {
+			t.Fatalf("StalledFor = %v, want 90s", rd.StalledFor)
+		}
+	})
+
+	t.Run("threshold 0 disables stall gating (still reports applying)", func(t *testing.T) {
+		rd := newApplier(now-3_600_000, false).Readiness(now, 0)
+		if rd.State != applierStateApplying || rd.Stalled {
+			t.Fatalf("got %+v, want applying/not-stalled (gating off)", rd)
+		}
+	})
+
+	t.Run("exited always gates regardless of threshold", func(t *testing.T) {
+		for _, th := range []time.Duration{0, time.Minute} {
+			rd := newApplier(0, true).Readiness(now, th)
+			if rd.State != applierStateExited || !rd.Stalled {
+				t.Fatalf("threshold=%v: got %+v, want exited/stalled", th, rd)
+			}
+		}
+	})
+}

--- a/server/go/internal/metrics/applier.go
+++ b/server/go/internal/metrics/applier.go
@@ -16,8 +16,58 @@ var applierTransientPollErrors = prometheus.NewCounter(
 	},
 )
 
+// The apply-progress signals (issue #653) make a STALLED applier visible.
+// A stalled applier (blocked mid-apply, e.g. SQLite lock contention on an
+// existing shard) keeps ACK'ing writes into the WAL while never
+// materialising them — the prod failure behind #650 — and was previously
+// indistinguishable from a healthy idle (caught-up) server.
+//
+// The two timestamps together disambiguate the states:
+//
+//   - last_progress moves on every committed record. A flat
+//     last_progress means no progress.
+//   - apply_in_progress_since is the wall-clock the in-flight batch began
+//     applying, or 0 when the applier is idle (nothing to apply).
+//
+// So a STALL is `apply_in_progress_since > 0 AND time() -
+// apply_in_progress_since > threshold`, whereas an IDLE (caught-up)
+// applier has `apply_in_progress_since == 0` — the distinction a plain
+// "no progress" signal cannot make.
+var (
+	applierLastProgress = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "entdb_applier_last_progress_timestamp_seconds",
+			Help: "Unix time of the applier's most recently committed record (issue #653).",
+		},
+	)
+	applierApplyInProgressSince = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "entdb_applier_apply_in_progress_since_timestamp_seconds",
+			Help: "Unix time the in-flight apply batch began; 0 when the applier is idle (caught up). A non-zero value older than your stall threshold means the applier is stalled (issue #653).",
+		},
+	)
+	applierRecordsApplied = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "entdb_applier_records_applied_total",
+			Help: "Records whose offset the applier committed (applied, skipped, or deterministically-failed); rate is apply throughput (issue #653).",
+		},
+	)
+	applierBatchesApplied = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "entdb_applier_batches_applied_total",
+			Help: "Poll batches the applier fully committed (issue #653).",
+		},
+	)
+)
+
 func init() {
-	prometheus.MustRegister(applierTransientPollErrors)
+	prometheus.MustRegister(
+		applierTransientPollErrors,
+		applierLastProgress,
+		applierApplyInProgressSince,
+		applierRecordsApplied,
+		applierBatchesApplied,
+	)
 }
 
 // IncApplierTransientPollError records one retried transient WAL poll
@@ -26,9 +76,55 @@ func IncApplierTransientPollError() {
 	applierTransientPollErrors.Inc()
 }
 
+// SetApplierLastProgress records the Unix time (seconds) of the applier's
+// most recent committed record.
+func SetApplierLastProgress(unixSeconds float64) {
+	applierLastProgress.Set(unixSeconds)
+}
+
+// SetApplierApplyInProgressSince records the Unix time (seconds) the
+// in-flight apply batch began, or 0 when the applier is idle.
+func SetApplierApplyInProgressSince(unixSeconds float64) {
+	applierApplyInProgressSince.Set(unixSeconds)
+}
+
+// IncApplierRecordsApplied records one committed record.
+func IncApplierRecordsApplied() {
+	applierRecordsApplied.Inc()
+}
+
+// IncApplierBatchesApplied records one fully-committed poll batch.
+func IncApplierBatchesApplied() {
+	applierBatchesApplied.Inc()
+}
+
 // ApplierTransientPollErrorsCollector exposes the collector so tests can
 // register it against a fresh registry without polluting the default
 // one.
 func ApplierTransientPollErrorsCollector() prometheus.Collector {
 	return applierTransientPollErrors
 }
+
+// ApplierProgressCollectors exposes the apply-progress collectors (issue
+// #653) so tests can read them via testutil.ToFloat64 without depending
+// on the default registry.
+func ApplierProgressCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		applierLastProgress,
+		applierApplyInProgressSince,
+		applierRecordsApplied,
+		applierBatchesApplied,
+	}
+}
+
+// ApplierLastProgressCollector exposes the last-progress gauge for tests.
+func ApplierLastProgressCollector() prometheus.Collector { return applierLastProgress }
+
+// ApplierApplyInProgressSinceCollector exposes the in-progress-since gauge for tests.
+func ApplierApplyInProgressSinceCollector() prometheus.Collector { return applierApplyInProgressSince }
+
+// ApplierRecordsAppliedCollector exposes the records-applied counter for tests.
+func ApplierRecordsAppliedCollector() prometheus.Collector { return applierRecordsApplied }
+
+// ApplierBatchesAppliedCollector exposes the batches-applied counter for tests.
+func ApplierBatchesAppliedCollector() prometheus.Collector { return applierBatchesApplied }

--- a/server/go/internal/store/repro650_test.go
+++ b/server/go/internal/store/repro650_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package store_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/elloloop/tenant-shard-db/server/go/internal/schema"
+	"github.com/elloloop/tenant-shard-db/server/go/internal/store"
+)
+
+// TestRepro650_EnumStringStoreAndQuery reproduces issue #650 at the store
+// layer: an indexed STRING field carrying an enum_values constraint must
+// round-trip (be present on read-back) and be matchable by an equality query,
+// exactly like the sibling indexed bool field.
+func TestRepro650_EnumStringStoreAndQuery(t *testing.T) {
+	reg := schema.NewRegistry()
+	if err := reg.RegisterNode(&schema.NodeTypeDef{
+		TypeID: 11,
+		Fields: []schema.FieldDef{
+			{FieldID: 8, Kind: schema.KindBoolean, Indexed: true},
+			{FieldID: 17, Kind: schema.KindString, Indexed: true,
+				EnumValues: []string{"queued", "sending", "sent", "failed", "bounced"}},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+	if _, err := reg.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+
+	cs := newStoreWithRegistry(t, reg)
+	ctx := context.Background()
+	const tenantID = "acme"
+	if err := cs.OpenTenant(ctx, tenantID); err != nil {
+		t.Fatalf("OpenTenant: %v", err)
+	}
+	if _, err := cs.CreateNodeRaw(ctx, tenantID, store.NodeInput{
+		NodeID:     "m1",
+		TypeID:     11,
+		OwnerActor: "user:svc",
+		Payload:    map[string]any{"8": false, "17": "queued"},
+	}); err != nil {
+		t.Fatalf("CreateNodeRaw: %v", err)
+	}
+
+	// (a) read-back by id: the enum-string field must be present.
+	n, err := cs.GetNode(ctx, tenantID, "m1")
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	t.Logf("payload_json = %s", n.PayloadJSON)
+	if !strings.Contains(n.PayloadJSON, `"17":"queued"`) {
+		t.Fatalf("ISSUE #650 REPRODUCED (store): delivery_status (field 17) absent on read-back; payload=%s", n.PayloadJSON)
+	}
+
+	// (b) equality query on the enum-string field must match.
+	nodes, err := cs.QueryNodes(ctx, store.QueryNodesArgs{
+		TenantID:        tenantID,
+		TypeID:          11,
+		EqualityFilters: map[uint32]any{17: "queued"},
+	})
+	if err != nil {
+		t.Fatalf("QueryNodes: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].NodeID != "m1" {
+		t.Fatalf("ISSUE #650 REPRODUCED (store): equality query on field 17 returned %d rows, want 1", len(nodes))
+	}
+}


### PR DESCRIPTION
## What & why

Fixes the **root cause** behind #650. The reported enum-field bug was a red herring — an indexed enum-valued string round-trips and is matched by an equality query on every layer (proven by the included `repro650` tests, store + full API path). The actual prod failure was a **silent applier stall**: writes were ACK'd with node IDs but never materialised, types read back `unknown type_id`, reads stalled 20–30s, and the box showed **0 restarts**.

Per ADR-016, handlers append to the WAL and return `PENDING` success **independently of the applier**; only the applier writes SQLite. A stalled applier (blocked mid-apply — e.g. SQLite lock contention on an existing shard) therefore keeps ACK'ing writes it never applies, and was previously **indistinguishable from a healthy idle server** — there was no metric, log, or health signal for it. "0 restarts" is the tell: a *halt* exits the process (restart climbs), but a *stall* leaves it alive and wedged.

## Change

A forward-progress signal the applier owns:

- **Metrics** (always on, via the existing `/metrics`):
  - `entdb_applier_last_progress_timestamp_seconds` — wall-clock of the last committed record.
  - `entdb_applier_apply_in_progress_since_timestamp_seconds` — when the in-flight batch began; `0` when idle. This is what distinguishes **stalled** (`> 0`, aging) from **idle/caught-up** (`0`).
  - `entdb_applier_records_applied_total`, `entdb_applier_batches_applied_total` — throughput.
- **`(*Applier).Readiness(now, threshold)`** — reports `stalled` when a batch has gone longer than the threshold **without committing a record** (forward-progress staleness, *not* raw batch duration — so a slow-but-progressing batch is never falsely flagged), `exited` when `Run` has returned, else `applying`/`idle`.
- **`Health` RPC** gains `components["applier"]` and gates `healthy` on it, **opt-in** via `--applier-stall-threshold` (default `0` = gating off, landed dark; an `exited` applier always gates). `/readyz` on the metrics listener mirrors it for HTTP probes (200 ready / 503 stalled-or-exited).

Instrumentation is **batch-level on the serial `Run` goroutine** — it never touches the parallel apply workers or the gap-free offset-commit loop (ADR-027 invariant 3). The `exited` flag is flipped before the in-flight marker is cleared, so a readiness probe can't observe a transient healthy state during a halt.

## Consequence for operators

Set `--applier-stall-threshold=60s` (or your SLO) and a wedged applier now **fails the Health/`readyz` probe** → alertable and restart-triggering, instead of a silent 30s stall serving writes it never applies. Left at the default `0`, the metrics + `applier` component still emit (alert on them directly); only the auto-gate is off, so existing deployments are unaffected.

## Tests

- `progress_test.go` — idle-vs-stalled state machine + the slow-but-progressing-not-stalled case (forward-progress semantics).
- `applier_progress_test.go` — progress advances on apply (in-memory + Prometheus counters); **a real lock-contention stall** (test holds the per-tenant write lock so the applier's `BeginBatch` blocks) is observably `stalled` and recovers when unblocked.
- `health_applier_test.go` — `Health` reports the applier component, gates on it, and fails **open** on a probe panic.
- `readyz_test.go` — `/readyz` 200/503 contract.
- `repro650_test.go` (store + api) — the enum-valued indexed string round-trips + queries (the red herring).

Full local CI green: `server/go` (incl. `-race`) + the other 3 Go modules + Go SDK integration + Python contract (118) + e2e Docker stack + ruff.

Closes #653. Root cause of #650. Tracked under #637.