### PR TITLE
test(applier): close #653 coverage gaps (gauge values/units, parallel batch, poison-halt readiness, replay-skip)

### DIFF
--- a/server/go/internal/apply/applier_progress_test.go
+++ b/server/go/internal/apply/applier_progress_test.go
@@ -38,6 +38,182 @@ func waitFor(t *testing.T, within time.Duration, what string, cond func() bool) 
 	t.Fatalf("timed out after %s waiting for %s", within, what)
 }
 
+// newApplierOn builds a second applier over the fixture's WAL+store under a
+// distinct group id (independent offset), optionally with an injected clock
+// for deterministic gauge-value assertions. nowFn nil => real time.
+func (f *fixture) newApplierOn(t *testing.T, groupID string, nowFn func() int64) *apply.Applier {
+	t.Helper()
+	a, err := apply.New(apply.Options{
+		Store:       f.store,
+		Global:      f.global,
+		Consumer:    f.wal,
+		Topic:       testTopic,
+		GroupID:     groupID,
+		PollTimeout: 25 * time.Millisecond,
+		NowFn:       nowFn,
+	})
+	if err != nil {
+		t.Fatalf("apply.New(%s): %v", groupID, err)
+	}
+	return a
+}
+
+// runUntilDone runs a's Run loop in a goroutine and registers cleanup that
+// cancels and joins it. Returns the done channel so a halting applier can be
+// awaited.
+func runInBackground(t *testing.T, a *apply.Applier) (cancel func(), done chan error) {
+	t.Helper()
+	ctx, cancelF := context.WithCancel(context.Background())
+	done = make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+	t.Cleanup(func() {
+		cancelF()
+		<-done
+	})
+	return cancelF, done
+}
+
+// TestApplier_GaugeValuesAndUnits pins the metric VALUES and the
+// millis->seconds conversion (#653 coverage). A silent /1000 typo or a
+// missing idle-clear would corrupt dashboards/alerts; the in-memory State
+// assertions elsewhere can't catch that. Uses a fixed clock so the gauge
+// values are exact.
+func TestApplier_GaugeValuesAndUnits(t *testing.T) {
+	const fixedMs = int64(1_700_000_123_000) // divisible by 1000 -> exact seconds
+	const wantSec = float64(fixedMs) / 1000.0
+
+	f := newFixture(t) // provides wal+store+global; its default applier is NOT started here
+	a := f.newApplierOn(t, "gauge-group", func() int64 { return fixedMs })
+
+	f.appendEvent(t, makeCreateEvent(testTenant, "k-gauge", "node-gauge"))
+	runInBackground(t, a)
+	f.waitForIdempKey(t, testTenant, "k-gauge")
+	waitFor(t, 2*time.Second, "batch to finalise", func() bool {
+		return a.State().ApplyingSinceMilli == 0
+	})
+
+	// last-progress gauge is the commit timestamp in SECONDS.
+	if got := testutil.ToFloat64(metrics.ApplierLastProgressCollector()); got != wantSec {
+		t.Fatalf("last_progress gauge = %v, want %v (millis %d / 1000)", got, wantSec, fixedMs)
+	}
+	// in-progress gauge is cleared to 0 once the batch finalises (idle).
+	if got := testutil.ToFloat64(metrics.ApplierApplyInProgressSinceCollector()); got != 0 {
+		t.Fatalf("apply_in_progress_since gauge = %v, want 0 (idle)", got)
+	}
+}
+
+// TestApplier_MultiTenantBatchProgress pins per-record vs per-batch counter
+// semantics under the PARALLEL apply path (#653 coverage): a single poll
+// batch spanning two tenants increments records_applied once per record but
+// batches_applied exactly once, and the batch-level in-flight marker clears.
+// NOT parallel — reads process-global counters.
+func TestApplier_MultiTenantBatchProgress(t *testing.T) {
+	f := newFixture(t)
+	const tenantB = "tenant_b"
+	if err := f.store.OpenTenant(context.Background(), tenantB); err != nil {
+		t.Fatalf("OpenTenant(%s): %v", tenantB, err)
+	}
+
+	beforeRecords := testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector())
+	beforeBatches := testutil.ToFloat64(metrics.ApplierBatchesAppliedCollector())
+
+	// Four records across two tenants, all appended before the applier
+	// starts, so they arrive in ONE poll batch (single partition, batchSize
+	// 32). Two distinct tenants exercises the cross-tenant parallel workers.
+	f.appendEvent(t, makeCreateEvent(testTenant, "a1", "na1"))
+	f.appendEvent(t, makeCreateEvent(testTenant, "a2", "na2"))
+	f.appendEvent(t, makeCreateEvent(tenantB, "b1", "nb1"))
+	f.appendEvent(t, makeCreateEvent(tenantB, "b2", "nb2"))
+
+	f.runApplierUntilApplied(t) // default applier: MaxApplyConcurrency = GOMAXPROCS -> parallel
+	f.waitForIdempKey(t, testTenant, "a2")
+	f.waitForIdempKey(t, tenantB, "b2")
+	waitFor(t, 2*time.Second, "batch to finalise", func() bool {
+		return f.applier.State().ApplyingSinceMilli == 0
+	})
+
+	if got := testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector()) - beforeRecords; got != 4 {
+		t.Fatalf("records_applied delta = %v, want 4 (one per record)", got)
+	}
+	if got := testutil.ToFloat64(metrics.ApplierBatchesAppliedCollector()) - beforeBatches; got != 1 {
+		t.Fatalf("batches_applied delta = %v, want 1 (once per batch, not per record/tenant)", got)
+	}
+}
+
+// TestApplier_PoisonHaltReportsExited is the integration counterpart to the
+// exit-window fix (#653 review): a real poison halt makes Readiness report
+// "exited"/Stalled even with stall gating disabled (threshold 0), and the
+// partial batch counts only its committed prefix (records_applied for the
+// good record, batches_applied NOT incremented because the batch never fully
+// committed). NOT parallel — reads process-global counters.
+func TestApplier_PoisonHaltReportsExited(t *testing.T) {
+	f := newFixture(t)
+	beforeRecords := testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector())
+	beforeBatches := testutil.ToFloat64(metrics.ApplierBatchesAppliedCollector())
+
+	f.appendEvent(t, makeCreateEvent(testTenant, "good", "n-good"))
+	// Poison: a create_node op with no id (mirrors TestApplier_HaltsOnPoison).
+	f.appendEvent(t, apply.Event{
+		TenantID: testTenant, Actor: "user:svc", IdempotencyKey: "poison",
+		Ops: []map[string]any{{"op": "create_node", "type_id": 1}},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- f.applier.Run(ctx) }()
+
+	var runErr error
+	select {
+	case runErr = <-done:
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("applier did not halt within 3s")
+	}
+	if runErr == nil {
+		t.Fatal("expected a poison-halt error from Run")
+	}
+
+	// Even with stall gating disabled (threshold 0), an exited applier gates.
+	rd := f.applier.Readiness(time.Now().UnixMilli(), 0)
+	if rd.State != "exited" || !rd.Stalled {
+		t.Fatalf("readiness after poison halt = %+v, want exited/stalled", rd)
+	}
+
+	if got := testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector()) - beforeRecords; got != 1 {
+		t.Fatalf("records_applied delta = %v, want 1 (only the good record's committed prefix)", got)
+	}
+	if got := testutil.ToFloat64(metrics.ApplierBatchesAppliedCollector()) - beforeBatches; got != 0 {
+		t.Fatalf("batches_applied delta = %v, want 0 (halted batch never fully committed)", got)
+	}
+}
+
+// TestApplier_ReplaySkipsCountAsProgress pins that a replaying applier
+// (re-consuming already-applied records, which the idempotency probe returns
+// as StatusSkipped) still advances the progress signal (#653 coverage) — so
+// an applier draining a backlog after restart is NOT mistaken for stalled.
+// NOT parallel — reads process-global counters.
+func TestApplier_ReplaySkipsCountAsProgress(t *testing.T) {
+	f := newFixture(t)
+	f.appendEvent(t, makeCreateEvent(testTenant, "k-replay", "n-replay"))
+	f.runApplierUntilApplied(t) // group testGroupID applies it once
+	f.waitForIdempKey(t, testTenant, "k-replay")
+
+	// A fresh consumer group re-consumes from offset 0; the record is already
+	// in applied_events, so the in-txn idempotency probe returns Skipped.
+	beforeRecords := testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector())
+	replay := f.newApplierOn(t, "replay-group", nil)
+	runInBackground(t, replay)
+
+	waitFor(t, 3*time.Second, "replay to skip-process the record", func() bool {
+		return testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector()) > beforeRecords
+	})
+	if got := testutil.ToFloat64(metrics.ApplierRecordsAppliedCollector()) - beforeRecords; got < 1 {
+		t.Fatalf("records_applied delta = %v, want >=1 (a skipped replay still counts as forward progress)", got)
+	}
+}
+
 // TestApplier_ProgressAdvancesOnApply pins that a committed batch advances
 // the apply-progress signal (#653): the in-memory State and the Prometheus
 // counters both move, and the applier reports a healthy, not-stalled,

--- a/server/go/internal/apply/progress_test.go
+++ b/server/go/internal/apply/progress_test.go
@@ -30,7 +30,18 @@ func TestApplierState_StalledFor(t *testing.T) {
 		// is the false-positive the per-record progress signal prevents.
 		{"slow but progressing (commit 0.5s ago)", now - 500, now - 30_000, 500 * time.Millisecond},
 		{"progressing (commit just now)", now, now - 30_000, 0},
+		// Committed THEN wedged: batch started 100s ago, committed a record
+		// 90s ago, then blocked -> the wedge clock runs from the last commit
+		// (ref = lastProgress, newer than applyingSince) = 90s, which DOES
+		// exceed a 60s threshold. Distinct from slow-but-progressing.
+		{"committed then wedged (last commit 90s ago)", now - 90_000, now - 100_000, 90 * time.Second},
+		// lastProgress exactly == applyingSince: ref stays at applyingSince
+		// (the `LastProgressMilli > ref` branch does not fire).
+		{"last commit equals batch start", now - 5_000, now - 5_000, 5 * time.Second},
 		{"clock skew (since in future)", now - 1_000, now + 1_000, 0},
+		// Backward clock step: now is before the reference -> 0 (no negative
+		// duration).
+		{"backward clock skew (now before commit)", now + 2_000, now - 1_000, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -114,6 +125,30 @@ func TestApplier_Readiness(t *testing.T) {
 			if rd.State != applierStateExited || !rd.Stalled {
 				t.Fatalf("threshold=%v: got %+v, want exited/stalled", th, rd)
 			}
+		}
+	})
+
+	t.Run("exited beats a batch still in-flight", func(t *testing.T) {
+		// exited transitions while a batch is mid-apply -> exited wins.
+		rd := newApplier(now-10_000, true).Readiness(now, time.Minute)
+		if rd.State != applierStateExited || !rd.Stalled {
+			t.Fatalf("got %+v, want exited (overrides in-flight)", rd)
+		}
+	})
+
+	t.Run("stall gate is inclusive at exactly the threshold", func(t *testing.T) {
+		// stalledFor == threshold must gate (the spec is `>=`). applyingSince
+		// is now-60_000 and lastProgress is older, so stalledFor == 60s.
+		rd := newApplier(now-60_000, false).Readiness(now, time.Minute)
+		if rd.State != applierStateStalled || !rd.Stalled {
+			t.Fatalf("got %+v, want stalled at the exact boundary (>=)", rd)
+		}
+	})
+
+	t.Run("negative threshold disables gating", func(t *testing.T) {
+		rd := newApplier(now-1_000_000, false).Readiness(now, -100*time.Millisecond)
+		if rd.State != applierStateApplying || rd.Stalled {
+			t.Fatalf("got %+v, want applying/not-stalled (threshold<=0)", rd)
 		}
 	})
 }


### PR DESCRIPTION
Tests-only follow-up to #653 (v2.5.0), from a coverage audit. **No production code changes** — shipped behavior is unchanged; these lock it in.

The original suite had the state machine at 100% line coverage but two real gap classes:

**Assertion depth** — `TestApplier_ProgressAdvancesOnApply` asserted the *counters* but never the *gauge values*, so a silent millis→seconds (`/1000`) bug in the timestamp gauges would ship undetected. `TestApplier_GaugeValuesAndUnits` now asserts the exact seconds value (via an injected fixed clock) and the idle-clear to 0.

**Integration paths** not exercised:
- **Multi-tenant parallel batch** — `records_applied` once per record, `batches_applied` exactly once, in-flight clears (the cross-tenant parallel apply path).
- **Poison halt → `Readiness` "exited"/Stalled** even with gating off (threshold 0), and partial-batch counters (committed prefix only; `batches_applied` not incremented) — the integration counterpart to the exit-window ordering fix.
- **Replay skips count as progress** — a fresh-group applier re-consuming already-applied records (`StatusSkipped`) still advances the signal, so a backlog-draining applier after restart isn't mistaken for stalled.

**Edge cases** folded into the unit tables: committed-then-wedged (`ref=lastProgress`), exact-threshold boundary (`>=`), exited-while-applying precedence, negative threshold disables, backward clock skew.

All pass under `-race`; gofmt + vet clean. No release needed.

Refs #653.