### PR TITLE
test(sdk): e2e coverage for /readyz + apply-progress metrics on a real booted server (#653)

### DIFF
--- a/sdk/go/entdb/integration_readyz_test.go
+++ b/sdk/go/entdb/integration_readyz_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+// End-to-end coverage for the applier readiness surface (#653) on a REAL
+// booted server. The unit tests cover applierReadyzHandler with mock probes
+// and Readiness in isolation; this is the only test that proves the full
+// wiring on a running binary: the --metrics-addr flag is parsed, the /readyz
+// endpoint is registered on the metrics mux, the main.go closure passes the
+// live applier's Readiness + threshold, and the apply-progress gauges are
+// actually registered and scraped on /metrics.
+//
+// The 200 (healthy/idle) path is what an end-to-end test can deterministically
+// reach — wedging a separately-booted server's applier from outside isn't
+// feasible. The 503 (stalled/exited) path is covered by the handler unit test
+// (cmd/entdb-server/readyz_test.go) and the in-process stall integration test
+// (internal/apply/applier_progress_test.go: TestApplier_StallIsObservable).
+
+package entdb
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func httpGet(t *testing.T, url string) (int, string) {
+	t.Helper()
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s body: %v", url, err)
+	}
+	return resp.StatusCode, string(body)
+}
+
+// TestIntegration_ReadyzAndApplierMetrics pins that a healthy booted server
+// serves /readyz (200, applier making progress / idle) and exposes the #653
+// apply-progress gauges on /metrics.
+func TestIntegration_ReadyzAndApplierMetrics(t *testing.T) {
+	if itMetricsAddr == "" {
+		t.Fatal("itMetricsAddr not set — metrics listener was not booted")
+	}
+	base := "http://" + itMetricsAddr
+
+	// /readyz: the applier on a healthy idle server is not stalled -> 200,
+	// and the body names a non-stalled state.
+	code, body := httpGet(t, base+"/readyz")
+	if code != http.StatusOK {
+		t.Fatalf("/readyz status = %d, want 200 (healthy server); body=%q", code, body)
+	}
+	state := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(body), "applier"))
+	switch state {
+	case "idle", "applying":
+		// expected on a healthy server
+	default:
+		t.Fatalf("/readyz body = %q, want applier idle|applying", body)
+	}
+
+	// /metrics: the apply-progress signals (#653) must be registered and
+	// scraped on the real server, not just in unit tests.
+	code, metricsBody := httpGet(t, base+"/metrics")
+	if code != http.StatusOK {
+		t.Fatalf("/metrics status = %d, want 200", code)
+	}
+	for _, want := range []string{
+		"entdb_applier_last_progress_timestamp_seconds",
+		"entdb_applier_apply_in_progress_since_timestamp_seconds",
+		"entdb_applier_records_applied_total",
+		"entdb_applier_batches_applied_total",
+	} {
+		if !strings.Contains(metricsBody, want) {
+			t.Fatalf("/metrics missing %q (apply-progress gauge not registered on the real server)", want)
+		}
+	}
+}

--- a/sdk/go/entdb/integration_test.go
+++ b/sdk/go/entdb/integration_test.go
@@ -59,6 +59,10 @@ const (
 // itClient is the live SDK client bound to the booted server.
 var itClient *DbClient
 
+// itMetricsAddr is the host:port of the booted server's Prometheus +
+// /readyz HTTP listener (--metrics-addr), used by the readiness e2e test.
+var itMetricsAddr string
+
 func TestMain(m *testing.M) { os.Exit(runIntegration(m)) }
 
 func runIntegration(m *testing.M) int {
@@ -98,6 +102,17 @@ func runIntegration(m *testing.M) int {
 	}
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 
+	// Enable the Prometheus + /readyz HTTP listener on a second free port so
+	// the readiness e2e (TestIntegration_ReadyzAndApplierMetrics, #653) can
+	// exercise the full wiring on a real booted server. Additive: existing
+	// gRPC tests ignore it.
+	metricsPort, err := freePort()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "integration:", err)
+		return 1
+	}
+	itMetricsAddr = fmt.Sprintf("127.0.0.1:%d", metricsPort)
+
 	// EMPTY BOOT (ADR-031). The server starts with no schema, tenant,
 	// or users; bootstrapIntegrationContract provisions them through the
 	// gRPC API below — same path a real client would use, mirror of the
@@ -106,6 +121,7 @@ func runIntegration(m *testing.M) int {
 		"--addr", addr,
 		"--data-dir", filepath.Join(tmp, "data"),
 		"--wal-backend", "memory",
+		"--metrics-addr", itMetricsAddr,
 	)
 	srv.Stdout, srv.Stderr = os.Stderr, os.Stderr
 	if err := srv.Start(); err != nil {


### PR DESCRIPTION
Final #653 coverage gap, closed. Tests-only; no production code change.

The applier readiness HTTP surface (`/readyz`) and the apply-progress metrics had unit + in-process coverage, but **nothing exercised the full wiring on a real booted binary**: `--metrics-addr` parsed → `/readyz` registered on the metrics mux → the `main.go` closure passing the live applier's `Readiness` + threshold → gauges registered and scraped.

- The integration `TestMain` now boots the server with `--metrics-addr` on a second free port (additive — existing gRPC tests ignore it).
- `TestIntegration_ReadyzAndApplierMetrics` asserts `/readyz` → 200 with a non-stalled state on a healthy server, and `/metrics` exposes all four `entdb_applier_*` series.
- The 503 (stalled/exited) path remains covered by the handler unit test (`cmd/entdb-server/readyz_test.go`) and the in-process lock-contention stall test (`internal/apply/applier_progress_test.go`).

Verified: full `-tags=integration` SDK suite green with the new boot; gofmt + vet clean. Refs #653.