### PR TITLE
chore(ci): pin Go 1.25.11 to clear stdlib vulns in the Go Vulnerability Scan

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
       - run: uv python install ${{ env.PYTHON_VERSION }}
       - run: |
           uv venv
@@ -119,7 +119,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
       - run: uv python install ${{ env.PYTHON_VERSION }}
       - run: |
           uv venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: server/go/go.sum
 
       - name: Build Go entdb-server
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: |
             server/go/go.sum
             sdk/go/entdb/go.sum
@@ -208,7 +208,7 @@ jobs:
       # the YAML simple.
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: server/go/go.sum
 
       # Prefer the released entdb-schema binary (issue #488 AC7). Fall
@@ -310,7 +310,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: server/go/go.sum
 
       - name: go vet
@@ -334,7 +334,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: |
             sdk/go/entdb/go.sum
             server/go/go.sum
@@ -364,7 +364,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: server/go/go.sum
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -446,7 +446,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache: false
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
       - if: matrix.language == 'go'
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: sdk/go/entdb/go.sum
 
       - uses: astral-sh/setup-uv@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,7 +508,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: server/go/go.sum
 
       - name: Build entdb-schema (${{ matrix.goos }}/${{ matrix.goarch }})

--- a/.github/workflows/schema-compat.yml
+++ b/.github/workflows/schema-compat.yml
@@ -39,7 +39,7 @@ jobs:
       # set it up unconditionally for simplicity.
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: server/go/go.sum
 
       # Prefer the released `entdb-schema` binary so this workflow

--- a/sdk/go/entdb/go.mod
+++ b/sdk/go/entdb/go.mod
@@ -1,6 +1,7 @@
 module github.com/elloloop/tenant-shard-db/sdk/go/entdb/v2
 
 go 1.25.0
+toolchain go1.25.11
 
 require (
 	connectrpc.com/connect v1.20.0

--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -1,6 +1,7 @@
 module github.com/elloloop/tenant-shard-db/server/go
 
 go 1.25.8
+toolchain go1.25.11
 
 require (
 	cloud.google.com/go/pubsub v1.50.2

--- a/tests/contract/go.mod
+++ b/tests/contract/go.mod
@@ -11,3 +11,4 @@
 module github.com/elloloop/tenant-shard-db/tests/contract
 
 go 1.25.0
+toolchain go1.25.11

--- a/tools/protoc-gen-entdb-keys/go.mod
+++ b/tools/protoc-gen-entdb-keys/go.mod
@@ -1,5 +1,6 @@
 module github.com/elloloop/tenant-shard-db/tools/protoc-gen-entdb-keys/v2
 
 go 1.25.0
+toolchain go1.25.11
 
 require google.golang.org/protobuf v1.36.11


### PR DESCRIPTION
## Why

`govulncheck` (CI `go-version: '1.25'` → 1.25.10) flags two **Go standard-library** vulnerabilities, failing the **Go Vulnerability Scan** on every PR and on `main`:

| Vuln | Package | Fixed in |
|---|---|---|
| GO-2026-5039 | `net/textproto` | go1.25.11 |
| GO-2026-5037 | `crypto/x509` | go1.25.11 |

**Not a runtime exposure** — the release Dockerfile already builds on `golang:1.26`, so the shipped image's stdlib is patched. This was a CI-scan gap (the scan job runs on the 1.25 line while the image ships on 1.26). Still, the scan correctly demands a patched toolchain, and a red `All Checks Passed` gate blocks every PR.

## What

- Pin all CI `go-version: '1.25'` → `'1.25.11'` (build / test / vuln-scan / codeql / docs / schema-compat / benchmarks / release-binary).
- Add `toolchain go1.25.11` to the four `go.mod` modules so local + CI builds use the patched stdlib.
- Same minor (1.25.x), so generated docs are unchanged — the Docs Coverage gate stays green.
- The `'1.22'` SDK-bootstrap pins in `release.yml` are left as-is (`GOTOOLCHAIN=auto` resolves them to the go.mod `toolchain`).

## Verified locally

All 4 Go modules `build` + `vet` clean; `server/go` apply/api/metrics/cmd tests pass. Local Go (1.26.3, newer than the floor) is used unchanged. The one thing only CI can confirm is the Docs Coverage regen under 1.25.11 — expected identical for a patch bump.

Unblocks #655 and turns `main` green again.